### PR TITLE
fix(help-text): read an aligned second spelling column as a spelling, not as the description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,21 @@ once it reaches a published 0.1.0 release.
   hold; and rows whose spelling cell carries a *lower-case* value word
   (`awk`'s `-f progfile\t--file=progfile`), which stays out because
   `is_value_placeholder_only` deliberately does not recognize lower-case
-  placeholders — widening it is what protects `arptables`' `-A chain`.
+  placeholders — widening it is what protects `arptables`' `-A chain`. Two
+  of nano's own 54 rows are also still missed for a third reason:
+  `-%  --stateflags` and `-_  --minibar` are not `is_flag_shaped`, because
+  `is_flag_char` allows alphanumerics plus `? # @` and neither `%` nor `_`
+  is in that set. Widening it reaches every other user of `is_flag_shaped`,
+  `xtask`'s misattribution oracle included, so it is left for its own
+  change.
 
 - **Two new corpus fixtures for the shape, `nano/7.2` and `awk/5.2.1`,** each
   with a `must_contain_flags` contract naming long spellings that did not
   reach the tree before this change (`--smarthome`, `--backupdir`,
-  `--minibar`, `--zero`; `--characters-as-bytes`, `--dump-variables`,
-  `--copyright`). Both are `provenance = "agent"` with no `verdict_scope`.
+  `--zero`; `--characters-as-bytes`, `--dump-variables`, `--copyright`).
+  Both are `provenance = "agent"` with no `verdict_scope`. The corpus is 98
+  fixtures: 82 ok (0 human, 39 agent-then-human, 43 agent), 16 xfail, 0
+  failed.
   `corpus/jdeprscan/audit-seed2` stays `[xfail]` — `--list` and `--verbose`
   now pass, `-h` still does not — with its `meta.toml` note rewritten to say
   which half moved. `nano/7.2`'s `meta.toml` also records a *separate*,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ once it reaches a published 0.1.0 release.
 
 ### Added
 
