### PR TITLE
fix(help_text): stop a nested command table folding into a flag description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A nested command table no longer folds into the flag description above
+  it.** `scan_flags_block`'s continuation rule was pure indentation: any line
+  deeper than the block's own entries continued the previous flag's
+  description, no matter what it actually was. `btrfs --help` puts
+  `--help`/`--version` at indent 2 and then, after a blank line, a large
+  command table at indent 4 whose rows each carry their own description one
+  indent deeper (indent 8) — the whole table, dozens of lines, folded into
+  `--version`'s description as one long run-on sentence.
+
+  A new shape-based, repetition-gated detector
+  (`nested_entry_table_starts_at`) now looks ahead from a candidate
+  continuation line for at least two name/description row pairs at the same
+  indent before treating it as a table rather than prose — a single ragged
+  continuation line still reads as an ordinary wrapped description, only
+  genuine repetition ends the block early. All seven of `btrfs --help`'s
+  real flags now parse with only their own description
+  (`corpus/btrfs/audit-seed2`); the command table itself still isn't
+  recovered as subcommands, so the fixture stays `[xfail]`.
+
 ## [0.3.2] - 2026-08-17
 
 Two user reports drove this release, and each was measured to its mechanism

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,26 @@ once it reaches a published 0.1.0 release.
   (`corpus/btrfs/audit-seed2`); the command table itself still isn't
   recovered as subcommands, so the fixture stays `[xfail]`.
 
