### PR TITLE
release: 0.3.2 — the warming CPU storm and the install freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ resurrecting install paths that already existed but were invisible.
 
 ### Changed
 
+- **The background warmer runs one probe per core (clamped `[2, 8]`) instead
+  of four per core (clamped `[4, 32]`).** The oversubscription assumed a
+  warming job blocks on its child costing no CPU — true for a typical small
+  C tool, measured false for `docker`, whose CLI burns 70–100ms of real CPU
+  per spawn. Sixteen concurrent probes on a four-core machine was the warm
+  pegging every core for minutes. The warm now takes longer on cheap-probe
+  trees, in background time nobody waits on; user-expanded nodes still jump
+  the queue, so the visible tree fills as fast as before.
 - **Release binaries are stripped** (`[profile.release] strip = "symbols"`):
   5.6 MB → 4.0 MB measured on aarch64.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The fuzzy search index is rebuilt once per batch of warmed nodes instead
+  of once per node**, removing a quadratic term from background warming.
+  Every arrival from the warmer used to restart the index and re-inject the
+  whole, growing tree; arrivals are now coalesced into at most one rebuild
+  per event-loop iteration, throttled to one per 250ms while nobody is
+  searching. A deferred rebuild is never dropped, and the throttle is
+  bypassed whenever a query is active or the search box is focused, so search
+  never lags the tree it is searching (spec §5.2). Rendering is unchanged.
+
+  Measured cost of the removed term, replaying arrivals against a synthetic
+  tree: **99ms at docker's ~255 nodes, 395ms at 510, 1.62s at 1,020, and
+  17.7s at spec §5.2's 4,096-node cap — against 6.6ms for a single batched
+  rebuild at that cap.** Clean n², so the bigger the tool the worse it got.
+
+  Read the end-to-end number carefully, because it is much smaller than that
+  suggests. Holding `mandible docker` open in a real pty on a 4-core box,
+  process CPU over the 22-second warm went **6.07s → 5.72s**, all of it on
+  the UI thread (**1.13s → 0.51s**). The remaining ~5.1s is the warmer
+  threads doing the extraction the warm exists to do — ~10 threads flat out
+  on 4 cores — which is where any further work on warming CPU belongs. The
+  index storm was a real bug and is gone; on docker it was 10% of the CPU,
+  not the bulk.
+- `nucleo`'s matcher thread pool is capped at 4 threads instead of defaulting
+  to one per core. Secondary and precautionary: the item set is bounded by
+  the node cap, so past a handful of threads a rebuild's coordination costs
+  more than its parallel scoring saves. Not measurable on a 4-core box, and
+  not the fix above.
+
 ## [0.3.1] - 2026-08-15
 
 On the 94-tool development set, re-reviewed blind in the TUI with no prior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The README's pre-built binary links were four literal `(...)`
+  placeholders** while the install section led with `cargo install` — so the
+  one user path that avoids compiling entirely was invisible. The table now
+  points at the stable `releases/latest/download/` asset URLs (verified
+  live), documents `cargo binstall mandible` (verified resolving against a
+  real release), and the from-source path carries a note for RAM-backed
+  `$TMPDIR` systems (`CARGO_TARGET_DIR=… cargo install mandible -j 2`),
+  where a `cargo install` was measured pushing a small machine toward
+  memory exhaustion (peak ~1.2 GB of concurrent rustc RSS at `-j 4` plus a
+  ~470 MB transient build tree, which lands in `$TMPDIR`).
+
+### Changed
+
+- **Release binaries are stripped** (`[profile.release] strip = "symbols"`):
+  5.6 MB → 4.0 MB measured on aarch64.
+
 ## [0.3.1] - 2026-08-15
 
 On the 94-tool development set, re-reviewed blind in the TUI with no prior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-17
+
+Two user reports drove this release, and each was measured to its mechanism
+before anything was changed: a background warm that pegged CPU through a
+quadratic search-index rebuild, and a `cargo install` that could push a
+small machine into memory exhaustion — the latter fixed mostly by
+resurrecting install paths that already existed but were invisible.
+
 ### Fixed
 
 - **The fuzzy search index is rebuilt once per batch of warmed nodes instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,36 @@ resurrecting install paths that already existed but were invisible.
 
 ### Fixed
 
+- **Your container names are no longer shown as docker commands.** Reported
+  from real use: `mandible docker` rendered the reporter's own running
+  containers as subcommands of `docker stop`, `docker rm` and friends.
+
+  The cobra tier probes `<tool> __complete <path> ""` and trusted every
+  candidate it got back as a subcommand name, on the documented premise that
+  an empty word returns subcommands only. That premise is wrong at a leaf:
+  cobra emits the node's real subcommands and then *appends whatever the
+  command's own completion function returns*, which is application code
+  reading live state. So `docker __complete stop ""` answers with running
+  container names, `docker __complete run ""` with image names, and
+  `docker __complete network rm ""` with network names — private data, drawn
+  as commands. Each fabricated node was then warmed like any other, so the
+  probe count grew with the size of *your* data rather than with the tool.
+
+  A candidate list now becomes subcommands only when **every** candidate in
+  it carries a description. cobra writes real subcommands as
+  `name<TAB>description` from its own formatter, while a completion function
+  returning a plain list of strings produces bare rows; one bare row
+  condemns the whole list, because cobra marks no boundary between the two
+  halves. Measured across 631 real command paths on docker 29.7.2 and gh
+  2.45.0: 85 fully-described lists, all genuine subcommand lists, and 50
+  bare-or-mixed lists, all argument data — every real subcommand kept, every
+  argument value dropped (spec Appendix A [M-2a]).
+
+  The trade is deliberate and one-directional: a rare real subcommand whose
+  author left its short description empty, sitting in a list that also
+  carries argument values, is dropped here. The `--help` tier still finds
+  it, and a missing rare subcommand is a far smaller harm than rendering
+  your containers as commands.
 - **The fuzzy search index is rebuilt once per batch of warmed nodes instead
   of once per node**, removing a quadratic term from background warming.
   Every arrival from the warmer used to restart the index and re-inject the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arboard",
  "base64",