+- **The aligned multi-column option table: a row's long spelling is no longer
+  eaten as the start of its own description.** A tool that lays its options
+  out in columns — short spelling, long spelling, and (sometimes) a
+  description — put the long spelling right where the description-boundary
+  splitter cuts, at the row's first 2+-space gap. Measured on `main`:
+  `nano --help`'s 52 flags each kept their short spelling only, with the long
+  one glued to the front of their description (`-A` described as
+  `"--smarthome Enable smart home key"`, `-C <dir>` as
+  `"--backupdir=<dir> Directory for saving unique backup files"`), and
+  `jdeprscan`'s `--list` and `--verbose` were lost outright, because their
+  rows have no description column for the spelling to hide in. `awk`/`gawk`/
+  `nawk` are the same shape aligned with tabs.
+
+  The fix is one new shape test and one recurrence test, both in
+  `help_text::sections`: a cell that is *nothing but* an option spelling —
+  flag-shaped, and then either stopping or carrying a bare value placeholder
+  (`--backupdir=<dir>`, `-C <dir>`) — is read as another spelling of the
+  option the row already named, but only in a block where that second column
+  actually recurs at the same character offset. Both halves matter, and the
+  narrow one carries the safety: a description that merely *begins* with
+  something flag-shaped (`-x   --foo is a synonym for --bar`) has real words
+  in the cell, so it is never claimed. Recurrence then excludes the one false
+  positive found over all 2,301 frozen captures in `audit/queue-captures/` —
+  `lto-dump --help`'s default-value column, whose `-1` would otherwise be
+  read as a short spelling, and whose three rows land at three different
+  offsets.
+
+  35–42 tools on this box's `PATH` show the shape. Deliberately **not**
+  claimed: rows naming several shorts at once (`jdeprscan`'s `-? -h --help`),
+  which `mandible_core::Flag` has one `short: Option<char>` and no field to
+  hold; and rows whose spelling cell carries a *lower-case* value word
+  (`awk`'s `-f progfile\t--file=progfile`), which stays out because
+  `is_value_placeholder_only` deliberately does not recognize lower-case
+  placeholders — widening it is what protects `arptables`' `-A chain`.
+
+- **Two new corpus fixtures for the shape, `nano/7.2` and `awk/5.2.1`,** each
+  with a `must_contain_flags` contract naming long spellings that did not
+  reach the tree before this change (`--smarthome`, `--backupdir`,
+  `--minibar`, `--zero`; `--characters-as-bytes`, `--dump-variables`,
+  `--copyright`). Both are `provenance = "agent"` with no `verdict_scope`.
+  `corpus/jdeprscan/audit-seed2` stays `[xfail]` — `--list` and `--verbose`
+  now pass, `-h` still does not — with its `meta.toml` note rewritten to say
+  which half moved. `nano/7.2`'s `meta.toml` also records a *separate*,
+  unfixed defect its snapshot freezes: nano's prose line `When a filename is
+  '-', nano reads data from standard input.` is read as a section heading and
+  becomes every flag's `group`.
+
 - **12 new corpus fixtures from the seed-4 human audit, and a named list of
   the tools that audit skipped.** `xtask audit fixtures` stages a fixture
   directory per reviewed tool with the reviewer's own verdict note as the

--- a/corpus/awk/5.2.1/expected.snap
+++ b/corpus/awk/5.2.1/expected.snap
@@ -1,0 +1,206 @@
+name: awk
+description: 'POSIX options: GNU long options: (standard) Short options: GNU long options: (extensions)'
+usage:
+- 'Usage: awk [POSIX or GNU style options] -f progfile [--] file ...'
+- 'Usage: awk [POSIX or GNU style options] [--] ''program'' file ...'
+positionals:
+- name: POSIX
+  provenance:
+    sources:
+    - help-text
+- name: GNU
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- short: 'f'
+  value_name: progfile
+  value_kind: Required
+  group: "POSIX options:\t\tGNU long options: (standard)"
+  provenance:
+    sources:
+    - help-text
+- short: 'F'
+  value_name: fs
+  value_kind: Required
+  group: "POSIX options:\t\tGNU long options: (standard)"
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  value_name: var=val
+  value_kind: Required
+  group: "POSIX options:\t\tGNU long options: (standard)"
+  provenance:
+    sources:
+    - help-text
+- short: 'b'
+  long: characters-as-bytes
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'c'
+  long: traditional
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'C'
+  long: copyright
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  long: dump-variables
+  value_name: file
+  value_kind: Optional
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'D'
+  long: debug
+  value_name: file
+  value_kind: Optional
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'e'
+  value_name: '''program-text'''
+  value_kind: Required
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'E'
+  value_name: file
+  value_kind: Required
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'g'
+  long: gen-pot
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'i'
+  value_name: includefile
+  value_kind: Required
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'I'
+  long: trace
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'l'
+  value_name: library
+  value_kind: Required
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'L'
+  long: lint
+  value_name: fatal|invalid|no-ext
+  value_kind: Optional
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'M'
+  long: bignum
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'N'
+  long: use-lc-numeric
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'n'
+  long: non-decimal-data
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'o'
+  long: pretty-print
+  value_name: file
+  value_kind: Optional
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'O'
+  long: optimize
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'p'
+  long: profile
+  value_name: file
+  value_kind: Optional
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'P'
+  long: posix
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'r'
+  long: re-interval
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  long: no-optimize
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'S'
+  long: sandbox
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  long: lint-old
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+- short: 'V'
+  long: version
+  group: "Short options:\t\tGNU long options: (extensions)"
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/awk/5.2.1/help.txt
+++ b/corpus/awk/5.2.1/help.txt
@@ -1,0 +1,47 @@
+Usage: awk [POSIX or GNU style options] -f progfile [--] file ...
+Usage: awk [POSIX or GNU style options] [--] 'program' file ...
+POSIX options:		GNU long options: (standard)
+	-f progfile		--file=progfile
+	-F fs			--field-separator=fs
+	-v var=val		--assign=var=val
+Short options:		GNU long options: (extensions)
+	-b			--characters-as-bytes
+	-c			--traditional
+	-C			--copyright
+	-d[file]		--dump-variables[=file]
+	-D[file]		--debug[=file]
+	-e 'program-text'	--source='program-text'
+	-E file			--exec=file
+	-g			--gen-pot
+	-h			--help
+	-i includefile		--include=includefile
+	-I			--trace
+	-l library		--load=library
+	-L[fatal|invalid|no-ext]	--lint[=fatal|invalid|no-ext]
+	-M			--bignum
+	-N			--use-lc-numeric
+	-n			--non-decimal-data
+	-o[file]		--pretty-print[=file]
+	-O			--optimize
+	-p[file]		--profile[=file]
+	-P			--posix
+	-r			--re-interval
+	-s			--no-optimize
+	-S			--sandbox
+	-t			--lint-old
+	-V			--version
+
+To report bugs, use the `gawkbug' program.
+For full instructions, see the node `Bugs' in `gawk.info'
+which is section `Reporting Problems and Bugs' in the
+printed version.  This same information may be found at
+https://www.gnu.org/software/gawk/manual/html_node/Bugs.html.
+PLEASE do NOT try to report bugs by posting in comp.lang.awk,
+or by using a web forum such as Stack Overflow.
+
+gawk is a pattern scanning and processing language.
+By default it reads standard input and writes standard output.
+
+Examples:
+	awk '{ sum += $1 }; END { print sum }' file
+	awk -F: '{ print $1 }' /etc/passwd

--- a/corpus/awk/5.2.1/meta.toml
+++ b/corpus/awk/5.2.1/meta.toml
@@ -13,7 +13,10 @@ stdout = "help.txt"
 
 [contract]
 expected_framework = "generic"
-min_status = "ok"
+# Not "ok": `awk --help` prints no descriptions at all, in any column, so
+# the tree is legitimately low-confidence however well it is parsed. The
+# claim this fixture makes is about the *spellings*, below.
+min_status = "low-confidence"
 # The regression assertion for the aligned multi-column option table: on
 # `main` before this fixture existed, every one of these long spellings was
 # read as the first word of its own row's description (or, where the row had

--- a/corpus/awk/5.2.1/meta.toml
+++ b/corpus/awk/5.2.1/meta.toml
@@ -1,0 +1,22 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "awk"
+version = "5.2.1"
+platform = "ubuntu-24.04"
+captured_with = "xtask audit"
+
+[[capture]]
+argv = ["awk", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+# The regression assertion for the aligned multi-column option table: on
+# `main` before this fixture existed, every one of these long spellings was
+# read as the first word of its own row's description (or, where the row had
+# no description column at all, discarded outright), so none of them reached
+# the tree.
+must_contain_flags = ["--characters-as-bytes", "--dump-variables", "--copyright"]

--- a/corpus/jdeprscan/audit-seed2/meta.toml
+++ b/corpus/jdeprscan/audit-seed2/meta.toml
@@ -18,10 +18,15 @@ stdout = "help.txt"
 expected_framework = "generic"
 # Lines with 3 alternate spellings ("-? -h --help") only keep 2 of 3 —
 # verified: the current tree has short='?' long='help' but no separate
-# '-h' anywhere. Lines with 2 alternates ("-l    --list",
-# "-v    --verbose") drop the long form entirely, keeping only the short
-# — verified: current flags have short='l'/short='v' with no `long` set
-# at all, so neither "--list" nor "--verbose" is recognized.
+# '-h' anywhere. `mandible_core::Flag` has one `short: Option<char>` and
+# no field to hold the second, so this half is a data-model limit, not a
+# splitter one, and it is what keeps this fixture [xfail].
+#
+# The other half is FIXED as of the aligned-spelling-column split: lines
+# with 2 alternates ("-l    --list", "-v    --verbose") used to drop the
+# long form entirely, keeping only the short. They now carry
+# short='l'/long='list' and short='v'/long='verbose', so "--list" and
+# "--verbose" below pass and only "-h" still fails.
 must_contain_flags = ["-h", "--list", "--verbose"]
 
 [xfail]

--- a/corpus/nano/7.2/expected.snap
+++ b/corpus/nano/7.2/expected.snap
@@ -1,0 +1,412 @@
+name: nano
+usage:
+- 'Usage: nano [OPTIONS] [[+LINE[,COLUMN]] FILE]...'
+positionals:
+- name: FILE
+  required: true
+  variadic: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- short: 'A'
+  long: smarthome
+  group: When a filename is '-', nano reads data from standard input.
+  description: Enable smart home key
+  provenance:
+    sources:
+    - help-text
+- short: 'B'
+  long: backup
+  group: When a filename is '-', nano reads data from standard input.
+  description: Save backups of existing files
+  provenance:
+    sources:
+    - help-text
+- short: 'C'
+  long: backupdir
+  value_name: <dir>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Directory for saving unique backup files
+  provenance:
+    sources:
+    - help-text
+- short: 'D'
+  long: boldtext
+  group: When a filename is '-', nano reads data from standard input.
+  description: Use bold instead of reverse video text
+  provenance:
+    sources:
+    - help-text
+- short: 'E'
+  long: tabstospaces
+  group: When a filename is '-', nano reads data from standard input.
+  description: Convert typed tabs to spaces
+  provenance:
+    sources:
+    - help-text
+- short: 'F'
+  long: multibuffer
+  group: When a filename is '-', nano reads data from standard input.
+  description: Read a file into a new buffer by default
+  provenance:
+    sources:
+    - help-text
+- short: 'G'
+  long: locking
+  group: When a filename is '-', nano reads data from standard input.
+  description: Use (vim-style) lock files
+  provenance:
+    sources:
+    - help-text
+- short: 'H'
+  long: historylog
+  group: When a filename is '-', nano reads data from standard input.
+  description: Save & reload old search/replace strings
+  provenance:
+    sources:
+    - help-text
+- short: 'I'
+  long: ignorercfiles
+  group: When a filename is '-', nano reads data from standard input.
+  description: Don't look at nanorc files
+  provenance:
+    sources:
+    - help-text
+- short: 'J'
+  long: guidestripe
+  value_name: <number>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Show a guiding bar at this column
+  provenance:
+    sources:
+    - help-text
+- short: 'K'
+  long: rawsequences
+  group: When a filename is '-', nano reads data from standard input.
+  description: Fix numeric keypad key confusion problem
+  provenance:
+    sources:
+    - help-text
+- short: 'L'
+  long: nonewlines
+  group: When a filename is '-', nano reads data from standard input.
+  description: Don't add an automatic newline
+  provenance:
+    sources:
+    - help-text
+- short: 'M'
+  long: trimblanks
+  group: When a filename is '-', nano reads data from standard input.
+  description: Trim tail spaces when hard-wrapping
+  provenance:
+    sources:
+    - help-text
+- short: 'N'
+  long: noconvert
+  group: When a filename is '-', nano reads data from standard input.
+  description: Don't convert files from DOS/Mac format
+  provenance:
+    sources:
+    - help-text
+- short: 'O'
+  long: bookstyle
+  group: When a filename is '-', nano reads data from standard input.
+  description: Leading whitespace means new paragraph
+  provenance:
+    sources:
+    - help-text
+- short: 'P'
+  long: positionlog
+  group: When a filename is '-', nano reads data from standard input.
+  description: Save & restore position of the cursor
+  provenance:
+    sources:
+    - help-text
+- short: 'Q'
+  long: quotestr
+  value_name: <regex>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Regular expression to match quoting
+  provenance:
+    sources:
+    - help-text
+- short: 'R'
+  long: restricted
+  group: When a filename is '-', nano reads data from standard input.
+  description: Restrict access to the filesystem
+  provenance:
+    sources:
+    - help-text
+- short: 'S'
+  long: softwrap
+  group: When a filename is '-', nano reads data from standard input.
+  description: Display overlong lines on multiple rows
+  provenance:
+    sources:
+    - help-text
+- short: 'T'
+  long: tabsize
+  value_name: <number>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Make a tab this number of columns wide
+  provenance:
+    sources:
+    - help-text
+- short: 'U'
+  long: quickblank
+  group: When a filename is '-', nano reads data from standard input.
+  description: Wipe status bar upon next keystroke
+  provenance:
+    sources:
+    - help-text
+- short: 'V'
+  long: version
+  group: When a filename is '-', nano reads data from standard input.
+  description: Print version information and exit
+  provenance:
+    sources:
+    - help-text
+- short: 'W'
+  long: wordbounds
+  group: When a filename is '-', nano reads data from standard input.
+  description: Detect word boundaries more accurately
+  provenance:
+    sources:
+    - help-text
+- short: 'X'
+  long: wordchars
+  value_name: <string>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Which other characters are word parts
+  provenance:
+    sources:
+    - help-text
+- short: 'Y'
+  long: syntax
+  value_name: <name>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Syntax definition to use for coloring
+  provenance:
+    sources:
+    - help-text
+- short: 'Z'
+  long: zap
+  group: When a filename is '-', nano reads data from standard input.
+  description: Let Bsp and Del erase a marked region
+  provenance:
+    sources:
+    - help-text
+- short: 'a'
+  long: atblanks
+  group: When a filename is '-', nano reads data from standard input.
+  description: When soft-wrapping, do it at whitespace
+  provenance:
+    sources:
+    - help-text
+- short: 'b'
+  long: breaklonglines
+  group: When a filename is '-', nano reads data from standard input.
+  description: Automatically hard-wrap overlong lines
+  provenance:
+    sources:
+    - help-text
+- short: 'c'
+  long: constantshow
+  group: When a filename is '-', nano reads data from standard input.
+  description: Constantly show cursor position
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  long: rebinddelete
+  group: When a filename is '-', nano reads data from standard input.
+  description: Fix Backspace/Delete confusion problem
+  provenance:
+    sources:
+    - help-text
+- short: 'e'
+  long: emptyline
+  group: When a filename is '-', nano reads data from standard input.
+  description: Keep the line below the title bar empty
+  provenance:
+    sources:
+    - help-text
+- short: 'f'
+  long: rcfile
+  value_name: <file>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Use only this file for configuring nano
+  provenance:
+    sources:
+    - help-text
+- short: 'g'
+  long: showcursor
+  group: When a filename is '-', nano reads data from standard input.
+  description: Show cursor in file browser & help text
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  group: When a filename is '-', nano reads data from standard input.
+  description: Show this help text and exit
+  provenance:
+    sources:
+    - help-text
+- short: 'i'
+  long: autoindent
+  group: When a filename is '-', nano reads data from standard input.
+  description: Automatically indent new lines
+  provenance:
+    sources:
+    - help-text
+- short: 'j'
+  long: jumpyscrolling
+  group: When a filename is '-', nano reads data from standard input.
+  description: Scroll per half-screen, not per line
+  provenance:
+    sources:
+    - help-text
+- short: 'k'
+  long: cutfromcursor
+  group: When a filename is '-', nano reads data from standard input.
+  description: Cut from cursor to end of line
+  provenance:
+    sources:
+    - help-text
+- short: 'l'
+  long: linenumbers
+  group: When a filename is '-', nano reads data from standard input.
+  description: Show line numbers in front of the text
+  provenance:
+    sources:
+    - help-text
+- short: 'm'
+  long: mouse
+  group: When a filename is '-', nano reads data from standard input.
+  description: Enable the use of the mouse
+  provenance:
+    sources:
+    - help-text
+- short: 'n'
+  long: noread
+  group: When a filename is '-', nano reads data from standard input.
+  description: Do not read the file (only write it)
+  provenance:
+    sources:
+    - help-text
+- short: 'o'
+  long: operatingdir
+  value_name: <dir>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Set operating directory
+  provenance:
+    sources:
+    - help-text
+- short: 'p'
+  long: preserve
+  group: When a filename is '-', nano reads data from standard input.
+  description: Preserve XON (^Q) and XOFF (^S) keys
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: indicator
+  group: When a filename is '-', nano reads data from standard input.
+  description: Show a position+portion indicator
+  provenance:
+    sources:
+    - help-text
+- short: 'r'
+  long: fill
+  value_name: <number>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Set width for hard-wrap and justify
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  long: speller
+  value_name: <program>
+  value_kind: Required
+  group: When a filename is '-', nano reads data from standard input.
+  description: Use this alternative spell checker
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  long: saveonexit
+  group: When a filename is '-', nano reads data from standard input.
+  description: Save changes on exit, don't prompt
+  provenance:
+    sources:
+    - help-text
+- short: 'u'
+  long: unix
+  group: When a filename is '-', nano reads data from standard input.
+  description: Save a file by default in Unix format
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: view
+  group: When a filename is '-', nano reads data from standard input.
+  description: View mode (read-only)
+  provenance:
+    sources:
+    - help-text
+- short: 'w'
+  long: nowrap
+  group: When a filename is '-', nano reads data from standard input.
+  description: Don't hard-wrap long lines [default]
+  provenance:
+    sources:
+    - help-text
+- short: 'x'
+  long: nohelp
+  group: When a filename is '-', nano reads data from standard input.
+  description: Don't show the two help lines
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  long: afterends
+  group: When a filename is '-', nano reads data from standard input.
+  description: Make Ctrl+Right stop at word ends
+  provenance:
+    sources:
+    - help-text
+- short: '%'
+  group: When a filename is '-', nano reads data from standard input.
+  description: --stateflags Show some states on the title bar
+  provenance:
+    sources:
+    - help-text
+- short: '_'
+  group: When a filename is '-', nano reads data from standard input.
+  description: --minibar Show a feedback bar at the bottom
+  provenance:
+    sources:
+    - help-text
+- short: '0'
+  long: zero
+  group: When a filename is '-', nano reads data from standard input.
+  description: Hide all bars, use whole terminal
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/nano/7.2/help.txt
+++ b/corpus/nano/7.2/help.txt
@@ -1,0 +1,61 @@
+Usage: nano [OPTIONS] [[+LINE[,COLUMN]] FILE]...
+
+To place the cursor on a specific line of a file, put the line number with
+a '+' before the filename.  The column number can be added after a comma.
+When a filename is '-', nano reads data from standard input.
+
+ Option         Long option             Meaning
+ -A             --smarthome             Enable smart home key
+ -B             --backup                Save backups of existing files
+ -C <dir>       --backupdir=<dir>       Directory for saving unique backup files
+ -D             --boldtext              Use bold instead of reverse video text
+ -E             --tabstospaces          Convert typed tabs to spaces
+ -F             --multibuffer           Read a file into a new buffer by default
+ -G             --locking               Use (vim-style) lock files
+ -H             --historylog            Save & reload old search/replace strings
+ -I             --ignorercfiles         Don't look at nanorc files
+ -J <number>    --guidestripe=<number>  Show a guiding bar at this column
+ -K             --rawsequences          Fix numeric keypad key confusion problem
+ -L             --nonewlines            Don't add an automatic newline
+ -M             --trimblanks            Trim tail spaces when hard-wrapping
+ -N             --noconvert             Don't convert files from DOS/Mac format
+ -O             --bookstyle             Leading whitespace means new paragraph
+ -P             --positionlog           Save & restore position of the cursor
+ -Q <regex>     --quotestr=<regex>      Regular expression to match quoting
+ -R             --restricted            Restrict access to the filesystem
+ -S             --softwrap              Display overlong lines on multiple rows
+ -T <number>    --tabsize=<number>      Make a tab this number of columns wide
+ -U             --quickblank            Wipe status bar upon next keystroke
+ -V             --version               Print version information and exit
+ -W             --wordbounds            Detect word boundaries more accurately
+ -X <string>    --wordchars=<string>    Which other characters are word parts
+ -Y <name>      --syntax=<name>         Syntax definition to use for coloring
+ -Z             --zap                   Let Bsp and Del erase a marked region
+ -a             --atblanks              When soft-wrapping, do it at whitespace
+ -b             --breaklonglines        Automatically hard-wrap overlong lines
+ -c             --constantshow          Constantly show cursor position
+ -d             --rebinddelete          Fix Backspace/Delete confusion problem
+ -e             --emptyline             Keep the line below the title bar empty
+ -f <file>      --rcfile=<file>         Use only this file for configuring nano
+ -g             --showcursor            Show cursor in file browser & help text
+ -h             --help                  Show this help text and exit
+ -i             --autoindent            Automatically indent new lines
+ -j             --jumpyscrolling        Scroll per half-screen, not per line
+ -k             --cutfromcursor         Cut from cursor to end of line
+ -l             --linenumbers           Show line numbers in front of the text
+ -m             --mouse                 Enable the use of the mouse
+ -n             --noread                Do not read the file (only write it)
+ -o <dir>       --operatingdir=<dir>    Set operating directory
+ -p             --preserve              Preserve XON (^Q) and XOFF (^S) keys
+ -q             --indicator             Show a position+portion indicator
+ -r <number>    --fill=<number>         Set width for hard-wrap and justify
+ -s <program>   --speller=<program>     Use this alternative spell checker
+ -t             --saveonexit            Save changes on exit, don't prompt
+ -u             --unix                  Save a file by default in Unix format
+ -v             --view                  View mode (read-only)
+ -w             --nowrap                Don't hard-wrap long lines [default]
+ -x             --nohelp                Don't show the two help lines
+ -y             --afterends             Make Ctrl+Right stop at word ends
+ -%             --stateflags            Show some states on the title bar
+ -_             --minibar               Show a feedback bar at the bottom
+ -0             --zero                  Hide all bars, use whole terminal

--- a/corpus/nano/7.2/meta.toml
+++ b/corpus/nano/7.2/meta.toml
@@ -1,0 +1,32 @@
+# KNOWN WRONG, and deliberately frozen rather than quietly blessed: every
+# flag in `expected.snap` carries
+# `group: "When a filename is '-', nano reads data from standard input."`.
+# That line is prose from nano's preamble, not a heading, and reading it as
+# one is a *separate* defect from the aligned-spelling-column split this
+# fixture was added for (the same shape the seed-5 review reported on
+# `uconv`). It is recorded here so the next reader knows the field is
+# unfixed rather than agreed with, and so a PR that fixes it shows up as a
+# visible snapshot diff.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "nano"
+version = "7.2"
+platform = "ubuntu-24.04"
+captured_with = "xtask audit"
+
+[[capture]]
+argv = ["nano", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+# The regression assertion for the aligned multi-column option table: on
+# `main` before this fixture existed, every one of these long spellings was
+# read as the first word of its own row's description (or, where the row had
+# no description column at all, discarded outright), so none of them reached
+# the tree.
+must_contain_flags = ["--smarthome", "--backupdir", "--minibar", "--zero"]

--- a/corpus/nano/7.2/meta.toml
+++ b/corpus/nano/7.2/meta.toml
@@ -29,4 +29,12 @@ min_status = "ok"
 # read as the first word of its own row's description (or, where the row had
 # no description column at all, discarded outright), so none of them reached
 # the tree.
-must_contain_flags = ["--smarthome", "--backupdir", "--minibar", "--zero"]
+must_contain_flags = ["--smarthome", "--backupdir", "--zero"]
+# Two of nano's 54 rows are still missed, and named here so the gap is
+# recorded rather than rounded off: `-%  --stateflags` and `-_  --minibar`.
+# `help_text::sections::is_flag_char` allows alphanumerics plus `? # @`, so
+# `-%` and `-_` are not `is_flag_shaped` and the recovery never opens on
+# them. Widening that character class reaches every other user of
+# `is_flag_shaped`, including `xtask`'s misattribution oracle, so it is left
+# for its own change. Both flags are still in the tree with their short
+# spelling; it is the long spelling that is missing.

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -2157,6 +2157,38 @@ fn flags_block_start(lines: &[&str], start: usize) -> Option<usize> {
 /// different offsets. `3` sits strictly between the two.
 pub const MIN_COLUMN_RECURRENCE: usize = 3;
 
+/// Minimum number of entry rows whose *second* spelling cell begins at the
+/// same character offset before [`scan_flags_block`] reads that cell as an
+/// aligned column of **alternate spellings** rather than as the row's
+/// description (see [`spelling_run`]).
+///
+/// Two, where [`MIN_COLUMN_RECURRENCE`] is three, because the two
+/// constants guard different questions and one of them is much harder to
+/// trip by accident. `MIN_COLUMN_RECURRENCE` asks "is a second
+/// flag+description pair hiding in this row?", where the rival reading —
+/// ordinary prose that happens to mention a flag — is common and only a
+/// count can separate them. This one asks "is this cell *nothing but*
+/// another spelling of the option already named?", and the shape test
+/// alone ([`is_spelling_only_cell`]) already excludes prose: every cell in
+/// the run must be a flag spelling and, at most, a bare value placeholder,
+/// with no words of its own. Recurrence here is only ruling out
+/// *coincidental* alignment, so two rows is enough.
+///
+/// Both halves of that were measured over the 2,301 frozen captures in
+/// `audit/queue-captures/` (2026-08-22):
+///
+/// - Three would exclude the shape's own reference case. `jdeprscan
+///   --help` writes exactly two such rows — `  -l    --list` and
+///   `  -v    --verbose` — and both long spellings were lost entirely
+///   before this rule existed.
+/// - The one measured false positive is excluded by *alignment*, not by
+///   count, so lowering the count does not readmit it: `lto-dump --help`
+///   prints a default-value column (`--param=prefetch-minimum-stride=
+///   <TAB> -1`) whose `-1` would be read as a short spelling, but its
+///   three rows have long names of three different lengths, so the `-1`
+///   lands at three different offsets and no offset recurs even once.
+const MIN_SPELLING_COLUMN_RECURRENCE: usize = 2;
+
 /// True if `token` is shaped like a flag spelling: `-x`, `--word`, `+x`, or
 /// `+|-x` — lsof spells several of its own flags with the `+` prefix
 /// (`+d`, `+m`). Deliberately permissive about the character right after a
@@ -2469,6 +2501,11 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
         })
         .collect();
     let multi_column = block_is_multi_column(&entry_lines);
+    // Independent of, and subordinate to, `multi_column`: a block can pack
+    // several flag+description pairs per line (that decision) *or* spell
+    // one option across aligned spelling columns (this one). Only a block
+    // the first decision did not claim consults the second.
+    let aligned_spellings = !multi_column && block_has_aligned_spelling_column(&entry_lines);
 
     let mut entries: Vec<(String, String)> = Vec::new();
     for row in rows {
@@ -2491,6 +2528,7 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
                                 .push((field.tokens.join(", "), field.trailing.trim().to_string()));
                         }
                     }