+  That detector's first version broke a different, equally real shape: a
+  flag with **no inline description of its own** (`pngfix --strip=[none|
+  crc|unsafe|...]:`, `pod2man --guesswork=rule[,rule...]`) whose entire
+  description is the deeper-indented block below it — a value-choice list
+  or keyword list that can itself look table-shaped once a long choice's
+  own wrapped continuation line, or a genuine bare-word keyword list,
+  supplies the "row followed by something deeper" pattern the detector
+  looks for. Breaking there doesn't mis-split, it deletes: the flag has
+  nowhere else for that text to go, so `--strip` and `--guesswork` were
+  each left with an empty description (`--guesswork` also fabricating a
+  bogus choice list from whatever came after the wrongly-ended block). The
+  break is now gated on the entry row actually being continued: it only
+  fires when that row already carries its own non-empty description on its
+  own line, which is exactly the shape `--version`'s `print version
+  string` has and `--strip`/`--guesswork` do not. New fixtures
+  `corpus/pngfix/1.6.43` and `corpus/pod2man/5.01` cover it; a full-`PATH`
+  sweep confirms every one of the six tools the first version moved
+  (`jpackage`, `less`, `pager`, `pngfix`, `pod2man`, `zstdless`) now parses
+  byte-identically to before that detector existed.
+
 ## [0.3.2] - 2026-08-17
 
 Two user reports drove this release, and each was measured to its mechanism

--- a/corpus/btrfs/audit-seed2/expected.snap
+++ b/corpus/btrfs/audit-seed2/expected.snap
@@ -1,0 +1,71 @@
+name: btrfs
+usage:
+- 'usage: btrfs [global] <group> [<group>...] <command> [<args>]'
+positionals:
+- name: group
+  provenance:
+    sources:
+    - help-text
+- name: command
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: args
+  provenance:
+    sources:
+    - help-text
+flags:
+- long: format
+  value_name: <format>
+  value_kind: Required
+  group: 'Global options:'
+  description: if supported, print subcommand output in that format (text, json)
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: verbose
+  group: 'Global options:'
+  description: increase verbosity of the subcommand
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quiet
+  group: 'Global options:'
+  description: print only errors
+  provenance:
+    sources:
+    - help-text
+- long: log
+  value_name: <level>
+  value_kind: Required
+  group: 'Global options:'
+  description: set log level (default, info, verbose, debug, quiet)
+  provenance:
+    sources:
+    - help-text
+- long: dry-run
+  group: 'Global options:'
+  description: if supported, do not do any active/changing actions
+  provenance:
+    sources:
+    - help-text
+- long: help
+  group: 'Options for the main command only:'
+  description: print condensed help for all subcommands
+  provenance:
+    sources:
+    - help-text
+- long: version
+  group: 'Options for the main command only:'
+  description: print version string
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.09
+children_filled: true

--- a/corpus/btrfs/audit-seed2/meta.toml
+++ b/corpus/btrfs/audit-seed2/meta.toml
@@ -18,7 +18,22 @@ expected_framework = "generic"
 # of them becomes a subcommand; the tree has zero, not `verbatim` (no
 # `unparsed` either — the lines are just silently dropped).
 min_subcommands = 1
+verdict_scope = ["flags"]
 
 [xfail]
 broken = true
-reason = "it lists out the subcommands as combinations of the options therefore current framework detection failed to detect subcommmands."
+reason = """
+Partially fixed: the nested command table (indent 4, each row's own \
+description one indent deeper at indent 8) used to fold whole, along with \
+every row's own description, into --version's description — one flag \
+carrying the entire command list as prose. scan_flags_block's nested-entry- \
+table detector now ends the flags block before that table instead, so all \
+seven real flags (--format, --verbose, --quiet, --log, --dry-run, --help, \
+--version) parse clean, each with only its own description.
+
+Still broken: the command table itself is not recovered as subcommands. \
+Nothing currently promotes an indent-4/indent-8 nested table sitting under \
+a flush headingless heading ("Options for the main command only:") to \
+subcommands — the lines are dropped silently once the flags block ends, \
+same as before the fix. min_subcommands stays unmet.
+"""

--- a/corpus/btrfs/audit-seed2/meta.toml
+++ b/corpus/btrfs/audit-seed2/meta.toml
@@ -18,7 +18,12 @@ expected_framework = "generic"
 # of them becomes a subcommand; the tree has zero, not `verbatim` (no
 # `unparsed` either — the lines are just silently dropped).
 min_subcommands = 1
-verdict_scope = ["flags"]
+# No `verdict_scope` on purpose. The flag half of this tree was read
+# line-by-line against help.txt before blessing — but by an agent, not a
+# human, and `verdict_scope` is documented (corpus/README.md, "What
+# --bless does and does not assert") as the record of what *a human*
+# looked at. Claiming it here would be exactly the overclaim the field
+# exists to prevent. Add it when a human has reviewed the bless.
 
 [xfail]
 broken = true

--- a/corpus/pngfix/1.6.43/expected.snap
+++ b/corpus/pngfix/1.6.43/expected.snap
@@ -1,0 +1,80 @@
+name: pngfix
+usage:
+- 'Usage: pngfix {[options] png-file} Tests, optimizes and optionally fixes the zlib header in PNG files. Optionally, when fixing, strips ancillary chunks from the file.'
+positionals:
+- name: PNG
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- long: optimize
+  value_name: '(-o):'
+  value_kind: Required
+  description: Find the smallest deflate window size for the compressed data.
+  provenance:
+    sources:
+    - help-text
+- long: strip
+  value_name: '[none|crc|unsafe|unused|transform|color|all]:'
+  value_kind: Required
+  description: 'none (default): Retain all chunks. crc: Remove chunks with a bad CRC. unsafe: Remove chunks that may be unsafe to retain if the image data is modified. This is set automatically if --max is given but may be cancelled by a later --strip=none. unused: Remove chunks not used by libpng when decoding an image. This retains any chunks that might be used by libpng image transformations. transform: unused+bKGD. color: transform+iCCP and cHRM. all: color+gAMA and sRGB. Only ancillary chunks are ever removed. In addition the tRNS and sBIT chunks are never removed as they affect exact interpretation of the image pixel values. The following known chunks are treated specially by the above options: gAMA, sRGB [all]: These specify the gamma encoding used for the pixel values. cHRM, iCCP [color]: These specify how colors are encoded. iCCP also specifies the exact encoding of a pixel value; however, in practice most programs will ignore it. bKGD [transform]: This is used by libpng transforms. --max=<number>: Use IDAT chunks sized <number>. If no number is given the IDAT chunks will be the maximum size permitted; 2^31-1 bytes. If the option is omitted the original chunk sizes will not be changed. When the option is given --strip=unsafe is set automatically. This may be cancelled if you know that all unknown unsafe-to-copy chunks really are safe to copy across an IDAT size change. This is true of all chunks that have ever been formally proposed as PNG extensions.'
+  provenance:
+    sources:
+    - help-text
+- long: quiet
+  value_name: '(-q):'
+  value_kind: Required
+  description: Do not output the summaries except for files that cannot be read. With two --quiets these are not output either.
+  provenance:
+    sources:
+    - help-text
+- long: errors
+  value_name: '(-e):'
+  value_kind: Required
+  description: Output errors from libpng and the program (except too-far-back).
+  provenance:
+    sources:
+    - help-text
+- long: warnings
+  value_name: '(-w):'
+  value_kind: Required
+  description: Output warnings from libpng.
+  provenance:
+    sources:
+    - help-text
+- long: out
+  value_name: <file>
+  value_kind: Required
+  description: Write the optimized/corrected version of the next PNG to <file>. This overrides the following two options
+  provenance:
+    sources:
+    - help-text
+- long: suffix
+  value_name: <suffix>
+  value_kind: Required
+  description: Set --out=<name><suffix> for all following files unless overridden on a per-file basis by explicit --out.
+  provenance:
+    sources:
+    - help-text
+- long: prefix
+  value_name: <prefix>
+  value_kind: Required
+  choices:
+  - and
+  - stdfast
+  - default
+  - libpng
+  - zlib
+  - invalid
+  - read
+  - write
+  description: Set --out=<prefix><name> for all the following files unless overridden on a per-file basis by explicit --out. These two options can be used together to produce a suffix and prefix.
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.17
+children_filled: true

--- a/corpus/pngfix/1.6.43/help.stderr.txt
+++ b/corpus/pngfix/1.6.43/help.stderr.txt
@@ -1,0 +1,155 @@
+Usage: pngfix {[options] png-file}
+  Tests, optimizes and optionally fixes the zlib header in PNG files.
+  Optionally, when fixing, strips ancillary chunks from the file.
+
+OPTIONS
+  OPERATION
+      By default files are just checked for readability with a summary of the
+      of zlib issues founds for each compressed chunk and the IDAT stream in
+      the file.
+    --optimize (-o):
+      Find the smallest deflate window size for the compressed data.
+    --strip=[none|crc|unsafe|unused|transform|color|all]:
+        none (default):   Retain all chunks.
+        crc:    Remove chunks with a bad CRC.
+        unsafe: Remove chunks that may be unsafe to retain if the image data
+                is modified.  This is set automatically if --max is given but
+                may be cancelled by a later --strip=none.
+        unused: Remove chunks not used by libpng when decoding an image.
+                This retains any chunks that might be used by libpng image
+                transformations.
+        transform: unused+bKGD.
+        color:  transform+iCCP and cHRM.
+        all:    color+gAMA and sRGB.
+      Only ancillary chunks are ever removed.  In addition the tRNS and sBIT
+      chunks are never removed as they affect exact interpretation of the
+      image pixel values.  The following known chunks are treated specially
+      by the above options:
+        gAMA, sRGB [all]: These specify the gamma encoding used for the pixel
+            values.
+        cHRM, iCCP [color]: These specify how colors are encoded.  iCCP also
+            specifies the exact encoding of a pixel value; however, in
+            practice most programs will ignore it.
+        bKGD [transform]: This is used by libpng transforms.    --max=<number>:
+      Use IDAT chunks sized <number>.  If no number is given the IDAT
+      chunks will be the maximum size permitted; 2^31-1 bytes.  If the option
+      is omitted the original chunk sizes will not be changed.  When the
+      option is given --strip=unsafe is set automatically. This may be
+      cancelled if you know that all unknown unsafe-to-copy chunks really are
+      safe to copy across an IDAT size change.  This is true of all chunks
+      that have ever been formally proposed as PNG extensions.
+  MESSAGES
+      By default the program only outputs summaries for each file.
+    --quiet (-q):
+      Do not output the summaries except for files that cannot be read. With
+      two --quiets these are not output either.
+    --errors (-e):
+      Output errors from libpng and the program (except too-far-back).
+    --warnings (-w):
+      Output warnings from libpng.
+  OUTPUT
+      By default nothing is written.
+    --out=<file>:
+      Write the optimized/corrected version of the next PNG to <file>.  This
+      overrides the following two options
+    --suffix=<suffix>:
+      Set --out=<name><suffix> for all following files unless overridden on
+      a per-file basis by explicit --out.
+    --prefix=<prefix>:
+      Set --out=<prefix><name> for all the following files unless overridden
+      on a per-file basis by explicit --out.
+      These two options can be used together to produce a suffix and prefix.
+  INTERNAL OPTIONS
+
+EXIT CODES
+  *** SUBJECT TO CHANGE ***
+  The program exit code is value in the range 0..127 holding a bit mask of
+  the following codes.  Notice that the results for each file are combined
+  together - check one file at a time to get a meaningful error code!
+    0x01: The zlib too-far-back error existed in at least one chunk.
+    0x02: At least one chunk had a CRC error.
+    0x04: A chunk length was incorrect.
+    0x08: The file was truncated.
+  Errors less than 16 are potentially recoverable, for a single file if the
+  exit code is less than 16 the file could be read (with corrections if a
+  non-zero code is returned).
+    0x10: The file could not be read, even with corrections.
+    0x20: The output file could not be written.
+    0x40: An unexpected, potentially internal, error occurred.
+  If the command line arguments are incorrect the program exits with exit
+  255.  Some older operating systems only support 7-bit exit codes, on those
+  systems it is suggested that this program is first tested by supplying
+  invalid arguments.
+
+DESCRIPTION
+  pngfix:
+  checks each PNG file on the command line for errors.  By default errors are
+  not output and the program just returns an exit code and prints a summary.
+  With the --quiet (-q) option the summaries are suppressed too and the
+  program only outputs unexpected errors (internal errors and file open
+  errors).
+  Various known problems in PNG files are fixed while the file is being read
+  The exit code says what problems were fixed.  In particular the zlib error:
+
+        "invalid distance too far back"
+
+  caused by an incorrect optimization of a zlib stream is fixed in any
+  compressed chunk in which it is encountered.  An integrity problem of the
+  PNG stream caused by a bug in libpng which wrote an incorrect chunk length
+  is also fixed.  Chunk CRC errors are automatically fixed up.
+
+  Setting one of the "OUTPUT" options causes the possibly modified file to
+  be written to a new file.
+
+  Notice that some PNG files with the zlib optimization problem can still be
+  read by libpng under some circumstances.  This program will still detect
+  and, if requested, correct the error.
+
+  The program will reliably process all files on the command line unless
+  either an invalid argument causes the usage message (this message) to be
+  produced or the program crashes.
+
+  The summary lines describe issues encountered with the zlib compressed
+  stream of a chunk.  They have the following format, which is SUBJECT TO
+  CHANGE in the future:
+
+     chunk reason comp-level p1 p2 p3 p4 file
+
+  p1 through p4 vary according to the 'reason'.  There are always 8 space
+  separated fields.  Reasons specific formats are:
+
+     chunk ERR status code read-errno write-errno message file
+     chunk SKP comp-level file-bits zlib-rc compressed message file
+     chunk ??? comp-level file-bits ok-bits compressed uncompress file
+
+  The various fields are
+
+$1 chunk:      The chunk type of a chunk in the file or 'HEAD' if a problem
+               is reported by libpng at the start of the IDAT stream.
+$2 reason:     One of:
+          CHK: A zlib header checksum was detected and fixed.
+          TFB: The zlib too far back error was detected and fixed.
+          OK : No errors were detected in the zlib stream and optimization
+               was not requested, or was not possible.
+          OPT: The zlib stream window bits value could be improved (and was).
+          SKP: The chunk was skipped because of a zlib issue (zlib-rc) with
+               explanation 'message'
+          ERR: The read of the file was aborted.  The parameters explain why.
+$3 status:     For 'ERR' the accumulated status code from 'EXIT CODES' above.
+               This is printed as a 2 digit hexadecimal value
+   comp-level: The recorded compression level (FLEVEL) of a zlib stream
+               expressed as a string {supfast,stdfast,default,maximum}
+$4 code:       The file exit code; where stop was called, as a fairly terse
+               string {warning,libpng,zlib,invalid,read,write,unexpected}.
+   file-bits:  The zlib window bits recorded in the file.
+$5 read-errno: A system errno value from a read translated by strerror(3).
+   zlib-rc:    A zlib return code as a string (see zlib.h).
+   ok-bits:    The smallest zlib window bits value that works.
+$6 write-errno:A system errno value from a write translated by strerror(3).
+   compressed: The count of compressed bytes in the zlib stream, when the
+               reason is 'SKP'; this is a count of the bytes read from the
+               stream when the fatal error was encountered.
+$7 message:    An error message (spaces replaced by _, as in all parameters),
+   uncompress: The count of bytes from uncompressing the zlib stream; this
+               may not be the same as the number of bytes in the image.
+$8 file:       The name of the file (this may contain spaces).

--- a/corpus/pngfix/1.6.43/meta.toml
+++ b/corpus/pngfix/1.6.43/meta.toml
@@ -1,0 +1,37 @@
+[tool]
+name = "pngfix"
+version = "1.6.43"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.3.2"
+
+# pngfix writes its usage message to stderr and exits non-zero (255) on
+# `--help` — see AGENTS.md §4's "`--help` output may go to stderr and exit
+# non-zero" note. stdout is genuinely empty for this capture, not omitted.
+[[capture]]
+argv = ["pngfix", "--help"]
+stdout = "help.txt"
+stderr = "help.stderr.txt"
+exit_code = 255
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+min_subcommands = 0
+# --max is deliberately absent from this list: the raw capture itself glues
+# "bKGD [transform]: This is used by libpng transforms." and "--max=<number>:"
+# onto one physical line (help.txt, that exact line) — a pre-existing quirk
+# of pngfix's own --help formatting, unrelated to this fixture's reason for
+# existing. --max's row is folded into --strip's description as a result,
+# and this contract records that honestly rather than asserting a flag the
+# parser cannot currently recover from this text.
+#
+# Also not this fixture's reason for existing, recorded honestly rather than
+# silently blessed: --prefix's expected.snap carries a fabricated `choices`
+# list (`and`, `stdfast`, `default`, `libpng`, `zlib`, `invalid`, `read`,
+# `write`) with no relation to --prefix at all. It is drawn from two
+# brace-lists many lines later, in the unrelated EXIT CODES section
+# ("{supfast,stdfast,default,maximum}", "{warning,libpng,zlib,invalid,read,
+# write,unexpected}") and misattributed to the nearest preceding flag. Not
+# the entry-row gate this fixture was captured for; no verdict_scope is set,
+# so no claim is made about description/choices accuracy here.
+must_contain_flags = ["--optimize", "--strip", "--quiet", "--errors", "--warnings", "--out", "--suffix", "--prefix"]

--- a/corpus/pod2man/5.01/expected.snap
+++ b/corpus/pod2man/5.01/expected.snap
@@ -1,0 +1,180 @@
+name: pod2man
+usage:
+- 'Usage:'
+- pod2man [--center=string] [--date=string] [--encoding=encoding] [--errors=style] [--fixed=font] [--fixedbold=font] [--fixeditalic=font] [--fixedbolditalic=font] [--guesswork=rule[,rule...]] [--name=name] [--nourls] [--official] [--release=version] [--section=manext] [--quotes=quotes] [--lquote=quote] [--rquote=quote] [--stderr] [--utf8] [--verbose] [input [output] ...]
+flags:
+- short: 'c'
+  long: center
+  value_name: string
+  value_kind: Required
+  description: '[1.00] Sets the centered page header for the ".TH" macro to string. The default is "User Contributed Perl Documentation", but also see'
+  provenance:
+    sources:
+    - help-text
+- long: official
+  value_name: below.
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  long: date
+  value_name: string
+  value_kind: Required
+  description: '[4.00] Set the left-hand footer string for the ".TH" macro to string. By default, the first of POD_MAN_DATE, SOURCE_DATE_EPOCH, the modification date of the input file, or the current date (if input comes from "STDIN") will be used, and the date will be in UTC. See "CLASS METHODS" in Pod::Man for more details.'
+  provenance:
+    sources:
+    - help-text
+- short: 'e'
+  long: encoding
+  value_name: encoding
+  value_kind: Required
+  description: '[5.00] Specifies the encoding of the output. encoding must be an encoding recognized by the Encode module (see Encode::Supported). The default on non-EBCDIC systems is UTF-8. If the output contains characters that cannot be represented in this encoding, that is an error that will be reported as configured by the --errors option. If error handling is other than "die", the unrepresentable character will be replaced with the Encode substitution character (normally "?"). If the "encoding" option is set to the special value "groff" (the default on EBCDIC systems), or if the Encode module is not available and the encoding is set to anything other than "roff" (see below), Pod::Man will translate all non-ASCII characters to "\[uNNNN]" Unicode escapes. These are not traditionally part of the *roff language, but are supported by groff and mandoc and thus by the majority of manual page processors in use today. If encoding is set to the special value "roff", pod2man will do its historic transformation of (some) ISO 8859-1 characters into *roff escapes that may be adequate in troff and may be readable (if ugly) in nroff. This was the default behavior of versions of pod2man before 5.00. With this encoding, all other non-ASCII characters will be replaced with "X". It may be required for very old troff and nroff implementations that do not support UTF-8, but its representation of any non-ASCII character is very poor and often specific to European languages. Its use is discouraged. WARNING: The input encoding of the POD source is independent from the output encoding, and setting this option does not affect the interpretation of the POD input. Unless your POD source is US-ASCII, its encoding should be declared with the "=encoding" command in the source. If this is not done, Pod::Simple will will attempt to guess the encoding and may be successful if it''s Latin-1 or UTF-8, but it will produce warnings. See perlpod(1) for more information.'
+  provenance:
+    sources:
+    - help-text
+- long: errors
+  value_name: style
+  value_kind: Required
+  description: '[2.5.0] Set the error handling style. "die" says to throw an exception on any POD formatting error. "stderr" says to report errors on standard error, but not to throw an exception. "pod" says to include a POD ERRORS section in the resulting documentation summarizing the errors. "none" ignores POD errors entirely, as much as possible. The default is "die".'
+  provenance:
+    sources:
+    - help-text
+- long: fixed
+  value_name: font
+  value_kind: Required
+  description: '[1.0] The fixed-width font to use for verbatim text and code. Defaults to "CW". Some systems may want "CR" instead. Only matters for troff output.'
+  provenance:
+    sources:
+    - help-text
+- long: fixedbold
+  value_name: font
+  value_kind: Required
+  description: '[1.0] Bold version of the fixed-width font. Defaults to "CB". Only matters for troff output.'
+  provenance:
+    sources:
+    - help-text
+- long: fixeditalic
+  value_name: font
+  value_kind: Required
+  description: '[1.0] Italic version of the fixed-width font (something of a misnomer, since most fixed-width fonts only have an oblique version, not an italic version). Defaults to "CI". Only matters for troff output.'
+  provenance:
+    sources:
+    - help-text
+- long: fixedbolditalic
+  value_name: font
+  value_kind: Required
+  description: '[1.0] Bold italic (in theory, probably oblique in practice) version of the fixed-width font. Pod::Man doesn''t assume you have this, and defaults to "CB". Some systems (such as Solaris) have this font available as "CX". Only matters for troff output.'
+  provenance:
+    sources:
+    - help-text
+- long: guesswork
+  value_name: rule[,rule...]
+  value_kind: Required
+  description: '[5.00] By default, pod2man applies some default formatting rules based on guesswork and regular expressions that are intended to make writing Perl documentation easier and require less explicit markup. These rules may not always be appropriate, particularly for documentation that isn''t about Perl. This option allows turning all or some of it off. The special rule "all" enables all guesswork. This is also the default for backward compatibility reasons. The special rule "none" disables all guesswork. Otherwise, the value of this option should be a comma-separated list of one or more of the following keywords: functions Convert function references like foo() to bold even if they have no markup. The function name accepts valid Perl characters for function names (including ":"), and the trailing parentheses must be present and empty. manref Make the first part (before the parentheses) of man page references like foo(1) bold even if they have no markup. The section must be a single number optionally followed by lowercase letters. quoting If no guesswork is enabled, any text enclosed in C<> is surrounded by double quotes in nroff (terminal) output unless the contents are already quoted. When this guesswork is enabled, quote marks will also be suppressed for Perl variables, function names, function calls, numbers, and hex constants. variables Convert Perl variable names to a fixed-width font even if they have no markup. This transformation will only be apparent in troff output, or some other output format (unlike nroff terminal output) that supports fixed-width fonts. Any unknown guesswork name is silently ignored (for potential future compatibility), so be careful about spelling.'
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  description: '[1.00] Print out usage information.'
+  provenance:
+    sources:
+    - help-text
+- short: 'l'
+  long: lax
+  description: '[1.00] No longer used. pod2man used to check its input for validity as a manual page, but this should now be done by podchecker(1) instead. Accepted for backward compatibility; this option no longer does anything.'
+  provenance:
+    sources:
+    - help-text
+- long: language
+  value_name: language
+  value_kind: Required
+  description: '[5.00] Add commands telling groff that the input file is in the given language. The value of this setting must be a language abbreviation for which groff provides supplemental configuration, such as "ja" (for Japanese) or "zh" (for Chinese). This adds: .mso <language>.tmac .hla <language> to the start of the file, which configure correct line breaking for the specified language. Without these commands, groff may not know how to add proper line breaks for Chinese and Japanese text if the man page is installed into the normal man page directory, such as /usr/share/man. On many systems, this will be done automatically if the man page is installed into a language-specific man page directory, such as /usr/share/man/zh_CN. In that case, this option is not required. Unfortunately, the commands added with this option are specific to groff and will not work with other troff and nroff implementations.'
+  provenance:
+    sources:
+    - help-text
+- long: lquote
+  value_name: quote
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- long: rquote
+  value_name: quote
+  value_kind: Required
+  description: '[4.08] Sets the quote marks used to surround C<> text. --lquote sets the left quote mark and --rquote sets the right quote mark. Either may also be set to the special value "none", in which case no quote mark is added on that side of C<> text (but the font is still changed for troff output). Also see the --quotes option, which can be used to set both quotes at once. If both --quotes and one of the other options is set,'
+  provenance:
+    sources:
+    - help-text
+- long: lquote
+  value_name: or
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- short: 'n'
+  long: name
+  value_name: name
+  value_kind: Required
+  description: '[4.08] Set the name of the manual page for the ".TH" macro to name. Without this option, the manual name is set to the uppercased base name of the file being converted unless the manual section is 3, in which case the path is parsed to see if it is a Perl module path. If it is, a path like ".../lib/Pod/Man.pm" is converted into a name like "Pod::Man". This option, if given, overrides any automatic determination of the name. Although one does not have to follow this convention, be aware that the convention for UNIX manual pages is for the title to be in all-uppercase, even if the command isn''t. (Perl modules traditionally use mixed case for the manual page title, however.) This option is probably not useful when converting multiple POD files at once. When converting POD source from standard input, the name will be set to "STDIN" if this option is not provided. Providing this option is strongly recommended to set a meaningful manual page name.'
+  provenance:
+    sources:
+    - help-text
+- long: nourls
+  description: '[2.5.0] Normally, L<> formatting codes with a URL but anchor text are formatted to show both the anchor text and the URL. In other words: L<foo|http://example.com/> is formatted as: foo <http://example.com/> This flag, if given, suppresses the URL when anchor text is given, so this example would be formatted as just "foo". This can produce less cluttered output in cases where the URLs are not particularly important.'
+  provenance:
+    sources:
+    - help-text
+- short: 'o'
+  long: official
+  description: '[1.00] Set the default header to indicate that this page is part of the standard Perl release, if --center is not also given.'
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quotes
+  value_name: quotes
+  value_kind: Required
+  description: '[4.00] Sets the quote marks used to surround C<> text to quotes. If quotes is a single character, it is used as both the left and right quote. Otherwise, it is split in half, and the first half of the string is used as the left quote and the second is used as the right quote. quotes may also be set to the special value "none", in which case no quote marks are added around C<> text (but the font is still changed for troff output). Also see the --lquote and --rquote options, which can be used to set the left and right quotes independently. If both --quotes and one of the other options is set, --lquote or --rquote overrides --quotes.'
+  provenance:
+    sources:
+    - help-text
+- short: 'r'
+  long: release
+  value_name: version
+  value_kind: Required
+  description: '[1.00] Set the centered footer for the ".TH" macro to version. By default, this is set to the version of Perl you run pod2man under. Setting this to the empty string will cause some *roff implementations to use the system default value. Note that some system "an" macro sets assume that the centered footer will be a modification date and will prepend something like "Last modified: ". If this is the case for your target system, you may want to set --release to the last modified date and --date to the version number.'
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  long: section
+  value_name: string
+  value_kind: Required
+  description: '[1.00] Set the section for the ".TH" macro. The standard section numbering convention is to use 1 for user commands, 2 for system calls, 3 for functions, 4 for devices, 5 for file formats, 6 for games, 7 for miscellaneous information, and 8 for administrator commands. There is a lot of variation here, however; some systems (like Solaris) use 4 for file formats, 5 for miscellaneous information, and 7 for devices. Still others use 1m instead of 8, or some mix of both. About the only section numbers that are reliably consistent are 1, 2, and 3. By default, section 1 will be used unless the file ends in ".pm", in which case section 3 will be selected.'
+  provenance:
+    sources:
+    - help-text
+- long: stderr
+  description: '[2.1.3] By default, pod2man dies if any errors are detected in the POD input. If --stderr is given and no --errors flag is present, errors are sent to standard error, but pod2man does not abort. This is equivalent to "--errors=stderr" and is supported for backward compatibility.'
+  provenance:
+    sources:
+    - help-text
+- short: 'u'
+  long: utf8
+  description: '[2.1.0] This option used to tell pod2man to produce UTF-8 output. Since this is now the default as of version 5.00, it is ignored and does nothing.'
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: verbose
+  description: '[1.11] Print out the name of each output file as it is being generated.'
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/pod2man/5.01/help.txt
+++ b/corpus/pod2man/5.01/help.txt
@@ -1,0 +1,278 @@
+Usage:
+    pod2man [--center=string] [--date=string] [--encoding=encoding]
+    [--errors=style] [--fixed=font] [--fixedbold=font] [--fixeditalic=font]
+    [--fixedbolditalic=font] [--guesswork=rule[,rule...]] [--name=name]
+    [--nourls] [--official] [--release=version] [--section=manext]
+    [--quotes=quotes] [--lquote=quote] [--rquote=quote] [--stderr] [--utf8]
+    [--verbose] [input [output] ...]
+
+    pod2man --help
+
+Options:
+    Each option is annotated with the version of podlators in which that
+    option was added with its current meaning.
+
+    -c string, --center=string
+        [1.00] Sets the centered page header for the ".TH" macro to string.
+        The default is "User Contributed Perl Documentation", but also see
+        --official below.
+
+    -d string, --date=string
+        [4.00] Set the left-hand footer string for the ".TH" macro to
+        string. By default, the first of POD_MAN_DATE, SOURCE_DATE_EPOCH,
+        the modification date of the input file, or the current date (if
+        input comes from "STDIN") will be used, and the date will be in UTC.
+        See "CLASS METHODS" in Pod::Man for more details.
+
+    -e encoding, --encoding=encoding
+        [5.00] Specifies the encoding of the output. encoding must be an
+        encoding recognized by the Encode module (see Encode::Supported).
+        The default on non-EBCDIC systems is UTF-8.
+
+        If the output contains characters that cannot be represented in this
+        encoding, that is an error that will be reported as configured by
+        the --errors option. If error handling is other than "die", the
+        unrepresentable character will be replaced with the Encode
+        substitution character (normally "?").
+
+        If the "encoding" option is set to the special value "groff" (the
+        default on EBCDIC systems), or if the Encode module is not available
+        and the encoding is set to anything other than "roff" (see below),
+        Pod::Man will translate all non-ASCII characters to "\[uNNNN]"
+        Unicode escapes. These are not traditionally part of the *roff
+        language, but are supported by groff and mandoc and thus by the
+        majority of manual page processors in use today.
+
+        If encoding is set to the special value "roff", pod2man will do its
+        historic transformation of (some) ISO 8859-1 characters into *roff
+        escapes that may be adequate in troff and may be readable (if ugly)
+        in nroff. This was the default behavior of versions of pod2man
+        before 5.00. With this encoding, all other non-ASCII characters will
+        be replaced with "X". It may be required for very old troff and
+        nroff implementations that do not support UTF-8, but its
+        representation of any non-ASCII character is very poor and often
+        specific to European languages. Its use is discouraged.
+
+        WARNING: The input encoding of the POD source is independent from
+        the output encoding, and setting this option does not affect the
+        interpretation of the POD input. Unless your POD source is US-ASCII,
+        its encoding should be declared with the "=encoding" command in the
+        source. If this is not done, Pod::Simple will will attempt to guess
+        the encoding and may be successful if it's Latin-1 or UTF-8, but it
+        will produce warnings. See perlpod(1) for more information.
+
+    --errors=style
+        [2.5.0] Set the error handling style. "die" says to throw an
+        exception on any POD formatting error. "stderr" says to report
+        errors on standard error, but not to throw an exception. "pod" says
+        to include a POD ERRORS section in the resulting documentation
+        summarizing the errors. "none" ignores POD errors entirely, as much
+        as possible.
+
+        The default is "die".
+
+    --fixed=font
+        [1.0] The fixed-width font to use for verbatim text and code.
+        Defaults to "CW". Some systems may want "CR" instead. Only matters
+        for troff output.
+
+    --fixedbold=font
+        [1.0] Bold version of the fixed-width font. Defaults to "CB". Only
+        matters for troff output.
+
+    --fixeditalic=font
+        [1.0] Italic version of the fixed-width font (something of a
+        misnomer, since most fixed-width fonts only have an oblique version,
+        not an italic version). Defaults to "CI". Only matters for troff
+        output.
+
+    --fixedbolditalic=font
+        [1.0] Bold italic (in theory, probably oblique in practice) version
+        of the fixed-width font. Pod::Man doesn't assume you have this, and
+        defaults to "CB". Some systems (such as Solaris) have this font
+        available as "CX". Only matters for troff output.
+
+    --guesswork=rule[,rule...]
+        [5.00] By default, pod2man applies some default formatting rules
+        based on guesswork and regular expressions that are intended to make
+        writing Perl documentation easier and require less explicit markup.
+        These rules may not always be appropriate, particularly for
+        documentation that isn't about Perl. This option allows turning all
+        or some of it off.
+
+        The special rule "all" enables all guesswork. This is also the
+        default for backward compatibility reasons. The special rule "none"
+        disables all guesswork. Otherwise, the value of this option should
+        be a comma-separated list of one or more of the following keywords:
+
+        functions
+            Convert function references like foo() to bold even if they have
+            no markup. The function name accepts valid Perl characters for
+            function names (including ":"), and the trailing parentheses
+            must be present and empty.
+
+        manref
+            Make the first part (before the parentheses) of man page
+            references like foo(1) bold even if they have no markup. The
+            section must be a single number optionally followed by lowercase
+            letters.
+
+        quoting
+            If no guesswork is enabled, any text enclosed in C<> is
+            surrounded by double quotes in nroff (terminal) output unless
+            the contents are already quoted. When this guesswork is enabled,
+            quote marks will also be suppressed for Perl variables, function
+            names, function calls, numbers, and hex constants.
+
+        variables
+            Convert Perl variable names to a fixed-width font even if they
+            have no markup. This transformation will only be apparent in
+            troff output, or some other output format (unlike nroff terminal
+            output) that supports fixed-width fonts.
+
+        Any unknown guesswork name is silently ignored (for potential future
+        compatibility), so be careful about spelling.
+
+    -h, --help
+        [1.00] Print out usage information.
+
+    -l, --lax
+        [1.00] No longer used. pod2man used to check its input for validity
+        as a manual page, but this should now be done by podchecker(1)
+        instead. Accepted for backward compatibility; this option no longer
+        does anything.
+
+    --language=language
+        [5.00] Add commands telling groff that the input file is in the
+        given language. The value of this setting must be a language
+        abbreviation for which groff provides supplemental configuration,
+        such as "ja" (for Japanese) or "zh" (for Chinese).
+
+        This adds:
+
+            .mso <language>.tmac
+            .hla <language>
+
+        to the start of the file, which configure correct line breaking for
+        the specified language. Without these commands, groff may not know
+        how to add proper line breaks for Chinese and Japanese text if the
+        man page is installed into the normal man page directory, such as
+        /usr/share/man.
+
+        On many systems, this will be done automatically if the man page is
+        installed into a language-specific man page directory, such as
+        /usr/share/man/zh_CN. In that case, this option is not required.
+
+        Unfortunately, the commands added with this option are specific to
+        groff and will not work with other troff and nroff implementations.
+
+    --lquote=quote
+    --rquote=quote
+        [4.08] Sets the quote marks used to surround C<> text. --lquote sets
+        the left quote mark and --rquote sets the right quote mark. Either
+        may also be set to the special value "none", in which case no quote
+        mark is added on that side of C<> text (but the font is still
+        changed for troff output).
+
+        Also see the --quotes option, which can be used to set both quotes
+        at once. If both --quotes and one of the other options is set,
+        --lquote or --rquote overrides --quotes.
+
+    -n name, --name=name
+        [4.08] Set the name of the manual page for the ".TH" macro to name.
+        Without this option, the manual name is set to the uppercased base
+        name of the file being converted unless the manual section is 3, in
+        which case the path is parsed to see if it is a Perl module path. If
+        it is, a path like ".../lib/Pod/Man.pm" is converted into a name
+        like "Pod::Man". This option, if given, overrides any automatic
+        determination of the name.
+
+        Although one does not have to follow this convention, be aware that
+        the convention for UNIX manual pages is for the title to be in
+        all-uppercase, even if the command isn't. (Perl modules
+        traditionally use mixed case for the manual page title, however.)
+
+        This option is probably not useful when converting multiple POD
+        files at once.
+
+        When converting POD source from standard input, the name will be set
+        to "STDIN" if this option is not provided. Providing this option is
+        strongly recommended to set a meaningful manual page name.
+
+    --nourls
+        [2.5.0] Normally, L<> formatting codes with a URL but anchor text
+        are formatted to show both the anchor text and the URL. In other
+        words:
+
+            L<foo|http://example.com/>
+
+        is formatted as:
+
+            foo <http://example.com/>
+
+        This flag, if given, suppresses the URL when anchor text is given,
+        so this example would be formatted as just "foo". This can produce
+        less cluttered output in cases where the URLs are not particularly
+        important.
+
+    -o, --official
+        [1.00] Set the default header to indicate that this page is part of
+        the standard Perl release, if --center is not also given.
+
+    -q quotes, --quotes=quotes
+        [4.00] Sets the quote marks used to surround C<> text to quotes. If
+        quotes is a single character, it is used as both the left and right
+        quote. Otherwise, it is split in half, and the first half of the
+        string is used as the left quote and the second is used as the right
+        quote.
+
+        quotes may also be set to the special value "none", in which case no
+        quote marks are added around C<> text (but the font is still changed
+        for troff output).
+
+        Also see the --lquote and --rquote options, which can be used to set
+        the left and right quotes independently. If both --quotes and one of
+        the other options is set, --lquote or --rquote overrides --quotes.
+
+    -r version, --release=version
+        [1.00] Set the centered footer for the ".TH" macro to version. By
+        default, this is set to the version of Perl you run pod2man under.
+        Setting this to the empty string will cause some *roff
+        implementations to use the system default value.
+
+        Note that some system "an" macro sets assume that the centered
+        footer will be a modification date and will prepend something like
+        "Last modified: ". If this is the case for your target system, you
+        may want to set --release to the last modified date and --date to
+        the version number.
+
+    -s string, --section=string
+        [1.00] Set the section for the ".TH" macro. The standard section
+        numbering convention is to use 1 for user commands, 2 for system
+        calls, 3 for functions, 4 for devices, 5 for file formats, 6 for
+        games, 7 for miscellaneous information, and 8 for administrator
+        commands. There is a lot of variation here, however; some systems
+        (like Solaris) use 4 for file formats, 5 for miscellaneous
+        information, and 7 for devices. Still others use 1m instead of 8, or
+        some mix of both. About the only section numbers that are reliably
+        consistent are 1, 2, and 3.
+
+        By default, section 1 will be used unless the file ends in ".pm", in
+        which case section 3 will be selected.
+
+    --stderr
+        [2.1.3] By default, pod2man dies if any errors are detected in the
+        POD input. If --stderr is given and no --errors flag is present,
+        errors are sent to standard error, but pod2man does not abort. This
+        is equivalent to "--errors=stderr" and is supported for backward
+        compatibility.
+
+    -u, --utf8
+        [2.1.0] This option used to tell pod2man to produce UTF-8 output.
+        Since this is now the default as of version 5.00, it is ignored and
+        does nothing.
+
+    -v, --verbose
+        [1.11] Print out the name of each output file as it is being
+        generated.
+

--- a/corpus/pod2man/5.01/meta.toml
+++ b/corpus/pod2man/5.01/meta.toml
@@ -1,0 +1,26 @@
+[tool]
+name = "pod2man"
+version = "5.01"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.3.2"
+
+[[capture]]
+argv = ["pod2man", "--help"]
+stdout = "help.txt"
+exit_code = 0
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+min_subcommands = 0
+# Not this fixture's reason for existing, recorded honestly rather than
+# silently blessed: two pre-existing, unrelated parser artifacts are visible
+# in expected.snap. (1) "--official" (a real flag) also appears a second
+# time with value_name "below." — an in-prose mention ("but also see
+# --official below.", inside --center's own description) misread as a new
+# entry. (2) "--lquote" (a real flag) similarly appears a second time with
+# value_name "or" — from "--lquote or --rquote overrides --quotes" inside
+# --rquote's description. Neither is the entry-row gate this fixture was
+# captured for; no verdict_scope is set, so no claim is made about
+# description accuracy here.
+must_contain_flags = ["--center", "--date", "--encoding", "--errors", "--guesswork", "--name", "--official", "--release", "--section", "--help"]

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -2545,6 +2545,18 @@ fn nested_entry_table_starts_at(lines: &[&str], start: usize, indent: usize) -> 
             if let Some(next) = lines.get(j + 1) {
                 if !next.trim().is_empty() && leading_whitespace(next) > indent {
                     rows += 1;
+                    // Nothing past the floor can change the answer, and
+                    // this scan runs once per candidate continuation line:
+                    // returning as soon as it is decided keeps a positive
+                    // match from walking the rest of a long table (the
+                    // "never call an O(n) function from inside a loop"
+                    // hazard in AGENTS.md §2). The negative case is
+                    // already short — it stops at the first line that
+                    // dedents past `indent`, which in an ordinary flags
+                    // block is the very next entry row.
+                    if rows >= MIN_NESTED_TABLE_ROWS {
+                        return true;
+                    }
                 }
             }
         }

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -2403,6 +2403,9 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
 
         let is_continuation = !rows.is_empty() && min_entry_indent.is_some_and(|m| indent > m);
         if is_continuation {
+            if nested_entry_table_starts_at(lines, i, indent) {
+                break;
+            }
             rows.push(FlagsBlockRow::Continuation(trimmed.trim_end()));
             i += 1;
             continue;
@@ -2462,6 +2465,92 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
         }
     }
     (i, entries)
+}
+
+/// The fewest name/description pairs a deeper-indented run must show before
+/// [`nested_entry_table_starts_at`] will read it as a table rather than an
+/// ordinary wrapped description.
+///
+/// Two, for the same reason [`scan_same_indent_entry_table`]'s `MIN_ROWS`
+/// is two: one ragged continuation line that happens to be followed by a
+/// still-deeper line is unremarkable prose, and must not trip this on its
+/// own. Only repetition — the same name/description shape recurring — is
+/// evidence of a table.
+const MIN_NESTED_TABLE_ROWS: usize = 2;
+
+/// Look ahead from a candidate continuation line at `lines[start]` (indent
+/// `indent`, already known to be deeper than the flags block's own entries)
+/// for a **nested entry table** — command rows with their own
+/// one-level-deeper descriptions — rather than an ordinary wrapped
+/// description of the flag above it.
+///
+/// # Why this exists
+///
+/// [`scan_flags_block`]'s continuation rule used to be indentation alone:
+/// *any* line deeper than the block's entries continues the previous
+/// entry's description. That is right for a wrapped sentence and wrong for
+/// a nested table, and nothing about indentation tells them apart — both
+/// are "deeper than the flag rows above."
+///
+/// `btrfs --help` (`corpus/btrfs/audit-seed2/help.txt`) has both, back to
+/// back. `Options for the main command only:` holds two ordinary flag rows
+/// at indent 2 (`--help`, `--version`). A blank line later, at indent 4, a
+/// large command table begins — `btrfs balance start [options] <path>`,
+/// each row followed by its own description one indent deeper (indent 8):
+///
+/// ```text
+///   --version         print version string
+///
+///     btrfs balance start [options] <path>
+///         Balance chunks across the devices
+///     btrfs balance pause <path>
+///         Pause running balance
+/// ```
+///
+/// Indentation alone reads every line of that table, and every one of its
+/// descriptions, as more of `--version`'s own description — the whole
+/// command table folds into one flag.
+///
+/// # The rule
+///
+/// A row is counted when a non-blank line sits at exactly `indent` and (a)
+/// is not [`looks_like_flag_start`] — a real flag row at this indent is
+/// business as usual for the block, not a nested table — and (b) is
+/// immediately followed by a non-blank line indented deeper still. The
+/// lookahead continues across blank lines and any line at or below
+/// `indent`'s depth, stopping the moment a non-blank line dedents past it
+/// (structure below `indent` belongs to whatever comes after the table, not
+/// to this scan). At least [`MIN_NESTED_TABLE_ROWS`] such rows makes it a
+/// table.
+///
+/// Returning `true` tells [`scan_flags_block`] to `break` at `start` — it
+/// **re-routes rather than drops**, the same contract [`bare_block_end`]'s
+/// flag-row break uses: the caller resumes its own scan at exactly this
+/// line, so a wrong call here loses nothing, it just leaves the text where
+/// it was for a later pass to read.
+fn nested_entry_table_starts_at(lines: &[&str], start: usize, indent: usize) -> bool {
+    let mut rows = 0usize;
+    let mut j = start;
+    while j < lines.len() {
+        let line = lines[j];
+        if line.trim().is_empty() {
+            j += 1;
+            continue;
+        }
+        let line_indent = leading_whitespace(line);
+        if line_indent < indent {
+            break;
+        }
+        if line_indent == indent && !looks_like_flag_start(line.trim_start()) {
+            if let Some(next) = lines.get(j + 1) {
+                if !next.trim().is_empty() && leading_whitespace(next) > indent {
+                    rows += 1;
+                }
+            }
+        }
+        j += 1;
+    }
+    rows >= MIN_NESTED_TABLE_ROWS
 }
 
 /// The original (pre-multi-column) way to split one flags-block entry line:
@@ -4452,6 +4541,59 @@ Usage: prog [bs=BS] [--help]
     fn a_bare_block_with_no_flag_rows_is_unchanged() {
         let lines = ["  alpha   first", "  beta    second", "  gamma   third"];
         assert_eq!(bare_block_end(&lines, 0), 3);
+    }
+
+    /// `btrfs --help`'s shape (`corpus/btrfs/audit-seed2/help.txt`): a
+    /// flags block at indent 2 (`--help`, `--version`), followed by a blank
+    /// line and then a nested command table at indent 4 whose own rows are
+    /// each followed by a description one indent deeper (indent 8). Before
+    /// this test's fix, [`scan_flags_block`]'s continuation rule only
+    /// checked "is this line indented past the block's entries?" — true for
+    /// every row and every description in the table below — so the entire
+    /// table folded into `--version`'s description instead of ending the
+    /// flags block.
+    ///
+    /// Three table groups, deliberately more than the
+    /// [`MIN_NESTED_TABLE_ROWS`] floor of two: a single ragged continuation
+    /// followed by one deeper line must never trip this detector, only
+    /// genuine repetition may.
+    #[test]
+    fn nested_command_table_does_not_swallow_into_a_flag_description() {
+        let help = "\
+Usage: widget [global] <group> <command> [<args>]
+
+Options for the main command only:
+  --help            print condensed help for all subcommands
+  --version         print version string
+
+    widget group one start
+        Start the first task
+    widget group one stop
+        Stop the first task
+    widget group two run
+        Run the second task
+";
+        let parsed = parse(help);
+        let version = flag_named(&parsed, "version");
+        assert_eq!(
+            version.description.as_ref().map(|t| t.as_str()),
+            Some("print version string"),
+            "--version's description must not absorb the command table below it"
+        );
+        for swallowed in [
+            "Start the first task",
+            "Stop the first task",
+            "Run the second task",
+        ] {
+            assert!(
+                !version
+                    .description
+                    .as_ref()
+                    .is_some_and(|d| d.as_str().contains(swallowed)),
+                "table row {swallowed:?} leaked into --version's description: {:?}",
+                version.description
+            );
+        }
     }
 
     /// `--quoting-style`'s valid arguments are introduced by a heading

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -2381,6 +2381,7 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
     let mut i = start;
     let mut rows: Vec<FlagsBlockRow<'a>> = Vec::new();
     let mut min_entry_indent: Option<usize> = None;