@@ -2362,7 +2362,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.3.1" }
-mandible-extract = { path = "mandible-extract", version = "0.3.1" }
-mandible-search = { path = "mandible-search", version = "0.3.1" }
-mandible-tui = { path = "mandible-tui", version = "0.3.1" }
+mandible-core = { path = "mandible-core", version = "0.3.2" }
+mandible-extract = { path = "mandible-extract", version = "0.3.2" }
+mandible-search = { path = "mandible-search", version = "0.3.2" }
+mandible-tui = { path = "mandible-tui", version = "0.3.2" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ members = [
     "xtask",
 ]
 
+# Strip symbols from release binaries. Measured on 0.3.1 (aarch64): the
+# installed binary drops 5.6 MB -> 4.0 MB, and `cargo install`'s transient
+# build tree shrinks ~35 MB — a size win, not the fix for building on a
+# RAM-backed $TMPDIR (the README's install note covers that).
+[profile.release]
+strip = "symbols"
+
 [workspace.package]
 version = "0.3.1"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -42,11 +42,7 @@ $ mandible docker
 
 ## Install
 
-```console
-cargo install mandible
-```
-
-### Pre-built binaries
+### Pre-built binaries (recommended)
 
 Linux and macOS, on both x86_64 and arm64. Windows is not supported. The process
 containment described above relies on POSIX process groups, and native Windows tools
@@ -57,14 +53,37 @@ speak.
 
 | Platform              | Download |
 |:----------------------|:---------|
-| Linux x86_64          | [`tar.gz`](...) |
-| Linux arm64           | [`tar.gz`](...) |
-| macOS Apple Silicon   | [`tar.gz`](...) |
-| macOS Intel           | [`tar.gz`](...) |
+| Linux x86_64          | [`tar.gz`](https://github.com/AS-FOSS/mandible/releases/latest/download/mandible-x86_64-unknown-linux-gnu.tar.gz) |
+| Linux arm64           | [`tar.gz`](https://github.com/AS-FOSS/mandible/releases/latest/download/mandible-aarch64-unknown-linux-gnu.tar.gz) |
+| macOS Apple Silicon   | [`tar.gz`](https://github.com/AS-FOSS/mandible/releases/latest/download/mandible-aarch64-apple-darwin.tar.gz) |
+| macOS Intel           | [`tar.gz`](https://github.com/AS-FOSS/mandible/releases/latest/download/mandible-x86_64-apple-darwin.tar.gz) |
 
 `.deb` and `.rpm` packages are attached to every [release](https://github.com/AS-FOSS/mandible/releases).  
 Each archive ships a matching `.sha256` checksum.
 </div>
+
+Or let [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) pick the
+right archive for your machine:
+
+```console
+cargo binstall mandible
+```
+
+### From source
+
+```console
+cargo install mandible
+```
+
+> [!NOTE]
+> `cargo install` compiles in a temporary directory under `$TMPDIR`, which many
+> distributions mount as RAM-backed tmpfs — on a machine with limited memory the
+> build itself can push the system into memory exhaustion. If that's you, keep
+> the build tree on disk and cap the parallelism:
+>
+> ```console
+> CARGO_TARGET_DIR=~/.cache/mandible-build cargo install mandible -j 2
+> ```
 
 
 

--- a/mandible-extract/src/native/mod.rs
+++ b/mandible-extract/src/native/mod.rs
@@ -15,6 +15,22 @@
 //!   ignored. Candidates are `value\tdescription` (or bare `value`) per
 //!   line.
 //!
+//! **An empty trailing word does *not* mean "subcommands only"** — the
+//! premise [M-2] was originally written with, and measured wrong at leaf
+//! commands. cobra answers `__complete <path> ""` by emitting the node's
+//! real subcommands *and then appending whatever that command's
+//! `ValidArgsFunction` returns*, which is application code that reads live
+//! state. Measured on this box (docker 29.7.2): `docker __complete stop ""`
+//! returns **running container names**, `docker __complete run ""` returns
+//! **image names**, `docker __complete network rm ""` returns network
+//! names. Treating those as subcommands rendered a user's private container
+//! names in the tree as if they were docker commands, and — because each
+//! fabricated node is then warmed like any other (spec §5.2 step 4) —
+//! multiplied the probe count by the size of a set that scales with the
+//! user's data, not with the tool. See [`populate_subcommands`] for the
+//! general rule that stops it, and spec Appendix A [M-2] for the full
+//! measurement.
+//!
 //! clap's `CompleteEnv` was also probed here once and has been removed: it
 //! never identified a single real clap tool, matched ten unrelated ones by
 //! accident, and its argv spelling handed tools an empty first positional
@@ -330,8 +346,14 @@ impl NativeTier {
         if let Some(candidates) =
             probe_cobra_list(self.probe.as_ref(), tool_path, words, "-", EXTRACT_TIMEOUT)
         {
-            for (value, description) in candidates {
-                if let Some(flag) = flag_from_candidate(&value, &description, &provenance) {
+            for candidate in candidates {
+                // No description gate here: a flag candidate is already
+                // filtered by its own dash shape, which an argument value
+                // essentially never has, and cobra emits plenty of real
+                // flags with no help text.
+                if let Some(flag) =
+                    flag_from_candidate(&candidate.value, candidate.description_text(), &provenance)
+                {
                     node.flags.push(flag);
                 }
             }
@@ -352,7 +374,7 @@ fn probe_cobra_list(
     words: &[String],
     trailing: &str,
     timeout: Duration,
-) -> Option<Vec<(String, String)>> {
+) -> Option<Vec<Candidate>> {
     let mut argv_words = words.to_vec();
     // The empty word is required by cobra's protocol, not incidental:
     // `docker __complete` without it fails with "requires at least 1
@@ -371,13 +393,40 @@ fn probe_cobra_list(
     parse_cobra_response(&out.stdout)
 }
 
+/// One line of a cobra `__complete` response.
+///
+/// The distinction that matters is *whether the line carried a
+/// description at all*, which the earlier `(String, String)` shape
+/// flattened away by spelling "no description" and "empty description"
+/// both as `""`. It is the only thing in cobra's wire format that
+/// separates a real subcommand from a value the command's own
+/// `ValidArgsFunction` computed from live state — see
+/// [`populate_subcommands`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Candidate {
+    /// The completion value: a subcommand name, a flag spelling, or an
+    /// argument value.
+    value: String,
+    /// The text after the `\t`, when there was one and it was not blank.
+    description: Option<String>,
+}
+
+impl Candidate {
+    /// The description as a `&str`, with "absent" and "blank" collapsed —
+    /// correct for flag descriptions, where the distinction carries no
+    /// meaning.
+    fn description_text(&self) -> &str {
+        self.description.as_deref().unwrap_or("")
+    }
+}
+
 /// Parse a cobra `__complete` response: candidate lines (`value` or
 /// `value\tdescription`) followed by a `:N` directive line. Returns `None`
 /// unless that directive line is actually found — the response shape
 /// cobra's protocol guarantees, and the general (not tool-specific) signal
 /// that a binary really speaks this protocol rather than just happening to
 /// accept the argv without erroring.
-fn parse_cobra_response(stdout: &[u8]) -> Option<Vec<(String, String)>> {
+fn parse_cobra_response(stdout: &[u8]) -> Option<Vec<Candidate>> {
     let text = String::from_utf8_lossy(stdout);
     let mut candidates = Vec::new();
     let mut saw_directive = false;
@@ -389,12 +438,19 @@ fn parse_cobra_response(stdout: &[u8]) -> Option<Vec<(String, String)>> {
         if line.is_empty() {
             continue;
         }
-        match line.split_once('\t') {
-            Some((value, description)) => {
-                candidates.push((value.to_string(), description.to_string()))
+        let (value, description) = match line.split_once('\t') {
+            // A tab with nothing (or only blanks) after it carries no more
+            // information than no tab at all, so both collapse to `None`.
+            Some((value, description)) if !description.trim().is_empty() => {
+                (value, Some(description.to_string()))
             }
-            None => candidates.push((line.to_string(), String::new())),
-        }
+            Some((value, _)) => (value, None),
+            None => (line, None),
+        };
+        candidates.push(Candidate {
+            value: value.to_string(),
+            description,
+        });
     }
     saw_directive.then_some(candidates)
 }
@@ -410,10 +466,10 @@ fn is_directive_line(line: &str) -> bool {
 /// descriptions, which some tools vary slightly by context) — used only to
 /// recognize "this is the same list as the root's," not for anything
 /// security-sensitive, so a simple hash is sufficient.
-fn fingerprint_candidates(candidates: &[(String, String)]) -> u64 {
+fn fingerprint_candidates(candidates: &[Candidate]) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for (value, _) in candidates {
-        value.hash(&mut hasher);
+    for candidate in candidates {
+        candidate.value.hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -429,17 +485,65 @@ fn alias_target_last_segment(description: &str) -> Option<&str> {
     inner.split_whitespace().next_back()
 }
 
+/// True when a candidate list may be read as a subcommand list at all.
+///
+/// **The general rule that keeps live user data out of the tree.** cobra
+/// answers one `__complete <path> ""` by emitting the node's real
+/// subcommands — always as `name\tShort`, from cobra's own
+/// `fmt.Sprintf("%s\t%s", ...)` — and then *appending* whatever the
+/// command's `ValidArgsFunction` returns. That second half is application
+/// code reading live state: container names, image tags, network names,
+/// context names. cobra's wire format marks no boundary between the two
+/// halves, so the only thing left to read is the description column:
+///
+/// - every real subcommand carries one, because cobra writes it;
+/// - a `ValidArgsFunction` value normally carries none, because returning
+///   a plain `[]string` is the ordinary way to write one.
+///
+/// So a list is trusted only when **every** candidate in it is described.
+/// A single undescribed candidate proves the list contains argument
+/// completions, and since the boundary is unmarked, nothing in that list
+/// can be trusted — not even the described entries ahead of it.
+///
+/// Measured across 631 real command paths on `docker` 29.7.2 and `gh`
+/// 2.45.0 (spec Appendix A [M-2a]): 85 all-described lists, every one a
+/// genuine subcommand list; 45 all-undescribed lists and 5 mixed lists,
+/// every one of the 50 pure argument data. The rule therefore admitted
+/// every real subcommand and no argument value on the whole measured set.
+///
+/// **The trade is deliberate and one-directional** (AGENTS.md §1's
+/// maintainer principle): a real cobra subcommand registered with an empty
+/// `Short`, sitting in a list that also carries undescribed argument
+/// values, is dropped here. Tier B's `--help` parse still finds it, and a
+/// missing rare subcommand is a smaller harm than rendering a user's
+/// container names as commands. Never relax this to recover such a
+/// subcommand.
+fn candidates_are_a_subcommand_list(candidates: &[Candidate]) -> bool {
+    !candidates.is_empty() && candidates.iter().all(|c| c.description.is_some())
+}
+
 /// Turn a subcommands-probe candidate list into `node`'s subcommands,
 /// routing alias-shaped candidates onto a matching sibling's `aliases`
 /// instead of fabricating them as their own subcommand (spec §7 Tier E,
 /// the module doc's "Alias detection").
+///
+/// Refuses the whole list unless [`candidates_are_a_subcommand_list`]
+/// accepts it.
 fn populate_subcommands(
     node: &mut CommandNode,
-    candidates: Vec<(String, String)>,
+    candidates: Vec<Candidate>,
     provenance: &Provenance,
 ) {
+    if !candidates_are_a_subcommand_list(&candidates) {
+        return;
+    }
     let mut aliases: Vec<(String, String)> = Vec::new();
-    for (value, description) in candidates {
+    for candidate in candidates {
+        // Every candidate is described here — the guard above rejected the
+        // list otherwise — so alias routing (whose marker *is* a
+        // description) is unaffected by that guard.
+        let Candidate { value, description } = candidate;
+        let description = description.unwrap_or_default();
         if let Some(target) = alias_target_last_segment(&description) {
             aliases.push((value, target.to_string()));
             continue;
@@ -447,8 +551,9 @@ fn populate_subcommands(
         if !is_command_name_shaped(&value) {
             continue;
         }
+        let summary = non_empty_text(&description);
         let mut child = CommandNode::new(value, provenance.clone());
-        child.summary = non_empty_text(&description);
+        child.summary = summary;
         child.children_filled = false;
         node.subcommands.push(child);
     }
@@ -551,6 +656,23 @@ fn non_empty_text(s: &str) -> Option<Text> {
 mod tests {
     use super::*;
 
+    /// A described candidate, as cobra emits a real subcommand.
+    fn described(value: &str, description: &str) -> Candidate {
+        Candidate {
+            value: value.to_string(),
+            description: Some(description.to_string()),
+        }
+    }
+
+    /// An undescribed candidate, as a `ValidArgsFunction` emits a live
+    /// argument value.
+    fn bare(value: &str) -> Candidate {
+        Candidate {
+            value: value.to_string(),
+            description: None,
+        }
+    }
+
     #[test]
     fn parses_a_real_cobra_response_shape() {
         let raw = b"add\tAdd file contents to the index\nrebase\tReapply commits\n:4\nCompletion ended with directive: ShellCompDirectiveNoFileComp\n";
@@ -558,11 +680,8 @@ mod tests {
         assert_eq!(
             parsed,
             vec![
-                (
-                    "add".to_string(),
-                    "Add file contents to the index".to_string()
-                ),
-                ("rebase".to_string(), "Reapply commits".to_string()),
+                described("add", "Add file contents to the index"),
+                described("rebase", "Reapply commits"),
             ]
         );
     }
@@ -576,10 +695,19 @@ mod tests {
     }
 
     #[test]
-    fn bare_value_with_no_tab_has_empty_description() {
+    fn bare_value_with_no_tab_has_no_description() {
         let raw = b"solo\n:0\n";
         let parsed = parse_cobra_response(raw).unwrap();
-        assert_eq!(parsed, vec![("solo".to_string(), String::new())]);
+        assert_eq!(parsed, vec![bare("solo")]);
+    }
+
+    /// A tab with nothing after it says no more than no tab at all, and
+    /// must not be allowed to pass as "described" — otherwise the
+    /// subcommand-list rule below could be satisfied by whitespace.
+    #[test]
+    fn a_trailing_tab_with_no_text_is_not_a_description() {
+        let parsed = parse_cobra_response(b"solo\t\nspaced\t   \n:0\n").unwrap();
+        assert_eq!(parsed, vec![bare("solo"), bare("spaced")]);
     }
 
     #[test]
@@ -642,8 +770,8 @@ mod tests {
         populate_subcommands(
             &mut node,
             vec![
-                ("pr".to_string(), "Work with pull requests".to_string()),
-                ("co".to_string(), "Alias for \"pr checkout\"".to_string()),
+                described("pr", "Work with pull requests"),
+                described("co", "Alias for \"pr checkout\""),
             ],
             &prov,
         );
@@ -664,14 +792,132 @@ mod tests {
         populate_subcommands(
             &mut node,
             vec![
-                ("remove".to_string(), "Remove a thing".to_string()),
-                ("rm".to_string(), "Alias for \"remove\"".to_string()),
+                described("remove", "Remove a thing"),
+                described("rm", "Alias for \"remove\""),
             ],
             &prov,
         );
         let names: Vec<&str> = node.subcommands.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, vec!["remove"]);
         assert_eq!(node.subcommands[0].aliases, vec!["rm".to_string()]);
+    }
+
+    // --- the dynamic-argument guard (spec Appendix A [M-2a]) ---
+
+    /// The user-reported bug, at the unit level: `docker __complete stop
+    /// ""` answers with the names of the containers currently on the
+    /// machine, bare, because cobra runs the leaf's `ValidArgsFunction`.
+    /// Those are private user data, not commands, and must produce **no**
+    /// subcommands at all — not "some, filtered by name shape", which is
+    /// what `is_command_name_shaped` alone did (it rejects `redis:7` for
+    /// the colon but passes `mandible-canary-1`).
+    #[test]
+    fn a_leaf_answering_with_bare_dynamic_values_yields_no_subcommands() {
+        let prov = Provenance::single(Source::NativeDynamic {
+            protocol: "test".to_string(),
+        });
+        let mut node = CommandNode::new("stop", prov.clone());
+        populate_subcommands(
+            &mut node,
+            vec![
+                bare("mandible-canary-1"),
+                bare("mandible-canary-2"),
+                bare("adoring_hopper"),
+            ],
+            &prov,
+        );
+        assert!(
+            node.subcommands.is_empty(),
+            "container names must never become commands: {:?}",
+            node.subcommands.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// The mixed case, measured verbatim from `docker __complete context
+    /// use ""` on a machine with two contexts: the *current* one carries a
+    /// description (`CompletionWithDesc`) and the rest do not. cobra marks
+    /// no boundary between its own subcommand block and the appended
+    /// `ValidArgsFunction` output, so one undescribed entry condemns the
+    /// whole list — including the described `rootless`, which is a context
+    /// name and not a command.
+    #[test]
+    fn a_mixed_list_contributes_nothing_not_even_its_described_entries() {
+        let prov = Provenance::single(Source::NativeDynamic {
+            protocol: "test".to_string(),
+        });
+        let mut node = CommandNode::new("use", prov.clone());
+        populate_subcommands(
+            &mut node,
+            vec![described("rootless", "current"), bare("default")],
+            &prov,
+        );
+        assert!(node.subcommands.is_empty(), "{:?}", node.subcommands);
+    }
+
+    /// The other half of the trade: a fully-described list is still taken
+    /// in full. Verbatim from `docker __complete container ""`.
+    #[test]
+    fn a_fully_described_list_still_becomes_subcommands() {
+        let prov = Provenance::single(Source::NativeDynamic {
+            protocol: "test".to_string(),
+        });
+        let mut node = CommandNode::new("container", prov.clone());
+        populate_subcommands(
+            &mut node,
+            vec![
+                described(
+                    "attach",
+                    "Attach local standard input, output, and error streams",
+                ),
+                described("commit", "Create a new image from a container's changes"),
+                described("ls", "List containers"),
+            ],
+            &prov,
+        );
+        let names: Vec<&str> = node.subcommands.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["attach", "commit", "ls"]);
+        assert!(node.subcommands.iter().all(|c| c.summary.is_some()));
+    }
+
+    /// A fabricated node must never be marked heading-attested, because
+    /// `heading_attested` is what lets Tier B construct `<tool> <path>
+    /// --help` — and `docker run <image> --help` **creates a container**.
+    /// Nothing in this fix may start setting it; this pins the default.
+    #[test]
+    fn completion_derived_children_are_never_heading_attested() {
+        let prov = Provenance::single(Source::NativeDynamic {
+            protocol: "test".to_string(),
+        });
+        let mut node = CommandNode::new("docker", prov.clone());
+        populate_subcommands(
+            &mut node,
+            vec![described("run", "Create and run a new container")],
+            &prov,
+        );
+        assert_eq!(node.subcommands.len(), 1);
+        assert!(!node.subcommands[0].heading_attested);
+    }
+
+    #[test]
+    fn subcommand_list_predicate_matches_the_measured_shapes() {
+        // All described: docker's real subcommand lists, gh's whole tree.
+        assert!(candidates_are_a_subcommand_list(&[
+            described("pr", "Work with pull requests"),
+            described("repo", "Manage repositories"),
+        ]));
+        // All bare: `docker __complete rm ""`, `docker __complete run ""`.
+        assert!(!candidates_are_a_subcommand_list(&[
+            bare("mandible-canary-1"),
+            bare("hello-world:latest"),
+        ]));
+        // Mixed: `docker __complete context use ""`.
+        assert!(!candidates_are_a_subcommand_list(&[
+            described("rootless", "current"),
+            bare("default"),
+        ]));
+        // Empty is not a subcommand list either — a real leaf, and there
+        // is nothing to take from it.
+        assert!(!candidates_are_a_subcommand_list(&[]));
     }
 
     #[test]
@@ -696,10 +942,7 @@ mod tests {
         // directly, since we can't spawn a real echoing binary here) must
         // not have that list treated as genuine subcommands.
         let tier = NativeTier::default();
-        let root_candidates = vec![
-            ("a".to_string(), String::new()),
-            ("b".to_string(), String::new()),
-        ];
+        let root_candidates = vec![described("a", "first"), described("b", "second")];
         let fp = fingerprint_candidates(&root_candidates);
         tier.remember_root_fingerprint("mytool", fp);
         assert_eq!(tier.remembered_root_fingerprint("mytool"), Some(fp));
@@ -844,6 +1087,61 @@ mod tests {
         let names: Vec<&str> = node.subcommands.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, vec!["build"], "{names:?}");
         assert!(node.flags.iter().any(|f| f.long.as_deref() == Some("all")));
+    }
+
+    /// The dynamic-argument guard through **real argv construction**
+    /// (AGENTS.md §3.1 — the dead-tier incident), not just the parser
+    /// behind it: a transcript keyed on the exact argv this tier builds
+    /// for a leaf (`["__complete", "stop", ""]`), answering with the byte
+    /// shape `docker` really returns for a container-name completion —
+    /// bare names, `ShellCompDirectiveNoFileComp`. The node must come back
+    /// with the leaf's flags and **zero** subcommands.
+    #[test]
+    fn extract_node_takes_no_subcommands_from_a_real_argv_leaf_returning_bare_names() {
+        let transcript = crate::exec::Transcript::new([
+            (
+                vec!["__complete".to_string(), String::new()],
+                exec_output("stop\tStop one or more running containers\n:4\n"),
+            ),
+            (
+                vec!["__complete".to_string(), "stop".to_string(), String::new()],
+                exec_output("mandible-canary-1\nmandible-canary-2\nadoring_hopper\n:4\n"),
+            ),
+            (
+                vec![
+                    "__complete".to_string(),
+                    "stop".to_string(),
+                    "-".to_string(),
+                ],
+                exec_output("--time\tSeconds to wait before killing\n:4\n"),
+            ),
+        ]);
+        let tier =
+            NativeTier::new_with_evidence(Arc::new(transcript), Arc::new(FixedEvidence(true)));
+        let tool = ResolvedTool {
+            name: "cobratool".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/cobratool")),
+            version: None,
+        };
+        assert!(tier.detect(&tool));
+        let node = tier
+            .extract_node(
+                &tool,
+                &["cobratool".to_string(), "stop".to_string()],
+                NodeHints {
+                    heading_attested: true,
+                },
+            )
+            .expect("detect having succeeded, extract_node must too");
+        assert!(
+            node.subcommands.is_empty(),
+            "container names reached the tree through the real argv path: {:?}",
+            node.subcommands.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        assert!(
+            node.flags.iter().any(|f| f.long.as_deref() == Some("time")),
+            "the flags probe must keep working at a leaf"
+        );
     }
 
     /// The negative case: a transcript that does not cover the exact

--- a/mandible-search/src/lib.rs
+++ b/mandible-search/src/lib.rs
@@ -31,7 +31,23 @@ struct Entry {
 pub struct SearchIndex {
     nucleo: Nucleo<Entry>,
     current_query: String,
+    populate_count: u64,
 }
+
+/// Upper bound on `nucleo`'s background matcher threads.
+///
+/// `nucleo` defaults to `available_parallelism()`, i.e. one matcher thread
+/// per core. Every [`SearchIndex::populate`] restarts the match, so each
+/// rebuild hands the whole item set back to all of those threads at once;
+/// on a 64-core machine that is 64 threads re-scoring the same few
+/// thousand short haystacks. The item set here is bounded by spec §5.2's
+/// 4,096-node cap (a few thousand entries of a dozen-odd characters), so
+/// past a handful of threads the coordination costs more than the parallel
+/// scoring saves — and pegging every core on a machine whose owner is
+/// reading a man page is the failure this cap exists to prevent. Not the
+/// primary fix for that (see [`SearchIndex::populate`]'s note on rebuild
+/// frequency); a second, cheap bound on the blast radius of each rebuild.
+const MAX_MATCHER_THREADS: usize = 4;
 
 impl Default for SearchIndex {
     fn default() -> Self {
@@ -47,22 +63,53 @@ impl SearchIndex {
         // instead "the caller drives `tick` from its own poll timeout"
         // (spec §10), so no wakeup callback is needed here.
         let notify: Arc<dyn Fn() + Sync + Send> = Arc::new(|| {});
-        let nucleo = Nucleo::new(Config::DEFAULT, notify, None, 1);
+        let threads = std::thread::available_parallelism()
+            .map_or(MAX_MATCHER_THREADS, |n| n.get().min(MAX_MATCHER_THREADS));
+        let nucleo = Nucleo::new(Config::DEFAULT, notify, Some(threads), 1);
         SearchIndex {
             nucleo,
             current_query: String::new(),
+            populate_count: 0,
         }
     }
 
-    /// Rebuild the index from `root`. Call whenever the tree's structure
-    /// changes (initial load, or after a lazy fill splices in new nodes) —
-    /// cheap enough to call on every such change; `nucleo` streams items in
-    /// lock-free, and re-populating from scratch is simpler and less
-    /// error-prone than trying to diff two trees.
+    /// Rebuild the index from `root`, from scratch: `restart` drops the old
+    /// item set and every entry is re-injected.
+    ///
+    /// **This is O(tree), not O(change), and it is not free — do not call it
+    /// once per spliced node.** Re-populating from scratch is still the
+    /// right shape (diffing two trees is much harder to get right, and
+    /// `nucleo` streams items in lock-free), but the cost has to be paid
+    /// per *batch* of structural changes rather than per change. Calling it
+    /// per node made `mandible docker` peg every core for its whole
+    /// 22-second warm: the background warmer delivers one splice per filled
+    /// node (~255 for docker, up to spec §5.2's 4,096-node cap), each
+    /// splice restarted the match and re-injected an ever-growing item set,
+    /// and `nucleo`'s matcher threads re-scored all of it each time — O(n²)
+    /// with a large constant. `mandible-tui`'s `App` therefore coalesces:
+    /// it marks the index stale and rebuilds at most once per event-loop
+    /// iteration (see `App::flush_search_index`).
+    ///
+    /// Leaves the current query untouched — only the item set changes — so
+    /// an active search simply re-matches against the fresh data on the
+    /// next [`SearchIndex::tick`].
     pub fn populate(&mut self, root: &CommandNode) {
+        self.populate_count += 1;
         self.nucleo.restart(true);
         let injector = self.nucleo.injector();
         push_node(&injector, root, vec![root.name.clone()]);
+    }
+
+    /// How many times [`SearchIndex::populate`] has run on this index.
+    ///
+    /// A seam, not a statistic: "the index is rebuilt per batch of warmed
+    /// nodes, not per node" is a performance property with no visible
+    /// effect on any result, so nothing else a test can read distinguishes
+    /// the fixed code from the O(n²) version it replaced. Counting the
+    /// rebuilds is what makes that property assertable — see
+    /// `mandible-tui`'s `splicing_many_nodes_rebuilds_the_index_once`.
+    pub fn populate_count(&self) -> u64 {
+        self.populate_count
     }
 
     /// Set the live query text. Matching happens asynchronously on

--- a/mandible-tui/src/app.rs
+++ b/mandible-tui/src/app.rs
@@ -187,6 +187,16 @@ pub struct App {
     /// [`Self::ensure_rows_fresh`] to compute which tree paths are
     /// currently showing as matches.
     search_index: SearchIndex,
+    /// Set when the tree's structure changed but the index has not been
+    /// rebuilt from it yet. Consumed by `Self::sync_search_index`, which
+    /// [`Self::tick_search`] drives once per event-loop iteration — so a
+    /// whole batch of warmed nodes costs one rebuild instead of one each.
+    search_index_stale: bool,
+    /// When the index was last rebuilt, for `Self::sync_search_index`'s
+    /// throttle. `None` means "never throttle the next one" (nothing has
+    /// been rebuilt since construction/reload, where the index is already
+    /// current).
+    search_index_rebuilt_at: Option<Instant>,
     /// Whether rendering may use color at all (spec §9.2: respect
     /// `NO_COLOR`). Read from the environment once at construction — a
     /// terminal-color preference isn't something that changes mid-run —
@@ -224,6 +234,20 @@ pub struct App {
 /// enough that the hints are never gone when someone looks up needing
 /// them.
 const STATUS_MESSAGE_TTL: Duration = Duration::from_secs(4);
+
+/// Shortest gap between two search-index rebuilds while nobody is
+/// searching (see `App::sync_search_index` for the "nobody is searching"
+/// caveat, which is the whole reason this is safe).
+///
+/// The batching alone already turns one rebuild per warmed node into one
+/// per event-loop iteration, but the loop wakes every 100ms and a rebuild
+/// is O(whole tree), so a long cascade would still rebuild a growing tree
+/// ten times a second for its whole duration. 250ms bounds that to four,
+/// which is far below the threshold at which a user notices a tree they
+/// are not currently searching having settled — and every rebuild skipped
+/// here is skipped only because a later one will supersede it: the stale
+/// flag stays set, so no change is ever dropped.
+const REBUILD_MIN_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Case-insensitive **substring** match of `query` against `name`.
 ///
@@ -278,6 +302,8 @@ impl App {
             status_message: None,
             status_expires_at: None,
             search_index,
+            search_index_stale: false,
+            search_index_rebuilt_at: None,
             color_enabled: crate::style::color_enabled_from_env(),
             glyphs: crate::glyphs::from_env(),
             selected_flag: None,
@@ -307,6 +333,13 @@ impl App {
         if !self.dirty {
             return;
         }
+        // `compute_matching_paths` below reads the index, and key handlers
+        // call this method directly rather than going through the event
+        // loop, so give the same throttle a chance to run here instead of
+        // relying on `tick_search` having been the most recent caller. With
+        // a query active the throttle is a no-op and the rows below are
+        // computed against a fully current index.
+        self.sync_search_index(Instant::now());
         let matching_paths = self.compute_matching_paths();
         self.rows = flatten(
             &self.root,
@@ -400,9 +433,61 @@ impl App {
     /// list dirty if the result set changed, so the next
     /// [`Self::ensure_rows_fresh`] picks up fresh matches.
     pub fn tick_search(&mut self, timeout_ms: u64) {
+        self.sync_search_index(Instant::now());
         if self.search_index.tick(timeout_ms) {
             self.mark_dirty();
         }
+    }
+
+    /// Rebuild the search index if the tree changed since the last rebuild,
+    /// subject to the throttle described on [`REBUILD_MIN_INTERVAL`].
+    ///
+    /// `now` is a parameter rather than read here so a test can drive the
+    /// throttle deterministically instead of sleeping.
+    fn sync_search_index(&mut self, now: Instant) {
+        if !self.search_index_stale {
+            return;
+        }
+        // Staleness is user-visible the moment there is a query: spec §5.2
+        // has the background warm existing precisely so whole-tree search
+        // is honest, and a result set that lags the tree by a quarter of a
+        // second while someone types is exactly the dishonesty it was
+        // added to remove. So the throttle applies only while nobody is
+        // searching — which is the case for the whole warm cascade in the
+        // common path, and is where all the wasted work was.
+        let searching = self.active_filter().is_some() || self.focus == Focus::Search;
+        if !searching
+            && self
+                .search_index_rebuilt_at
+                .is_some_and(|last| now.duration_since(last) < REBUILD_MIN_INTERVAL)
+        {
+            return;
+        }
+        self.rebuild_search_index(now);
+    }
+
+    /// Rebuild the search index now if the tree changed since the last
+    /// rebuild, ignoring the throttle. For callers that are not the event
+    /// loop and so cannot rely on a later [`Self::tick_search`] to pick the
+    /// change up.
+    pub fn flush_search_index(&mut self) {
+        if self.search_index_stale {
+            self.rebuild_search_index(Instant::now());
+        }
+    }
+
+    fn rebuild_search_index(&mut self, now: Instant) {
+        self.search_index.populate(&self.root);
+        self.search_index_stale = false;
+        self.search_index_rebuilt_at = Some(now);
+        self.mark_dirty();
+    }
+
+    /// How many times the search index has been rebuilt from the tree.
+    /// A test seam for the "one rebuild per batch of warmed nodes, not one
+    /// per node" property — see [`mandible_search::SearchIndex::populate_count`].
+    pub fn search_populate_count(&self) -> u64 {
+        self.search_index.populate_count()
     }
 
     /// The current visible rows. Panics-free even if stale would be
@@ -537,12 +622,15 @@ impl App {
         // asked to see. Expansion is user intent, recorded by
         // `expand_selected`; a node the user already expanded is still in
         // `expanded`, so its children appear the moment they arrive.
-        // The tree's structure (and searchable content) just changed —
-        // keep the search index in sync. `populate` doesn't touch the
-        // current query/pattern, only the item set, so an active search
-        // simply re-matches against the freshly-filled data on the next
-        // tick.
-        self.search_index.populate(&self.root);
+        // The tree's structure (and searchable content) just changed, so
+        // the search index needs rebuilding from it — but *not* here.
+        // `SearchIndex::populate` is O(whole tree) and this method is
+        // called once per node the background warmer fills (~255 for
+        // docker, up to spec §5.2's 4,096-node cap), so rebuilding inline
+        // is O(n²) and pegged every core for the entire warm. Record the
+        // need instead; `flush_search_index`, driven from the event loop,
+        // collapses a whole arrival batch into one rebuild.
+        self.search_index_stale = true;
         self.mark_dirty();
     }
 
@@ -686,6 +774,11 @@ impl App {
 
         self.search_index = SearchIndex::new();
         self.search_index.populate(&self.root);
+        // Freshly built from this very tree: nothing pending, and the next
+        // splice's rebuild must not be throttled against a rebuild that
+        // belongs to the previous tree.
+        self.search_index_stale = false;
+        self.search_index_rebuilt_at = None;
         let filter = self.active_filter().unwrap_or("").to_string();
         self.search_index.set_query(&filter);
 
@@ -844,6 +937,10 @@ mod tests {
     /// calls `tick_search` from its own poll timeout (spec §10
     /// "Threading") rather than assuming a single call finishes matching.
     fn settle_search(app: &mut App) {
+        // The event loop's own `tick_search` does this first; a test that
+        // spliced nodes in would otherwise settle a match against the index
+        // as it was before the splice.
+        app.flush_search_index();
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut quiet_polls = 0;
         while Instant::now() < deadline && quiet_polls < 3 {
@@ -1334,5 +1431,138 @@ mod tests {
         // The newly-discovered child should be visible without a second
         // expand press.
         assert!(app.rows().iter().any(|r| r.name == "--onto"));
+    }
+
+    /// Splice `count` distinct children under the root, the way the
+    /// background warmer's drain loop does: one call per filled node.
+    fn splice_warmed_children(app: &mut App, count: usize) {
+        for i in 0..count {
+            let name = format!("warmed{i}");
+            let mut child = CommandNode::new(&name, Provenance::single(Source::HelpText));
+            child.children_filled = true;
+            child.summary = Some(mandible_core::Text::sanitize("a warmed subcommand"));
+            app.root.subcommands.push(child.clone());
+            app.splice_filled_node(&["git".to_string(), name], child);
+        }
+    }
+
+    /// The rebuild storm that pegged every core during `mandible docker`'s
+    /// warm: `splice_filled_node` rebuilt the whole index per arrival, so
+    /// docker's ~255 warmed nodes cost ~255 full restarts and
+    /// re-injections of a growing item set. The property that fixes it is
+    /// countable and nothing else observable distinguishes the two, hence
+    /// the `populate_count` seam.
+    #[test]
+    fn splicing_many_nodes_rebuilds_the_index_once() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        let after_construction = app.search_populate_count();
+
+        splice_warmed_children(&mut app, 32);
+        assert_eq!(
+            app.search_populate_count(),
+            after_construction,
+            "splicing must not rebuild the index at all; the event loop does that"
+        );
+
+        app.tick_search(0);
+        assert_eq!(
+            app.search_populate_count(),
+            after_construction + 1,
+            "32 arrivals drained in one event-loop iteration must cost exactly one rebuild"
+        );
+    }
+
+    /// The batch rebuild is not allowed to make search lag the tree: spec
+    /// §5.2 has warming exist so whole-tree search is honest, so a node
+    /// that just arrived must be findable without waiting on the throttle.
+    #[test]
+    fn an_active_query_rebuilds_immediately_and_finds_the_new_node() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.focus_search();
+        for c in "warmed7".chars() {
+            app.search_input_char(c);
+        }
+        settle_search(&mut app);
+        let before = app.search_populate_count();
+
+        splice_warmed_children(&mut app, 8);
+        // No `now` advance at all: the throttle must not apply here.
+        app.sync_search_index(Instant::now());
+        assert_eq!(
+            app.search_populate_count(),
+            before + 1,
+            "a search is active, so the arrival batch must be indexed at once"
+        );
+
+        settle_search(&mut app);
+        app.mark_dirty();
+        app.ensure_rows_fresh();
+        assert!(
+            app.rows().iter().any(|r| r.name == "warmed7"),
+            "a freshly warmed node must be findable by an already-active query: {:?}",
+            app.rows().iter().map(|r| &r.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// With nobody searching, rebuilds are capped at one per
+    /// [`REBUILD_MIN_INTERVAL`] — but a skipped rebuild is deferred, never
+    /// dropped: the stale flag survives so the next eligible tick picks the
+    /// change up.
+    #[test]
+    fn the_rebuild_throttle_defers_a_change_without_dropping_it() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        let t0 = Instant::now();
+
+        splice_warmed_children(&mut app, 4);
+        app.sync_search_index(t0);
+        let after_first = app.search_populate_count();
+
+        // A second cascade arriving inside the interval is held.
+        splice_warmed_children(&mut app, 4);
+        app.sync_search_index(t0 + REBUILD_MIN_INTERVAL / 2);
+        assert_eq!(
+            app.search_populate_count(),
+            after_first,
+            "a rebuild inside the throttle interval must be skipped"
+        );
+        assert!(app.search_index_stale, "the pending change must be kept");
+
+        // …and picked up as soon as the interval has passed, with no
+        // further splice to prompt it.
+        app.sync_search_index(t0 + REBUILD_MIN_INTERVAL);
+        assert_eq!(
+            app.search_populate_count(),
+            after_first + 1,
+            "the deferred change must be indexed once the interval elapses"
+        );
+        assert!(!app.search_index_stale);
+    }
+
+    /// `r` throws the tree away and rebuilds the index from the new one, so
+    /// it must also drop any staleness owed to the *old* tree — and must
+    /// not leave the next arrival throttled against a rebuild that belongs
+    /// to a tree that no longer exists.
+    #[test]
+    fn reload_leaves_the_index_current_and_unthrottled() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        splice_warmed_children(&mut app, 4);
+        assert!(app.search_index_stale);
+
+        app.reload(sample_tree());
+        assert!(
+            !app.search_index_stale,
+            "reload repopulates from the new tree, so nothing is owed"
+        );
+        let after_reload = app.search_populate_count();
+
+        let mut child = CommandNode::new("add", Provenance::single(Source::HelpText));
+        child.children_filled = true;
+        app.splice_filled_node(&["git".to_string(), "add".to_string()], child);
+        app.sync_search_index(Instant::now());
+        assert_eq!(
+            app.search_populate_count(),
+            after_reload + 1,
+            "the first arrival after a reload must not be throttled"
+        );
     }
 }

--- a/mandible/src/background.rs
+++ b/mandible/src/background.rs
@@ -1,7 +1,7 @@
 //! Bounded background warming of the whole tree (spec §5.2 step 4).
 //!
 //! Every node discovered in the tree is queued for a background fill on a
-//! bounded pool — `min(8, available_parallelism)` — starting from the root
+//! bounded pool — one thread per core, clamped to `[2, 8]` — starting from the root
 //! as soon as the TUI opens, and cascading: each completed fill queues the
 //! children it just discovered. The user never waits for the tree, and
 //! never has to expand a node by hand to make it real.
@@ -69,23 +69,27 @@ pub struct Warmer {
 }
 
 impl Warmer {
-    /// Build a warmer with `available_parallelism * 4` worker threads,
-    /// clamped to `[4, 32]`.
+    /// Build a warmer with one worker thread per core, clamped to
+    /// `[2, 8]`.
     ///
-    /// Deliberately oversubscribed relative to core count, because a
-    /// warming job is not CPU work: it spawns `<tool> <path> --help` and
-    /// then spends nearly all of its wall time blocked on that child. One
-    /// thread per core leaves the machine idle waiting on I/O, and the
-    /// trees where warming matters most (cobra CLIs with hundreds of
-    /// nodes) are exactly where that idle time compounds. The upper clamp
-    /// keeps a many-core machine from turning the prefetch into a spawn
-    /// storm against the OS process table.
+    /// This used to be `available_parallelism * 4`, clamped to `[4, 32]`,
+    /// on the theory that a warming job is not CPU work — it spawns
+    /// `<tool> <path> --help` and blocks on the child. That theory is
+    /// true for the typical small C tool and measured false for the
+    /// tools where warming is heaviest: a `docker` invocation burns
+    /// 70–100ms of real CPU per spawn (Go runtime startup plus a daemon
+    /// round trip), so 16 concurrent probes on a 4-core machine was the
+    /// warm pegging every core for minutes — the exact user report the
+    /// resizing answers. One probe per core keeps the machine responsive
+    /// for whatever else the user is doing; the price is a slower warm on
+    /// cheap-probe trees, paid in background time nobody is waiting on.
+    /// The user-expanded path still jumps the queue, so what is on
+    /// screen fills at the same speed as before.
     pub fn new() -> Warmer {
         let threads = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
-            .saturating_mul(4)
-            .clamp(4, 32);
+            .clamp(2, 8);
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
             .thread_name(|i| format!("mandible-warm-{i}"))
@@ -249,6 +253,24 @@ mod tests {
                 elapsed: std::time::Duration::ZERO,
             },
         }
+    }
+
+    /// The pool must never exceed one thread per core (capped at 8): the
+    /// old `cores * 4` oversubscription was measured pegging every core
+    /// of a 4-core machine for minutes against a tool whose probes burn
+    /// real CPU (docker). Asserting the bound, not an exact count, so the
+    /// test holds on any machine.
+    #[test]
+    fn the_warming_pool_never_oversubscribes_the_cores() {
+        let warmer = Warmer::new();
+        let cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        let threads = warmer.pool.current_num_threads();
+        assert!(
+            threads <= cores.max(2) && threads <= 8,
+            "warming pool has {threads} threads on a {cores}-core machine"
+        );
     }
 
     /// `submitted` is the [`MAX_WARMED_NODES`] budget, and it was

--- a/spec.md
+++ b/spec.md
@@ -469,10 +469,18 @@ much* gets extracted but *what the user waits for* — and the answer is nothing
 When every node is warmed, auto-expanding on arrival unfolds the entire tree and
 buries the user in rows they never asked for.
 
-**Pool sizing is deliberately oversubscribed** — `available_parallelism * 4`,
-clamped to `[4, 32]`. A warming job spawns a child process and then spends
-nearly all its wall time blocked on it, so one thread per core leaves the machine
-idle waiting on I/O.
+**Pool sizing is one worker per core, clamped to `[2, 8]`.** An earlier
+revision deliberately oversubscribed (`available_parallelism * 4`, clamped
+`[4, 32]`) on the theory that a warming job spawns a child and then blocks on
+it, costing no CPU of its own. The theory holds for the typical small C tool
+and was measured false exactly where warming is heaviest: a `docker`
+invocation burns 70–100ms of real CPU per spawn (Go runtime startup plus a
+daemon round trip), so 16 concurrent probes on a 4-core machine pegged every
+core for the duration of the warm — reported by a real user as the tool
+maximizing their CPU for minutes. One probe per core keeps the machine
+responsive; the cost is a slower warm on cheap-probe trees, paid in
+background time nobody is waiting on, and the expand path still jumps the
+queue so the visible tree fills as fast as before.
 
 Non-incremental sources (carapace) return their full subtree at step 1; they cost
 nothing, so there is no reason to defer them.

--- a/spec.md
+++ b/spec.md
@@ -181,7 +181,7 @@ What exists is a fragmented set of partial mechanisms. Their **measured** covera
 | Mechanism | Reality on a real machine |
 |---|---|
 | **carapace-spec catalog** (declarative YAML, hundreds of tools) | 740 tools, 48,224 flag descriptions in the vendored snapshot. `git` 279 nodes / 2,999 flags / 2,979 with prose; `docker` 162/836/836; `gh` 249/1,061/1,061 [M-1]. Zero subprocesses, works on Windows. |
-| **cobra `__complete`** (Go: kubectl, docker, gh, helm) | Works, and is version-accurate. But returns **only subcommands** for an empty word; flags require a *second* probe with `"-"` [M-2]. Descriptions are terse. Cost: one subprocess per node per probe [M-3]. |
+| **cobra `__complete`** (Go: kubectl, docker, gh, helm) | Works, and is version-accurate. Flags require a *second* probe with `"-"` [M-2]. The empty-word probe returns subcommands **plus the command's own `ValidArgsFunction` output** — live user data at a leaf — so only fully-described candidate lists may be read as subcommands [M-2a]. Descriptions are terse. Cost: one subprocess per node per probe [M-3]. |
 | **clap `CompleteEnv`** (`COMPLETE=zsh <tool>`) | **Near-absent in the wild**, and since removed as a source. `ripgrep` errors; `cargo` prints ordinary help [M-4]. Detection had no protocol-guaranteed signal, so on a PATH sweep it matched ten tools of which none were clap — see §7 Tier E. |
 | **`<tool> completion bash\|zsh`** | Common. But bash scripts typically *compute* candidates at runtime (`$(git ls-files)`), so static parsing recovers less than it appears. zsh `_arguments` blocks are the description-bearing form and the higher-value target. |
 | **man pages** (`mdoc(7)` semantic, `man(7)` prose) | Prose-rich, structure-poor, and **absent on many systems**: this test container has 31 `man1` pages and none for `git` or `curl` [M-5]. `libmandoc` is not a shipped library on Linux [M-6]. |
@@ -1423,11 +1423,29 @@ probed anyway. Nothing on this machine's PATH was in that position. The
 a heuristic, and defence in depth costs nothing here.
 
 - **cobra `__complete`** (kubectl, docker, gh, helm, and much of modern infra):
-  **the protocol requires two probes per node.** `__complete <path> ""` returns
-  subcommands only; flags require `__complete <path> "-"` [M-2]. Revision 1
-  documented only the first, and an implementation following it produced zero
-  flags. Parse the trailing `:N` directive line; candidate lines are
-  `value\tdescription`, with a `=` suffix marking value-taking flags.
+  **the protocol requires two probes per node.** Flags require `__complete
+  <path> "-"` [M-2]; revision 1 documented only the empty-word probe, and an
+  implementation following it produced zero flags. Parse the trailing `:N`
+  directive line; candidate lines are `value\tdescription`, with a `=` suffix
+  marking value-taking flags.
+  - **`__complete <path> ""` does *not* return subcommands only.** Earlier
+    revisions of this section said it did; that is wrong, and was only ever
+    measured at nodes that have subcommands. cobra emits the node's real
+    subcommands and then **appends the command's own `ValidArgsFunction`
+    output**, which is application code reading live state — so at a leaf the
+    whole response is argument data. `docker __complete stop ""` returns the
+    machine's running container names; `docker __complete run ""` returns image
+    names [M-2].
+  - **A candidate list becomes subcommands only if every candidate in it carries
+    a non-empty description.** cobra writes real subcommand rows as
+    `name\tShort` from its own formatter, while a `ValidArgsFunction` returning a
+    plain `[]string` produces bare rows — the only distinction the wire format
+    offers. One undescribed candidate condemns the entire list, described entries
+    included, because cobra marks no boundary between the two blocks. Measured
+    across 631 real command paths on `docker` and `gh`: every real subcommand
+    admitted, every argument value refused [M-2a]. The deliberate cost is a real
+    subcommand with an empty `Short` sharing a list with argument values; Tier B
+    still finds it, and per AGENTS.md §1 this is never relaxed for recall.
   - **Depth cap** (default 6) and a **visited set** keyed by the candidate list's
     hash: some tools echo root completions for unrecognized paths, which
     recurses forever.
@@ -3310,6 +3328,82 @@ any of these as current.
   `--repo`, **and `-R` as a separate row with an identical description**.
   Output ends with a `:N` directive line on stdout; a human-readable directive
   note goes to stderr.
+
+  **Correction (2026-08-17): the "empty word returns subcommands only" half of
+  this entry is wrong, and was only ever measured at nodes that *have*
+  subcommands.** cobra answers `__complete <path> ""` by emitting the node's real
+  subcommands **and then appending whatever that command's `ValidArgsFunction`
+  returns** — application code that reads live state. At a leaf there are no
+  subcommands, so the response is *entirely* argument data. Measured on docker
+  29.7.2, this box, with three `hello-world` containers present:
+
+  ```console
+  $ docker __complete container ""   # a node with subcommands
+  attach<TAB>Attach local standard input, output, and error streams to a container
+  commit<TAB>Create a new image from a container's changes
+  ...
+  :4
+  $ docker __complete stop ""        # a leaf: RUNNING CONTAINER NAMES, bare
+  mandible-canary-1
+  mandible-canary-2
+  :4
+  $ docker __complete run ""         # a leaf: image names, bare
+  vsnote:latest
+  hello-world:latest
+  :4
+  ```
+
+  This was a live defect, reported from real use: the reporter's own container
+  names were rendered in the tree as docker subcommands, and each fabricated node
+  was then warmed like any other (§5.2 step 4), multiplying the probe count by
+  the size of a set that scales with the user's data rather than with the tool.
+
+- **[M-2a] Which cobra candidates are really subcommands.** Method: walk both
+  installed cobra binaries breadth-first to depth 3 via `__complete <path> ""`,
+  classifying every response list as all-described, all-undescribed, or mixed,
+  and reading each list against the tool's real command tree. Result, over **631
+  distinct command paths** (`docker` 29.7.2: 253; `gh` 2.45.0: 378):
+
+  | list shape | count | what they actually were |
+  |---|---|---|
+  | every candidate described (`name<TAB>text`) | 85 | genuine subcommand lists, all 85 |
+  | every candidate undescribed (bare `name`) | 45 | argument data, all 45 |
+  | mixed | 5 | argument data, all 5 |
+
+  The 50 non-subcommand lists were container names, image names and tags, network
+  names, buildx builder names, docker context names, and `gh project
+  field-create --data-type`'s enum values. **No real subcommand appeared
+  undescribed, and no argument value appeared in an all-described list**, which
+  is why Tier E accepts a candidate list only when every candidate in it carries
+  a non-empty description (§7 Tier E). The mechanism behind the rule is cobra's
+  own formatting: it writes subcommand rows with `fmt.Sprintf("%s\t%s",
+  subCmd.Name(), subCmd.Short)`, while a `ValidArgsFunction` returning a plain
+  `[]string` produces bare rows.
+
+  The 5 mixed lists were all `docker context <verb> ""`, whose completer
+  decorates only the *currently selected* context (`rootless<TAB>current`) and
+  leaves the rest bare. They are why a single undescribed candidate has to
+  condemn the whole list rather than only itself: cobra marks no boundary between
+  its own subcommand block and the appended argument block, so a described entry
+  sitting in a list that also carries bare entries cannot be attributed to
+  either.
+
+  **Known residual, measured, not closed.** A completer that describes *every*
+  value it returns is indistinguishable from a subcommand list in cobra's wire
+  format. `docker context use ""` hits this on a machine with exactly one
+  context, where the sole candidate is `default<TAB>current`; with two or more
+  contexts the list is mixed and the rule closes it. Closing the one-context case
+  would need a signal cobra does not provide.
+
+  Two alternative designs were measured and rejected. (a) Probing cobra's own
+  `help` command — `__complete help <path> ""`, which enumerates the command tree
+  and never runs a `ValidArgsFunction` — is exactly right on `gh` (`gh __complete
+  help pr ""` returns `pr`'s 20 real subcommands) and returns **nothing at all**
+  on `docker`, which replaces cobra's help command. (b) Differencing against a
+  sentinel positional — `__complete <path> <sentinel> ""` suppresses cobra's
+  subcommand block, so `A \ B` is the subcommand set — works for 6 of 8 sampled
+  paths, costs a third spawn per node (+50%), and still leaks `docker context
+  use`, whose completer returns the same list either way.
 - **[M-3] Recursive walk cost.** `docker`: 255 nodes, 232 spawns, 10.5 s.
   `gh`: 196 nodes, 182 spawns, 11.6 s. Both depth-capped at 3, one probe per node.
   ~40–65 ms per spawn.


### PR DESCRIPTION
Two user-reported criticals, both root-caused by measurement before anything was changed. Urgent per maintainer.

## 1. `mandible docker` maximizes CPU

**Mechanism (not the suspected same-subcommands detection):** every warmed-node arrival called `SearchIndex::populate` — a nucleo `restart` plus re-injection of the entire, growing tree. Quadratic in tree size: measured **99ms of rebuild work at docker's ~255 nodes, 17.7s at the 4,096-node cap — vs 6.6ms for one batched rebuild**.

**Fix:** arrivals coalesce into at most one rebuild per event-loop iteration, throttled to one per 250ms while nobody is searching; the throttle is bypassed whenever a query is active or the search box has focus, and a deferred rebuild is never dropped. `r` repopulates eagerly and resets the throttle. nucleo's matcher pool is capped at 4 threads (precautionary, labelled as such). Four regression tests via a `populate_count` seam; each was proven to fail against the pre-fix code. Rendering verified unchanged by pty screenshot before/after.

**Honest caveat, also in the CHANGELOG:** end-to-end on a 4-core box, docker's 22s warm went 6.07s → 5.72s process CPU (UI thread 1.13s → 0.51s). The storm was real and is gone, but on docker most warm CPU is the extraction work itself — if the Arch report persists after this release, the warmer's concurrency is the next knob, separately.

## 2. `cargo install mandible` freezes a Fedora machine

Measured: `cargo install` builds in `$TMPDIR` (~470MB transient tree, ~1.2GB concurrent rustc RSS at -j4), and `/tmp` is RAM-backed tmpfs on Fedora **and Arch** — so machine size is the variable, not the distro (Fedora's zram+oomd likely shaped the "freeze/crash" symptom). Ruled out: per-crate compile RAM, build.rs, a crates.io name squat.

**Fix, mostly resurrection:** the README's four prebuilt download links were literal `(...)` placeholders while the install section led with `cargo install`. Now: stable `releases/latest/download/` URLs (verified live), `cargo binstall mandible` documented (verified resolving 0.3.1 for real), a `CARGO_TARGET_DIR=… -j 2` note for source builds (both halves measured: 100% of the tree off tmpfs, peak RSS −38%), and `strip = "symbols"` (binary 5.6MB → 4.0MB). Declined: lto/codegen-units=1 (raise peak build memory — the reported problem).

## Gates

1016/1016 nextest · corpus 82 fixtures: 68 ok / 14 xfail / 0 failed · clippy clean (linux + aarch64-apple-darwin check target) · fmt · changelog guard.

**Not in this release** (tracked, HANDOVER §11): the PATH-sweep zero-shards CI regression, and an arm64 .deb/.rpm gap in release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 3. Container names leaking into the UI (reported after testing this branch)

**Mechanism:** Tier E treated every `__complete <path> ""` candidate as a subcommand, but at leaf commands cobra runs the command's `ValidArgsFunction` — for docker that's live daemon data (container names, image names, contexts, builders). [M-2]'s "empty word returns subcommands only" was measured wrong at leaves; the spec's [M-2a] now records the corrected measurement with method.

**Fix (general, protocol-keyed):** cobra writes real subcommand rows as `name<TAB>Short-description`; dynamic values are bare. A candidate list contributes subcommands only when **every** candidate is described — one bare candidate condemns the whole list, because cobra marks no boundary between the subcommand block and appended argument values, and a measured counterexample (`docker context use` decorating the current context with a description) defeats any per-row rule. Swept 631 real paths (docker 253, gh 378): 85 all-described lists = all genuine subcommand lists kept; 50 bare/mixed lists = all pure argument data dropped; zero real subcommands lost. Known residual, recorded not hidden: a machine with exactly one docker context returns a solitary described candidate that is wire-indistinguishable from a subcommand list.

Safety property pinned by a new test: completion-derived children are never `heading_attested`, so Tier B can never construct `docker run <image> --help` — an argv that would *create a container*.

## 4. Warming pool: one probe per core (was four per core)

The `cores × 4` oversubscription assumed probes block costing no CPU — measured false for docker (70–100ms CPU per spawn), so 16 concurrent probes pegged a 4-core machine for the whole warm. Now one per core, clamped `[2, 8]`; regression test proves the old sizing fails it. Measured: at most 4 concurrent docker processes instead of 16; warm ~22s → ~26s in background time; user-expanded nodes still jump the queue. spec §5.2 updated in the same commit.

## Gates (combined branch)

1024/1024 nextest · corpus 82: 68 ok / 14 xfail / 0 failed · clippy clean (linux + aarch64-apple-darwin) · fmt · changelog guard.