+                    None if aligned_spellings => entries.push(split_aligned_spelling_entry(line)),
                     None => entries.push(split_single_column_entry(line)),
                 }
             }
@@ -2647,6 +2685,172 @@ fn entry_row_carries_own_description(entry_line: &str) -> bool {
     }
     let (_, desc) = split_single_column_entry(entry_line);
     !desc.trim().is_empty()
+}
+
+/// A row's leading run of cells that are **nothing but option spellings**,
+/// recovered by [`spelling_run`].
+struct SpellingRun {
+    /// Character offset of the run's *second* cell — the column
+    /// [`block_has_aligned_spelling_column`] buckets recurrence counts by.
+    second_offset: usize,
+    /// The run's cells verbatim, value placeholder and all
+    /// (`-C <dir>`, `--backupdir=<dir>`), so nothing a row spelled out is
+    /// dropped on the way to the flag grammar.
+    spellings: Vec<String>,
+    /// Character offset where the first cell *past* the run begins, or
+    /// `None` when the run consumed every cell on the line (a two-column
+    /// table with no description column at all — `awk --help`).
+    description_start: Option<usize>,
+}
+
+/// True if `cell` holds one option spelling and nothing else: a
+/// flag-shaped first word ([`is_flag_shaped`]) whose remainder is either
+/// empty or a bare value placeholder ([`is_value_placeholder_only`]).
+///
+/// This is the whole discriminator against the inverse case, and it is
+/// deliberately the strict half of the pair (`misattribution`'s and
+/// [`fields_in_line`]'s fold-while-bare rule is the permissive half).
+/// A description that legitimately *starts* with something flag-shaped —
+/// `--foo is a synonym for --bar`, `-1 means unlimited` — is one cell with
+/// real words in it, so it fails here and the row keeps its ordinary
+/// single-column split. Only a cell that is a spelling and stops can be
+/// mistaken for one, and that is the case this recovery is for.
+fn is_spelling_only_cell(cell: &str) -> bool {
+    let token = first_word(cell);
+    // `+d`/`+|-x` (lsof) are flag-shaped but are never spelled as a second
+    // aligned column, and admitting them would widen this rule past
+    // anything measured. Plain `-`-initial spellings only.
+    if !token.starts_with('-') || !is_flag_shaped(token) {
+        return false;
+    }
+    let rest = cell.strip_prefix(token).unwrap_or("").trim();
+    rest.is_empty() || is_value_placeholder_only(rest)
+}
+
+/// Recover the leading run of alternate spellings from one flags-block
+/// entry row laid out as an aligned **multi-column option table** — short
+/// spelling in column 1, long spelling in column 2, description (if the
+/// tool prints one at all) in column 3:
+///
+/// ```text
+///  -A             --smarthome             Enable smart home key
+///  -C <dir>       --backupdir=<dir>       Directory for saving unique backup files
+///   -l    --list
+/// ```
+///
+/// # Why this exists
+///
+/// [`find_description_gap`] cuts at the row's *first* 2+-space gap, which
+/// in this layout is the gap before the long spelling — so the long
+/// spelling is read as the start of the description. Measured on `main`
+/// before this rule: `jdeprscan`'s `--list` and `--verbose` vanished from
+/// the tree completely (their rows carry no description, so
+/// [`is_synonym_not_description`] correctly refused to assert the spelling
+/// as prose — and then there was nowhere else for it to go), and every one
+/// of `nano`'s 52 flags kept its short spelling only, with its long
+/// spelling glued onto the front of its own description
+/// (`--smarthome Enable smart home key`). Both are the same cut in the
+/// same place; the tools differ only in whether a third column follows.
+///
+/// # The rule
+///
+/// Returns `Some` only when **all** of the following hold:
+///
+/// - the row opens with at least two consecutive [`is_spelling_only_cell`]
+///   cells, and
+/// - exactly one of them is a long (`--`) spelling.
+///
+/// The second condition is what keeps this from merging two *independent*
+/// flags. A run of two longs (`--foo  --bar`) or two shorts (`-a  -b`) is
+/// as easily a genuine two-column table of separate options as an alias
+/// pair, and merging there would destroy a flag; short-plus-long is the
+/// one combination that is an alias pair in every layout this project has
+/// measured. Rows naming several shorts at once (`jdeprscan`'s
+/// `-? -h --help`) are **not** in scope and are not touched here: they are
+/// blocked one step earlier, because `-? -h` is a single cell with real
+/// trailing text, and even if they were not, `mandible_core::Flag` has one
+/// `short: Option<char>` and no field to hold the second.
+///
+/// The caller applies this only to a block that shows the column actually
+/// recurring — see [`block_has_aligned_spelling_column`].
+fn spelling_run(line: &str) -> Option<SpellingRun> {
+    let cells = cells(line);
+    let mut spellings: Vec<String> = Vec::new();
+    let mut second_offset = None;
+    let mut description_start = None;
+    for (offset, content) in &cells {
+        if !is_spelling_only_cell(content) {
+            description_start = Some(*offset);
+            break;
+        }
+        if spellings.len() == 1 {
+            second_offset = Some(*offset);
+        }
+        spellings.push(content.clone());
+    }
+    if spellings.len() < 2 {
+        return None;
+    }
+    let longs = spellings
+        .iter()
+        .filter(|c| first_word(c).starts_with("--"))
+        .count();
+    if longs != 1 {
+        return None;
+    }
+    Some(SpellingRun {
+        second_offset: second_offset?,
+        spellings,
+        description_start,
+    })
+}
+
+/// True if `entry_lines` (a flags block's raw entry rows) shows a real,
+/// aligned column of alternate spellings: at least
+/// [`MIN_SPELLING_COLUMN_RECURRENCE`] rows whose [`spelling_run`]'s second
+/// cell starts at the same character offset. Same instrument, and same
+/// reasoning, as [`block_is_multi_column`]'s recurrence check — a table is
+/// evidenced by repetition, never by one suggestive row.
+fn block_has_aligned_spelling_column(entry_lines: &[&str]) -> bool {
+    let mut offset_counts: std::collections::HashMap<usize, usize> =
+        std::collections::HashMap::new();
+    for line in entry_lines {
+        if let Some(run) = spelling_run(line) {
+            *offset_counts.entry(run.second_offset).or_insert(0) += 1;
+        }
+    }
+    offset_counts
+        .values()
+        .any(|&count| count >= MIN_SPELLING_COLUMN_RECURRENCE)
+}
+
+/// Split one entry row of a block [`block_has_aligned_spelling_column`]
+/// accepted, falling back to the ordinary single-column split for a row
+/// that is not itself laid out that way (a block's occasional
+/// `-x  description` line among its aligned ones).
+fn split_aligned_spelling_entry(line: &str) -> (String, String) {
+    let Some(run) = spelling_run(line) else {
+        return split_single_column_entry(line);
+    };
+    // Rejoin as the flag grammar's own canonical alias separator, so the
+    // recovered row reaches it as the `-A, --smarthome` it means. A cell's
+    // own trailing comma (`-V,  --version`, where the padding after the
+    // comma was wide enough to make it two cells) is dropped rather than
+    // doubled.
+    let spec = run
+        .spellings
+        .iter()
+        .map(|cell| cell.trim_end_matches(',').trim_end())
+        .collect::<Vec<_>>()
+        .join(", ");
+    // Character offsets, never byte offsets (AGENTS.md §2), and the
+    // description's own internal spacing is preserved by slicing the line
+    // rather than rejoining its cells.
+    let description = match run.description_start {
+        Some(start) => line.chars().skip(start).collect::<String>(),
+        None => String::new(),
+    };
+    (spec, description.trim_end().to_string())
 }
 
 /// The original (pre-multi-column) way to split one flags-block entry line:
@@ -3314,14 +3518,20 @@ fn find_description_gap(line: &str) -> Option<usize> {
 /// The fewest consecutive spaces that separate a row's columns rather than
 /// merely decorating it — the boundary [`find_multi_space_gap`] cuts at.
 ///
-/// Named rather than left as a literal `2` because it is what puts a whole
-/// shape out of the flag-spec grammar's reach: `jdeprscan`'s
+/// Named rather than left as a literal `2` because it is what once put a
+/// whole shape out of the flag-spec grammar's reach: `jdeprscan`'s
 /// `  -l    --list` writes its two spellings four spaces apart, so the long
-/// form arrives as a *description* and no fragment ever names both. A
+/// form arrived as a *description* and no fragment ever named both. A
 /// detector that declares that shape out of its scope has to cite this
 /// constant to say so structurally (`xtask`'s
 /// `detector::Ground::AcrossDescriptionColumn`), and a retyped copy of the
 /// value could drift away from the splitter it claims to describe.
+///
+/// **That shape is now recovered** — see [`spelling_run`], which reads a
+/// second cell that is nothing but another spelling as the option's other
+/// spelling rather than as its description. This constant still marks the
+/// boundary the naive splitter cuts at; it is no longer the end of the
+/// story for a row whose second column is itself a spelling.
 pub const MIN_COLUMN_GAP_SPACES: usize = 2;
 
 /// The original heuristic, unchanged: a run of two or more spaces, or any
@@ -6623,5 +6833,224 @@ Options:
             "btrfs balance start [options] <path>",
             "nonexistent"
         ));
