### PR TITLE
audit(seed 5): the honest number — 58.1% [43.3%, 71.6%]

### DIFF
--- a/audit/5-report.txt
+++ b/audit/5-report.txt
@@ -1,0 +1,42 @@
+audit seed=5 sample_size=30 (44 entries total)
+
+stratum             correct/judged   accuracy   95% CI            skipped   pending   out-of-scope
+forced-inclusion        2/14      14.3%   [  4.0%,  39.9%]         0         0              0
+low-confidence          1/1       100.0%   [ 20.7%, 100.0%]         0         0              0
+ok                     20/25      80.0%   [ 60.9%,  91.1%]         0         0              0
+verbatim                2/3       66.7%   [ 20.8%,  93.9%]         1         0              0
+OVERALL                25/43      58.1%   [ 43.3%,  71.6%]         1         0              0
+
+note: the 95% CI above bounds sampling error only — how much this sample's accuracy could plausibly vary on a fresh draw of the same size — never reviewer error. Read the accuracy figure as "accuracy of the parser as judged by this reviewer," not an absolute truth.
+note: no verdict in this file has been amended yet (`xtask audit amend`) — this says nothing about whether the recorded verdicts are all correct, only that none has been corrected so far.
+
+K1/K2/K3 sensitivity (15 entries tagged K1, 0 entries tagged K2, 0 entries tagged K3 — see mandible_core::audit's Entry::k1/k2/k3 doc comments and this module's *_signature functions):
+view                      correct/judged   accuracy   95% CI
+all-inclusive                25/43      58.1%   [ 43.3%,  71.6%]
+K1-excluded                  16/28      57.1%   [ 39.1%,  73.5%]
+K2-excluded                  25/43      58.1%   [ 43.3%,  71.6%]
+K3-excluded                  25/43      58.1%   [ 43.3%,  71.6%]
+K1+K2+K3-excluded            16/28      57.1%   [ 39.1%,  73.5%]
+
+tools judged wrong or incomplete (the next bugs):
+  aarch64-linux-gnu-ar     incomplete  subcommands and flags are fine. but still marking as incomplete because lacks modifiers
+  aarch64-linux-gnu-gcc-ar incomplete  similar command as previous
+  ar                       incomplete  same modifier/arch audit
+  bzless                   wrong       failed to parse anything
+  bzmore                   wrong       failed to parse anything
+  c_rehash                 wrong       this tool uses -h instead of --help
+  dbiprof                  wrong       i thought we have fixed this issue, where a single dash + long flag name is given. parse failed miserably, see why the previous fix not applied to this
+  gcc-ar                   incomplete  same modifier incompleteness
+  gcc-ar-13                incomplete  same modifier incompleteness
+  ip                       wrong       similar issue appeared in the previous audit where single and long flag was presented together, example: -V[ersion]
+  jsondiff                 incomplete  missing possitionals, simplest example
+  pastebinit               wrong       bad flag descriptions and false positive flag types
+  pptpsetup                incomplete  some of the flags got parsed as description, and not all of the flags are present
+  rnano                    wrong       three column layout where 1st is short flag, 2nd is long flag, and 3rd is description
+  setleds                  incomplete  i think incomplete, the line from usage is not displayed and im not sure how: [[{+|-}num | caps | scroll]] which roughly translates to [{+|-}num] [{+|-}caps] [{+|-}scroll] which in turn means that you can add + or - before those flags. I think bracket resolution might help
+  ssh-keygen               incomplete  some of the types after flags got swallowed
+  uconv                    wrong       since the flag '-h' was in front of 'Options:' it got swallowed into the section header
+  update-xmlcatalog        wrong       ok so since the flags '--verbose' and '--sort' got parsed from earlier part of the help, like usage. it got deduplicated and never got parsed from lower 'options' section, thus losing the descriptions ofthem and appearing empty
+
+tools skipped (1 — recorded, never omitted; excluded from every accuracy figure above, so this is the list that makes that exclusion checkable):
+  rubycalls-bpfcc          (no reason recorded)

--- a/audit/5.toml
+++ b/audit/5.toml
@@ -5,204 +5,266 @@ sample_size = 30
 [[entry]]
 tool = "aarch64-linux-gnu-ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "subcommands and flags are fine. but still marking as incomplete because lacks modifiers"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "aarch64-linux-gnu-gcc-ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "similar command as previous"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "applydeltarpm"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "same modifier/arch audit"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "autoupdate"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "btrfs-find-root"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "byobu-config"
 stratum = "verbatim"
+verdict = "correct"
 
 [[entry]]
 tool = "bzcmp"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "bzless"
 stratum = "ok"
+verdict = "wrong"
+note = "failed to parse anything"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "bzmore"
 stratum = "ok"
+verdict = "wrong"
+note = "failed to parse anything"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "c_rehash"
 stratum = "verbatim"
+verdict = "wrong"
+note = "this tool uses -h instead of --help"
 
 [[entry]]
 tool = "dbiprof"
 stratum = "ok"
+verdict = "wrong"
+note = "i thought we have fixed this issue, where a single dash + long flag name is given. parse failed miserably, see why the previous fix not applied to this"
 k1 = true
 
 [[entry]]
 tool = "debconf-escape"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "diffstat"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "ebtables-nft-restore"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "egrep"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "faillock"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "gcc-ar"
 stratum = "ok"
+verdict = "incomplete"
+note = "same modifier incompleteness"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "gcc-ar-13"
 stratum = "ok"
