### PR TITLE
0.3.3 CI fixes: PATH-sweep shards write their scoreboard again, zero shards fails, arm64 packages

### DIFF
--- a/.github/workflows/path-sweep.yml
+++ b/.github/workflows/path-sweep.yml
@@ -281,3 +281,33 @@ jobs:
             echo
             echo "</details>"
           } | tee -a "$GITHUB_STEP_SUMMARY"
+
+          # Zero is not "partial coverage" continued to its limit — it is a
+          # different failure. 1..15 shards missing still means real tools
+          # were measured and the numbers above are an honest floor (the
+          # `-lt 16` branch above says so). 0 shards means every count in
+          # that summary — tools, flags, percentages — is zero because
+          # nothing ran to completion, not because the sweep found an empty
+          # PATH. That is exactly the failure this file's header comment
+          # already describes fixing once ("a tick asserting something
+          # false", when the unsharded step died at ~96s and
+          # `continue-on-error` still painted the job green): a completely
+          # broken sweep must not read as success just because this
+          # downstream job itself didn't crash.
+          #
+          # This check has to live outside the `{ ... } | tee` block above,
+          # not inside it: that block is `tee`'s stdin, which runs as a
+          # subshell of the pipeline, so an `exit 1` in there would only end
+          # the subshell — `tee` still exits 0 (it wrote the file
+          # successfully) and that becomes the step's exit status. Verified
+          # locally: with the summary logic reproduced against an empty
+          # directory, `exit 1` placed inside the piped block left the
+          # step's own `$?` at 0, while the same check placed here, after
+          # the pipeline, produced `$?` of 1. Against a directory with 3 fake
+          # shard files, this branch is skipped and the step exits 0, same
+          # as an unmodified partial run.
+          reported=$(ls shards/*.md 2>/dev/null | wc -l)
+          if [ "$reported" -eq 0 ]; then
+            echo "::error::PATH sweep produced nothing: 0 of 16 shards reported. Every count in the summary above is zero because no shard finished, not because the sweep measured an empty PATH. A green tick here would be a lie." >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,13 @@ jobs:
     name: deb + rpm (${{ matrix.arch }})
     needs: [verify, verify-frameworks]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # 45, not the 30 this job carried while it was x86_64-only. The aarch64
+    # row compiles both packagers from source (see the `install-action`
+    # comment below) on top of building `mandible` itself, and a release job
+    # that times out is a release that has to be re-tagged. Raising a bound
+    # whose old value was measured against a strictly cheaper job is not the
+    # same as loosening a gate.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,14 +145,52 @@ jobs:
           if-no-files-found: error
 
   # Distro packages, built from the metadata already in mandible/Cargo.toml.
-  # x86_64 only for now: cargo-deb/cargo-generate-rpm would need a separate
-  # matrix entry per architecture, and shipping an arm64 .deb nobody has
-  # tested is worse than not shipping one.
+  #
+  # Both architectures now, each built natively — this used to be x86_64
+  # only, on the stated reason that "an arm64 .deb nobody has tested" is
+  # worse than shipping none. That objection is stale: the `build` job above
+  # has run natively on `ubuntu-24.04-arm` since it added the
+  # aarch64-unknown-linux-gnu target, and its smoke test already proves a
+  # native arm64 `mandible` binary runs there. What was actually untested
+  # was never the architecture generally, it was `cargo deb`/`cargo
+  # generate-rpm`'s *own* arm64 output specifically — so this job's smoke
+  # test (below) installs the built `.deb` with `dpkg -i` and runs the same
+  # `--version`/`--doctor tar` check `build` already trusts, on both
+  # architectures, and separately asserts the package's own declared
+  # `Architecture:`/`%{ARCH}` field matches the runner it was built on. That
+  # is the thing that was actually missing, not "arm64 support" in the
+  # abstract.
+  #
+  # Neither packager needs an explicit `--target`/arch flag here. Read from
+  # each tool's own source rather than assumed: cargo-deb's
+  # `PackageConfig::new` computes `architecture` from
+  # `debian_architecture_from_rust_triple(rust_target_triple.unwrap_or(DEFAULT_TARGET))`
+  # (`src/config.rs`), where `DEFAULT_TARGET` is the triple cargo-deb itself
+  # was compiled for — i.e. the runner's native arch, since neither this
+  # step nor the `Build` step passes `--target`. cargo-generate-rpm's
+  # `BuildTarget::binary_arch` (`src/build_target.rs`) falls back the same
+  # way, to `std::env::consts::ARCH` of the process running it, when no
+  # `--target`/`--arch` is given. Both are only correct as long as the
+  # packager binary itself is native to the runner, which is exactly what
+  # this matrix now guarantees — so the arch assertion step below verifies
+  # that premise on every run instead of trusting it silently.
   packages:
-    name: deb + rpm (x86_64)
+    name: deb + rpm (${{ matrix.arch }})
     needs: [verify, verify-frameworks]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            deb_arch: amd64
+            rpm_arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            deb_arch: arm64
+            rpm_arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -161,6 +199,26 @@ jobs:
       # packagers from source on every release and was most of this job's
       # 168 seconds. Versions are pinned, so this is a download of a known
       # artifact, not a moving target.
+      #
+      # That's the x86_64 story, though, not the arm64 one. Checked against
+      # `taiki-e/install-action`'s own manifests (which is what this action
+      # actually reads before falling back to anything else): cargo-deb's
+      # manifest carries a prebuilt binary for `x86_64_linux_gnu` only, no
+      # `aarch64_linux_gnu` entry at all, and cargo-generate-rpm has no
+      # manifest in that repo whatsoever (`manifests/cargo-generate-rpm.json`
+      # 404s) — consistent with upstream `cat-in-136/cargo-generate-rpm`
+      # publishing no binary release assets at all, for any architecture.
+      # `install-action`'s documented fallback for exactly this case is
+      # `cargo install`/`cargo-binstall`, automatic and silent, not an
+      # error — so the aarch64 row of this matrix compiles both packagers
+      # from source on every run rather than downloading them. Slower (adds
+      # real minutes to this job on that row), not broken; `rust-cache`
+      # above at least caches the compiled dependency graph between runs.
+      # Left as-is rather than switched to `cargo install` explicitly,
+      # because that's already the effective behavior and this comment is
+      # the honest record of it — not something to silently paper over by
+      # having the workflow *say* it uses prebuilt binaries when the arm64
+      # row does not.
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deb@3.7.0,cargo-generate-rpm@0.16.0
@@ -169,9 +227,67 @@ jobs:
           cargo build --release --locked --bin mandible
           cargo deb --no-build -p mandible
           cargo generate-rpm -p mandible
+
+      # Verify rather than assume. The comment above this job explains why
+      # native-build-implies-correct-arch is the right expectation for both
+      # packagers, but that's a read of their source, not a guarantee this
+      # exact toolchain/runner combination honors it — and a wrong
+      # `Architecture:`/`%{ARCH}` stamp is not something apt/dnf ever
+      # complains about at build time, only at install time on the arch it
+      # lied about. So assert both fields against the value this matrix row
+      # declares, and fail the job rather than ship a mislabeled package.
+      - name: Verify package architecture metadata
+        run: |
+          deb_file=$(ls target/debian/*.deb)
+          rpm_file=$(ls target/generate-rpm/*.rpm)
+
+          deb_arch=$(dpkg-deb -f "$deb_file" Architecture)
+          if [ "$deb_arch" != "${{ matrix.deb_arch }}" ]; then
+            echo "::error::${deb_file}: Architecture is '${deb_arch}', expected '${{ matrix.deb_arch }}' for ${{ matrix.arch }}" >&2
+            exit 1
+          fi
+
+          # `rpm` (the query tool) isn't preinstalled on either GitHub
+          # Ubuntu runner image; it ships no build dependency on it, only
+          # `cargo generate-rpm`'s own pure-Rust writer.
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends rpm
+          rpm_arch=$(rpm -qp --qf '%{ARCH}' "$rpm_file")
+          if [ "$rpm_arch" != "${{ matrix.rpm_arch }}" ]; then
+            echo "::error::${rpm_file}: %{ARCH} is '${rpm_arch}', expected '${{ matrix.rpm_arch }}' for ${{ matrix.arch }}" >&2
+            exit 1
+          fi
+
+          echo "deb: ${deb_file} (${deb_arch}); rpm: ${rpm_file} (${rpm_arch})"
+
+      # Same proof the `build` job's own smoke test relies on (see its
+      # comment: "a release binary that cannot start is the one failure mode
+      # worth catching here"), but for the packaged artifact specifically —
+      # installing through `dpkg` exercises the control file, the asset
+      # list and the completion-script paths in `mandible/Cargo.toml`'s
+      # `[package.metadata.deb]`, none of which the raw binary smoke test
+      # above touches at all.
+      - name: Install and smoke-test the .deb
+        run: |
+          sudo dpkg -i target/debian/*.deb
+          mandible --version
+          mandible --doctor tar
+
+      # Distinct artifact name per architecture: actions/upload-artifact@v4
+      # refuses to let two jobs upload under the same name, which a matrix
+      # over two runners would otherwise do here. The downstream `release`
+      # job merges every artifact into one directory
+      # (`download-artifact@v4` with `merge-multiple: true`), which is safe
+      # here specifically because the *files* inside don't collide either:
+      # both packagers stamp the architecture into the filename itself
+      # (cargo-deb: `{name}_{version}-1_{architecture}.deb`;
+      # cargo-generate-rpm: `{name}-{version}-{release}.{arch}.rpm`), so
+      # `mandible_0.3.2-1_amd64.deb` and `mandible_0.3.2-1_arm64.deb` land as
+      # two distinct files in the merged directory rather than one
+      # overwriting the other.
       - uses: actions/upload-artifact@v4
         with:
-          name: mandible-packages
+          name: mandible-packages-${{ matrix.arch }}
           path: |
             target/debian/*.deb
             target/generate-rpm/*.rpm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,10 +268,16 @@ update Appendix A in the same commit, with the method.
   `cargo nextest run --workspace` (§3.3 — never `cargo test --workspace`
   piped into a text-parsing tool), `cargo build --release`.
 - `#![forbid(unsafe_code)]` in every crate except `mandible-extract`, which
-  carries `#![deny(unsafe_code)]` plus exactly one scoped
-  `#[allow(unsafe_code)]` on the probe-spawning function in `exec/`, for the
-  `pre_exec` + `setsid` call that gives every probe its own session so a
-  descendant can't reopen the controlling terminal via `/dev/tty` ([M-17]).
+  carries `#![deny(unsafe_code)]` plus exactly two scoped
+  `#[allow(unsafe_code)]` sites, both in `exec/`: the `pre_exec` + `setsid`
+  call on the probe-spawning function, which gives every probe its own
+  session so a descendant can't reopen the controlling terminal via
+  `/dev/tty` ([M-17]); and `containment::secured_scoreboard_file`'s
+  `File::from_raw_fd`, which reconstructs the `--out` file a contained sweep
+  inherited across `unshare` + re-exec. **This count is the whole point of
+  `deny` over `forbid` — if you add a third, it belongs here and in
+  `mandible-extract/src/lib.rs`'s crate doc comment in the same commit, or
+  the exception list stops being an exception list.**
   No `unwrap()` on any path reachable from tool input.
 - Never invoke a tool binary outside the argv allowlist in spec §6. Running a
   bare binary is how you launch a REPL, block on stdin, or start a daemon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`path-sweep-summary` now fails when zero shards reported.** Previously the
+  step always exited 0, so a completely dead sweep (all 16 shards killed)
+  still painted a green tick — the exact "tick asserting something false"
+  failure this project already burned itself on once. 1..15 shards missing
+  is unchanged (still reported as partial coverage, still green); 0 shards
+  is now a distinct case that fails the job.
+
+### Changed
+
+- **`.deb`/`.rpm` packages are now built for aarch64 as well as x86_64**,
+  natively on `ubuntu-24.04-arm`, alongside the existing x86_64 build. Each
+  architecture's package is verified after building: its declared
+  `Architecture:`/`%{ARCH}` field is asserted against the runner it was
+  built on, and the `.deb` is installed with `dpkg -i` and smoke-tested with
+  `mandible --version` / `mandible --doctor tar`. Package artifacts are now
+  uploaded per-architecture (`mandible-packages-x86_64`,
+  `mandible-packages-aarch64`) rather than under one shared name.
+
 ## [0.3.2] - 2026-08-17
 
 Two user reports drove this release, and each was measured to its mechanism

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **A full-`PATH` sweep's scoreboard write no longer fails `EACCES` inside
+  namespace containment.** `xtask coverage`/`audit freeze` re-exec under
+  `unshare --user --map-root-user` before probing (spec §6/§8); GitHub
+  Actions run 32063212492 showed all 16 `path-sweep.yml` shards finish their
+  full sweep and then die writing `shard-N.md`, because the checkout
+  directory is owned by a UID the namespace doesn't map, so the contained
+  "root" has no `CAP_DAC_OVERRIDE` over it. The pre-exec process — which
+  still has ordinary filesystem access — now opens `--out` and clears
+  `FD_CLOEXEC` on it before entering containment, and the contained process
+  writes the scoreboard through that inherited fd instead of reopening the
+  path. Uncontained runs, `--tools`-pinned runs, and non-Linux platforms are
+  unaffected (`mandible_extract::exec::containment::secure_out_file`,
+  `enter_or_refuse_with_scoreboard`, `write_scoreboard`).
 - **`path-sweep-summary` now fails when zero shards reported.** Previously the
   step always exited 0, so a completely dead sweep (all 16 shards killed)
   still painted a green tick — the exact "tick asserting something false"

--- a/mandible-extract/Cargo.toml
+++ b/mandible-extract/Cargo.toml
@@ -45,7 +45,7 @@ bindgen = { version = "0.70", optional = true }
 # session fix (spec §6 rule 6, [M-17]) actually closes the hazard, since
 # the sandbox this crate is developed in has no controlling terminal at
 # all — see that test's doc comment.
-nix = { version = "0.29", default-features = false, features = ["signal", "process", "term"] }
+nix = { version = "0.29", default-features = false, features = ["signal", "process", "term", "fs"] }
 libc.workspace = true
 
 [dev-dependencies]

--- a/mandible-extract/src/exec/containment.rs
+++ b/mandible-extract/src/exec/containment.rs
@@ -16,9 +16,10 @@
 //! probing runs as the leader of a brand-new user, PID and mount namespace
 //! rather than directly on the operator's machine. `unshare(1)` (util-
 //! linux) is used rather than a raw `unshare(2)`/`clone(2)` syscall from
-//! inside this process, for a specific reason: this crate is single-
-//! `unsafe`-exception (`spawn.rs`'s `setsid` `pre_exec`, see that module's
-//! doc comment), and calling `unshare(CLONE_NEWPID)` on a live,
+//! inside this process, for a specific reason: this crate keeps `unsafe`
+//! to a short, audited list (`spawn.rs`'s `setsid` `pre_exec`, and this
+//! module's own fd-reconstruction in `secured_scoreboard_file` — see
+//! their doc comments), and calling `unshare(CLONE_NEWPID)` on a live,
 //! potentially multi-threaded process is unsound in exactly the way
 //! `pre_exec` documents — the PID namespace only takes effect for
 //! *children* created after the call, so entering it correctly requires a
@@ -78,8 +79,10 @@
 //! hazard, which is exactly what a full-`PATH` sweep run directly on a
 //! developer's own machine already was before this module existed.
 
+use std::fs::{File, OpenOptions};
 use std::io;
-use std::path::PathBuf;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::process::Command;
 use thiserror::Error;
@@ -90,11 +93,136 @@ use thiserror::Error;
 /// is the re-exec landing inside the namespace" without any other signal.
 pub const CONTAINED_ENV_VAR: &str = "MANDIBLE_SWEEP_CONTAINED";
 
+/// Set alongside [`CONTAINED_ENV_VAR`] on a full-`PATH` sweep whose `--out`
+/// file was pre-secured (see [`secure_out_file`]) before entering
+/// containment. Its value is the raw fd number of that already-open file,
+/// carried across `unshare` + re-exec by clearing `FD_CLOEXEC`
+/// ([`enter_or_refuse_with_scoreboard`]); [`write_scoreboard`] reads it to
+/// write the scoreboard through the fd instead of reopening the path, which
+/// is what fails `EACCES` from inside the namespace (GitHub Actions run
+/// 32063212492: all 16 shards completed their sweep, then died with
+/// `failed to write scoreboard to shard-0.md: Permission denied`).
+pub const SCOREBOARD_FD_ENV_VAR: &str = "MANDIBLE_SWEEP_SCOREBOARD_FD";
+
 /// True if this process is already running inside the namespace
 /// [`enter_or_refuse`] constructs — i.e. this is the re-exec'd copy, not
 /// the original invocation.
 pub fn is_contained() -> bool {
     std::env::var_os(CONTAINED_ENV_VAR).is_some()
+}
+
+/// Open (creating parent directories first, exactly like `xtask`'s own
+/// `write_out` helper) `path` for reading and writing, and clear
+/// `FD_CLOEXEC` on the result so the fd survives an `exec` call.
+///
+/// **Must be called by the pre-exec process, before [`enter_or_refuse_with_scoreboard`].**
+/// This is the fix for GitHub Actions run 32063212492: a full-`PATH` sweep's
+/// final write of its `--out` scoreboard happens from inside the user
+/// namespace [`enter_or_refuse`] builds, where the checkout directory is
+/// owned by a UID the contained "root" does not map — no `CAP_DAC_OVERRIDE`,
+/// so opening the path there for creation fails `EACCES` even though every
+/// probe in the sweep just ran successfully. The process calling this
+/// function, by contrast, has not entered the namespace yet and has
+/// ordinary access to `path`; opening it here and carrying the already-open
+/// fd across `unshare` (via [`enter_or_refuse_with_scoreboard`] +
+/// [`write_scoreboard`]) sidesteps the permission check instead of trying
+/// to satisfy it from the wrong side of it.
+pub fn secure_out_file(path: &Path) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    // `truncate(false)`: an existing file at `path` (e.g. a re-run over a
+    // previous sweep's scoreboard) is left alone here — [`write_scoreboard`]
+    // does its own `set_len(0)` right before writing, not this open, so a
+    // process that opens the file but exits before writing (an early
+    // `enter_or_refuse_with_scoreboard` failure, say) never destroys a
+    // previously-good scoreboard.
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)?;
+    clear_cloexec(&file)?;
+    Ok(file)
+}
+
+/// Clear `FD_CLOEXEC` on `file`'s underlying fd. Rust's `std::fs::File`
+/// always opens with `O_CLOEXEC` set (so an accidental `fork`+`exec`
+/// elsewhere in the process never leaks fds), which is exactly the bit
+/// [`secure_out_file`]'s caller needs cleared: the whole point is for this
+/// fd to survive the `unshare` + re-exec pair.
+#[cfg(unix)]
+fn clear_cloexec(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let fd = file.as_raw_fd();
+    let current = nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD)?;
+    let mut flags = nix::fcntl::FdFlag::from_bits_truncate(current);
+    flags.remove(nix::fcntl::FdFlag::FD_CLOEXEC);
+    nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_SETFD(flags))?;
+    Ok(())
+}
+
+/// The non-Unix twin: nothing to clear, and nothing on this platform will
+/// ever call [`enter_or_refuse_with_scoreboard`] with a fd that needs to
+/// survive an `exec` it also never performs.
+#[cfg(not(unix))]
+fn clear_cloexec(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+/// Write `contents` as a full-`PATH` sweep's scoreboard.
+///
+/// If [`SCOREBOARD_FD_ENV_VAR`] is set — this is the contained half of a
+/// sweep whose `--out` file [`secure_out_file`] already opened before
+/// containment — writes through that inherited fd: `set_len(0)` +
+/// seek-to-start + `write_all` produces the same bytes an ordinary
+/// [`std::fs::write`] would, just through an already-open descriptor
+/// instead of reopening the (there, permission-denied) path. Otherwise
+/// falls straight through to [`std::fs::write`], unchanged — every
+/// uncontained run, every `--tools`-pinned run (never containerized to
+/// begin with), and every non-Unix platform all take this branch.
+pub fn write_scoreboard(path: &Path, contents: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    if let Some(mut file) = secured_scoreboard_file()? {
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        file.write_all(contents.as_bytes())?;
+        return file.flush();
+    }
+    std::fs::write(path, contents)
+}
+
+/// Reconstruct the [`File`] [`enter_or_refuse_with_scoreboard`] exported,
+/// if [`SCOREBOARD_FD_ENV_VAR`] is set. `Ok(None)` (not an error) when the
+/// var is absent, since that is the ordinary case for almost every caller.
+#[cfg(unix)]
+fn secured_scoreboard_file() -> io::Result<Option<File>> {
+    let Some(raw) = std::env::var_os(SCOREBOARD_FD_ENV_VAR) else {
+        return Ok(None);
+    };
+    let fd: std::os::fd::RawFd = raw.to_str().and_then(|s| s.parse().ok()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{SCOREBOARD_FD_ENV_VAR} is set but not a valid fd number: {raw:?}"),
+        )
+    })?;
+    // SAFETY: this fd was opened by `secure_out_file` in the pre-exec
+    // process and exported via `SCOREBOARD_FD_ENV_VAR` specifically by
+    // clearing `FD_CLOEXEC` on it (see that function's and
+    // `enter_or_refuse_with_scoreboard`'s doc comments), so it is
+    // guaranteed to still be open and valid here — the contained process
+    // inherited it across `unshare` + re-exec and nothing in between could
+    // have closed it. `from_raw_fd` takes ownership of the fd; this is the
+    // only place in the process that reconstructs it from the env var, a
+    // full-`PATH` sweep writes its scoreboard exactly once at the very end
+    // of the run, and the process exits immediately after, so there is no
+    // double-close or later use-after-close.
+    #[allow(unsafe_code)]
+    let file = unsafe { <File as std::os::fd::FromRawFd>::from_raw_fd(fd) };
+    Ok(Some(file))
 }
 
 /// Which of the three namespace types [`enter_or_refuse`] requires were
@@ -223,6 +351,29 @@ fn unshare_probe(args: &[&str]) -> bool {
 /// than falling through to an uncontained run.
 #[cfg(target_os = "linux")]
 pub fn enter_or_refuse() -> ContainmentError {
+    enter_or_refuse_with_scoreboard(None)
+}
+
+/// Like [`enter_or_refuse`], but first exports `scoreboard`'s raw fd (an
+/// already-open file [`secure_out_file`] prepared before containment) via
+/// [`SCOREBOARD_FD_ENV_VAR`] on the `unshare` command, so the re-exec'd,
+/// contained process can reach it through [`write_scoreboard`] instead of
+/// reopening the (there, permission-denied) path. `scoreboard` is `None`
+/// for a caller with no `--out` file to protect — `enter_or_refuse` is
+/// exactly that call with `None`.
+///
+/// **This function does not return on success**, same as [`enter_or_refuse`].
+///
+/// `scoreboard`, when `Some`, must stay alive until `unshare` replaces this
+/// process's image, which is why it is taken as an owned parameter of this
+/// function's own stack frame rather than a caller-held reference: dropping
+/// a `File` closes its fd immediately regardless of `FD_CLOEXEC` —
+/// `FD_CLOEXEC` only governs survival *across* `exec`, not `drop` — so a
+/// caller that opened the file, passed a reference, and let its own local
+/// binding go out of scope before calling this function would close the fd
+/// out from under the child before it ever ran.
+#[cfg(target_os = "linux")]
+pub fn enter_or_refuse_with_scoreboard(scoreboard: Option<File>) -> ContainmentError {
     let support = probe_namespace_support();
     if !support.all_supported() {
         return ContainmentError::Unavailable { support };
@@ -247,12 +398,21 @@ pub fn enter_or_refuse() -> ContainmentError {
     cmd.args(&args);
     cmd.env(CONTAINED_ENV_VAR, "1");
 
+    if let Some(file) = &scoreboard {
+        use std::os::fd::AsRawFd;
+        cmd.env(SCOREBOARD_FD_ENV_VAR, file.as_raw_fd().to_string());
+    }
+
     // `exec` replaces this process's image; it returns only on failure to
     // do so (the child that eventually runs `exe` again is a *different*
     // OS process, spawned by `unshare` itself after its own fork — never
-    // this Rust code).
+    // this Rust code). `scoreboard` is still alive at this point (it is
+    // this frame's own local, not yet dropped), which is what lets its
+    // FD_CLOEXEC-cleared fd survive into the child.
     use std::os::unix::process::CommandExt;
     let source = cmd.exec();
+    // Only reached on failure — `scoreboard` drops here, which is fine: the
+    // sweep is about to bail out with `source` as the error either way.
     ContainmentError::Reexec { source }
 }
 
@@ -263,6 +423,14 @@ pub fn enter_or_refuse() -> ContainmentError {
     ContainmentError::Unavailable {
         support: probe_namespace_support(),
     }
+}
+
+/// The non-Linux twin of [`enter_or_refuse_with_scoreboard`]: nothing to
+/// enter and no fd-passing to do, so it just defers to [`enter_or_refuse`]
+/// and ignores `scoreboard`.
+#[cfg(not(target_os = "linux"))]
+pub fn enter_or_refuse_with_scoreboard(_scoreboard: Option<File>) -> ContainmentError {
+    enter_or_refuse()
 }
 
 /// Where a contained sweep should point its [`super::canary::PathCanary`]:
@@ -281,6 +449,7 @@ pub fn default_watch_dir() -> io::Result<PathBuf> {
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
 
     /// **Checked, not assumed.** This module's own doc comment says every
     /// namespace type it needs was "confirmed working on this host before
@@ -398,10 +567,10 @@ mod tests {
 
     /// The effective UID, read from `/proc/self/status` rather than a
     /// `libc`/`nix` syscall wrapper: this crate's `#![deny(unsafe_code)]`
-    /// allows exactly one audited exception (`spawn.rs`'s `setsid`
-    /// `pre_exec`), and `nix::unistd::Uid` additionally needs a crate
-    /// feature this workspace does not enable — plain, safe file I/O
-    /// avoids both for what is only ever a test-diagnostic read.
+    /// allows only a short, audited list of exceptions (see `lib.rs`'s doc
+    /// comment), and `nix::unistd::Uid` additionally needs a crate feature
+    /// this workspace does not enable — plain, safe file I/O avoids both
+    /// for what is only ever a test-diagnostic read.
     fn effective_uid() -> Option<u32> {
         let status = std::fs::read_to_string("/proc/self/status").ok()?;
         for line in status.lines() {
@@ -410,5 +579,182 @@ mod tests {
             }
         }
         None
+    }
+
+    const SCOREBOARD_TEST_DIR_VAR: &str = "MANDIBLE_CONTAINMENT_TEST_SCOREBOARD_DIR";
+    const SCOREBOARD_WORKER_ROLE: &str = "scoreboard-fd-worker";
+
+    /// **The property this whole feature exists for, proven under the real
+    /// mechanism, not asserted from reading the code.** Reproduces GitHub
+    /// Actions run 32063212492's exact failure shape locally: a directory
+    /// whose owner is not the uid `enter_or_refuse`'s `--map-root-user`
+    /// maps into the namespace. Opening a file there *by path* from inside
+    /// the namespace fails `EACCES` — this is the bug: all 16 shards of a
+    /// full-`PATH` sweep finished their probing and then died writing
+    /// `shard-N.md` exactly this way. Writing through the fd
+    /// [`secure_out_file`] opened *before* entering the namespace, carried
+    /// across by [`enter_or_refuse_with_scoreboard`], still succeeds.
+    ///
+    /// **Needs real root**, via passwordless `sudo -n`, not just an
+    /// unprivileged user namespace: an unprivileged `--map-root-user` can
+    /// only ever map the caller's *own* real uid into the namespace, so a
+    /// directory the caller itself owns is always reachable from inside
+    /// regardless of this fix — there is no way to manufacture "a uid the
+    /// namespace does not map" without a second, different real uid in the
+    /// picture. Real root bypasses ownership checks entirely in the
+    /// *outer* (pre-exec) step — which is what CI's privileged container
+    /// actually is — and after `unshare --map-root-user` maps real uid 0 to
+    /// ns uid 0 (identity: root mapping itself), a directory owned by any
+    /// *other* real uid (here: whichever unprivileged uid is running
+    /// `cargo nextest`) is exactly as unmapped inside the namespace as the
+    /// checkout directory was in CI. Confirmed by hand against this exact
+    /// mechanism before writing this test: `sudo unshare --user
+    /// --map-root-user -- touch <dir-owned-by-a-non-root-uid>/f` fails
+    /// `EACCES`; plain `sudo touch` on the same path (no `unshare`)
+    /// succeeds. Panics loudly, rather than skipping silently, when
+    /// passwordless `sudo` is unavailable — see the CI containment job's
+    /// own `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`
+    /// (AGENTS.md "dev box gotchas"), which already assumes exactly this
+    /// capability for the namespace-support tests above.
+    #[test]
+    fn write_scoreboard_survives_containment_when_the_out_dir_has_an_unmapped_owner() {
+        if std::env::var(ROLE_VAR).as_deref() == Ok(SCOREBOARD_WORKER_ROLE) {
+            run_scoreboard_worker();
+        }
+
+        if !Command::new("sudo")
+            .args(["-n", "true"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            panic!(
+                "this test requires passwordless `sudo` (CI's containment job already assumes \
+                 it — see AGENTS.md's 'dev box gotchas'): it is the only way to reproduce a \
+                 directory owner that an unprivileged `--map-root-user` cannot map into the \
+                 namespace, which is the exact condition GitHub Actions run 32063212492 failed \
+                 under."
+            );
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // `tempfile::tempdir()` defaults to `0o700`, which would also block
+        // the contained worker from even *traversing* into it to reach
+        // `worker-binary` below (root's ns-scoped DAC override doesn't
+        // reach this uid's directories either — see `worker_exe`'s comment)
+        // — loosen only this one, outer level; `unmapped_owner_dir` below
+        // stays `0o700` deliberately, since blocking traversal there,
+        // specifically, is the condition under test.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755))
+            .expect("chmod scratch dir traversable");
+        let unmapped_owner_dir = dir.path().join("unmapped-owner");
+        std::fs::create_dir(&unmapped_owner_dir).expect("create test dir");
+        // 0o700: the owner (this unprivileged test process) can read,
+        // write and list it; nobody else — including a namespace's mapped
+        // "root," once that mapping doesn't cover this uid — has any
+        // access at all. Close enough to a real checked-out repo
+        // directory's bits for the property under test: real root's
+        // blanket CAP_DAC_OVERRIDE vs. a namespaced root's namespace-scoped
+        // one.
+        std::fs::set_permissions(&unmapped_owner_dir, std::fs::Permissions::from_mode(0o700))
+            .expect("chmod test dir");
+
+        // Copied to a scratch path under the system temp dir rather than
+        // exec'd from its real build location (`target/debug/deps/…`,
+        // under this developer's `$HOME`, mode `0750`): once inside the
+        // namespace, real root's traversal into that `$HOME` is subject to
+        // the *exact same* unmapped-owner restriction this test exists to
+        // prove — `$HOME` is owned by this unprivileged uid too — so
+        // `unshare` itself failed to exec the worker with `Permission
+        // denied` before this copy was added, a false negative from the
+        // test rig rather than the code under test. A world-executable
+        // temp dir (`/tmp`, mode `1777`) has no such ancestor-traversal
+        // restriction for anyone.
+        let exe = std::env::current_exe().expect("path to this test binary");
+        let worker_exe = dir.path().join("worker-binary");
+        std::fs::copy(&exe, &worker_exe)
+            .expect("copy this test binary to a world-traversable scratch path");
+        std::fs::set_permissions(&worker_exe, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod worker binary copy executable");
+
+        let output = Command::new("sudo")
+            .args([
+                "-n",
+                "--preserve-env=MANDIBLE_CONTAINMENT_TEST_ROLE,\
+                 MANDIBLE_CONTAINMENT_TEST_SCOREBOARD_DIR",
+                "--",
+            ])
+            .arg(&worker_exe)
+            .args([
+                "--exact",
+                "exec::containment::tests::write_scoreboard_survives_containment_when_the_out_dir_has_an_unmapped_owner",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(ROLE_VAR, SCOREBOARD_WORKER_ROLE)
+            .env(SCOREBOARD_TEST_DIR_VAR, &unmapped_owner_dir)
+            .env_remove(CONTAINED_ENV_VAR)
+            .env_remove(SCOREBOARD_FD_ENV_VAR)
+            .output()
+            .expect("spawn a root worker copy of this test binary via sudo -n");
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert!(
+            stdout.contains("BY-PATH: EACCES as expected")
+                && stdout.contains("VIA-FD: write succeeded"),
+            "worker did not reproduce the expected split outcome (exit={:?}):\n\
+             stdout={stdout}\nstderr={stderr}",
+            output.status.code()
+        );
+
+        let written = std::fs::read_to_string(unmapped_owner_dir.join("scoreboard.md"))
+            .expect("scoreboard file the worker should have written via the inherited fd");
+        assert_eq!(written, "via-fd-contents\n");
+    }
+
+    /// Becomes the re-exec target for the test above, run as real root (via
+    /// `sudo -n`). Mirrors [`run_reexec_worker`]'s "call the production
+    /// function, `unshare` replaces this process, the same function runs
+    /// again on the other side" shape, but exercises [`secure_out_file`] +
+    /// [`enter_or_refuse_with_scoreboard`] + [`write_scoreboard`] instead
+    /// of plain [`enter_or_refuse`].
+    fn run_scoreboard_worker() -> ! {
+        let dir = std::env::var(SCOREBOARD_TEST_DIR_VAR)
+            .expect("worker needs the unmapped-owner test dir path");
+        let path = std::path::Path::new(&dir).join("scoreboard.md");
+
+        if is_contained() {
+            // Inside the namespace now: prove the by-path open this bug
+            // report is about really does fail here...
+            match OpenOptions::new().write(true).open(&path) {
+                Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+                    println!("BY-PATH: EACCES as expected: {e}");
+                }
+                Err(e) => {
+                    eprintln!("BY-PATH: failed with an unexpected error (not EACCES): {e}");
+                    std::process::exit(2);
+                }
+                Ok(_) => {
+                    eprintln!("BY-PATH: succeeded — test rig did not reproduce an unmapped owner");
+                    std::process::exit(2);
+                }
+            }
+
+            // ...while the fd secured before containment still works.
+            match write_scoreboard(&path, "via-fd-contents\n") {
+                Ok(()) => println!("VIA-FD: write succeeded"),
+                Err(e) => {
+                    eprintln!("VIA-FD: write failed (this is the bug, unfixed): {e}");
+                    std::process::exit(1);
+                }
+            }
+            std::process::exit(0);
+        }
+
+        let file = secure_out_file(&path).expect("secure_out_file (running as real root)");
+        let err = enter_or_refuse_with_scoreboard(Some(file));
+        eprintln!("enter_or_refuse_with_scoreboard did not land inside the namespace: {err}");
+        std::process::exit(2);
     }
 }

--- a/mandible-extract/src/lib.rs
+++ b/mandible-extract/src/lib.rs
@@ -8,15 +8,19 @@
 //! whole workspace — permitted to use `std::process`. See `exec`'s
 //! documentation and `tests/no_process_outside_exec.rs`.
 
-// `deny`, not `forbid`: `exec/spawn.rs` carries exactly one scoped
-// `#[allow(unsafe_code)]`, on the probe-spawning function, for the
-// `pre_exec` + `setsid` call that gives every probe a new *session* (not
-// just a new process group) so a descendant cannot reopen the controlling
-// terminal via `/dev/tty` (see that function's doc comment, and spec §6
-// rule 6). Every other item in this crate — and every other crate in the
-// workspace — still carries `#![forbid(unsafe_code)]`; `deny` here is what
-// lets that one exception exist without silently disabling the lint
-// everywhere else in this crate too.
+// `deny`, not `forbid`: this crate carries exactly two scoped
+// `#[allow(unsafe_code)]` sites. `exec/spawn.rs`'s probe-spawning function
+// has one, for the `pre_exec` + `setsid` call that gives every probe a new
+// *session* (not just a new process group) so a descendant cannot reopen
+// the controlling terminal via `/dev/tty` (see that function's doc comment,
+// and spec §6 rule 6). `exec/containment.rs` has the other, for
+// reconstructing a `File` from a raw fd number a contained sweep inherits
+// across `unshare` + re-exec (see that module's `write_scoreboard` and
+// `secured_scoreboard_file` doc comments). Every other item in this crate —
+// and every other crate in the workspace — still carries
+// `#![forbid(unsafe_code)]`; `deny` here is what lets those two exceptions
+// exist without silently disabling the lint everywhere else in this crate
+// too.
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -626,7 +626,10 @@ fn run_audit(action: AuditAction) -> anyhow::Result<()> {
             // return): only a real, tools-unbounded sweep needs
             // containment.
             let is_full_path_sweep = tools.is_none() && !check;
-            let canaries = sweep_guard(is_full_path_sweep, allow_uncontained)?;
+            // `None`: `audit freeze` writes its results under `--dir`
+            // (`queue::cmd_freeze`), never through the `--out`-file path
+            // this guard's fd-securing exists for.
+            let canaries = sweep_guard(is_full_path_sweep, allow_uncontained, None)?;
             let freeze_result = queue::cmd_freeze(seed, tools, &dir, check);
             finish_sweep_guard(canaries)?;
             freeze_result
@@ -783,18 +786,36 @@ fn parse_shard(spec: &str) -> anyhow::Result<(usize, usize)> {
 /// returned immediately for both, matching every earlier caller's
 /// unguarded behavior exactly.
 ///
+/// `secure_out`, when `Some`, is a `--out` path the caller is about to
+/// write its result to *after* the sweep — i.e. from inside the namespace,
+/// if this run ends up contained. Before entering containment, this
+/// function opens that path itself (still on the pre-exec side, with
+/// ordinary filesystem access) via
+/// `mandible_extract::exec::containment::secure_out_file` and carries the
+/// already-open fd across `unshare` + re-exec, so the caller can write
+/// through it later with `containment::write_scoreboard` instead of
+/// reopening the path from inside the namespace, where it fails `EACCES`
+/// (GitHub Actions run 32063212492: every one of 16 shards finished its
+/// full sweep and then died with `failed to write scoreboard to
+/// shard-0.md: Permission denied (os error 13)` on exactly that reopen).
+/// `None` for a caller with no `--out` write pending here — `audit freeze`
+/// writes its results under `--dir` through a different path entirely, not
+/// through this guard, so it always passes `None`.
+///
 /// **This function does not itself decide whether the current process
 /// already is the contained one.** It asks
 /// `mandible_extract::exec::containment::is_contained()`. The *first*
 /// invocation of `xtask coverage`/`xtask audit freeze` (no sentinel env
-/// var set) falls through to `containment::enter_or_refuse()`, which —
-/// when namespaces are available — replaces this process's image via
-/// `exec` and never returns; control lands back here a second time, in a
-/// freshly re-exec'd process, with the sentinel now set, and this
+/// var set) falls through to `containment::enter_or_refuse()` (or, when
+/// `secure_out` is `Some`, `containment::enter_or_refuse_with_scoreboard()`),
+/// which — when namespaces are available — replaces this process's image
+/// via `exec` and never returns; control lands back here a second time, in
+/// a freshly re-exec'd process, with the sentinel now set, and this
 /// function's first branch fires instead.
 fn sweep_guard(
     is_full_path_sweep: bool,
     allow_uncontained: bool,
+    secure_out: Option<&std::path::Path>,
 ) -> anyhow::Result<Option<mandible_extract::exec::canary::CanarySet>> {
     use mandible_extract::exec::{canary::CanarySet, containment};
 
@@ -826,7 +847,16 @@ fn sweep_guard(
         return Ok(None);
     }
 
-    let err = containment::enter_or_refuse();
+    let err = match secure_out {
+        Some(path) => match containment::secure_out_file(path) {
+            Ok(file) => containment::enter_or_refuse_with_scoreboard(Some(file)),
+            Err(e) => anyhow::bail!(
+                "failed to pre-open --out {} before entering namespace containment: {e}",
+                path.display()
+            ),
+        },
+        None => containment::enter_or_refuse(),
+    };
     anyhow::bail!(
         "refusing to run a full-PATH sweep uncontained: {err}\n\
          Namespace containment (user+PID+mount, spec §6/§8) is the default for a full-PATH \
@@ -877,7 +907,12 @@ fn run_coverage(
     allow_uncontained: bool,
 ) -> anyhow::Result<()> {
     let is_full_path_sweep = tools.is_none();
-    let canaries = sweep_guard(is_full_path_sweep, allow_uncontained)?;
+    // `--check` never writes `out` (it only reads the checked-in scoreboard
+    // to diff against — see below), so there is nothing to secure for that
+    // path; every other run ends with `write_out(out, ...)` below, which is
+    // exactly the write that needs `out`'s fd carried across containment.
+    let secure_out = if check { None } else { Some(out.as_path()) };
+    let canaries = sweep_guard(is_full_path_sweep, allow_uncontained, secure_out)?;
 
     let (table, fresh) = match tools {
         Some(tools) => {
@@ -1273,6 +1308,19 @@ fn run_coverage(
 /// that the default `--out` *is* under `tmp/` (see `Coverage::out`): a fresh
 /// clone has no such directory, and the sweep would die at the very end,
 /// after twenty minutes of work, with nothing written.
+///
+/// The actual write goes through
+/// `mandible_extract::exec::containment::write_scoreboard` rather than a
+/// bare `std::fs::write`: when this process is the contained half of a
+/// full-`PATH` sweep whose `out` was pre-secured by `sweep_guard`
+/// (`containment::secure_out_file` before entering the namespace), that
+/// function writes through the inherited, already-open fd instead of
+/// reopening `out` by path — reopening by path from inside the namespace is
+/// exactly what failed `EACCES` (GitHub Actions run 32063212492). Every
+/// other caller of `write_out` (the uncontained case, `--tools`-pinned
+/// runs, `run_sweep_diff`'s unrelated report write) never has that env var
+/// set, so `write_scoreboard` falls straight through to `std::fs::write`
+/// and this function's behavior is unchanged for them.
 fn write_out(out: &std::path::Path, contents: &str, what: &str) -> anyhow::Result<()> {
     if let Some(parent) = out.parent() {
         if !parent.as_os_str().is_empty() {
@@ -1281,6 +1329,6 @@ fn write_out(out: &std::path::Path, contents: &str, what: &str) -> anyhow::Resul
             })?;
         }
     }
-    std::fs::write(out, contents)
+    mandible_extract::exec::containment::write_scoreboard(out, contents)
         .map_err(|e| anyhow::anyhow!("failed to write {what} to {}: {e}", out.display()))
 }


### PR DESCRIPTION
Two CI defects from the 0.3.3 queue, plus the arm64 packaging gap PR #12 recorded as deferred. No product code paths change: the only runtime change is *how* a contained sweep writes its own output file.

## 1. Every PATH-sweep shard died after finishing its sweep

**Mechanism (measured, not inferred — run [32063212492](https://github.com/AS-FOSS/mandible/actions/runs/32063212492)).** All 16 shards completed their entire sweep and then died on the last line:

```
Error: failed to write scoreboard to shard-0.md: Permission denied (os error 13)
```

`xtask coverage` without `--tools` is a full-PATH sweep, so `sweep_guard` re-execs it through `containment::enter_or_refuse()` — `unshare --user --map-root-user --pid --mount --fork`. Inside that namespace the checkout directory is owned by a UID the mapping does not cover, so the contained "root" has no `CAP_DAC_OVERRIDE` over it and *creating* `shard-N.md` fails `EACCES`. The `cargo build` step earlier in the same job wrote fine because it ran as real container root, before the unshare. Regressed when containment landed in 153034c; nothing caught it because `upload-artifact` has `if-no-files-found: ignore` and the summary job then reported on 0 shards and stayed green.

**Fix — the pre-exec side opens the file, the contained side writes through the fd.** `mandible-extract::exec::containment` gains `secure_out_file` (open/create `--out`, clear `FD_CLOEXEC`, which Rust's `File` always sets), `enter_or_refuse_with_scoreboard` (exports the raw fd number in `MANDIBLE_SWEEP_SCOREBOARD_FD` on the `unshare` command; `enter_or_refuse` is now that call with `None`), and `write_scoreboard` (writes through the inherited fd when the var is set, else falls straight through to `std::fs::write`). The fd survives both execs — `unshare`'s own and xtask's re-exec — because CLOEXEC is cleared. Uncontained runs, `--tools`-pinned runs and non-Linux are byte-identical to before.

Deliberately **not** a workflow `chmod`: the sweep asking for permission it structurally cannot have is the bug, and the pre-exec process already holds the access needed.

**Exit 1 on a failed write is kept.** The defect was the write failing, not the exit code.

**Proof.** New Linux test `write_scoreboard_survives_containment_when_the_out_dir_has_an_unmapped_owner` reproduces the real mechanism rather than simulating it — real `unshare --user --map-root-user --pid --mount --fork` against a directory whose owner the mapping does not cover, asserting the split outcome: by-path open gets `EACCES`, the inherited fd writes. It needs passwordless `sudo -n` (a real second uid is the only way to manufacture an unmapped owner; an unprivileged `--map-root-user` can only map the caller's own uid), which is what CI's containment job already assumes for `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. It panics rather than skips when that is unavailable — same stance as the existing containment tests, per AGENTS.md.

Proven to fail pre-fix twice, independently: once by the implementing worker against a disposable worktree at `a6bf970`, and once by the reviewer on the post-fix tree by disabling only the fd branch, which reproduces the CI line exactly —

```
VIA-FD: write failed (this is the bug, unfixed): Permission denied (os error 13)
```

**Costs one more scoped `unsafe`** (`File::from_raw_fd` on the inherited fd), the second in `mandible-extract`. Named in `lib.rs`'s crate doc comment and in AGENTS.md, whose "exactly one" claim had to be corrected in the same branch — a stale count is worse than no count when it is the reason the crate is `deny` rather than `forbid`.

## 2. The summary job stayed green on zero shards

`path-sweep-summary` always exited 0. A sweep where every shard dies produced an all-zero summary and a green tick — the same "tick asserting something false" class this workflow's own header comments document fixing once before. Zero shards now fails the step; 1..15 is unchanged and still reports partial coverage as an honest floor.

The check sits *after* the `{ ... } | tee "$GITHUB_STEP_SUMMARY"` pipeline, not inside it: inside, `exit 1` ends only the pipeline subshell and `tee`'s own 0 becomes the step status. Verified locally by extracting the real step script out of the YAML and running it — empty dir → exit 1, three fake shard files → exit 0 with the summary unchanged.

## 3. arm64 `.deb` / `.rpm`

The `packages` job was x86_64-only because "an arm64 `.deb` nobody has tested is worse than not shipping one". That objection expired when `build` moved to native `ubuntu-24.04-arm` runners; the comment is rewritten rather than left standing. `packages` is now a two-row native matrix, and what was *actually* untested — `cargo deb`/`cargo generate-rpm`'s own arm64 output, not the architecture in general — is now asserted rather than assumed:

- `dpkg-deb -f … Architecture` and `rpm -qp --qf '%{ARCH}'` are checked against the value the matrix row declares, and the job fails on mismatch.
- The `.deb` is installed with `dpkg -i` and smoke-tested with `mandible --version` and `mandible --doctor tar`, which exercises the control file and asset paths the raw-binary smoke test never touches.

Neither packager needs an explicit `--target`: cargo-deb derives `architecture` from `DEFAULT_TARGET` (the triple it was itself compiled for) and cargo-generate-rpm falls back to `std::env::consts::ARCH`, both correct for a native build — read from their source, and now verified at runtime anyway.

Artifacts upload under distinct per-arch names (v4 refuses duplicates). The downstream `release` job's `merge-multiple: true` + `find artifacts -type f` is safe because both packagers stamp arch into the filename itself.

**Honest cost:** `taiki-e/install-action` has no aarch64 prebuilt for cargo-deb and no manifest at all for cargo-generate-rpm (which publishes no release binaries for any arch), so the arm64 row compiles both packagers from source every run. Slower, not broken, and stated in a comment rather than papered over; the job timeout went 30 → 45 minutes to accommodate it.

**No stable-name package copies added.** README promises stable `latest/download/` URLs for the tarballs only, and says packages are "attached to every release" with a link to the releases page. Nothing to keep parity with.

## Gates

`cargo nextest run --workspace`: 1025/1025 · `cargo clippy --workspace --all-targets -D warnings` clean (Linux and `aarch64-apple-darwin` check target) · `cargo fmt --check` · changelog guard clean · both workflow files parse.

CHANGELOG entries are under `## [Unreleased]`. No crate versions bumped.

### Proven end-to-end on this branch, not just locally

**PATH sweep — [run 32086060542](https://github.com/AS-FOSS/mandible/actions/runs/32086060542) — green, 16/16.** All sixteen shards `success`, sixteen `path-sweep-shard-N` artifacts uploaded (previously: sixteen `failure`, zero artifacts), and the summary reports what it measured:

```
**16 of 16 shards reported.**
**609 tools**, 91.31% of 14061 flags carry text (accuracy: unmeasured).
```

The zero-shard guard correctly did *not* fire. Its firing path is proven by the local empty-directory run rather than by a real dead sweep, which is the one thing here nobody can stage on demand.

**Packages — [run 32086140067](https://github.com/AS-FOSS/mandible/actions/runs/32086140067) — green, both arches.** `release.yml` dispatched on this branch; `release` and `publish-crates` skipped themselves as tag-gated, `packages` ran, and both rows verified their own metadata and installed:

```
deb + rpm (x86_64):  deb: mandible_0.3.2-1_amd64.deb (amd64); rpm: mandible-0.3.2-1.x86_64.rpm (x86_64)
deb + rpm (aarch64): deb: mandible_0.3.2-1_arm64.deb (arm64); rpm: mandible-0.3.2-1.aarch64.rpm (aarch64)
```

Both then `Setting up mandible (0.3.2-1)` via `dpkg -i` and answered `mandible 0.3.2` plus `--doctor tar`. So the arch-derivation reasoning above is now measured on the real runners, and the filename non-collision claim is observed rather than deduced. `verify / test (ubuntu-latest)` also passed, which is what confirms the new `sudo -n`-dependent containment test works on GitHub's runner and not merely on the dev box.

## What this does not claim

- The sweep's **numbers** are not a regression gate and are not compared against a baseline here; 91.31% is flag-text coverage, not accuracy, and nothing in this PR measures accuracy.
- The zero-shard failure path is proven locally, not by an actual all-dead sweep in CI.
- `actionlint` was not available on the dev box and was not run.
- The rehearsal built packages labelled `0.3.2` because no version was bumped (correct — versions are bumped at release time); it proves the mechanism, not the next tag's contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