+    }
+
+    // --- the aligned multi-column option table --------------------------
+    //
+    // `spelling_run` + `block_has_aligned_spelling_column`: a row whose
+    // second column is itself another spelling of the same option, not the
+    // start of its description. Every fixture below is byte-exact from a
+    // real tool's own `--help`, and every one of the three positive tests
+    // fails on the parent commit.
+
+    /// `nano --help`, verbatim (`corpus/nano/7.2/help.txt`): short column,
+    /// long column, description column, with and without a value.
+    const NANO_TABLE: &str = concat!(
+        " Option         Long option             Meaning\n",
+        " -A             --smarthome             Enable smart home key\n",
+        " -B             --backup                Save backups of existing files\n",
+        " -C <dir>       --backupdir=<dir>       Directory for saving unique backup files\n",
+        " -J <number>    --guidestripe=<number>  Show a guiding bar at this column\n",
+    );
+
+    /// `jdeprscan --help`, verbatim (`corpus/jdeprscan/audit-seed2/help.txt`):
+    /// two columns and no description column at all. The `-? -h --help` row
+    /// is included deliberately — it is the out-of-scope multi-short shape,
+    /// and it must come through exactly as it did before.
+    const JDEPRSCAN_TABLE: &str = concat!(
+        "options:\n",
+        "        --for-removal\n",
+        "  -? -h --help\n",
+        "  -l    --list\n",
+        "  -v    --verbose\n",
+    );
+
+    /// `awk --help`, verbatim (`corpus/awk/5.2.1/help.txt`): the same shape
+    /// aligned with tabs rather than spaces.
+    const AWK_TABLE: &str = concat!(
+        "Short options:\t\tGNU long options: (extensions)\n",
+        "\t-b\t\t\t--characters-as-bytes\n",
+        "\t-c\t\t\t--traditional\n",
+        "\t-C\t\t\t--copyright\n",
+        "\t-d[file]\t\t--dump-variables[=file]\n",
+    );
+
+    #[test]
+    fn nanos_long_column_is_a_spelling_not_the_start_of_the_description() {
+        let parsed = parse(NANO_TABLE);
+        let a = flag_named(&parsed, "smarthome");
+        assert_eq!(a.short, Some('A'));
+        assert_eq!(
+            a.description.as_ref().map(|t| t.as_str()),
+            Some("Enable smart home key"),
+            "the description must be the third column only — before this \
+             rule it read `--smarthome Enable smart home key`"
+        );
+        let c = flag_named(&parsed, "backupdir");
+        assert_eq!(c.short, Some('C'));
+        assert_eq!(c.value_name.as_deref(), Some("<dir>"));
+        assert_eq!(c.value_kind, ValueKind::Required);
+        assert_eq!(
+            c.description.as_ref().map(|t| t.as_str()),
+            Some("Directory for saving unique backup files")
+        );
+        // Nothing invented from the table's own header row.
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("option")),
+            "the `Option  Long option  Meaning` header is not a flag"
+        );
+    }
+
+    #[test]
+    fn jdeprscans_two_column_table_recovers_the_long_form_it_used_to_drop() {
+        let parsed = parse(JDEPRSCAN_TABLE);
+        for (long, short) in [("list", 'l'), ("verbose", 'v')] {
+            let flag = flag_named(&parsed, long);
+            assert_eq!(flag.short, Some(short));
+            assert_eq!(
+                flag.description, None,
+                "the row has no description column, and none may be invented"
+            );
+        }
+        // The out-of-scope shape, unchanged: `-? -h --help` names two
+        // shorts and `Flag::short` is one `Option<char>`, so the second is
+        // still lost. Asserted rather than left implicit so that a future
+        // data-model change has to come here and say so.
+        let help = flag_named(&parsed, "help");
+        assert_eq!(help.short, Some('?'));
+        assert!(
+            !parsed.flags.iter().any(|f| f.short == Some('h')),
+            "`-h` is still dropped — see corpus/jdeprscan/audit-seed2"
+        );
+    }
+
+    #[test]
+    fn awks_tab_aligned_spelling_columns_are_read_as_spellings() {
+        let parsed = parse(AWK_TABLE);
+        assert_eq!(flag_named(&parsed, "characters-as-bytes").short, Some('b'));
+        assert_eq!(flag_named(&parsed, "traditional").short, Some('c'));
+        assert_eq!(flag_named(&parsed, "copyright").short, Some('C'));
+        let d = flag_named(&parsed, "dump-variables");
+        assert_eq!(d.short, Some('d'));
+        assert_eq!(d.value_kind, ValueKind::Optional);
+    }
+
+    #[test]
+    fn a_description_that_merely_begins_with_a_flag_spelling_keeps_it() {
+        // The inverse case, and the whole reason `is_spelling_only_cell`
+        // requires the cell to be a spelling *and stop*: these second cells
+        // carry real words, so they are descriptions and must survive whole.
+        let parsed = parse(concat!(
+            "options:\n",
+            "  -x    --foo is a synonym for --bar\n",
+            "  -y    --baz is a synonym for --qux\n",
+            "  -z    -1 means unlimited here\n",
+        ));
+        let x = parsed
+            .flags
+            .iter()
+            .find(|f| f.short == Some('x'))
+            .expect("-x survives");
+        assert_eq!(
+            x.description.as_ref().map(|t| t.as_str()),
+            Some("--foo is a synonym for --bar"),
+            "a description beginning with a spelling is still a description"
+        );
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("foo")),
+            "`--foo` here is prose about another flag, not this flag's own name"
+        );
+    }
+
+    #[test]
+    fn a_second_column_that_never_aligns_is_not_read_as_a_spelling() {
+        // `lto-dump --help`, verbatim: the second column is a *default
+        // value*, not a spelling, and the only thing separating it from a
+        // real alias column is that it never lands twice at the same
+        // offset. This is the one false positive the per-row shape test
+        // alone admitted over all 2,301 frozen captures.
+        let parsed = parse(concat!(
+            "options:\n",
+            "  --param=logical-op-non-short-circuit=<0,1> \t-1\n",
+            "  --param=prefetch-minimum-stride= \t-1\n",
+            "  --param=vect-max-peeling-for-alignment=<0,64> \t-1\n",
+        ));
+        assert!(
+            !parsed.flags.iter().any(|f| f.short == Some('1')),
+            "a misaligned default-value column must not become a short spelling: {:?}",
+            parsed
+                .flags
+                .iter()
+                .map(|f| f.spelling())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn two_independent_spellings_of_the_same_kind_are_never_merged() {
+        // A run of two longs, or two shorts, is as easily a genuine
+        // two-column table of separate options as an alias pair, and
+        // merging there would destroy a flag — so `spelling_run` claims
+        // only short-plus-long and leaves this shape exactly as it found
+        // it.
+        //
+        // What it finds is *already* lossy, and that is not this rule's
+        // doing: the single-column split cuts at the gap and
+        // `is_synonym_not_description` then blanks the second spelling
+        // rather than asserting it as prose, so `--beta`, `--delta` and
+        // `--zeta` are dropped here on the parent commit too. This test
+        // pins the no-merge promise, not that loss.
+        let parsed = parse(concat!(
+            "options:\n",
+            "  --alpha    --beta\n",
+            "  --gamma    --delta\n",
+            "  --epsilon  --zeta\n",
+        ));
+        for long in ["alpha", "gamma", "epsilon"] {
+            let flag = flag_named(&parsed, long);
+            assert_eq!(
+                flag.short, None,
+                "--{long} must not absorb its neighbour as a spelling"
+            );
+            assert_eq!(
+                flag.description, None,
+                "--{long} must not absorb its neighbour as a description either"
+            );
+        }
+        assert_eq!(
+            parsed.flags.len(),
+            3,
+            "no flag invented and none merged away: {:?}",
+            parsed
+                .flags
+                .iter()
+                .map(|f| f.spelling())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn one_suggestive_row_is_not_a_column() {
+        // Recurrence, not suggestion: a single row of the shape in an
+        // otherwise ordinary block changes nothing.
+        let parsed = parse(concat!(
+            "options:\n",
+            "  -a    do the first thing\n",
+            "  -b    --beta\n",
+            "  -c    do the third thing\n",
+        ));
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("beta")),
+            "one row is not evidence of a column"
+        );
     }
 }

--- a/xtask/src/detector.rs
+++ b/xtask/src/detector.rs
@@ -1300,10 +1300,13 @@ const DROPPED_ALIAS_EXCLUSIONS: &[Exclusion] = &[
             column_gap: mandible_extract::help_text::MIN_COLUMN_GAP_SPACES,
         },
         note: "two shapes in one tool, neither an interrupted alias list: `-l    --list` puts its \
-               long form past the description column, and `-? -h --help` names a second short \
-               that `mandible_core::Flag` has no field to hold (one `short: Option<char>`), \
-               exactly as `-A, --catenate, --concatenate` names a second long it cannot hold \
-               either",
+               long form past the description column — since recovered, by the aligned-spelling- \
+               column split (`help_text::sections::spelling_run`), so this half of the ground is \
+               now historical and the row is kept here because the ground is still *measured* \
+               from it — and `-? -h --help` names a second short that `mandible_core::Flag` has \
+               no field to hold (one `short: Option<char>`), exactly as `-A, --catenate, \
+               --concatenate` names a second long it cannot hold either; that second half is \
+               what still excludes the tool",
     },
 ];
 