+verdict = "incomplete"
+note = "same modifier incompleteness"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "ip"
 stratum = "ok"
+verdict = "wrong"
+note = "similar issue appeared in the previous audit where single and long flag was presented together, example: -V[ersion]"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "ischroot"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "jsondiff"
 stratum = "ok"
+verdict = "incomplete"
+note = "missing possitionals, simplest example"
 
 [[entry]]
 tool = "linux32"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "lldb-argdumper-18"
 stratum = "verbatim"
+verdict = "correct"
 
 [[entry]]
 tool = "mariadb-fix-extensions"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "mount.ntfs-3g"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "msgexec"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "nice"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "pastebinit"
 stratum = "ok"
+verdict = "wrong"
+note = "bad flag descriptions and false positive flag types"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "pdb3.12"
 stratum = "low-confidence"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "pptpsetup"
 stratum = "ok"
+verdict = "incomplete"
+note = "some of the flags got parsed as description, and not all of the flags are present"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "printenv"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "ptargrep"
 stratum = "ok"
+verdict = "correct"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "rmiregistry"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "rmt-tar"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "rnano"
 stratum = "ok"
+verdict = "wrong"
+note = "three column layout where 1st is short flag, 2nd is long flag, and 3rd is description"
 k1 = true
 
 [[entry]]
 tool = "rubycalls-bpfcc"
 stratum = "verbatim"
+verdict = "skip"
 
 [[entry]]
 tool = "rust-lldb"
 stratum = "ok"
+verdict = "correct"
 k1 = true
 
 [[entry]]
 tool = "setkeycodes"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "setleds"
 stratum = "ok"
+verdict = "incomplete"
+note = "i think incomplete, the line from usage is not displayed and im not sure how: [[{+|-}num | caps | scroll]] which roughly translates to [{+|-}num] [{+|-}caps] [{+|-}scroll] which in turn means that you can add + or - before those flags. I think bracket resolution might help"
 
 [[entry]]
 tool = "sos-collector"
 stratum = "ok"
+verdict = "correct"
 
 [[entry]]
 tool = "ssh-keygen"
 stratum = "ok"
+verdict = "incomplete"
+note = "some of the types after flags got swallowed"
 k1 = true
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"
 
 [[entry]]
 tool = "uconv"
 stratum = "ok"
+verdict = "wrong"
+note = "since the flag '-h' was in front of 'Options:' it got swallowed into the section header"
 k1 = true
 
 [[entry]]
 tool = "update-xmlcatalog"
 stratum = "ok"
+verdict = "wrong"
+note = "ok so since the flags '--verbose' and '--sort' got parsed from earlier part of the help, like usage. it got deduplicated and never got parsed from lower 'options' section, thus losing the descriptions ofthem and appearing empty"
 include_reason = "unaudited promotion (3464b0c): low-confidence -> ok, never independently reviewed"


### PR DESCRIPTION
The frozen queue's first honest number. Reviewed in the TUI (`mandible --review 5`), 43 judged, 1 skipped.

## Headline

| stratum | correct/judged | accuracy | 95% CI |
|---|---|---|---|
| ok | 20/25 | 80.0% | [60.9%, 91.1%] |
| verbatim | 2/3 | 66.7% | [20.8%, 93.9%] |
| low-confidence | 1/1 | 100.0% | [20.7%, 100.0%] |
| **forced-inclusion** | **2/14** | **14.3%** | **[4.0%, 39.9%]** |
| **OVERALL** | **25/43** | **58.1%** | **[43.3%, 71.6%]** |

## The finding the headline hides

**The forced-inclusion cohort scores 2 of 14.** Those are commit `3464b0c`'s fleet-wide `low-confidence → ok` promotions — minted by a heuristic that shipped unreviewed during a declared grammar freeze. They were force-included precisely so a random draw could not miss them, and **twelve of the fourteen are not `ok`**.

Compare against the `ok` stratum's own 80.0%: this was not a small overreach, and it is the single largest drag on the overall figure. The overall 58.1% is therefore *not* a like-for-like successor to seed 4's 62.4% — this sample deliberately over-weights a known-bad cohort.

## Test-retest: 11/16 exact, 13/16 correct-vs-not

Sixteen tools carry a seed-4 verdict too. Five disagree, and the direction matters:

| tool | seed 4 | seed 5 |
|---|---|---|
| pastebinit | correct | wrong |
| update-xmlcatalog | correct | wrong |
| ssh-keygen | correct | incomplete |
| bzmore | skip | wrong |
| pptpsetup | wrong | incomplete |

**Four of five moved stricter.** So part of the 62.4% → 58.1% gap is a reviewer applying a harsher standard, not a parser that regressed — and no CI in this report accounts for reviewer drift, only sampling error. The repeat set is also 14/16 the promoted cohort rather than a random draw, so treat 68.8% as a floor-ish indication, not a reliability coefficient.

## What this buys

Eighteen tools judged `wrong`/`incomplete`, and they group into a small number of shapes rather than eighteen separate bugs — the next fix queue, with the reviewer's own words attached. The largest single group is the `ar` modifiers family (5 tools); the most alarming is `update-xmlcatalog`, where flags parsed from the usage line deduplicate against the same flags in the options section and the *described* copy loses, which is a merge-precedence bug and not a grammar one.

## Caveats

- Accuracy is "as judged by this reviewer", never absolute truth.
- No verdict has been amended; that says nothing about whether all verdicts are right.
- One aarch64 Linux box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJWGGJ4FTA41EYRQ6W5zUm