### PR TITLE
audit(seed 5): record the draw before reviewing it

### DIFF
--- a/audit/5.toml
+++ b/audit/5.toml
@@ -1,0 +1,208 @@
+[meta]
+seed = 5
+sample_size = 30
+
+[[entry]]
+tool = "aarch64-linux-gnu-ar"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "aarch64-linux-gnu-gcc-ar"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "applydeltarpm"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "ar"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "autoupdate"
+stratum = "ok"
+
+[[entry]]
+tool = "btrfs-find-root"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "byobu-config"
+stratum = "verbatim"
+
+[[entry]]
+tool = "bzcmp"
+stratum = "ok"
+
+[[entry]]
+tool = "bzless"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "bzmore"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "c_rehash"
+stratum = "verbatim"
+
+[[entry]]
+tool = "dbiprof"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "debconf-escape"
+stratum = "ok"
+
+[[entry]]
+tool = "diffstat"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "ebtables-nft-restore"
+stratum = "ok"
+
+[[entry]]
+tool = "egrep"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "faillock"
+stratum = "ok"
+
+[[entry]]
+tool = "gcc-ar"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "gcc-ar-13"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "ip"
+stratum = "ok"
+k1 = true
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "ischroot"
+stratum = "ok"
+
+[[entry]]
+tool = "jsondiff"
+stratum = "ok"
+
+[[entry]]
+tool = "linux32"
+stratum = "ok"
+
+[[entry]]
+tool = "lldb-argdumper-18"
+stratum = "verbatim"
+
+[[entry]]
+tool = "mariadb-fix-extensions"
+stratum = "ok"
+
+[[entry]]
+tool = "mount.ntfs-3g"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "msgexec"
+stratum = "ok"
+
+[[entry]]
+tool = "nice"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "pastebinit"
+stratum = "ok"
+k1 = true
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "pdb3.12"
+stratum = "low-confidence"
+k1 = true
+
+[[entry]]
+tool = "pptpsetup"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "printenv"
+stratum = "ok"
+
+[[entry]]
+tool = "ptargrep"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "rmiregistry"
+stratum = "ok"
+k1 = true
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "rmt-tar"
+stratum = "ok"
+
+[[entry]]
+tool = "rnano"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "rubycalls-bpfcc"
+stratum = "verbatim"
+
+[[entry]]
+tool = "rust-lldb"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "setkeycodes"
+stratum = "ok"
+
+[[entry]]
+tool = "setleds"
+stratum = "ok"
+
+[[entry]]
+tool = "sos-collector"
+stratum = "ok"
+
+[[entry]]
+tool = "ssh-keygen"
+stratum = "ok"
+k1 = true
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
+
+[[entry]]
+tool = "uconv"
+stratum = "ok"
+k1 = true
+
+[[entry]]
+tool = "update-xmlcatalog"
+stratum = "ok"
+include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"

--- a/audit/queue.toml
+++ b/audit/queue.toml
@@ -2,7 +2,7 @@
 freeze_date = "2026-08-14"
 population_hash = "9818ac066f23868a"
 seed = 3
-cursor = 0
+cursor = 30
 
 [[entry]]
 tool = "bzcmp"
@@ -4598,7 +4598,7 @@ stratum = "ok"
 
 [[entry]]
 tool = "git-lfs"
-stratum = "suspicious"
+stratum = "low-confidence"
 
 [[entry]]
 tool = "killall5"
@@ -6082,7 +6082,7 @@ stratum = "ok"
 
 [[entry]]
 tool = "oomkill-bpfcc"
-stratum = "verbatim"
+stratum = "no-tier"
 
 [[entry]]
 tool = "sgm_dd"
@@ -8918,7 +8918,7 @@ stratum = "ok"
 
 [[entry]]
 tool = "mdflush-bpfcc"
-stratum = "verbatim"
+stratum = "no-tier"
 
 [[entry]]
 tool = "systemd-cgls"
@@ -9070,7 +9070,7 @@ stratum = "ok"
 
 [[entry]]
 tool = "bitesize-bpfcc"
-stratum = "verbatim"
+stratum = "no-tier"
 
 [[entry]]
 tool = "statsnoop.bt"


### PR DESCRIPTION
The frozen queue's first honest-number draw, committed **before any verdict is recorded**.

That ordering is the point. A sample that can still be redrawn after its first few verdicts look bad is not a measurement — and the queue exists because the tools we fixed cannot be the tools we score (re-scoring those measures the fix, not the parser).

## The draw

`reclassify --update` ran first, so the draw stratifies against the *current* parser rather than the one frozen on 2026-08-14. **4 of 2,299 tools moved stratum:**

| tool(s) | transition | what it is |
|---|---|---|
| `git-lfs` | suspicious → low-confidence | a real improvement, on 24 KB of real help text |
| `oomkill-bpfcc`, `mdflush-bpfcc`, `bitesize-bpfcc` | verbatim → no-tier | **zero-byte captures** — they timed out at freeze; this is a relabelling of empty input, not a parse change |

Then 30 tools at cursor `0 → 30`: 25 `ok`, 4 `verbatim`, 1 `low-confidence` — tracking the population's own 82.7 / 13.5 / 2.6 split.

## Test-retest, and its honest limit

Plus the 14 unconditional force-includes (commit `3464b0c`'s unaudited `low-confidence → ok` promotions). All 14 already carry a seed-4 verdict, so they double as [M-20]'s test-retest pairs; `rubycalls-bpfcc` and `rust-lldb` repeat from seed 4 as well, for **16 retest pairs**.

They are **not a random repeat set** — 14 of the 16 are a specific promoted cohort. Any reliability figure computed from them has to say so.

**28 of the 44 have never been reviewed by anyone.**

## What happens next

`audit/5/` holds the emitted review pairs (raw `--help` beside the parsed tree) and stays untracked, matching `audit/4/`. Review is human work by definition — an agent verdict here would measure the parser against itself.

```
cargo run -p xtask -- audit review --seed 5        # interactive, saves after every tool
cargo run -p xtask -- audit report --seed 5        # counts + confidence intervals, never a bare %
```

## Caveats

- No verdicts are recorded here. This PR is the draw and nothing else.
- The 82.7% `ok` population share is a parse-*status* distribution, not an accuracy claim; status is what the parser says about itself.
- Measured on one aarch64 Linux box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJWGGJ4FTA41EYRQ6W5zUm