### PR DESCRIPTION
## Mechanism

Some tools lay their options out as an **aligned multi-column table**: short
spelling in column 1, **long spelling in column 2**, and — sometimes — the
description in column 3.

```text
 -A             --smarthome             Enable smart home key          (nano)
 -C <dir>       --backupdir=<dir>       Directory for saving unique backup files
  -l    --list                                                         (jdeprscan)
\t-b\t\t\t--characters-as-bytes                                        (awk, tab-aligned)
```

`find_description_gap` cuts a flags-block row at its **first** 2+-space (or
tab) gap. In this layout that gap is the one *before the long spelling*, so
the long spelling was read as the beginning of the description. Two symptoms,
one cut:

- **Column 3 exists** (`nano`): the flag keeps its short spelling only, and its
  description is the long spelling glued to the front of the real text —
  `-A` described as `"--smarthome Enable smart home key"`, `-C <dir>` as
  `"--backupdir=<dir> Directory for saving unique backup files"`. All 52 rows.
- **Column 3 does not exist** (`jdeprscan`, `awk`): there is no prose for the
  spelling to hide inside, so `is_synonym_not_description` correctly refuses to
  assert it — and the long spelling is then **discarded entirely**.
  `jdeprscan --list` and `--verbose` did not exist in the tree at all.