+    let mut current_entry_line: Option<&'a str> = None;
 
     while i < lines.len() {
         let line = lines[i];
@@ -2397,13 +2398,16 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
         if is_entry_start {
             rows.push(FlagsBlockRow::Entry(line));
             min_entry_indent = Some(min_entry_indent.map_or(indent, |m| m.min(indent)));
+            current_entry_line = Some(line);
             i += 1;
             continue;
         }
 
         let is_continuation = !rows.is_empty() && min_entry_indent.is_some_and(|m| indent > m);
         if is_continuation {
-            if nested_entry_table_starts_at(lines, i, indent) {
+            let entry_has_own_description =
+                current_entry_line.is_some_and(entry_row_carries_own_description);
+            if entry_has_own_description && nested_entry_table_starts_at(lines, i, indent) {
                 break;
             }
             rows.push(FlagsBlockRow::Continuation(trimmed.trim_end()));
@@ -2563,6 +2567,52 @@ fn nested_entry_table_starts_at(lines: &[&str], start: usize, indent: usize) -> 
         j += 1;
     }
     rows >= MIN_NESTED_TABLE_ROWS
+}
+
+/// Does the flags-block entry row currently being continued already carry
+/// its own, non-empty description **on its own line**?
+///
+/// # Why this exists
+///
+/// [`nested_entry_table_starts_at`] cannot tell apart two shapes that look
+/// identical from indentation alone: a nested table that does not belong to
+/// the flag above it (break away — `btrfs --help`, whose
+/// `--version         print version string` already has its description
+/// inline, and the command table below it is not that description), and a
+/// value-choice list or keyword list that **is** the flag's description
+/// (never break — pngfix's `--strip=[none|crc|unsafe|unused|...]:`
+/// and pod2man's `--guesswork=rule[,rule...]` both carry nothing on their
+/// own line; everything below, including any run that happens to look
+/// table-shaped, is the only description that flag will ever have).
+/// Breaking there does not mis-split, it deletes: `--strip` and
+/// `--guesswork` both lost their entire description this way before this
+/// gate existed, `--guesswork` also fabricating a bogus `choices` list from
+/// whatever the parser found past the wrongly-ended block.
+///
+/// # The rule
+///
+/// The entry row already has real description text of its own only when a
+/// conservative single-column split of that one line ([`split_single_column_entry`],
+/// the same split an ungated single-column block would use) yields a
+/// non-empty description. A row that instead looks multi-column-shaped
+/// ([`fields_in_line`] finds more than one field) is read conservatively as
+/// *not* having settled its description yet — this file's block-wide
+/// multi-column decision ([`block_is_multi_column`]) isn't available yet
+/// mid-scan, so a single-line probe here can't be trusted to say which
+/// field, if any, is real; refusing the break is always safe, since the
+/// worst case is the same as the pre-fix behaviour these two regressions
+/// need to keep.
+///
+/// Evaluated once per candidate continuation line from the *entry row's own
+/// text*, never from the continuation rows accumulated so far — so it gives
+/// the same answer at the first continuation line and at the fiftieth, and
+/// a description already underway can never be truncated part-way through.
+fn entry_row_carries_own_description(entry_line: &str) -> bool {
+    if fields_in_line(entry_line).len() > 1 {
+        return false;
+    }
+    let (_, desc) = split_single_column_entry(entry_line);
+    !desc.trim().is_empty()
 }
 
 /// The original (pre-multi-column) way to split one flags-block entry line:
@@ -4606,6 +4656,100 @@ Options for the main command only:
                 version.description
             );
         }
