### PR TITLE
audit(seed 5): the honest number — 58.1% [43.3%, 71.6%]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,65 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **A flag is now associated with the description prose it owns in two
+  shapes the grammar used to drop it in.** Both are cases where the text was
+  sitting right there in the tool's own `--help` output and never reached the
+  flag it belongs to.
+
+  The first is **a description written one space after the spec**, which is
+  what a long flag name does to a fixed-width option table: the name overruns
+  the description column and the formatter emits a single space instead of
+  the padding it can no longer supply. `find_description_gap` found no column,
+  the whole line went to the flag grammar as the spec, and its ` VALUE` arm
+  took the first word of the prose as a `value_name` and discarded the rest —
+  `--md5 Control MD5 generation` became `--md5` valued `Control`, with "MD5
+  generation" gone from the tree entirely. `find_sentence_start_gap` is a
+  sibling of the existing `find_placeholder_boundary_gap` under the same
+  precondition (consulted only when no 2+-space column exists anywhere in the
+  line, so no already-working split can move), and it is deliberately narrow
+  because the inverse case is the whole risk: the candidate word must be an
+  initial capital followed by nothing but lowercase, must have at least one
+  more word after it, and the scan stops at the first token that is neither
+  that nor value-shaped. `PATH`, `7|8|9|10|11`, `<manifest-path>` and a
+  lowercase metavar followed by a capitalized word deeper in the line all
+  keep parsing as values, each with its own test.
+
+  The second is **a description written as a flush-left prose paragraph
+  naming the option**, the way `jdeprscan` documents all eight of its
+  options ("The --for-removal option limits scanning or listing to APIs
+  that are deprecated for removal."): its `options:` block has no
+  description column at all, so it measured 8 flags, 0.0% with text.
+  `backfill_prose_paragraph_descriptions` is a third pass over the assembled
+  flag list, alongside the two flag repairs already there. It never creates
+  a flag (a paragraph naming an option the table does not list — like
+  `apt-ftparchive`'s `--source-override` — cannot fabricate one) and never
+  overwrites a description the table already supplied (`apropos` describes
+  `--regex` in both places; the table wins). A sentence *indented under*
+  another flag's row is that row's continuation text and is never lifted out.
+
+  Measured on a full `PATH` sweep of this box: 94.64% → 95.54% of flags carry
+  text across 2,308 tools, 97 tools changed, and every other counter in the
+  scoreboard is byte-identical (no-tier, suspicious, verbatim, man-shaped,
+  ok-with-zero-flags, misattribution, existence-fabrication, bundle-collapse,
+  framework detection). Five tools moved `low-confidence` → `ok`; none moved
+  down. In the corpus, `curl/8.5.0-all` alone gains 59 descriptions, each
+  replacing a fabricated `value_name`.
+
+- **`pair_aliases` no longer unifies two rows that disagree about taking a
+  value.** Recovering `ld`/`gold`'s real descriptions made two genuinely
+  separate options collide on one shared sentence —
+  `--allow-multiple-definition Allow multiple definitions of symbols` and
+  `-z muldefs  Allow multiple definitions of symbols` — and pairing them
+  destroyed one of the two while giving the survivor
+  `--allow-multiple-definition muldefs`, a value neither row documents.
+  Measured on the same sweep: 7 tools, 1 flag each, and the only losses in
+  it. Pairing now also requires the two rows to agree about taking a value at
+  all; coarse on purpose (`ValueKind` only, never the placeholder's
+  spelling), since a source may legitimately name the metavar on one row and
+  not the other. Same failure shape as the `lto-dump` incident the
+  single-dash exclusion already documents: a description common enough to
+  collide.
+
 - **`xtask sweep-diff` now diffs each tool's flags, choices, and subcommands
   by content, not just by count.** During PR #14 the same run that deleted
   `pngfix`'s and `pod2man`'s flag descriptions and fabricated a choices list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,13 +110,24 @@ once it reaches a published 0.1.0 release.
   `--regex` in both places; the table wins). A sentence *indented under*
   another flag's row is that row's continuation text and is never lifted out.
 
+  A third case came out of reviewing the sweep field by field, and is the
+  reason the boundary is not simply "the first sentence-shaped word":
+  `mariadb`'s `--init-command=name SQL Command to execute ...` split after
+  `SQL`, and since the spec already had its `=name` value (first value wins)
+  nothing ever read `SQL` back out and the word was dropped. A spec carrying
+  its own inline value cannot take another one, so the boundary is now fixed
+  at that token and every word after it is description, value-shaped or not.
+
   Measured on a full `PATH` sweep of this box: 94.64% → 95.54% of flags carry
-  text across 2,308 tools, 97 tools changed, and every other counter in the
+  text across 2,308 tools, 101 tools changed, and every other counter in the
   scoreboard is byte-identical (no-tier, suspicious, verbatim, man-shaped,
   ok-with-zero-flags, misattribution, existence-fabrication, bundle-collapse,
   framework detection). Five tools moved `low-confidence` → `ok`; none moved
-  down. In the corpus, `curl/8.5.0-all` alone gains 59 descriptions, each
-  replacing a fabricated `value_name`.
+  down. **Zero flags lost fleet-wide**; 7 tools gained one each, every one of
+  them a false alias merge coming apart (below). Every changed field on all
+  101 tools was checked against the tool's own frozen `--help` capture. In
+  the corpus, `curl/8.5.0-all` alone gains 59 descriptions, each replacing a
+  fabricated `value_name`.
 
 - **`pair_aliases` no longer unifies two rows that disagree about taking a
   value.** Recovering `ld`/`gold`'s real descriptions made two genuinely
@@ -126,7 +137,11 @@ once it reaches a published 0.1.0 release.
   destroyed one of the two while giving the survivor
   `--allow-multiple-definition muldefs`, a value neither row documents.
   Measured on the same sweep: 7 tools, 1 flag each, and the only losses in
-  it. Pairing now also requires the two rows to agree about taking a value at
+  it. Narrowing it also un-did three false merges that predate this branch,
+  each two unrelated options sharing one sentence: `as`'s `-w` absorbed into
+  `--hash-size=<N>` (both "ignored"), `lto-dump`'s `--help` absorbed into
+  `-Waggressive-loop-optimizations` (both "[enabled]"), and `gold`'s `-z defs`
+  absorbed into `--no-undefined`. Pairing now also requires the two rows to agree about taking a value at
   all; coarse on purpose (`ValueKind` only, never the placeholder's
   spelling), since a source may legitimately name the metavar on one row and
   not the other. Same failure shape as the `lto-dump` incident the

--- a/audit/5-report.txt
+++ b/audit/5-report.txt
@@ -1,0 +1,42 @@
+audit seed=5 sample_size=30 (44 entries total)
+
+stratum             correct/judged   accuracy   95% CI            skipped   pending   out-of-scope
+forced-inclusion        2/14      14.3%   [  4.0%,  39.9%]         0         0              0
+low-confidence          1/1       100.0%   [ 20.7%, 100.0%]         0         0              0
+ok                     20/25      80.0%   [ 60.9%,  91.1%]         0         0              0
+verbatim                2/3       66.7%   [ 20.8%,  93.9%]         1         0              0
+OVERALL                25/43      58.1%   [ 43.3%,  71.6%]         1         0              0
+
+note: the 95% CI above bounds sampling error only — how much this sample's accuracy could plausibly vary on a fresh draw of the same size — never reviewer error. Read the accuracy figure as "accuracy of the parser as judged by this reviewer," not an absolute truth.
+note: no verdict in this file has been amended yet (`xtask audit amend`) — this says nothing about whether the recorded verdicts are all correct, only that none has been corrected so far.
+
+K1/K2/K3 sensitivity (15 entries tagged K1, 0 entries tagged K2, 0 entries tagged K3 — see mandible_core::audit's Entry::k1/k2/k3 doc comments and this module's *_signature functions):
+view                      correct/judged   accuracy   95% CI
+all-inclusive                25/43      58.1%   [ 43.3%,  71.6%]
+K1-excluded                  16/28      57.1%   [ 39.1%,  73.5%]
+K2-excluded                  25/43      58.1%   [ 43.3%,  71.6%]
+K3-excluded                  25/43      58.1%   [ 43.3%,  71.6%]
+K1+K2+K3-excluded            16/28      57.1%   [ 39.1%,  73.5%]
+
+tools judged wrong or incomplete (the next bugs):
+  aarch64-linux-gnu-ar     incomplete  subcommands and flags are fine. but still marking as incomplete because lacks modifiers
+  aarch64-linux-gnu-gcc-ar incomplete  similar command as previous
+  ar                       incomplete  same modifier/arch audit
+  bzless                   wrong       failed to parse anything
+  bzmore                   wrong       failed to parse anything
+  c_rehash                 wrong       this tool uses -h instead of --help
+  dbiprof                  wrong       i thought we have fixed this issue, where a single dash + long flag name is given. parse failed miserably, see why the previous fix not applied to this
+  gcc-ar                   incomplete  same modifier incompleteness
+  gcc-ar-13                incomplete  same modifier incompleteness
+  ip                       wrong       similar issue appeared in the previous audit where single and long flag was presented together, example: -V[ersion]
+  jsondiff                 incomplete  missing possitionals, simplest example
+  pastebinit               wrong       bad flag descriptions and false positive flag types
+  pptpsetup                incomplete  some of the flags got parsed as description, and not all of the flags are present
+  rnano                    wrong       three column layout where 1st is short flag, 2nd is long flag, and 3rd is description
+  setleds                  incomplete  i think incomplete, the line from usage is not displayed and im not sure how: [[{+|-}num | caps | scroll]] which roughly translates to [{+|-}num] [{+|-}caps] [{+|-}scroll] which in turn means that you can add + or - before those flags. I think bracket resolution might help
+  ssh-keygen               incomplete  some of the types after flags got swallowed
+  uconv                    wrong       since the flag '-h' was in front of 'Options:' it got swallowed into the section header
+  update-xmlcatalog        wrong       ok so since the flags '--verbose' and '--sort' got parsed from earlier part of the help, like usage. it got deduplicated and never got parsed from lower 'options' section, thus losing the descriptions ofthem and appearing empty
+
+tools skipped (1 — recorded, never omitted; excluded from every accuracy figure above, so this is the list that makes that exclusion checkable):
+  rubycalls-bpfcc          (no reason recorded)

--- a/audit/5.toml
+++ b/audit/5.toml
@@ -5,204 +5,266 @@ sample_size = 30
 [[entry]]
 tool = "aarch64-linux-gnu-ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "subcommands and flags are fine. but still marking as incomplete because lacks modifiers"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "aarch64-linux-gnu-gcc-ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "similar command as previous"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "applydeltarpm"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "same modifier/arch audit"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "autoupdate"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "btrfs-find-root"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "byobu-config"
 stratum = "verbatim"
+verdict = "correct"
 
 [[entry]]
 tool = "bzcmp"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "bzless"
 stratum = "ok"
+verdict = "wrong"
+note = "failed to parse anything"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "bzmore"
 stratum = "ok"
+verdict = "wrong"
+note = "failed to parse anything"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "c_rehash"
 stratum = "verbatim"
+verdict = "wrong"
+note = "this tool uses -h instead of --help"
 
 [[entry]]
 tool = "dbiprof"
 stratum = "ok"
+verdict = "wrong"
+note = "i thought we have fixed this issue, where a single dash + long flag name is given. parse failed miserably, see why the previous fix not applied to this"
 k1 = true
 
 [[entry]]
 tool = "debconf-escape"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "diffstat"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "ebtables-nft-restore"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "egrep"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "faillock"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "gcc-ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "same modifier incompleteness"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "gcc-ar-13"
 stratum = "ok"
+verdict = "incomplete"
+note = "same modifier incompleteness"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "ip"
 stratum = "ok"
+verdict = "wrong"
+note = "similar issue appeared in the previous audit where single and long flag was presented together, example: -V[ersion]"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "ischroot"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "jsondiff"
 stratum = "ok"
+verdict = "incomplete"
+note = "missing possitionals, simplest example"
 
 [[entry]]
 tool = "linux32"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "lldb-argdumper-18"
 stratum = "verbatim"
+verdict = "correct"
 
 [[entry]]
 tool = "mariadb-fix-extensions"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "mount.ntfs-3g"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "msgexec"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "nice"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "pastebinit"
 stratum = "ok"
+verdict = "wrong"
+note = "bad flag descriptions and false positive flag types"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "pdb3.12"
 stratum = "low-confidence"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "pptpsetup"
 stratum = "ok"
+verdict = "incomplete"
+note = "some of the flags got parsed as description, and not all of the flags are present"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "printenv"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "ptargrep"
 stratum = "ok"
+verdict = "correct"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "rmiregistry"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "rmt-tar"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "rnano"
 stratum = "ok"
+verdict = "wrong"
+note = "three column layout where 1st is short flag, 2nd is long flag, and 3rd is description"
 k1 = true
 
 [[entry]]
 tool = "rubycalls-bpfcc"
 stratum = "verbatim"
+verdict = "skip"
 
 [[entry]]
 tool = "rust-lldb"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "setkeycodes"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "setleds"
 stratum = "ok"
+verdict = "incomplete"
+note = "i think incomplete, the line from usage is not displayed and im not sure how: [[{+|-}num | caps | scroll]] which roughly translates to [{+|-}num] [{+|-}caps] [{+|-}scroll] which in turn means that you can add + or - before those flags. I think bracket resolution might help"
 
 [[entry]]
 tool = "sos-collector"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "ssh-keygen"
 stratum = "ok"
+verdict = "incomplete"
+note = "some of the types after flags got swallowed"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "uconv"
 stratum = "ok"
+verdict = "wrong"
+note = "since the flag '-h' was in front of 'Options:' it got swallowed into the section header"
 k1 = true
 
 [[entry]]
 tool = "update-xmlcatalog"
 stratum = "ok"
+verdict = "wrong"
+note = "ok so since the flags '--verbose' and '--sort' got parsed from earlier part of the help, like usage. it got deduplicated and never got parsed from lower 'options' section, thus losing the descriptions ofthem and appearing empty"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"

--- a/corpus/aarch64-linux-gnu-gcc-nm-13/audit-seed2/expected.snap
+++ b/corpus/aarch64-linux-gnu-gcc-nm-13/audit-seed2/expected.snap
@@ -45,9 +45,8 @@ flags:
     sources:
     - help-text
 - long: no-recurse-limit
-  value_name: Disable
-  value_kind: Required
   group: 'The options are:'
+  description: Disable a demangling recursion limit.
   provenance:
     sources:
     - help-text

--- a/corpus/apt-ftparchive/audit-seed2/expected.snap
+++ b/corpus/apt-ftparchive/audit-seed2/expected.snap
@@ -1,0 +1,63 @@
+name: apt-ftparchive
+description: 'apt 2.8.3 (arm64) Commands: packages binarypath [overridefile [pathprefix]]'
+usage:
+- 'Usage: apt-ftparchive [options] command'
+flags:
+- short: 'h'
+  description: This help text
+  provenance:
+    sources:
+    - help-text
+- long: md5
+  description: Control MD5 generation
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  value_name: '?'
+  value_kind: Required
+  description: Source override file
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  description: Quiet
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  value_name: '?'
+  value_kind: Required
+  description: Select the optional caching database
+  provenance:
+    sources:
+    - help-text
+- long: no-delink
+  description: Enable delinking debug mode
+  provenance:
+    sources:
+    - help-text
+- long: contents
+  description: Control contents file generation
+  provenance:
+    sources:
+    - help-text
+- short: 'c'
+  value_name: '?'
+  value_kind: Required
+  description: Read this configuration file
+  provenance:
+    sources:
+    - help-text
+- short: 'o'
+  value_name: '?'
+  value_kind: Required
+  description: Set an arbitrary configuration option
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/apt-ftparchive/audit-seed2/meta.toml
+++ b/corpus/apt-ftparchive/audit-seed2/meta.toml
@@ -25,4 +25,12 @@ min_subcommands = 1
 
 [xfail]
 broken = true
+# Still broken, and for the reason above only: the "Commands:" block.
+# The *descriptions* are fixed — `--md5 Control MD5 generation` and
+# `--no-delink Enable delinking debug mode` write their description one
+# space after the spec, and used to be read as `value_name: Control` /
+# `value_name: Enable` with the rest of the sentence discarded
+# (`find_sentence_start_gap`). `expected.snap` is committed while `[xfail]`
+# so that gain cannot silently regress before the commands bug is fixed and
+# this fixture is promoted.
 reason = "missing commands, I can see in help text, but not parsed"

--- a/corpus/curl/8.5.0-all/expected.snap
+++ b/corpus/curl/8.5.0-all/expected.snap
@@ -73,8 +73,7 @@ flags:
     sources:
     - help-text
 - long: cert-status
-  value_name: Verify
-  value_kind: Required
+  description: Verify the status of the server cert via OCSP-staple
   provenance:
     sources:
     - help-text
@@ -98,8 +97,7 @@ flags:
     sources:
     - help-text
 - long: compressed-ssh
-  value_name: Enable
-  value_kind: Required
+  description: Enable SSH compression
   provenance:
     sources:
     - help-text
@@ -150,8 +148,7 @@ flags:
     sources:
     - help-text
 - long: create-dirs
-  value_name: Create
-  value_kind: Required
+  description: Create necessary local directory hierarchy
   provenance:
     sources:
     - help-text
@@ -236,20 +233,17 @@ flags:
     sources:
     - help-text
 - long: disable-eprt
-  value_name: Inhibit
-  value_kind: Required
+  description: Inhibit using EPRT or LPRT
   provenance:
     sources:
     - help-text
 - long: disable-epsv
-  value_name: Inhibit
-  value_kind: Required
+  description: Inhibit using EPSV
   provenance:
     sources:
     - help-text
 - long: disallow-username-in-url
-  value_name: Disallow
-  value_kind: Required
+  description: Disallow username in URL
   provenance:
     sources:
     - help-text
@@ -282,14 +276,12 @@ flags:
     sources:
     - help-text
 - long: doh-cert-status
-  value_name: Verify
-  value_kind: Required
+  description: Verify the status of the DoH server cert via OCSP-staple
   provenance:
     sources:
     - help-text
 - long: doh-insecure
-  value_name: Allow
-  value_kind: Required
+  description: Allow insecure DoH server connections
   provenance:
     sources:
     - help-text
@@ -355,14 +347,12 @@ flags:
     sources:
     - help-text
 - long: fail-with-body
-  value_name: Fail
-  value_kind: Required
+  description: Fail on HTTP errors but save the body
   provenance:
     sources:
     - help-text
 - long: false-start
-  value_name: Enable
-  value_kind: Required
+  description: Enable TLS False Start
   provenance:
     sources:
     - help-text
@@ -375,8 +365,7 @@ flags:
     sources:
     - help-text
 - long: form-escape
-  value_name: Escape
-  value_kind: Required
+  description: Escape multipart form field/file names using backslash
   provenance:
     sources:
     - help-text
@@ -402,8 +391,7 @@ flags:
     sources:
     - help-text
 - long: ftp-create-dirs
-  value_name: Create
-  value_kind: Required
+  description: Create the remote dirs if not present
   provenance:
     sources:
     - help-text
@@ -433,14 +421,12 @@ flags:
     sources:
     - help-text
 - long: ftp-skip-pasv-ip
-  value_name: Skip
-  value_kind: Required
+  description: Skip the IP address for PASV
   provenance:
     sources:
     - help-text
 - long: ftp-ssl-ccc
-  value_name: Send
-  value_kind: Required
+  description: Send CCC after authenticating
   provenance:
     sources:
     - help-text
@@ -452,8 +438,7 @@ flags:
     sources:
     - help-text
 - long: ftp-ssl-control
-  value_name: Require
-  value_kind: Required
+  description: Require SSL/TLS for FTP login, clear for transfer
   provenance:
     sources:
     - help-text
@@ -477,14 +462,12 @@ flags:
     sources:
     - help-text
 - long: haproxy-clientip
-  value_name: Sets
-  value_kind: Required
+  description: Sets client IP in HAProxy PROXY protocol v1 header
   provenance:
     sources:
     - help-text
 - long: haproxy-protocol
-  value_name: Send
-  value_kind: Required
+  description: Send HAProxy PROXY protocol v1 header
   provenance:
     sources:
     - help-text
@@ -559,8 +542,7 @@ flags:
     sources:
     - help-text
 - long: http2-prior-knowledge
-  value_name: Use
-  value_kind: Required
+  description: Use HTTP 2 without HTTP/1.1 Upgrade
   provenance:
     sources:
     - help-text
@@ -575,8 +557,7 @@ flags:
     sources:
     - help-text
 - long: ignore-content-length
-  value_name: Ignore
-  value_kind: Required
+  description: Ignore the size of the remote resource
   provenance:
     sources:
     - help-text
@@ -627,8 +608,7 @@ flags:
     - help-text
 - short: 'j'
   long: junk-session-cookies
-  value_name: Ignore
-  value_kind: Required
+  description: Ignore session cookies read from file
   provenance:
     sources:
     - help-text
@@ -694,8 +674,7 @@ flags:
     sources:
     - help-text
 - long: location-trusted
-  value_name: Like
-  value_kind: Required
+  description: Like --location, and send auth to other hosts
   provenance:
     sources:
     - help-text
@@ -728,8 +707,7 @@ flags:
     sources:
     - help-text
 - long: mail-rcpt-allowfails
-  value_name: Allow
-  value_kind: Required
+  description: Allow RCPT TO command to fail for some recipients
   provenance:
     sources:
     - help-text
@@ -785,8 +763,7 @@ flags:
     sources:
     - help-text
 - long: netrc-optional
-  value_name: Use
-  value_kind: Required
+  description: Use either .netrc or URL
   provenance:
     sources:
     - help-text
@@ -813,8 +790,7 @@ flags:
     sources:
     - help-text
 - long: no-keepalive
-  value_name: Disable
-  value_kind: Required
+  description: Disable TCP keepalive on the connection
   provenance:
     sources:
     - help-text
@@ -824,14 +800,12 @@ flags:
     sources:
     - help-text
 - long: no-progress-meter
-  value_name: Do
-  value_kind: Required
+  description: Do not show the progress meter
   provenance:
     sources:
     - help-text
 - long: no-sessionid
-  value_name: Disable
-  value_kind: Required
+  description: Disable SSL session-ID reusing
   provenance:
     sources:
     - help-text
@@ -881,8 +855,7 @@ flags:
     sources:
     - help-text
 - long: parallel-immediate
-  value_name: Do
-  value_kind: Required
+  description: Do not wait for multiplexing (with --parallel)
   provenance:
     sources:
     - help-text
@@ -936,8 +909,7 @@ flags:
     - help-text
 - short: '#'
   long: progress-bar
-  value_name: Display
-  value_kind: Required
+  description: Display transfer progress as a bar
   provenance:
     sources:
     - help-text
@@ -971,20 +943,17 @@ flags:
     sources:
     - help-text
 - long: proxy-anyauth
-  value_name: Pick
-  value_kind: Required
+  description: Pick any proxy authentication method
   provenance:
     sources:
     - help-text
 - long: proxy-basic
-  value_name: Use
-  value_kind: Required
+  description: Use Basic authentication on the proxy
   provenance:
     sources:
     - help-text
 - long: proxy-ca-native
-  value_name: Use
-  value_kind: Required
+  description: Use CA certificates from the native OS for proxy
   provenance:
     sources:
     - help-text
@@ -1031,8 +1000,7 @@ flags:
     sources:
     - help-text
 - long: proxy-digest
-  value_name: Use
-  value_kind: Required
+  description: Use Digest authentication on the proxy
   provenance:
     sources:
     - help-text
@@ -1044,14 +1012,12 @@ flags:
     sources:
     - help-text
 - long: proxy-http2
-  value_name: Use
-  value_kind: Required
+  description: Use HTTP/2 with HTTPS proxy
   provenance:
     sources:
     - help-text
 - long: proxy-insecure
-  value_name: Do
-  value_kind: Required
+  description: Do HTTPS proxy connections without verifying the proxy
   provenance:
     sources:
     - help-text
@@ -1070,8 +1036,7 @@ flags:
     sources:
     - help-text
 - long: proxy-negotiate
-  value_name: Use
-  value_kind: Required
+  description: Use HTTP Negotiate (SPNEGO) authentication on the proxy
   provenance:
     sources:
     - help-text
@@ -1102,14 +1067,12 @@ flags:
     sources:
     - help-text
 - long: proxy-ssl-allow-beast
-  value_name: Allow
-  value_kind: Required
+  description: Allow security flaw for interop for HTTPS proxy
   provenance:
     sources:
     - help-text
 - long: proxy-ssl-auto-client-cert
-  value_name: Use
-  value_kind: Required
+  description: Use auto client certificate for proxy (Schannel)
   provenance:
     sources:
     - help-text
@@ -1142,8 +1105,7 @@ flags:
     sources:
     - help-text
 - long: proxy-tlsv1
-  value_name: Use
-  value_kind: Required
+  description: Use TLSv1 for HTTPS proxy
   provenance:
     sources:
     - help-text
@@ -1164,8 +1126,7 @@ flags:
     - help-text
 - short: 'p'
   long: proxytunnel
-  value_name: Operate
-  value_kind: Required
+  description: Operate through an HTTP proxy tunnel (using CONNECT)
   provenance:
     sources:
     - help-text
@@ -1221,34 +1182,29 @@ flags:
     - help-text
 - short: 'J'
   long: remote-header-name
-  value_name: Use
-  value_kind: Required
+  description: Use the header-provided filename
   provenance:
     sources:
     - help-text
 - short: 'O'
   long: remote-name
-  value_name: Write
-  value_kind: Required
+  description: Write output to a file named as the remote file
   provenance:
     sources:
     - help-text
 - long: remote-name-all
-  value_name: Use
-  value_kind: Required
+  description: Use the remote file name for all URLs
   provenance:
     sources:
     - help-text
 - short: 'R'
   long: remote-time
-  value_name: Set
-  value_kind: Required
+  description: Set the remote file's time on the local output
   provenance:
     sources:
     - help-text
 - long: remove-on-error
-  value_name: Remove
-  value_kind: Required
+  description: Remove output file on errors
   provenance:
     sources:
     - help-text
@@ -1282,14 +1238,12 @@ flags:
     sources:
     - help-text
 - long: retry-all-errors
-  value_name: Retry
-  value_kind: Required
+  description: Retry all errors (use with --retry)
   provenance:
     sources:
     - help-text
 - long: retry-connrefused
-  value_name: Retry
-  value_kind: Required
+  description: Retry on connection refused (use with --retry)
   provenance:
     sources:
     - help-text
@@ -1360,20 +1314,17 @@ flags:
     sources:
     - help-text
 - long: socks5-basic
-  value_name: Enable
-  value_kind: Required
+  description: Enable username/password auth for SOCKS5 proxies
   provenance:
     sources:
     - help-text
 - long: socks5-gssapi
-  value_name: Enable
-  value_kind: Required
+  description: Enable GSS-API auth for SOCKS5 proxies
   provenance:
     sources:
     - help-text
 - long: socks5-gssapi-nec
-  value_name: Compatibility
-  value_kind: Required
+  description: Compatibility with NEC SOCKS5 server
   provenance:
     sources:
     - help-text
@@ -1413,20 +1364,17 @@ flags:
     sources:
     - help-text
 - long: ssl-allow-beast
-  value_name: Allow
-  value_kind: Required
+  description: Allow security flaw to improve interop
   provenance:
     sources:
     - help-text
 - long: ssl-auto-client-cert
-  value_name: Use
-  value_kind: Required
+  description: Use auto client certificate (Schannel)
   provenance:
     sources:
     - help-text
 - long: ssl-no-revoke
-  value_name: Disable
-  value_kind: Required
+  description: Disable cert revocation checks (Schannel)
   provenance:
     sources:
     - help-text
@@ -1436,8 +1384,7 @@ flags:
     sources:
     - help-text
 - long: ssl-revoke-best-effort
-  value_name: Ignore
-  value_kind: Required
+  description: Ignore missing/offline cert CRL dist points (Schannel)
   provenance:
     sources:
     - help-text
@@ -1461,26 +1408,22 @@ flags:
     sources:
     - help-text
 - long: styled-output
-  value_name: Enable
-  value_kind: Required
+  description: Enable styled output for HTTP headers
   provenance:
     sources:
     - help-text
 - long: suppress-connect-headers
-  value_name: Suppress
-  value_kind: Required
+  description: Suppress proxy CONNECT response headers
   provenance:
     sources:
     - help-text
 - long: tcp-fastopen
-  value_name: Use
-  value_kind: Required
+  description: Use TCP Fast Open
   provenance:
     sources:
     - help-text
 - long: tcp-nodelay
-  value_name: Use
-  value_kind: Required
+  description: Use the TCP_NODELAY option
   provenance:
     sources:
     - help-text
@@ -1500,8 +1443,7 @@ flags:
     sources:
     - help-text
 - long: tftp-no-options
-  value_name: Do
-  value_kind: Required
+  description: Do not send any TFTP options
   provenance:
     sources:
     - help-text
@@ -1583,8 +1525,7 @@ flags:
     sources:
     - help-text
 - long: tr-encoding
-  value_name: Request
-  value_kind: Required
+  description: Request compressed transfer encoding
   provenance:
     sources:
     - help-text

--- a/corpus/gcc/13.3.0/expected.snap
+++ b/corpus/gcc/13.3.0/expected.snap
@@ -102,6 +102,7 @@ flags:
     - help-text
 - long: print-multi-os-directory
   single_dash: true
+  description: Display the relative path to OS libraries.
   provenance:
     sources:
     - help-text
@@ -113,6 +114,7 @@ flags:
     - help-text
 - long: print-sysroot-headers-suffix
   single_dash: true
+  description: Display the sysroot suffix used to find headers.
   provenance:
     sources:
     - help-text

--- a/corpus/jdeprscan/audit-seed2/expected.snap
+++ b/corpus/jdeprscan/audit-seed2/expected.snap
@@ -1,0 +1,54 @@
+name: jdeprscan
+usage:
+- 'Usage: jdeprscan [options] {dir|jar|class} ...'
+flags:
+- long: class-path
+  value_name: PATH
+  value_kind: Required
+  description: The --class-path option provides a search path for resolution of dependent classes.
+  provenance:
+    sources:
+    - help-text
+- long: for-removal
+  description: The --for-removal option limits scanning or listing to APIs that are deprecated for removal. Cannot be used with a release value of 6, 7, or 8.
+  provenance:
+    sources:
+    - help-text
+- long: full-version
+  description: The --full-version option prints out the full version string of the tool.
+  provenance:
+    sources:
+    - help-text
+- short: '?'
+  long: help
+  description: The --help (-? -h) option prints out a full help message.
+  provenance:
+    sources:
+    - help-text
+- short: 'l'
+  description: The --list (-l) option prints out the set of deprecated APIs. No scanning is done, so no directory, jar, or class arguments should be provided.
+  provenance:
+    sources:
+    - help-text
+- long: release
+  value_name: 7|8|9|10|11|12|13|14|15|16|17
+  value_kind: Required
+  description: The --release option specifies the Java SE release that provides the set of deprecated APIs for scanning.
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  description: The --verbose (-v) option enables additional message output during processing.
+  provenance:
+    sources:
+    - help-text
+- long: version
+  description: The --version option prints out the abbreviated version string of the tool.
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/jdeprscan/audit-seed2/meta.toml
+++ b/corpus/jdeprscan/audit-seed2/meta.toml
@@ -26,4 +26,12 @@ must_contain_flags = ["-h", "--list", "--verbose"]
 
 [xfail]
 broken = true
+# Still broken, and for the reason above only: the alias columns.
+# The *descriptions* this fixture also lacked are fixed — jdeprscan writes
+# every option's prose as its own flush-left paragraph ("The --for-removal
+# option limits ...") rather than in a description column, and
+# `backfill_prose_paragraph_descriptions` now associates the two. All 8
+# flags carry their own text in `expected.snap`, which is committed while
+# `[xfail]` precisely so that gain cannot silently regress before the alias
+# bug is fixed and this fixture is promoted.
 reason = "flags are not properly matched together, or missing"

--- a/corpus/mariadb-repair/audit-seed4/expected.snap
+++ b/corpus/mariadb-repair/audit-seed4/expected.snap
@@ -30,14 +30,13 @@ flags:
 - long: defaults-group-suffix
   value_name: '#'
   value_kind: Required
+  description: 'Additionally read default groups with # appended as a suffix.'
   provenance:
     sources:
     - help-text
 - short: 'A'
   long: all-databases
-  value_name: Check
-  value_kind: Required
-  description: with all databases selected.
+  description: Check all the databases. This is the same as --databases with all databases selected.
   provenance:
     sources:
     - help-text
@@ -79,9 +78,7 @@ flags:
     - help-text
 - short: 'g'
   long: check-upgrade
-  value_name: Check
-  value_kind: Required
-  description: with --auto-repair to correct tables requiring version-dependent updates.
+  description: Check tables for version-dependent changes. May be used with --auto-repair to correct tables requiring version-dependent updates.
   provenance:
     sources:
     - help-text
@@ -124,6 +121,7 @@ flags:
 - long: default-auth
   value_name: name
   value_kind: Required
+  description: Default authentication client-side plugin to use.
   provenance:
     sources:
     - help-text

--- a/corpus/mariadbcheck/audit-seed4/expected.snap
+++ b/corpus/mariadbcheck/audit-seed4/expected.snap
@@ -30,14 +30,13 @@ flags:
 - long: defaults-group-suffix
   value_name: '#'
   value_kind: Required
+  description: 'Additionally read default groups with # appended as a suffix.'
   provenance:
     sources:
     - help-text
 - short: 'A'
   long: all-databases
-  value_name: Check
-  value_kind: Required
-  description: with all databases selected.
+  description: Check all the databases. This is the same as --databases with all databases selected.
   provenance:
     sources:
     - help-text
@@ -79,9 +78,7 @@ flags:
     - help-text
 - short: 'g'
   long: check-upgrade
-  value_name: Check
-  value_kind: Required
-  description: with --auto-repair to correct tables requiring version-dependent updates.
+  description: Check tables for version-dependent changes. May be used with --auto-repair to correct tables requiring version-dependent updates.
   provenance:
     sources:
     - help-text
@@ -124,6 +121,7 @@ flags:
 - long: default-auth
   value_name: name
   value_kind: Required
+  description: Default authentication client-side plugin to use.
   provenance:
     sources:
     - help-text

--- a/corpus/rust-lldb/audit-seed2/expected.snap
+++ b/corpus/rust-lldb/audit-seed2/expected.snap
@@ -336,9 +336,8 @@ flags:
     sources:
     - help-text
 - long: python-path
-  value_name: Prints
-  value_kind: Required
   group: 'SCRIPTING:'
+  description: Prints out the path to the lldb.py file for this version of lldb.
   provenance:
     sources:
     - help-text

--- a/mandible-core/src/merge.rs
+++ b/mandible-core/src/merge.rs
@@ -473,7 +473,10 @@ pub fn pair_aliases(flags: Vec<Flag>) -> Vec<Flag> {
             continue;
         }
         for existing in result.iter_mut() {
-            if complementary(existing, &flag) && same_description(existing, &flag) {
+            if complementary(existing, &flag)
+                && same_description(existing, &flag)
+                && same_value_shape(existing, &flag)
+            {
                 absorb_pair(existing, flag);
                 continue 'outer;
             }
@@ -502,6 +505,34 @@ fn complementary(a: &Flag, b: &Flag) -> bool {
     }
     (a.short.is_some() && a.long.is_none() && b.short.is_none() && b.long.is_some())
         || (a.long.is_some() && a.short.is_none() && b.long.is_none() && b.short.is_some())
+}
+
+/// Whether `a` and `b` agree about *taking a value at all* — the second
+/// half of "these two rows are one flag", alongside [`same_description`].
+///
+/// A source that emits one flag as two rows emits the same value spec on
+/// both; two rows that disagree about it are two different options that
+/// happen to share a summary line. `ld` and `gold` are the specimen, and
+/// they are the same failure shape as the `lto-dump` incident
+/// [`complementary`] documents — a description common enough to collide:
+///
+/// ```text
+///   --allow-multiple-definition Allow multiple definitions of symbols
+///   -z muldefs                  Allow multiple definitions of symbols
+/// ```
+///
+/// Two real, separately spelled options with one shared sentence. Pairing
+/// them destroys one of the two and gives the survivor a value
+/// (`--allow-multiple-definition muldefs`) that neither row documents.
+/// Measured on a full `PATH` sweep: 7 tools, 1 flag each, and the only
+/// losses in the sweep that found it.
+///
+/// Deliberately coarse — [`ValueKind`] only, never the placeholder's
+/// spelling. A source may legitimately name the metavar on one row and not
+/// the other (`-R` beside `--repo <string>`), and requiring those to match
+/// would un-pair the aliases this function exists to let through.
+fn same_value_shape(a: &Flag, b: &Flag) -> bool {
+    a.value_kind == b.value_kind
 }
 
 fn same_description(a: &Flag, b: &Flag) -> bool {
@@ -535,6 +566,7 @@ fn absorb_pair(existing: &mut Flag, other: Flag) {
 mod tests {
     use super::*;
     use crate::provenance::Source;
+    use crate::node::ValueKind;
 
     fn node_from(source: Source, name: &str) -> CommandNode {
         CommandNode::new(name, Provenance::single(source))
@@ -704,6 +736,46 @@ mod tests {
         assert_eq!(paired.len(), 1);
         assert_eq!(paired[0].short, Some('R'));
         assert_eq!(paired[0].long.as_deref(), Some("repo"));
+    }
+
+    /// Two rows that disagree about taking a value are two different
+    /// options that happen to share a summary line, not one flag emitted
+    /// twice. `ld`/`gold` write exactly that:
+    ///
+    /// ```text
+    ///   --allow-multiple-definition Allow multiple definitions of symbols
+    ///   -z muldefs                  Allow multiple definitions of symbols
+    /// ```
+    ///
+    /// Paired, one of the two is destroyed and the survivor claims
+    /// `--allow-multiple-definition muldefs`, a value neither row
+    /// documents. Found by `sweep-diff` on a full `PATH` sweep — 7 tools,
+    /// 1 flag each, and the only losses in it.
+    #[test]
+    fn does_not_pair_two_rows_that_disagree_about_taking_a_value() {
+        let long = paired_flag(
+            None,
+            Some("allow-multiple-definition"),
+            "Allow multiple definitions of symbols",
+        );
+        let mut short = paired_flag(Some('z'), None, "Allow multiple definitions of symbols");
+        short.value_name = Some("muldefs".to_string());
+        short.value_kind = ValueKind::Required;
+        let paired = pair_aliases(vec![long, short]);
+        assert_eq!(
+            paired.len(),
+            2,
+            "both options must survive: {:?}",
+            paired.iter().map(|f| f.spelling()).collect::<Vec<_>>()
+        );
+        assert!(
+            paired
+                .iter()
+                .any(|f| f.long.as_deref() == Some("allow-multiple-definition")
+                    && f.short.is_none()
+                    && f.value_kind == ValueKind::None),
+            "the long form takes no value: {paired:?}"
+        );
     }
 
     /// A single-dash long option has no short alias to be paired with —

--- a/mandible-core/src/merge.rs
+++ b/mandible-core/src/merge.rs
@@ -565,8 +565,8 @@ fn absorb_pair(existing: &mut Flag, other: Flag) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provenance::Source;
     use crate::node::ValueKind;
+    use crate::provenance::Source;
 
     fn node_from(source: Source, name: &str) -> CommandNode {
         CommandNode::new(name, Provenance::single(source))

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -3380,6 +3380,15 @@ fn find_sentence_start_gap(line: &str) -> Option<usize> {
     let mut i = 0usize;
     let mut token_count = 0usize;
     let mut previous_token_end: Option<usize> = None;
+    // A spec that already carries its own value (`--init-command=name`,
+    // `--color[=WHEN]`) cannot take another one, so the boundary is fixed
+    // at that first token and every word after it is description — even a
+    // value-shaped one. Without this, `mariadb`'s
+    // `--init-command=name SQL Command to execute ...` splits after `SQL`
+    // instead, and the word "SQL" is dropped from the tree: the spec keeps
+    // its `=name` value (first value wins) and nothing ever reads `SQL`
+    // back out. Never discard a word the tool wrote.
+    let mut spec_is_closed = false;
     while i < bytes.len() {
         if bytes[i] == b' ' || bytes[i] == b'\t' {
             i += 1;
@@ -3403,8 +3412,14 @@ fn find_sentence_start_gap(line: &str) -> Option<usize> {
             if !is_value_spec_token(token) {
                 return None;
             }
+        } else {
+            spec_is_closed = token.contains('=') || token.contains('[');
         }
-        previous_token_end = Some(i);
+        // The spelling run's own token always sets the boundary; a closed
+        // spec then freezes it there.
+        if token_count == 0 || !spec_is_closed {
+            previous_token_end = Some(i);
+        }
         token_count += 1;
     }
     None
@@ -6331,6 +6346,29 @@ Options:
         // A lone capitalized trailing token is ambiguous and keeps the
         // pre-existing value reading — one word is not a sentence.
         assert_eq!(by_long("quiet").value_name.as_deref(), Some("Quiet"));
+    }
+
+    /// A spec that already carries its own value cannot take another one,
+    /// so nothing between it and the sentence may be swallowed as a second
+    /// value name and then discarded. Real `mariadb --help`:
+    /// `--init-command=name SQL Command to execute ...` must keep the word
+    /// "SQL", which the spec has no room for and which nothing downstream
+    /// would ever read back out.
+    #[test]
+    fn a_self_valued_spec_keeps_every_word_of_its_description() {
+        let help = "Usage: mariadb [OPTIONS]\n\nOptions:\n  \
+                    --init-command=name SQL Command to execute when connecting to server.\n";
+        let parsed = parse(help);
+        let flag = parsed
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("init-command"))
+            .expect("--init-command must be recovered");
+        assert_eq!(flag.value_name.as_deref(), Some("name"));
+        assert_eq!(
+            flag.description.as_ref().map(|d| d.as_str()),
+            Some("SQL Command to execute when connecting to server.")
+        );
     }
 
     /// `jdeprscan --help` documents every option in its own flush-left

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -3392,9 +3392,7 @@ fn find_sentence_start_gap(line: &str) -> Option<usize> {
         // `start` and `i` only ever land on ASCII space/tab boundaries or
         // the ends of the string, so neither can fall inside a multi-byte
         // character — `get` rather than `[..]` regardless (AGENTS.md §2).
-        let Some(token) = line.get(start..i) else {
-            return None;
-        };
+        let token = line.get(start..i)?;
         if token_count > 0 {
             let more_words_follow = line
                 .get(i..)

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -6244,6 +6244,210 @@ Options:
         );
     }
 
+    /// A description one space after the spec, with no placeholder to key
+    /// off of — the shape a long flag name forces on a fixed-width table
+    /// when the name overruns the description column. Real
+    /// `apt-ftparchive --help`: `--md5` used to arrive carrying
+    /// `value_name: Control`, with the words "MD5 generation" discarded
+    /// from the tree entirely.
+    #[test]
+    fn a_sentence_one_space_after_the_spec_is_a_description_not_a_value() {
+        let help = "Usage: apt-ftparchive [options] command\n\nOptions:\n  \
+                    -h    This help text\n  \
+                    --md5 Control MD5 generation\n  \
+                    --no-delink Enable delinking debug mode\n  \
+                    --contents  Control contents file generation\n";
+        let parsed = parse(help);
+        let by_long = |name: &str| {
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.long.as_deref() == Some(name))
+                .unwrap_or_else(|| panic!("--{name} must be recovered"))
+        };
+        for (name, text) in [
+            ("md5", "Control MD5 generation"),
+            ("no-delink", "Enable delinking debug mode"),
+        ] {
+            let flag = by_long(name);
+            assert_eq!(
+                flag.description.as_ref().map(|d| d.as_str()),
+                Some(text),
+                "--{name}"
+            );
+            assert_eq!(flag.value_name, None, "--{name} takes no value");
+            assert_eq!(flag.value_kind, ValueKind::None, "--{name} takes no value");
+        }
+        // The already-working padded rows must be untouched.
+        assert_eq!(
+            by_long("contents").description.as_ref().map(|d| d.as_str()),
+            Some("Control contents file generation")
+        );
+        assert_eq!(
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.short == Some('h'))
+                .and_then(|f| f.description.as_ref())
+                .map(|d| d.as_str()),
+            Some("This help text")
+        );
+    }
+
+    /// The inverse case, and the reason the predicate is what it is: a
+    /// genuine ` VALUE` spec must keep parsing as a value. Every shape
+    /// here is a real one this project already gets right —
+    /// `jdeprscan`'s uppercase `PATH` and pipe-alternation
+    /// `7|8|9|…`, `cargo-fmt`'s `<manifest-path>` — plus a lowercase
+    /// metavar followed by a capitalized word deeper in the line, which
+    /// must not be split at that word.
+    #[test]
+    fn a_real_value_placeholder_is_never_read_as_a_description() {
+        let help = "Usage: tool [options]\n\nOptions:\n  \
+                    --class-path PATH\n  \
+                    --release 7|8|9|10|11\n  \
+                    --manifest-path <manifest-path>\n  \
+                    --opt value do a Thing here\n  \
+                    --quiet Quiet\n";
+        let parsed = parse(help);
+        let by_long = |name: &str| {
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.long.as_deref() == Some(name))
+                .unwrap_or_else(|| panic!("--{name} must be recovered"))
+        };
+        for (name, value) in [
+            ("class-path", "PATH"),
+            ("release", "7|8|9|10|11"),
+            ("manifest-path", "<manifest-path>"),
+        ] {
+            let flag = by_long(name);
+            assert_eq!(flag.value_name.as_deref(), Some(value), "--{name}");
+            assert_eq!(flag.description, None, "--{name} has no description");
+        }
+        // A lowercase metavar ends the scan: no split may happen at the
+        // capitalized `Thing` three words later.
+        assert_eq!(by_long("opt").value_name.as_deref(), Some("value"));
+        assert_eq!(by_long("opt").description, None);
+        // A lone capitalized trailing token is ambiguous and keeps the
+        // pre-existing value reading — one word is not a sentence.
+        assert_eq!(by_long("quiet").value_name.as_deref(), Some("Quiet"));
+    }
+
+    /// `jdeprscan --help` documents every option in its own flush-left
+    /// prose paragraph, and its `options:` table has no description column
+    /// at all: 8 flags, 0.0% with text before this. The paragraph names the
+    /// option it documents, so the two can be associated.
+    ///
+    /// `--list` is the load-bearing case: the table row `-l    --list`
+    /// loses its long spelling to a separate, still-unfixed bug, so the
+    /// only way to reach that flag is the `(-l)` in the paragraph's own
+    /// parenthetical.
+    #[test]
+    fn a_prose_paragraph_naming_an_option_supplies_its_description() {
+        let help = "Usage: jdeprscan [options] {dir|jar|class} ...\n\
+                    \n\
+                    options:\n        \
+                    --for-removal\n  \
+                    -l    --list\n\
+                    \n\
+                    Scans each argument for usages of deprecated APIs.\n\
+                    \n\
+                    The --for-removal option limits scanning or listing to APIs that are\n\
+                    deprecated for removal.\n\
+                    \n\
+                    The --list (-l) option prints out the set of deprecated APIs.\n";
+        let parsed = parse(help);
+        assert_eq!(
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.long.as_deref() == Some("for-removal"))
+                .and_then(|f| f.description.as_ref())
+                .map(|d| d.as_str()),
+            Some(
+                "The --for-removal option limits scanning or listing to APIs that are \
+                 deprecated for removal."
+            )
+        );
+        assert_eq!(
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.short == Some('l'))
+                .and_then(|f| f.description.as_ref())
+                .map(|d| d.as_str()),
+            Some("The --list (-l) option prints out the set of deprecated APIs.")
+        );
+    }
+
+    /// The backfill's two hard limits, which are what bound its cost:
+    /// it may never invent a flag, and it may never overwrite a
+    /// description the table itself supplied.
+    ///
+    /// Both cases are real. `apt-ftparchive`'s prose mentions
+    /// `--source-override`, an option its table never lists; `apropos`
+    /// describes `--regex` in its own table *and* mentions it in a
+    /// trailing paragraph.
+    #[test]
+    fn the_prose_backfill_never_invents_a_flag_or_overwrites_a_description() {
+        let help = "Usage: tool [options]\n\
+                    \n\
+                    Options:\n  \
+                    -r, --regex                interpret each keyword as a regex\n\
+                    \n\
+                    The --regex option is enabled by default.\n\
+                    \n\
+                    The --source-override option can be used to specify a src override file\n";
+        let parsed = parse(help);
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("source-override")),
+            "a paragraph must never create a flag: {:?}",
+            parsed.flags
+        );
+        assert_eq!(
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.long.as_deref() == Some("regex"))
+                .and_then(|f| f.description.as_ref())
+                .map(|d| d.as_str()),
+            Some("interpret each keyword as a regex"),
+            "the table's own description must win"
+        );
+    }
+
+    /// A "The --x option ..." sentence *indented under another flag's row*
+    /// is that flag's continuation text, not a standalone paragraph — so
+    /// it must never be lifted out and attached to `--x`. Real shape:
+    /// `java`, `jdeps` and `rg` all write such sentences inside a
+    /// description column.
+    #[test]
+    fn an_indented_sentence_is_continuation_text_not_a_prose_paragraph() {
+        let help = "Usage: tool [options]\n\
+                    \n\
+                    Options:\n      \
+                    --dry-run\n      \
+                    --validate-modules   Validate all modules.\n                  \
+                    The --dry-run option may be useful for validating the\n                  \
+                    command line.\n";
+        let parsed = parse(help);
+        assert_eq!(
+            parsed
+                .flags
+                .iter()
+                .find(|f| f.long.as_deref() == Some("dry-run"))
+                .map(|f| f.description.is_none()),
+            Some(true),
+            "an indented sentence belongs to the row above it: {:?}",
+            parsed.flags
+        );
+    }
+
     /// The fallback must never fire when an ordinary aligned gap already
     /// exists — it is consulted only when [`find_multi_space_gap`] finds
     /// nothing anywhere in the line, so a `>`/`]` that happens to sit

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -861,6 +861,10 @@ pub fn parse_with_profile(
     // the fixes as well. The explicit condition-6 check below is kept
     // anyway, so the disjointness does not rest on the call order.
     repair_single_dash_long_options(&mut result.flags, raw);
+    // Third pass of the same kind, and last because it can only fill what
+    // the two above have finished naming: descriptions that the document
+    // wrote as free prose paragraphs instead of as option-table columns.
+    backfill_prose_paragraph_descriptions(&mut result.flags, &lines);
 
     result.confidence = compute_confidence(total_entries, clean_entries, !result.usage.is_empty());
     result
@@ -3308,7 +3312,162 @@ fn find_description_gap(line: &str) -> Option<usize> {
     }
     // Only ever consulted when the rule above found nothing anywhere in
     // the line — see `find_placeholder_boundary_gap`'s own doc comment.
-    find_placeholder_boundary_gap(line)
+    if let Some(col) = find_placeholder_boundary_gap(line) {
+        return Some(col);
+    }
+    // Same "no aligned column anywhere" precondition, one shape further
+    // out: no placeholder either, just a sentence. See
+    // `find_sentence_start_gap`.
+    find_sentence_start_gap(line)
+}
+
+/// Second fallback for a flag row with no aligned column at all: the
+/// description simply starts one space after the spec, and it is
+/// recognizable because it starts an **English sentence** rather than
+/// naming a value.
+///
+/// The shape is what a long flag name does to a fixed-width option table —
+/// the name overruns the description column, and the formatter emits one
+/// space instead of the padding it can no longer supply:
+///
+/// ```text
+///   --md5 Control MD5 generation                    (apt-ftparchive)
+///   --no-delink Enable delinking debug mode         (apt-ftparchive)
+///   --allow-multiple-definition Allow multiple definitions of symbols   (ld)
+///   -print-multi-os-directory Display the relative path to OS libraries (gcc)
+/// ```
+///
+/// Without this, `find_description_gap` returns `None`, the *whole line*
+/// is handed to `grammar::parse_flag_spec` as the spec, and its
+/// ` VALUE` arm takes the first word of the prose as a `value_name` and
+/// **discards the rest of the sentence** — `--md5` acquires the value
+/// `Control` and the words "MD5 generation" are lost from the tree
+/// entirely. Measured on `apt-ftparchive --help`: 9 flags, 2 of them
+/// carrying another flag's job in their `value_name` and no description.
+///
+/// **Only ever consulted when both gap-finders above found nothing
+/// anywhere in the line**, exactly as [`find_placeholder_boundary_gap`]
+/// is, so no already-working split can move — this only recovers text
+/// that would otherwise be dropped.
+///
+/// The predicate is deliberately narrow, because the inverse case is the
+/// whole risk: ` VALUE` is a real and common shape (`--class-path PATH`,
+/// `--release 7|8|9|…|17`, `--manifest-path <manifest-path>`), and reading
+/// a value name as prose would delete a real field. Three conditions, all
+/// required:
+///
+/// 1. The line starts with a flag (`-`). Bare-word blocks — subcommand
+///    tables, enum-value lists — never reach this at all.
+/// 2. The candidate token [`starts_a_sentence`]: an initial ASCII
+///    uppercase letter followed by nothing but ASCII lowercase ones
+///    (`Control`, `Enable`, `Display`). Every value placeholder shape this
+///    project has measured fails that test — `PATH` and `MD5` are all-caps,
+///    `<path>` and `[=WHEN]` are bracketed, `7|8|9` is punctuated.
+/// 3. At least one more word follows it, so a lone trailing token
+///    (`-v Verbose`, `--md5 Control`) is still read as a value. A single
+///    word is genuinely ambiguous and stays with the pre-existing reading.
+///
+/// Scanning stops at the first token that is neither sentence-shaped nor
+/// [`is_value_spec_token`] — so a *lowercase* metavar ends the search
+/// rather than letting a capitalized word deeper in the line become a
+/// false boundary (`--opt value do a Thing here` splits nowhere, instead
+/// of splitting before `Thing`).
+fn find_sentence_start_gap(line: &str) -> Option<usize> {
+    if !line.trim_start().starts_with('-') {
+        return None;
+    }
+    let bytes = line.as_bytes();
+    let mut i = 0usize;
+    let mut token_count = 0usize;
+    let mut previous_token_end: Option<usize> = None;
+    while i < bytes.len() {
+        if bytes[i] == b' ' || bytes[i] == b'\t' {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < bytes.len() && bytes[i] != b' ' && bytes[i] != b'\t' {
+            i += 1;
+        }
+        // `start` and `i` only ever land on ASCII space/tab boundaries or
+        // the ends of the string, so neither can fall inside a multi-byte
+        // character — `get` rather than `[..]` regardless (AGENTS.md §2).
+        let Some(token) = line.get(start..i) else {
+            return None;
+        };
+        if token_count > 0 {
+            let more_words_follow = line
+                .get(i..)
+                .is_some_and(|rest| rest.split_whitespace().next().is_some());
+            if more_words_follow && starts_a_sentence(token) {
+                return previous_token_end;
+            }
+            if !is_value_spec_token(token) {
+                return None;
+            }
+        }
+        previous_token_end = Some(i);
+        token_count += 1;
+    }
+    None
+}
+
+/// True if `token` reads as the first word of an English sentence rather
+/// than as a value placeholder: an ASCII uppercase letter followed by at
+/// least one, and nothing but, ASCII lowercase letters.
+///
+/// Checked against every distinct occurrence of the shape in this box's
+/// 2,301 captured `--help` documents: all 108 of them are verbs
+/// (`Use`, `Do`, `Disable`, `Allow`, `Print`, `Enable`, `Display`, …) and
+/// none is a metavar. All-caps (`PATH`), mixed (`MD5`, `IPv6`) and
+/// punctuated (`7|8|9`) tokens are excluded by construction.
+fn starts_a_sentence(token: &str) -> bool {
+    let mut chars = token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_uppercase() {
+        return false;
+    }
+    let mut saw_rest = false;
+    for c in chars {
+        if !c.is_ascii_lowercase() {
+            return false;
+        }
+        saw_rest = true;
+    }
+    saw_rest
+}
+
+/// True if `token` can plausibly still be part of a flag *spec* rather
+/// than of its description — used by [`find_sentence_start_gap`] to decide
+/// how far it may keep looking for a sentence boundary.
+///
+/// Anything that names a spelling, a placeholder, or a metavar qualifies:
+/// a leading `-`, any notation punctuation, a digit or a `-`/`_`/`.`
+/// inside the word, or an all-caps run. A bare all-lowercase alphabetic
+/// word does *not* — that is where the scan stops, which is what keeps a
+/// capitalized word in the middle of a description from being mistaken for
+/// its start.
+fn is_value_spec_token(token: &str) -> bool {
+    if token.starts_with('-') {
+        return true;
+    }
+    if token.chars().any(|c| {
+        matches!(
+            c,
+            '<' | '>' | '[' | ']' | '{' | '}' | '(' | ')' | '=' | '|' | ',' | '/' | ':'
+        )
+    }) {
+        return true;
+    }
+    if token
+        .chars()
+        .any(|c| c.is_ascii_digit() || c == '-' || c == '_' || c == '.')
+    {
+        return true;
+    }
+    token.chars().all(|c| c.is_ascii_uppercase())
 }
 
 /// The fewest consecutive spaces that separate a row's columns rather than
@@ -3957,6 +4116,188 @@ fn split_top_level_pipe(content: &str) -> Vec<&str> {
     out.push(content[start..].trim());
     out.retain(|s| !s.is_empty());
     out
+}
+
+/// The largest indent at which a line may still be read as flush-left
+/// document prose rather than as part of some block's own body.
+///
+/// Prose paragraphs that document an option are written at the document's
+/// own margin; the same sentence *indented under an option row* is that
+/// option's continuation text, and already belongs to whichever flag the
+/// row named. Keeping the two apart is the whole reason this is a bound
+/// and not simply "any line": `java`, `jdeps` and `rg` all write
+/// "The --x option …" sentences deep inside another flag's description
+/// column, and reading those as standalone paragraphs would attach one
+/// flag's prose to a different flag.
+const MAX_PROSE_PARAGRAPH_INDENT: usize = 3;
+
+/// Fill in descriptions a document wrote as **prose paragraphs keyed by
+/// option name**, rather than as text in the option table's own
+/// description column.
+///
+/// `jdeprscan --help` is the specimen. Its `options:` block is a bare list
+/// of spellings with no description column at all, and every option's
+/// prose lives further down the document in its own flush-left paragraph:
+///
+/// ```text
+/// options:
+///         --for-removal
+///   -l    --list
+/// …
+/// The --for-removal option limits scanning or listing to APIs that are
+/// deprecated for removal. Cannot be used with a release value of 6, 7, or 8.
+///
+/// The --list (-l) option prints out the set of deprecated APIs. No scanning is done,
+/// so no directory, jar, or class arguments should be provided.
+/// ```
+///
+/// The table parses correctly — the spellings are all recovered — and then
+/// every description is dropped on the floor, because nothing in the
+/// grammar ever revisits a flag with text found later in the document
+/// (measured: 8 flags, 0.0% with text). This is that revisit, and it is a
+/// pass over the assembled flag list for the same reason
+/// [`repair_repeated_character_flags`] and
+/// [`repair_single_dash_long_options`] are: the question it answers needs
+/// the whole node's flags, so it cannot be answered at the row that
+/// produced any one of them.
+///
+/// Shape-keyed, never tool-keyed (spec §1). A paragraph qualifies when:
+///
+/// 1. Every one of its lines sits at indent ≤ [`MAX_PROSE_PARAGRAPH_INDENT`]
+///    and none of them starts with `-`, so an option table's own rows and
+///    an option's indented continuation text can never be read as one.
+/// 2. Its first line opens `The <spelling> option …` — an article, one
+///    option spelling, an optional parenthesised alias list, then the word
+///    `option`, `flag` or `switch`. That is a *reference* to an option, the
+///    one form in which running prose names one unambiguously.
+///
+/// Two invariants bound what this can cost, and both matter more than the
+/// recall it gives up:
+///
+/// - **It never creates a flag.** A spelling that names nothing already in
+///   `flags` is ignored, so a paragraph mentioning an option the tool did
+///   not table (`apt-ftparchive`'s `--source-override`) cannot fabricate
+///   one — the invention class spec §7 Tier B forbids.
+/// - **It never overwrites a description.** Only a flag whose description
+///   is `None` can be filled, so a table that already said something keeps
+///   saying it (`apropos`'s `--regex` is described in its own table *and*
+///   mentioned in a trailing paragraph; the table wins, untouched).
+///
+/// Matching is by *any* spelling the reference names, primary or
+/// parenthesised, which is what makes it independent of how well the table
+/// row parsed: jdeprscan's `-l    --list` row yields a flag with
+/// `short: 'l'` and no long name at all, and `The --list (-l) option …`
+/// still finds it through the `-l` in the parenthetical.
+fn backfill_prose_paragraph_descriptions(flags: &mut [Flag], lines: &[&str]) {
+    if flags.is_empty() {
+        return;
+    }
+    let mut i = 0usize;
+    while i < lines.len() {
+        if lines[i].trim().is_empty() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < lines.len() && !lines[i].trim().is_empty() {
+            i += 1;
+        }
+        let paragraph = &lines[start..i];
+        if !paragraph.iter().all(|l| {
+            leading_whitespace(l) <= MAX_PROSE_PARAGRAPH_INDENT && !l.trim_start().starts_with('-')
+        }) {
+            continue;
+        }
+        let Some(spellings) = prose_option_reference(paragraph[0]) else {
+            continue;
+        };
+        let text = paragraph
+            .iter()
+            .map(|l| l.trim())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let Some(description) = non_empty_text(&text) else {
+            continue;
+        };
+        for flag in flags.iter_mut() {
+            if flag.description.is_some() {
+                continue;
+            }
+            if spellings.iter().any(|s| flag_answers_to_spelling(flag, s)) {
+                flag.description = Some(description.clone());
+                break;
+            }
+        }
+    }
+}
+
+/// Every option spelling named by a paragraph-opening option *reference* —
+/// `The --list (-l) option …` → `["--list", "-l"]` — or `None` when the
+/// line does not open with one.
+///
+/// Grammar, all of it required and in this order: an optional article
+/// (`The`/`A`/`An`), one dash-led spelling, an optional parenthesised list
+/// of further dash-led spellings, then the literal word `option`, `flag` or
+/// `switch`. The trailing noun is what distinguishes a reference from a
+/// sentence that merely happens to start with a flag-shaped token, and the
+/// leading article keeps it clear of an option *table* row, which starts
+/// with the spelling itself.
+fn prose_option_reference(line: &str) -> Option<Vec<String>> {
+    let mut words = line.split_whitespace().peekable();
+    let first = words.peek()?;
+    if matches!(*first, "The" | "A" | "An" | "the" | "a" | "an") {
+        words.next();
+    }
+    let primary = words.next()?;
+    if !primary.starts_with('-') || primary.len() < 2 {
+        return None;
+    }
+    let mut spellings = vec![primary.to_string()];
+    // An optional parenthesised alias list: `(-? -h)`, `(-l)`.
+    if words.peek().is_some_and(|w| w.starts_with('(')) {
+        let mut closed = false;
+        for word in words.by_ref() {
+            let inner = word.trim_start_matches('(').trim_end_matches(')');
+            if inner.starts_with('-') && inner.len() >= 2 {
+                spellings.push(inner.to_string());
+            }
+            if word.ends_with(')') {
+                closed = true;
+                break;
+            }
+        }
+        if !closed {
+            return None;
+        }
+    }
+    let noun = words.next()?;
+    if !matches!(noun, "option" | "flag" | "switch") {
+        return None;
+    }
+    Some(spellings)
+}
+
+/// True if `flag` is the flag `spelling` names — `--list` against its
+/// `long`, `-l` against its `short`, and a single-dash long option
+/// (`-print-sysroot`) against its `long` when [`Flag::single_dash`] says
+/// that is how the tool spells it.
+fn flag_answers_to_spelling(flag: &Flag, spelling: &str) -> bool {
+    if let Some(long) = spelling.strip_prefix("--") {
+        return !long.is_empty() && flag.long.as_deref() == Some(long) && !flag.single_dash;
+    }
+    let Some(rest) = spelling.strip_prefix('-') else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    let mut chars = rest.chars();
+    if let (Some(c), None) = (chars.next(), chars.next()) {
+        if flag.short == Some(c) {
+            return true;
+        }
+    }
+    flag.single_dash && flag.long.as_deref() == Some(rest)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The frozen queue's first honest number. Reviewed in the TUI (`mandible --review 5`), 43 judged, 1 skipped.

## Headline

| stratum | correct/judged | accuracy | 95% CI |
|---|---|---|---|
| ok | 20/25 | 80.0% | [60.9%, 91.1%] |
| verbatim | 2/3 | 66.7% | [20.8%, 93.9%] |
| low-confidence | 1/1 | 100.0% | [20.7%, 100.0%] |
| **forced-inclusion** | **2/14** | **14.3%** | **[4.0%, 39.9%]** |
| **OVERALL** | **25/43** | **58.1%** | **[43.3%, 71.6%]** |

## The finding the headline hides

**The forced-inclusion cohort scores 2 of 14.** Those are commit `3464b0c`'s fleet-wide `low-confidence → ok` promotions — minted by a heuristic that shipped unreviewed during a declared grammar freeze. They were force-included precisely so a random draw could not miss them, and **twelve of the fourteen are not `ok`**.

Compare against the `ok` stratum's own 80.0%: this was not a small overreach, and it is the single largest drag on the overall figure. The overall 58.1% is therefore *not* a like-for-like successor to seed 4's 62.4% — this sample deliberately over-weights a known-bad cohort.

## Test-retest: 11/16 exact, 13/16 correct-vs-not

Sixteen tools carry a seed-4 verdict too. Five disagree, and the direction matters:

| tool | seed 4 | seed 5 |
|---|---|---|
| pastebinit | correct | wrong |
| update-xmlcatalog | correct | wrong |
| ssh-keygen | correct | incomplete |
| bzmore | skip | wrong |
| pptpsetup | wrong | incomplete |

**Four of five moved stricter.** So part of the 62.4% → 58.1% gap is a reviewer applying a harsher standard, not a parser that regressed — and no CI in this report accounts for reviewer drift, only sampling error. The repeat set is also 14/16 the promoted cohort rather than a random draw, so treat 68.8% as a floor-ish indication, not a reliability coefficient.

## What this buys

Eighteen tools judged `wrong`/`incomplete`, and they group into a small number of shapes rather than eighteen separate bugs — the next fix queue, with the reviewer's own words attached. The largest single group is the `ar` modifiers family (5 tools); the most alarming is `update-xmlcatalog`, where flags parsed from the usage line deduplicate against the same flags in the options section and the *described* copy loses, which is a merge-precedence bug and not a grammar one.

## Caveats

- Accuracy is "as judged by this reviewer", never absolute truth.
- No verdict has been amended; that says nothing about whether all verdicts are right.
- One aarch64 Linux box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJWGGJ4FTA41EYRQ6W5zUm