## Fix

Two new functions in `mandible-extract/src/help_text/sections.rs`, consulted
only for a block that `block_is_multi_column` did **not** claim:

- `spelling_run(line)` — the row's leading run of cells that are *nothing but
  option spellings*. A cell qualifies (`is_spelling_only_cell`) when its first
  word is `is_flag_shaped` and starts with `-`, and the remainder is either
  empty or a bare value placeholder (`--backupdir=<dir>`, `-C <dir>`). The run
  must be at least two cells and contain **exactly one** long (`--`) spelling.
- `block_has_aligned_spelling_column(entry_lines)` — that second cell must
  start at the same character offset on at least
  `MIN_SPELLING_COLUMN_RECURRENCE` (= 2) rows of the block.

The run is rejoined as `-A, --smarthome` — the grammar's own canonical alias
separator — and the description becomes the remainder of the line, sliced by
**character** offset so its internal spacing survives.

**Shape-based only. No tool name is consulted anywhere (spec §1).**

### Why the inverse case is safe

The whole risk is a description that legitimately *begins* with something
flag-shaped. It is excluded by construction, not by a list: such a cell has
real words in it (`--foo is a synonym for --bar`, `-1 means unlimited`), so it
is not a spelling-*only* cell and the run never opens. `MIN_COLUMN_GAP_SPACES`
means the description sits in its own cell, so nothing that is not itself a
spelling can be absorbed — and the description can only ever lose text that was
a bare spelling.

Recurrence is the second net. Scanning all **2,301 frozen captures** in
`audit/queue-captures/` with the per-row shape test alone found exactly one
false positive: `lto-dump --help` prints a *default-value* column
(`--param=prefetch-minimum-stride=\t-1`) whose `-1` would become a short
spelling. Its three rows have long names of three different lengths, so the
`-1` lands at three different offsets and no offset recurs even once —
excluded by alignment, which is why lowering the count to 2 does not readmit
it. `MIN_SPELLING_COLUMN_RECURRENCE = 2` rather than `MIN_COLUMN_RECURRENCE`'s
3 because `jdeprscan` — the shape's own reference case — writes exactly two
such rows.

Also excluded by construction: a run of two longs or two shorts, which is as
easily a genuine two-column table of *separate* options as an alias pair, and
where merging would destroy a flag. Over all 2,301 captures **every** recovered
run is exactly one short plus one long; no run of three was ever produced.

PR #19 is open and untouched by this — its tools do not appear in the
sweep-diff below.

## Family membership

**51 tools changed** on this box's `PATH` (2,254 matched tools, 19 excluded as
near the 10s cap). Grouped by shape:

- *short / long / description*: `nano`, `pico`, `editor`, `sensible-editor`,
  `rnano`, `wget`, `patch`, `prove`, `ntfswipe`, `ntfsmove`, `ntfsdecrypt`,
  `debian-distro-info`, `distro-info`, `ubuntu-distro-info`, `bc`, `xvfb-run`,
  `thin_metadata_size`, `size`, `aarch64-linux-gnu-size`, `agetty`, `getty`,
  `snapfuse`, `vmhgfs-fuse`, `vmware-vmblock-fuse`, `time`, `pigz`, `unpigz`,
  `lcf`, `ucf`, `ucfr`, `debconf`, `debconf-communicate`, `dpkg-preconfigure`,
  `dpkg-reconfigure`
- *long / short / description* (same shape, columns swapped): `innotop`,
  `mdmon`, `iptables`(+`-legacy`/`-nft`/`-translate`), `ip6tables`(×4),
  `ebtables`, `ebtables-nft`, `xtables-monitor`
- *two columns, no description at all*: `jdeprscan`, `awk`, `gawk`, `nawk`

## Evidence

### Field-level sweep-diff, full `PATH`, before vs after

Two full `xtask coverage` sweeps on this box (base `3b9a3a4` vs this branch),
diffed with `xtask sweep-diff`, then re-diffed **spelling by spelling** from the
`#fp` fingerprint footer.

```
overall: CHANGED
sweep transition: 2254 -> 2254 tools, 2254 matched, 0 appeared, 0 disappeared
# status transitions
(none)
# flag-count losses (the bar — never netted): 2 lost across 1 tool(s)
  xtables-monitor: 7 -> 5 (-2)
# flag-count gains: 0 gained across 0 tool(s)
# field-level changes: 47 tool(s)
```