+    }
+
+    /// `pngfix --strip`'s shape (`corpus/pngfix/*/help.txt`): the flag row
+    /// carries **no inline description at all** — it just ends in `:` — and
+    /// everything below it, at one indent deeper, *is* that flag's
+    /// description: a value-choice list whose own rows wrap onto a second,
+    /// still-deeper physical line for the longer choices (`unsafe`,
+    /// `unused`). That wrap is what [`nested_entry_table_starts_at`] misreads
+    /// as table rows: two choices whose explanation happens to overflow onto
+    /// a deeper-indented continuation line is exactly the "row at `indent`
+    /// followed by something deeper" shape it looks for, even though this is
+    /// ordinary wrapped prose, not a nested command table. Before the entry-
+    /// row gate, the detector fired here too, breaking the flags block right
+    /// at the first continuation line and leaving `--strip` with **no
+    /// description at all** — the whole choice list, gone, not merely
+    /// mis-split. Since the entry row itself has nothing on its own line,
+    /// there is nowhere else for this text to go: the break must never
+    /// trigger when the row being continued is bare like this.
+    #[test]
+    fn value_choice_list_with_wrapped_entries_is_not_read_as_a_nested_table() {
+        let help = "\
+Usage: widget [options] file
+
+OPTIONS
+    --strip=[none|crc|unsafe|unused]:
+        none (default): Retain all chunks.
+        crc: Remove chunks with a bad CRC.
+        unsafe: Remove chunks that may be unsafe to retain if the image data
+                is modified. This is set automatically if --max is given.
+        unused: Remove chunks not used when decoding an image. This retains
+                any chunks that might be used by transformations.
+    --optimize (-o):
+        Find the smallest deflate window size for the compressed data.
+";
+        let parsed = parse(help);
+        let strip = flag_named(&parsed, "strip");
+        let desc = strip.description.as_ref().map_or("", |t| t.as_str());
+        assert!(
+            desc.contains("Retain all chunks"),
+            "--strip's own description must not be dropped: {desc:?}"
+        );
+        assert!(
+            desc.contains("Remove chunks not used"),
+            "--strip's own description must not be dropped: {desc:?}"
+        );
+    }
+
+    /// `pod2man --guesswork`'s shape (`corpus/pod2man/*/help.txt`): the flag
+    /// row also carries no inline description — an ordinary wrapped
+    /// paragraph follows, then (this is the part that trips the detector) a
+    /// genuine bare-word keyword list (`functions`, `manref`, `quoting`,
+    /// `variables`), each keyword followed by its own explanation one indent
+    /// deeper. That keyword list is real repetition, so
+    /// [`nested_entry_table_starts_at`] is right that *something* table-
+    /// shaped is down there — it is simply wrong that it's a *different*
+    /// entry's table rather than more of `--guesswork`'s own description.
+    /// Before the entry-row gate this broke the flags block at the very
+    /// first continuation line, so `--guesswork` lost its paragraph *and*
+    /// its keyword list both — its entire description, gone.
+    #[test]
+    fn guesswork_style_keyword_list_is_not_read_as_a_nested_table() {
+        let help = "\
+Usage: widget [options]
+
+Options:
+    --guesswork=rule[,rule...]
+        By default, widget applies some default formatting rules based on
+        guesswork. This option allows turning all or some of it off.
+
+        Otherwise, the value of this option should be a comma-separated
+        list of one or more of the following keywords:
+
+        functions
+            Convert function references like foo() to bold even if they
+            have no markup.
+
+        manref
+            Make the first part of man page references like foo(1) bold
+            even if they have no markup.
+
+    --help
+        Show this help.
+";
+        let parsed = parse(help);
+        let guesswork = flag_named(&parsed, "guesswork");
+        let desc = guesswork.description.as_ref().map_or("", |t| t.as_str());
+        assert!(
+            desc.contains("default formatting rules"),
+            "--guesswork's own description must not be dropped: {desc:?}"
+        );
+        assert!(
+            desc.contains("functions"),
+            "--guesswork's keyword list must not be dropped: {desc:?}"
+        );
     }
 
     /// `--quoting-style`'s valid arguments are introduced by a heading


### PR DESCRIPTION
## Mechanism

`scan_flags_block`'s continuation rule was pure indentation:

```rust
let is_continuation = !rows.is_empty() && min_entry_indent.is_some_and(|m| indent > m);
```

Any line deeper than the block's own entries continued the previous flag's description, whatever it actually was. `btrfs --help` puts `--help`/`--version` at indent 2 and then, after a blank line, a large command table at indent 4 whose rows each carry their own description one indent deeper (indent 8). The entire table — dozens of lines — folded into `--version`'s description as one run-on sentence.

This is the mirror image of the bare-block bug already fixed in this file, where `bare_block_end` learned to break on `looks_like_flag_start`. Same shape, opposite direction: there a flag row had to end a bare block; here a nested table has to end a flags block.

## Fix

Two pieces, both shape-based; no code condition names any tool (spec §1).

1. **`nested_entry_table_starts_at`** — from a candidate continuation line, look ahead for at least `MIN_NESTED_TABLE_ROWS` (2) *rows*: a non-blank line at exactly that indent, not `looks_like_flag_start`, immediately followed by a non-blank line indented deeper. Two such pairs is a table; one is prose (same reasoning as `scan_same_indent_entry_table`'s `MIN_ROWS`). On a match the flags block ends there. It **re-routes rather than drops** — the caller resumes its own scan at exactly that line — which is `bare_block_end`'s existing contract.

2. **`entry_row_carries_own_description`** — the gate that makes it safe. The break only fires when the flag row being continued *already carries its own description on its own line*. This is the discriminator between the two shapes that indentation alone cannot separate:

   - `btrfs`: `--version         print version string` already has its description inline, so the table below it is not that description → break.
   - `pngfix`: `--strip=[none|crc|unsafe|unused|transform|color|all]:` carries nothing on its own line; the value-choice list below **is** its description → never break.
   - `pod2man`: `--guesswork=rule[,rule...]` likewise, with its `functions`/`manref`/`quoting`/`variables` keyword list.

   The predicate reads the entry row's own text only, never accumulated continuation state, so it answers the same at the first continuation line and at the fiftieth — a description can never be truncated part-way through. A row that looks multi-column-shaped refuses the break (the block-wide multi-column decision is not available mid-scan, and refusing is always safe).

## Evidence

**Regression tests, each proven to fail first.** The btrfs shape:

```
assertion `left == right` failed: --version's description must not absorb the command table below it
  left: Some("print version string widget group one start Start the first task widget group one stop ...")
 right: Some("print version string")
```

and, against the ungated first draft of this branch, the two value-choice shapes:

```
--strip's own description must not be dropped: ""
--guesswork's own description must not be dropped: ""
```

**Corpus.** All 84 fixtures were blessed twice — once with pre-fix `main`'s parser, once with this branch's — and the two trees diffed file-by-file. **`btrfs/audit-seed2` is the only tree that changes.** Its diff is exactly the intended one:

```diff
 - long: version
-  description: print version string btrfs balance start [options] <path> Balance chunks across the devices btrfs balance pause <path> ...
+  description: print version string
-  confidence: 0.5
+  confidence: 0.09
```

The confidence drop is honest, not a regression: the inflated 0.5 came from counting that bogus mega-description as "described" text. btrfs genuinely has 7 flags and no recovered subcommands, and the UI now says so.

**Second affected tool — the one that could not be named.** A full-PATH sweep with the project's own `xtask coverage` harness (2,308 executables, both parsers, diffed with `xtask sweep-diff` *and* field-by-field because `sweep-diff`'s flag counts are too coarse to see description content) found the same shape in **`pngfix`** and **`pod2man`** — but as the *inverse* case: there the "table" is the flag's own description. The ungated first draft deleted `--strip`'s and `--guesswork`'s descriptions entirely, and `--guesswork` additionally fabricated a wrong `choices: [function, names, numbers]` list. That is what commit `41c9711`'s gate fixes. Both tools are now byte-identical to pre-fix `main`, confirmed three ways: the corpus double-bless above, `xtask corpus --show` diffs, and identical pty screenshots.