**Spelling-level result: `TOOLS WITH A LOST SPELLING: []`. Zero spellings lost,
zero descriptions lost, across all 2,254 matched tools.** The 2,203 unchanged
tools are byte-identical in their fingerprints. The aggregate line is identical
on both sides (`94.64% of flags carry text across 2308 tools`, 0 suspicious,
16 misattribution-suspect, 66 existence-fabrication, 0 bundle-collapse) — the
polluted descriptions already counted as "carrying text", so this fix moves
correctness, not that percentage.

Two rows in the diff need reading rather than trusting:

- **`xtables-monitor: 7 -> 5` is not a loss.** Its help is
  `--trace    -t    trace ruleset traversal…` with `Usage: xtables-monitor [ -t | -e ]`
  above it. Before, `-e` and `-t` arrived from the synopsis as two separate,
  *undescribed* flags alongside `--event` and `--trace`. After, they merge into
  `-e,--event` and `-t,--trace`. Spelling count goes **8 → 10**; the flag count
  falls because two duplicate half-entries collapsed into the right ones.
- **`size` / `aarch64-linux-gnu-size` show "flags removed" with no matching
  "added" line.** That is a rendering artefact of the `#fp` format: the added
  keys carry `{sysv|berkeley|gnu}` and `{8|10|16}`, and `|` is the fingerprint's
  own record separator. The raw fingerprints show 8 → 13 spellings and no loss.

Representative gains, field by field:

| tool | spellings | also recovered |
|---|---|---|
| `nano` / `pico` / `editor` / `sensible-editor` | 54 → 106 | all 52 descriptions de-polluted |
| `rnano` | 46 → 90 | same |
| `wget` | 154 → 193 | 18 value names (`-A LIST`, `-O FILE`, `-T SECONDS`, …) |
| `patch` | 38 → 62 | `--strip`, `--fuzz`, `--ifdef`, … |
| `awk` / `gawk` / `nawk` | 28 → 49 | 21 long spellings that did not exist before |
| `prove` | 45 → 63 | `-j` gains its value `N` |
| `thin_metadata_size` | 7 → 13 | 4 value names |
| `size` | 8 → 13 | `-A {sysv\|berkeley\|gnu}`, `-o {8\|10\|16}` |
| `jdeprscan` | 9 → 11 | `--list`, `--verbose` |

### Corpus

98 fixtures, **82 ok, 16 xfail, 0 failed**. Every one of the 96 pre-existing
fixtures parses **byte-identically** to before — `xtask corpus --bless` rewrote
no tracked `expected.snap`.

New: `corpus/nano/7.2` and `corpus/awk/5.2.1`, both `provenance = "agent"`, no
`verdict_scope`. Each carries a `must_contain_flags` contract naming long
spellings that did not reach the tree before this change.
`corpus/jdeprscan/audit-seed2` stays `[xfail]`: pre-fix it failed with
`missing -h, --list, --verbose`, now with `missing -h` alone.

### Regression tests, proven to fail pre-fix

Disabling only the wiring line (`let aligned_spellings = false && …`):

```
FAIL nanos_long_column_is_a_spelling_not_the_start_of_the_description
FAIL jdeprscans_two_column_table_recovers_the_long_form_it_used_to_drop
FAIL awks_tab_aligned_spelling_columns_are_read_as_spellings
PASS a_description_that_merely_begins_with_a_flag_spelling_keeps_it
PASS a_second_column_that_never_aligns_is_not_read_as_a_spelling
PASS two_independent_spellings_of_the_same_kind_are_never_merged
PASS one_suggestive_row_is_not_a_column
```

The three positives fail without the fix and pass with it; the four guards pass
on both sides, which is the point of them. Same run against the fixtures:
`nano/7.2 FAIL … missing --smarthome, --backupdir, --zero`,
`awk/5.2.1 FAIL … missing --characters-as-bytes, --dump-variables, --copyright`.

### Screenshots (`scripts/pty_screenshot.py`, 110×34, real pty)

`nano`, before → after:

```
│   -A             --smarthome Enable smart home key  │      │   -A, --smarthome                              │
│   -B             --backup Save backups of existing  │      │       Enable smart home key                    │
│                  files                              │  →   │   -B, --backup                                 │
│   -C  <dir>      --backupdir=<dir> Directory for    │      │       Save backups of existing files           │
│                  saving unique backup files         │      │   -C, --backupdir <dir>                        │
│                                                     │      │       Directory for saving unique backup files │
```

`jdeprscan`: `-l` → `-l, --list`, `-v` → `-v, --verbose`.
`awk`: `-b` → `-b, --characters-as-bytes`, `-d [file]` → `-d, --dump-variables [file]`.

## See it yourself

```console
$ cargo build --release --bin mandible
$ cargo run --release --bin mandible -- nano
```

- **Before:** every flag row reads `-A   --smarthome Enable smart home key` —
  the long spelling is *inside the description*, at the start, for all 52 rows.
- **After:** the row reads `-A, --smarthome` with `Enable smart home key`
  beneath it, and `-C, --backupdir <dir>` carries its value.

```console
$ cargo run --release --bin mandible -- jdeprscan
```

- **Before:** the flag list shows a bare `-l` and a bare `-v`. `--list` and
  `--verbose` appear nowhere.
- **After:** `-l, --list` and `-v, --verbose`.

```console
$ cargo run --release --bin mandible -- awk
```

- **Before:** `-b`, `-c`, `-C`, `-d [file]` — no long spellings anywhere.
- **After:** `-b, --characters-as-bytes`, `-c, --traditional`,
  `-d, --dump-variables [file]`, and 18 more.

## Honest caveats and residuals

1. **`nano`'s section header is wrong, and this PR does not fix it.** The prose
   line `When a filename is '-', nano reads data from standard input.` is read
   as a heading and rendered uppercased above the flag list (visible in both
   screenshots), and lands in every flag's `group`. Same shape the seed-5
   review reported on `uconv`. It is a **separate family**; it is recorded in
   `corpus/nano/7.2/meta.toml` so the snapshot freezing it is not mistaken for
   agreement.
2. **Rows naming several shorts at once are out of scope**, and this fix makes
   them *more* visible rather than less: `jdeprscan`'s `-? -h --help` still
   loses `-h`, because `mandible_core::Flag` has one `short: Option<char>`.
   That needs a data-model change and belongs with the IR-entities decision.
   `corpus/jdeprscan/audit-seed2` stays `[xfail]` on exactly that.
3. **A spelling cell carrying a lower-case value word is not recovered.**
   `awk`'s `-f progfile\t\t--file=progfile` keeps `-f progfile` and drops
   `--file`, because `is_value_placeholder_only` deliberately does not
   recognise lower-case placeholders — that narrowness is what protects
   `arptables`' `-A chain`. Loosening it to gain 8 of awk's 28 rows is exactly
   the trade this project has twice been burnt by, so it is left alone.
4. **`-%` and `-_` are not `is_flag_shaped`.** `is_flag_char` allows
   alphanumerics plus `? # @`, so nano's `-%  --stateflags` and
   `-_  --minibar` are missed (2 of its 54 rows; both flags keep their short
   spelling). Widening that character class reaches every other user of
   `is_flag_shaped`, `xtask`'s misattribution oracle included, so it belongs in
   its own change.
5. **The sweep is one machine's `PATH`,** never a portable baseline (spec
   §13.1a), and the family count is a count of *tools showing the shape here*.
   The corpus and the unit tests are the portable half.
6. `Ground::AcrossDescriptionColumn`'s `jdeprscan` exclusion note in
   `xtask/src/detector.rs` is amended rather than removed: the ground is still
   *measured* from the row, but half of what it excused is now fixed.

## Gates

`cargo nextest run --workspace` 1064/1064 · `cargo clippy --workspace
--all-targets -- -D warnings` clean · `cargo fmt --check` clean ·
`cargo run -p xtask -- corpus` 98 fixtures, 0 failed ·
`bash scripts/changelog_guard.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJWGGJ4FTA41EYRQ6W5zUm