Two new fixtures, `corpus/pngfix/1.6.43` and `corpus/pod2man/5.01`, lock this in so the same over-reach cannot return.

## See it yourself

```console
$ cargo run --bin mandible -- btrfs
```

**Before** — scroll the detail pane to `OPTIONS FOR THE MAIN COMMAND ONLY`; `--version`'s description runs on for pages:

```
│   --version                                         │
│       print version string btrfs balance start      │
│       [options] <path> Balance chunks across the    │
│       devices btrfs balance pause <path> Pause      │
│       running balance btrfs balance cancel <path>   │
```

**After** — one line, and the status bar reports the tree's real confidence rather than an inflated one:

```
│   --version                                         │
│       print version string                          │
  ...                                    low confidence: 9% parsed
```

Then check the two tools the fix had to *not* break:

```console
$ cargo run --bin mandible -- pngfix     # --strip keeps its full choice list
$ cargo run --bin mandible -- pod2man    # --guesswork keeps its full description
```

Both render exactly as they did before this branch.

## Honest caveats

- **btrfs is only half fixed.** The command table is no longer glued to `--version`, but it is still not recovered as subcommands — the lines are dropped once the flags block correctly ends, the same as before. `min_subcommands` stays unmet and the fixture stays `[xfail]`, with its `meta.toml` reason rewritten to say exactly that. Recovering a headingless, synopsis-shaped command table is a separate and harder problem, deliberately not attempted here.
- **No `verdict_scope` is claimed** on any fixture in this PR. The blessed trees were read line-by-line against their raw captures — but by an agent, and `corpus/README.md` defines that field as the record of what *a human* reviewed. Adding it is a reviewer's call, not this branch's.
- The two new fixtures document a few pre-existing, unrelated quirks in their `meta.toml` (pngfix's `--max` folding into `--strip` because the raw capture itself glues those lines; a fabricated `choices` list on `--prefix`; two duplicate flag entries in pod2man from in-prose mentions) rather than hiding them. None are caused or changed by this PR.
- The PATH sweep showed one status transition, `ps: verbatim -> ok`, which reproduces on *both* parsers in isolated runs and is sweep flakiness unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
