### PR TITLE
fix(help-text): pair valued spelling cells on the value they both name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,16 +40,75 @@ once it reaches a published 0.1.0 release.
   35–42 tools on this box's `PATH` show the shape. Deliberately **not**
   claimed: rows naming several shorts at once (`jdeprscan`'s `-? -h --help`),
   which `mandible_core::Flag` has one `short: Option<char>` and no field to
-  hold; and rows whose spelling cell carries a *lower-case* value word
-  (`awk`'s `-f progfile\t--file=progfile`), which stays out because
-  `is_value_placeholder_only` deliberately does not recognize lower-case
-  placeholders — widening it is what protects `arptables`' `-A chain`. Two
+  hold; and (**since fixed** — see the next entry) rows whose spelling cell
+  carries a *lower-case* value word (`awk`'s
+  `-f progfile\t--file=progfile`). Two
   of nano's own 54 rows are also still missed for a third reason:
   `-%  --stateflags` and `-_  --minibar` are not `is_flag_shaped`, because
   `is_flag_char` allows alphanumerics plus `? # @` and neither `%` nor `_`
   is in that set. Widening it reaches every other user of `is_flag_shaped`,
   `xtask`'s misattribution oracle included, so it is left for its own
   change.
+
+- **Valued cells in an aligned spelling column now pair too: `-f progfile`
+  keeps its `--file`.** The residual the entry above named. A cell that is a
+  spelling *plus a lower-case value word* is not an
+  `is_value_placeholder_only` cell, and that check must stay narrow — a
+  lower-case word alone is not distinguishable from prose, which is what
+  keeps `arptables --help`'s `--append  -A chain` from being merged into one
+  valued flag. So the pairing evidence here is a different one: **two
+  adjacent cells that name the same value token.** `-f progfile` beside
+  `--file=progfile`, `-d[file]` beside `--dump-variables[=file]`,
+  `-v var=val` beside `--assign=var=val` — one option, spelled twice, with
+  its value restated. `--append` names no value at all, so `-A chain` has
+  nothing to match and that row is untouched.
+
+  Measured over all 2,301 frozen captures in `audit/queue-captures/`
+  (2026-08-22): 24 adjacent cell pairs across 5 tools satisfy the test and
+  **every one is a genuine short/long alias pair** — `awk`/`gawk`/`nawk`
+  (7 rows each: `--file`, `--field-separator`, `--assign`, `--source`,
+  `--exec`, `--include`, `--load`) and `ntfsmove`/`ntfswipe`, which write
+  the value detached on both sides with a real description after it
+  (`-c num  --count num  Number of times to write`). No capture pairs two
+  independent flags this way; the near misses correctly refused are
+  `arptables`'s `-A chain`, `lsof`'s genuine three-column table, `objcopy`'s
+  `--strip-symbols <file>   -N for all symbols listed in <file>`
+  cross-reference, and `prove`'s `-a,  --archive out.tgz Store ...`.
+
+  The recovered flag carries the shared value **once**: such a row is
+  rejoined as *spellings, then the value* — every cell reduced to its bare
+  spelling, and the value appended in the form the first cell that named it
+  wrote it. Both halves are load-bearing. Rejoining both cells verbatim
+  handed the flag grammar a detached value it terminated the alias list on,
+  which lost `--source` from `-e 'program-text'\t--source='program-text'`
+  entirely; and taking the value's *form* from the first cell is what keeps
+  the rewrite from changing a flag that already parsed. `less --help` writes
+  `-P [prompt]   --prompt=[prompt]`, where the short cell's brackets say
+  optional and the long cell's `=` says required — keeping the long cell
+  verbatim promoted `-P` from `Optional` to `Required` and left the brackets
+  stranded inside the value's name. As shipped, `less`'s `-p`, `-P` and `-x`
+  gain `--pattern`, `--prompt` and `--tabs` with `value_name` and
+  `value_kind` byte-identical to before, and `awk`'s
+  `-d[file]`/`--dump-variables[=file]` stays `Optional`/`file` while
+  `-f progfile`/`--file=progfile` is `Required`/`progfile`.
+
+  `corpus/awk/5.2.1` gains all seven long spellings in its `expected.snap`
+  and names them in its `must_contain_flags` contract. Still **not** claimed,
+  unchanged by this: `awk`'s multi-short rows, and its
+  `POSIX options:\tGNU long options: (standard)` header line, which is read
+  as a section heading and becomes every flag's `group` (the `uconv`/`nano`
+  family, already queued).
+
+  A full-`PATH` sweep before and after (2,254 tools matched) reports **zero
+  flags lost and zero descriptions changed**; five tools change at all, all
+  by gaining a long spelling on a flag that had none: `less`, `pager` and
+  `zstdless` (the same `less` help text) plus `ntfsmove` and `ntfswipe`,
+  whose `-c num  --count num  Number of times to write` rows *also* stop
+  reading the long spelling as the first words of their own description.
+  `awk`/`gawk`/`nawk` change too but are invisible to `xtask sweep-diff`,
+  which splits a `#fp` line's flag list on `|` and so cannot represent
+  `--lint`'s `fatal|invalid|no-ext` value; their fingerprints were compared
+  by hand instead.
 
 - **Two new corpus fixtures for the shape, `nano/7.2` and `awk/5.2.1`,** each
   with a `must_contain_flags` contract naming long spellings that did not

--- a/corpus/awk/5.2.1/expected.snap
+++ b/corpus/awk/5.2.1/expected.snap
@@ -15,6 +15,7 @@ positionals:
     - help-text
 flags:
 - short: 'f'
+  long: file
   value_name: progfile
   value_kind: Required
   group: "POSIX options:\t\tGNU long options: (standard)"
@@ -22,6 +23,7 @@ flags:
     sources:
     - help-text
 - short: 'F'
+  long: field-separator
   value_name: fs
   value_kind: Required
   group: "POSIX options:\t\tGNU long options: (standard)"
@@ -29,6 +31,7 @@ flags:
     sources:
     - help-text
 - short: 'v'
+  long: assign
   value_name: var=val
   value_kind: Required
   group: "POSIX options:\t\tGNU long options: (standard)"
@@ -70,6 +73,7 @@ flags:
     sources:
     - help-text
 - short: 'e'
+  long: source
   value_name: '''program-text'''
   value_kind: Required
   group: "Short options:\t\tGNU long options: (extensions)"
@@ -77,6 +81,7 @@ flags:
     sources:
     - help-text
 - short: 'E'
+  long: exec
   value_name: file
   value_kind: Required
   group: "Short options:\t\tGNU long options: (extensions)"
@@ -96,6 +101,7 @@ flags:
     sources:
     - help-text
 - short: 'i'
+  long: include
   value_name: includefile
   value_kind: Required
   group: "Short options:\t\tGNU long options: (extensions)"
@@ -109,6 +115,7 @@ flags:
     sources:
     - help-text
 - short: 'l'
+  long: load
   value_name: library
   value_kind: Required
   group: "Short options:\t\tGNU long options: (extensions)"

--- a/corpus/awk/5.2.1/meta.toml
+++ b/corpus/awk/5.2.1/meta.toml
@@ -22,4 +22,22 @@ min_status = "low-confidence"
 # read as the first word of its own row's description (or, where the row had
 # no description column at all, discarded outright), so none of them reached
 # the tree.
-must_contain_flags = ["--characters-as-bytes", "--dump-variables", "--copyright"]
+#
+# `--file`, `--field-separator`, `--assign`, `--source`, `--exec`,
+# `--include` and `--load` are the *valued* half of the same table, added
+# once the spelling column was paired on the value both cells name rather
+# than on the short cell being bare. Every one of them was absent from this
+# tree until then: `-f progfile` parsed as a short flag with a value and no
+# long spelling at all.
+must_contain_flags = [
+    "--characters-as-bytes",
+    "--dump-variables",
+    "--copyright",
+    "--file",
+    "--field-separator",
+    "--assign",
+    "--source",
+    "--exec",
+    "--include",
+    "--load",
+]

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -2191,6 +2191,10 @@ pub const MIN_COLUMN_RECURRENCE: usize = 3;
 ///   <TAB> -1`) whose `-1` would be read as a short spelling, but its
 ///   three rows have long names of three different lengths, so the `-1`
 ///   lands at three different offsets and no offset recurs even once.
+///   [`block_has_aligned_spelling_column`]'s second arm — this same count
+///   of *value-paired* rows ([`cells_name_the_same_value`]) — does not
+///   readmit it either: `-1` names no value, so no row of that block is
+///   value-paired.
 const MIN_SPELLING_COLUMN_RECURRENCE: usize = 2;
 
 /// True if `token` is shaped like a flag spelling: `-x`, `--word`, `+x`, or
@@ -2705,6 +2709,14 @@ struct SpellingRun {
     /// `None` when the run consumed every cell on the line (a two-column
     /// table with no description column at all — `awk --help`).
     description_start: Option<usize>,
+    /// True when every cell in the run that names a value at all names
+    /// the *same* one (`-f progfile` / `--file=progfile`) — the evidence
+    /// [`cells_name_the_same_value`] describes. Two things read it:
+    /// [`block_has_aligned_spelling_column`], as evidence on its own that
+    /// the block really is a two-column table, and
+    /// [`split_aligned_spelling_entry`], which then emits that shared
+    /// value exactly once.
+    value_paired: bool,
 }
 
 /// True if `cell` holds one option spelling and nothing else: a
@@ -2731,6 +2743,152 @@ fn is_spelling_only_cell(cell: &str) -> bool {
     rest.is_empty() || is_value_placeholder_only(rest)
 }
 
+/// The value token a flag-spelling cell names, normalized so that a short
+/// and a long spelling of the *same* option compare equal — `-f progfile`
+/// and `--file=progfile` both yield `progfile`, `-d[file]` and
+/// `--dump-variables[=file]` both yield `file`. `Some("")` means the cell
+/// names no value at all (`--copyright`); `None` means the cell is not a
+/// single `-`-initial flag spelling this rule models.
+///
+/// Normalization strips one layer of value punctuation — a leading `=`,
+/// `[`, `<` or `{` and a trailing `]`, `>` or `}` — because that
+/// punctuation is where the two spellings of one option legitimately
+/// differ (`-d[file]` attaches an optional value with a bracket, its long
+/// form with `[=`). Everything inside is compared verbatim, including
+/// case, quotes and `|` alternations (`-L[fatal|invalid|no-ext]` /
+/// `--lint[=fatal|invalid|no-ext]`).
+///
+/// A cell that names a value *twice* — attached to the token and again as
+/// a following word — is refused outright rather than guessed at: nothing
+/// measured writes that, so it is outside what this rule has evidence for.
+fn value_token(cell: &str) -> Option<String> {
+    let token = first_word(cell);
+    if !token.starts_with('-') || !is_flag_shaped(token) {
+        return None;
+    }
+    let dashes = token.chars().take_while(|&c| c == '-').count();
+    let name_len = token
+        .chars()
+        .skip(dashes)
+        .take_while(|&c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        .count();
+    if name_len == 0 {
+        // `-?`, `-#`: no name to end, so nothing after it is a value.
+        return None;
+    }
+    let attached: String = token.chars().skip(dashes + name_len).collect();
+    let detached = cell
+        .chars()
+        .skip(token.chars().count())
+        .collect::<String>()
+        .trim()
+        .to_string();
+    let raw = match (attached.is_empty(), detached.is_empty()) {
+        (true, true) => return Some(String::new()),
+        (false, true) => attached,
+        (true, false) => detached,
+        (false, false) => return None,
+    };
+    Some(
+        raw.trim()
+            .trim_start_matches(['=', '[', '<', '{'])
+            .trim_end_matches([']', '>', '}'])
+            .trim()
+            .to_string(),
+    )
+}
+
+/// A flag-spelling cell reduced to the spelling alone — `--file=progfile`
+/// to `--file`, `-f progfile` to `-f` — using the same leading-dashes-plus-
+/// name scan as [`value_token`], so the two can never disagree about where
+/// a spelling ends and its value begins. Falls back to the cell's first
+/// word for anything that scan does not model.
+fn bare_spelling(cell: &str) -> String {
+    let token = first_word(cell);
+    let dashes = token.chars().take_while(|&c| c == '-').count();
+    let name_len = token
+        .chars()
+        .skip(dashes)
+        .take_while(|&c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        .count();
+    if name_len == 0 {
+        return token.trim_end_matches(',').to_string();
+    }
+    token.chars().take(dashes + name_len).collect()
+}
+
+/// The value a flag-spelling cell names, in the cell's *own* notation but
+/// detached from the spelling — `--file=progfile` and `-f progfile` both
+/// give `progfile`, `--dump-variables[=file]` and `-d[file]` both give
+/// `[file]`, `--prompt=[prompt]` and `-P [prompt]` both give `[prompt]`.
+/// `None` when the cell names no value.
+///
+/// Only the `=` that *attaches* a value to its spelling is removed;
+/// brackets and angles are the value's own notation and are kept, because
+/// the flag grammar reads `ValueKind` off exactly those (a bracketed value
+/// is optional, a bare or `=`-attached one is required). That is the whole
+/// reason this returns the written form rather than [`value_token`]'s
+/// normalized one.
+fn value_suffix(cell: &str) -> Option<String> {
+    let token = first_word(cell);
+    let dashes = token.chars().take_while(|&c| c == '-').count();
+    let name_len = token
+        .chars()
+        .skip(dashes)
+        .take_while(|&c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        .count();
+    if name_len == 0 {
+        return None;
+    }
+    let attached: String = token.chars().skip(dashes + name_len).collect();
+    let raw = if attached.is_empty() {
+        cell.chars()
+            .skip(token.chars().count())
+            .collect::<String>()
+            .trim()
+            .to_string()
+    } else if let Some(rest) = attached.strip_prefix('=') {
+        // `--file=progfile`
+        rest.to_string()
+    } else if let Some(rest) = attached.strip_prefix("[=") {
+        // `--dump-variables[=file]` — the `=` is inside the bracket that
+        // marks the value optional, so only the `=` goes.
+        format!("[{rest}")
+    } else {
+        attached
+    };
+    (!raw.is_empty()).then_some(raw)
+}
+
+/// True when two adjacent cells name **the same, non-empty value token**
+/// ([`value_token`]) — `-f progfile` beside `--file=progfile`.
+///
+/// This is the discriminator that lets [`spelling_run`] pair *valued*
+/// cells without widening [`is_spelling_only_cell`], which must stay
+/// narrow (see its doc comment, and `fields_in_line`'s, on `arptables`'s
+/// `--append  -A chain`). Two cells restating one option's value is
+/// evidence of one option spelled twice in a way that a flag followed by
+/// unrelated text is not: `--append` names no value at all, so it can
+/// never pair with `-A chain` here, and `lsof`'s genuine multi-column
+/// rows (`-n no host names  -N select NFS files`) name different trailing
+/// text in every cell.
+///
+/// Measured over all 2,301 frozen captures in `audit/queue-captures/`
+/// (2026-08-22): 24 adjacent cell pairs in 5 tools (`awk`, `gawk`,
+/// `nawk`, `ntfsmove`, `ntfswipe`) satisfy this and **every one of them
+/// is a genuine short/long alias pair**; no capture pairs two independent
+/// flags this way. The near misses it correctly refuses are `arptables`'s
+/// `-A chain`, `lsof`'s three-column table, `objcopy`'s
+/// `--strip-symbols <file>   -N for all symbols listed in <file>`
+/// cross-reference (the second cell's "value" is a whole sentence, not
+/// the first's token), and `prove`'s `-a,  --archive out.tgz Store ...`.
+fn cells_name_the_same_value(a: &str, b: &str) -> bool {
+    match (value_token(a), value_token(b)) {
+        (Some(x), Some(y)) => !x.is_empty() && x == y,
+        _ => false,
+    }
+}
+
 /// Recover the leading run of alternate spellings from one flags-block
 /// entry row laid out as an aligned **multi-column option table** — short
 /// spelling in column 1, long spelling in column 2, description (if the
@@ -2740,6 +2898,8 @@ fn is_spelling_only_cell(cell: &str) -> bool {
 ///  -A             --smarthome             Enable smart home key
 ///  -C <dir>       --backupdir=<dir>       Directory for saving unique backup files
 ///   -l    --list
+///  -f progfile    --file=progfile
+///  -c num         --count num             Number of times to write
 /// ```
 ///
 /// # Why this exists
@@ -2760,8 +2920,11 @@ fn is_spelling_only_cell(cell: &str) -> bool {
 ///
 /// Returns `Some` only when **all** of the following hold:
 ///
-/// - the row opens with at least two consecutive [`is_spelling_only_cell`]
-///   cells, and
+/// - the row opens with at least two consecutive cells that are each
+///   either an [`is_spelling_only_cell`] — a spelling that stops — or a
+///   cell naming the same value token as the cell beside it
+///   ([`cells_name_the_same_value`], the arm that admits `awk`'s
+///   `-f progfile` / `--file=progfile`), and
 /// - exactly one of them is a long (`--`) spelling.
 ///
 /// The second condition is what keeps this from merging two *independent*
@@ -2782,8 +2945,21 @@ fn spelling_run(line: &str) -> Option<SpellingRun> {
     let mut spellings: Vec<String> = Vec::new();
     let mut second_offset = None;
     let mut description_start = None;
-    for (offset, content) in &cells {
-        if !is_spelling_only_cell(content) {
+    for (i, (offset, content)) in cells.iter().enumerate() {
+        // A cell earns its place in the run either by being a spelling and
+        // nothing else, or by naming the same value token as the cell
+        // immediately before or after it (see
+        // [`cells_name_the_same_value`]). The backward and forward arms are
+        // both needed and they always agree: the run breaks at the first
+        // rejected cell, so `i - 1` is by construction already in the run,
+        // and a cell admitted by its successor admits that successor in
+        // turn on the next iteration.
+        let in_run = is_spelling_only_cell(content)
+            || (i > 0 && cells_name_the_same_value(&cells[i - 1].1, content))
+            || cells
+                .get(i + 1)
+                .is_some_and(|(_, next)| cells_name_the_same_value(content, next));
+        if !in_run {
             description_start = Some(*offset);
             break;
         }
@@ -2802,10 +2978,17 @@ fn spelling_run(line: &str) -> Option<SpellingRun> {
     if longs != 1 {
         return None;
     }
+    let named: Vec<String> = spellings
+        .iter()
+        .filter_map(|cell| value_token(cell))
+        .filter(|v| !v.is_empty())
+        .collect();
+    let value_paired = named.len() >= 2 && named.iter().all(|v| v == &named[0]);
     Some(SpellingRun {
         second_offset: second_offset?,
         spellings,
         description_start,
+        value_paired,
     })
 }
 
@@ -2818,14 +3001,19 @@ fn spelling_run(line: &str) -> Option<SpellingRun> {
 fn block_has_aligned_spelling_column(entry_lines: &[&str]) -> bool {
     let mut offset_counts: std::collections::HashMap<usize, usize> =
         std::collections::HashMap::new();
+    let mut value_paired_rows = 0usize;
     for line in entry_lines {
         if let Some(run) = spelling_run(line) {
             *offset_counts.entry(run.second_offset).or_insert(0) += 1;
+            if run.value_paired {
+                value_paired_rows += 1;
+            }
         }
     }
     offset_counts
         .values()
         .any(|&count| count >= MIN_SPELLING_COLUMN_RECURRENCE)
+        || value_paired_rows >= MIN_SPELLING_COLUMN_RECURRENCE
 }
 
 /// Split one entry row of a block [`block_has_aligned_spelling_column`]
@@ -2841,12 +3029,43 @@ fn split_aligned_spelling_entry(line: &str) -> (String, String) {
     // own trailing comma (`-V,  --version`, where the padding after the
     // comma was wide enough to make it two cells) is dropped rather than
     // doubled.
-    let spec = run
-        .spellings
-        .iter()
-        .map(|cell| cell.trim_end_matches(',').trim_end())
-        .collect::<Vec<_>>()
-        .join(", ");
+    // A value-paired run names one value in every cell (`-f progfile`
+    // `--file=progfile`). Rejoining both verbatim would hand the flag
+    // grammar the same value twice, and a detached one (`-e
+    // 'program-text', --source=...`) does not even survive that round trip
+    // intact — the alias list terminates on it and the long spelling is
+    // lost. So such a run is rejoined as *spellings, then the value once*:
+    // every cell reduced to its bare spelling ([`bare_spelling`]), and the
+    // shared value appended in the form the first cell that named it wrote
+    // it ([`value_suffix`]).
+    //
+    // Taking the value's *form* from the first cell, rather than keeping
+    // the last cell verbatim, is what makes this rewrite value-preserving.
+    // `less --help` writes `-P [prompt]   --prompt=[prompt]`: the short
+    // cell's brackets say the value is optional, and the long cell's `=`
+    // says it is required. Keeping the long cell verbatim silently promoted
+    // `-P` from `Optional` to `Required` and left the brackets stranded
+    // inside the value's own name. The short cell's spelling of the same
+    // value is the one both readings agree came first, and the flag grammar
+    // reads `--prompt [prompt]` exactly as it read `-P [prompt]` before.
+    let spec = if run.value_paired {
+        let spellings = run
+            .spellings
+            .iter()
+            .map(|cell| bare_spelling(cell))
+            .collect::<Vec<_>>()
+            .join(", ");
+        match run.spellings.iter().find_map(|cell| value_suffix(cell)) {
+            Some(value) => format!("{spellings} {value}"),
+            None => spellings,
+        }
+    } else {
+        run.spellings
+            .iter()
+            .map(|cell| cell.trim_end_matches(',').trim_end())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     // Character offsets, never byte offsets (AGENTS.md §2), and the
     // description's own internal spacing is preserved by slicing the line
     // rather than rejoining its cells.
@@ -7517,6 +7736,200 @@ Options:
         let d = flag_named(&parsed, "dump-variables");
         assert_eq!(d.short, Some('d'));
         assert_eq!(d.value_kind, ValueKind::Optional);
+    }
+
+    /// `awk --help`, verbatim (`corpus/awk/5.2.1/help.txt`): the same
+    /// tab-aligned table, but every row's cells carry a **value**. The
+    /// second cell of each row is the long spelling of the option the
+    /// first cell names, and both spell out the same value token.
+    const AWK_VALUED_TABLE: &str = concat!(
+        "POSIX options:\t\tGNU long options: (standard)\n",
+        "\t-f progfile\t\t--file=progfile\n",
+        "\t-F fs\t\t\t--field-separator=fs\n",
+        "\t-v var=val\t\t--assign=var=val\n",
+    );
+
+    #[test]
+    fn awks_valued_columns_pair_on_the_value_they_both_name() {
+        // The residual PR #21 left behind: the cells are spellings *plus a
+        // value*, so `is_value_placeholder_only` (deliberately narrow, to
+        // protect `arptables`'s `-A chain`) never recognized them and all
+        // three long spellings were lost. Verified on the parent commit:
+        // `-f`, `-F` and `-v` parse with no `long` at all.
+        let parsed = parse(AWK_VALUED_TABLE);
+        for (long, short, value) in [
+            ("file", 'f', "progfile"),
+            ("field-separator", 'F', "fs"),
+            ("assign", 'v', "var=val"),
+        ] {
+            let flag = flag_named(&parsed, long);
+            assert_eq!(flag.short, Some(short));
+            assert_eq!(
+                flag.value_name.as_deref(),
+                Some(value),
+                "the shared value is carried once, verbatim, never doubled"
+            );
+            assert_eq!(flag.value_kind, ValueKind::Required);
+            assert_eq!(
+                flag.description, None,
+                "this table has no description column, and none may be invented"
+            );
+        }
+        assert_eq!(parsed.flags.len(), 3, "no fourth flag invented");
+    }
+
+    #[test]
+    fn a_valued_pair_keeps_an_optional_value_optional() {
+        // `-d[file]` / `--dump-variables[=file]`, and the quoted and
+        // alternation-valued rows beside them: the recovered flag must
+        // carry the value's own *kind*, not merely its name. The bracket
+        // is where a short and a long spelling of one option legitimately
+        // differ (`[file]` against `[=file]`), which is why `value_token`
+        // compares them with that punctuation stripped.
+        let parsed = parse(concat!(
+            "Short options:\t\tGNU long options: (extensions)\n",
+            "\t-d[file]\t\t--dump-variables[=file]\n",
+            "\t-e 'program-text'\t--source='program-text'\n",
+            "\t-E file\t\t\t--exec=file\n",
+            "\t-L[fatal|invalid|no-ext]\t--lint[=fatal|invalid|no-ext]\n",
+        ));
+        let d = flag_named(&parsed, "dump-variables");
+        assert_eq!(d.short, Some('d'));
+        assert_eq!(d.value_name.as_deref(), Some("file"));
+        assert_eq!(d.value_kind, ValueKind::Optional);
+        let e = flag_named(&parsed, "source");
+        assert_eq!(e.short, Some('e'));
+        assert_eq!(
+            e.value_name.as_deref(),
+            Some("'program-text'"),
+            "a quoted value survives whole — rejoining both cells verbatim \
+             used to leave `'program-text',` and lose `--source` entirely"
+        );
+        assert_eq!(e.value_kind, ValueKind::Required);
+        let exec = flag_named(&parsed, "exec");
+        assert_eq!(exec.short, Some('E'));
+        assert_eq!(exec.value_name.as_deref(), Some("file"));
+        assert_eq!(exec.value_kind, ValueKind::Required);
+        let lint = flag_named(&parsed, "lint");
+        assert_eq!(lint.short, Some('L'));
+        assert_eq!(lint.value_name.as_deref(), Some("fatal|invalid|no-ext"));
+        assert_eq!(lint.value_kind, ValueKind::Optional);
+    }
+
+    #[test]
+    fn pairing_never_changes_the_value_a_row_already_parsed_to() {
+        // `less --help`, verbatim with its overstrike bytes stripped: the
+        // short cell's brackets say the value is optional and the long
+        // cell's `=` says it is required, so the two cells disagree about
+        // `ValueKind` while naming the same value.
+        //
+        // This one is a **guard, not a proof of the fix**, and says so:
+        // stripped of the overstrike these cells are already
+        // `is_value_placeholder_only`, so the parent commit pairs this row
+        // by the older rule and reaches `Optional`/`prompt` on its own.
+        // What it pins is the rejoin. An earlier draft of this change kept
+        // the *last* cell of a value-paired run verbatim, which turned this
+        // row into `-P, --prompt=[prompt]` and silently promoted it to
+        // `Required` with `[prompt]` stranded inside the value's own name.
+        // Real `less --help` does not strip the overstrike, and its raw
+        // bytes desync the column offsets enough that the row only pairs at
+        // all through `cells_name_the_same_value` — which is how that
+        // promotion was caught, in a full-`PATH` sweep, on three tools that
+        // were working fine.
+        let parsed = parse(concat!(
+            "  -p [pattern]  --pattern=[pattern]\n",
+            "                  Start at pattern (from command line).\n",
+            "  -P [prompt]   --prompt=[prompt]\n",
+            "                  Define new prompt.\n",
+        ));
+        let prompt = flag_named(&parsed, "prompt");
+        assert_eq!(prompt.short, Some('P'));
+        assert_eq!(prompt.value_name.as_deref(), Some("prompt"));
+        assert_eq!(
+            prompt.value_kind,
+            ValueKind::Optional,
+            "the bracket the short cell wrote still decides the kind"
+        );
+        assert_eq!(
+            prompt.description.as_ref().map(|t| t.as_str()),
+            Some("Define new prompt.")
+        );
+        let pattern = flag_named(&parsed, "pattern");
+        assert_eq!(pattern.short, Some('p'));
+        assert_eq!(pattern.value_name.as_deref(), Some("pattern"));
+        assert_eq!(pattern.value_kind, ValueKind::Optional);
+    }
+
+    #[test]
+    fn a_valued_pair_with_a_third_description_column_keeps_the_description() {
+        // `ntfsmove`/`ntfswipe --help`, verbatim: the same shape with the
+        // value detached on *both* sides and a real description after it.
+        let parsed = parse(concat!(
+            "Options:\n",
+            "    -c num   --count num   Number of times to write(default = 1)\n",
+            "    -b list  --bytes list  List of values to write(default = 0)\n",
+        ));
+        let count = flag_named(&parsed, "count");
+        assert_eq!(count.short, Some('c'));
+        assert_eq!(count.value_name.as_deref(), Some("num"));
+        assert_eq!(count.value_kind, ValueKind::Required);
+        assert_eq!(
+            count.description.as_ref().map(|t| t.as_str()),
+            Some("Number of times to write(default = 1)")
+        );
+        let bytes = flag_named(&parsed, "bytes");
+        assert_eq!(bytes.short, Some('b'));
+        assert_eq!(bytes.value_name.as_deref(), Some("list"));
+    }
+
+    #[test]
+    fn a_flag_followed_by_unrelated_text_is_never_paired_by_value() {
+        // `arptables --help`, verbatim — the case `is_value_placeholder_only`
+        // stays narrow for, and the reason the value test is *equality
+        // between two cells* rather than "the cell has a trailing word".
+        // `--append` names no value at all, so there is nothing for `-A
+        // chain` to match, and the row keeps the reading it had.
+        let parsed = parse(concat!(
+            "Commands:\n",
+            "--append  -A chain\t\tAppend to chain\n",
+            "--delete  -D chain rulenum\t\tDelete rule rulenum from chain\n",
+            "--insert  -I chain [rulenum]\t\tInsert in chain as rulenum\n",
+        ));
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.value_name.as_deref() == Some("chain")
+                    && f.long.as_deref() == Some("append")
+                    && f.short == Some('A')),
+            "`--append  -A chain` must not be merged into one valued flag: {:?}",
+            parsed
+                .flags
+                .iter()
+                .map(|f| f.spelling())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn two_cells_naming_different_values_are_not_paired() {
+        // `objcopy --help`, verbatim: the second cell is a cross-reference
+        // sentence that happens to start with a flag and end with the same
+        // placeholder the first cell used. The value tokens differ (`<file>`
+        // against a whole sentence), so no pairing happens and the sentence
+        // stays the description it is.
+        let parsed = parse(concat!(
+            "Options:\n",
+            "     --strip-symbols <file>        -N for all symbols listed in <file>\n",
+            "     --keep-symbols <file>         -K for all symbols listed in <file>\n",
+            "     --weaken-symbols <file>       -W for all symbols listed in <file>\n",
+        ));
+        let strip = flag_named(&parsed, "strip-symbols");
+        assert_eq!(
+            strip.short, None,
+            "`-N for all symbols listed in <file>` is prose, not this flag's short spelling"
+        );
+        assert_eq!(strip.value_name.as_deref(), Some("<file>"));
     }
 
     #[test]


### PR DESCRIPTION
## Mechanism

PR #21 recovers a long spelling from an aligned second column, but only when the
cells are **bare** spellings. `is_spelling_only_cell` requires the cell's
remainder to be empty or an `is_value_placeholder_only` token, and that check is
deliberately narrow — a *lower-case* trailing word is not reliably
distinguishable from prose, which is exactly what keeps `arptables --help`'s
`--append  -A chain` from being merged into one valued flag. That narrowness
must be preserved, and this PR does not touch it.

So `awk`/`gawk`/`nawk`'s valued rows still lost their long spelling:

```
	-f progfile		--file=progfile
	-v var=val		--assign=var=val
	-e 'program-text'	--source='program-text'
```

`-f progfile` parsed as a short flag with a value and **no `--file` at all**,
while `-b  --characters-as-bytes` two rows down paired correctly.

## The discriminator, and why it is safe

**Two adjacent cells that name the same value token are one option spelled
twice.** `-f progfile` beside `--file=progfile`; `-d[file]` beside
`--dump-variables[=file]`; `-v var=val` beside `--assign=var=val`. Comparison is
on the value with one layer of attachment punctuation stripped (`=`, `[`, `<`,
`{` … `]`, `>`, `}`), because that punctuation is precisely where a short and a
long spelling of one option legitimately differ. Everything inside is compared
verbatim — case, quotes, `|` alternations included.

This is safe in a way "the cell has a trailing word" is not, and the inverse
cases are the proof: **`--append` names no value at all**, so `-A chain` has
nothing to match and that row keeps the reading it had.

Measured over **all 2,301 frozen captures** in `audit/queue-captures/`
(2026-08-22): **24 adjacent cell pairs across 5 tools** satisfy the test, and
**every one of them is a genuine short/long alias pair** — `awk`/`gawk`/`nawk`
(7 rows each) and `ntfsmove`/`ntfswipe`, which write the value detached on both
sides with a real description after it. **No capture pairs two independent flags
this way.** The near misses it correctly refuses:

| tool | row | why it is refused |
|---|---|---|
| `arptables` | `--append  -A chain` | `--append` names no value |
| `lsof` | `-n no host names  -N select NFS files` | different trailing text in every cell |
| `objcopy` | `--strip-symbols <file>   -N for all symbols listed in <file>` | the second cell's "value" is a whole sentence |
| `prove` | `-a,  --archive out.tgz Store ...` | `-a,` names no value |
| `lto-dump` | `--param=prefetch-minimum-stride=  <TAB>  -1` | `-1` names no value (the documented false positive stays excluded) |

The block-level recurrence rule is kept: a block is trusted when the second
column recurs at one offset **or** when at least two of its rows are
value-paired. Repetition, never one suggestive row.

## The rejoin, and the bug it caught

A value-paired row is rejoined as **spellings, then the value once**: every cell
reduced to its bare spelling, and the value appended in the form *the first cell
that named it* wrote it.

Both halves are load-bearing:

- Rejoining both cells **verbatim** hands the flag grammar a detached value it
  terminates the alias list on — that alone lost `--source` from
  `-e 'program-text'	--source='program-text'` outright.
- Taking the value's **form from the first cell** is what keeps the rewrite from
  changing a flag that already parsed. `less --help` writes
  `-P [prompt]   --prompt=[prompt]`: the short cell's brackets say *optional*,
  the long cell's `=` says *required*. An earlier draft kept the last cell
  verbatim and silently promoted `-P` from `Optional` to `Required`, with the
  brackets stranded inside the value's own name. Caught by the full-`PATH`
  sweep, on three tools that were working fine.

## Evidence

**Full-`PATH` sweep, before (built at `c8245de`) and after, 2,254 tools
matched**, via `xtask sweep-diff` field-level `#fp` comparison:

```
# flag-count losses (the bar — never netted): 0 lost across 0 tool(s)
# flag-count gains: 0 gained across 0 tool(s)
# field-level changes: 5 tool(s)
```

Every changed field, tool by tool:

| tool | change | `value_name` | `value_kind` | description |
|---|---|---|---|---|
| `less`, `pager`, `zstdless` | `-p`→`-p,--pattern`, `-P`→`-P,--prompt`, `-x`→`-x,--tabs` | unchanged | unchanged | unchanged (same hash) |
| `ntfsmove` | `-C`→`-C,--cluster` | unchanged (`num`) | unchanged | **fixed** — was `--cluster num Move to this cluster offset` |
| `ntfswipe` | `-b`→`-b,--bytes`, `-c`→`-c,--count` | unchanged | unchanged | **fixed** — was `--count num Number of times to write(default = 1)` |
| `awk`, `gawk`, `nawk` | 7 flags each gain `--file`, `--field-separator`, `--assign`, `--source`, `--exec`, `--include`, `--load` | unchanged | unchanged | none (this table has none) |

**25 flags gained a long spelling; 3 descriptions were repaired; nothing was
lost or altered anywhere else.**

`awk`/`gawk`/`nawk` are **invisible to `xtask sweep-diff`** and were compared by
hand: it splits a `#fp` line's flag list on `|`, and `--lint`'s
`fatal|invalid|no-ext` value contains `|`, so those three rows cannot round-trip
through the report. That is a pre-existing limitation of the instrument, not of
this change; worth its own fix.

**Regression tests** — six new, in `help_text::sections`, all from byte-exact
real tool output. Three fail on `c8245de` and are the proof of the fix:

```
FAIL awks_valued_columns_pair_on_the_value_they_both_name
     no flag long=="file" in ["-f progfile", "-F fs", "-v var=val"]
FAIL a_valued_pair_keeps_an_optional_value_optional
     no flag long=="dump-variables" in ["-d[=file]", "-e 'program-text'", ...]
FAIL a_valued_pair_with_a_third_description_column_keeps_the_description
     no flag long=="count" in ["-c num", "-b list"]
```

Three pass on `c8245de` and are guards, labelled as such in their own comments:
`arptables`'s `-A chain` is never paired, `objcopy`'s cross-reference sentence is
never paired, and the `less` rejoin never changes a value that already parsed.

**Corpus**: `corpus/awk/5.2.1` gains the seven long spellings in `expected.snap`
(seven added lines, nothing removed or altered) and names them in its
`must_contain_flags` contract. 98 fixtures: 82 ok, 16 xfail, 0 failed.

## See it yourself

```console
$ cargo build --release
$ ./target/release/mandible awk      # then Tab into the detail pane
```

**Before** — the POSIX table's three flags have no long spelling, and `-e`/`-E`/
`-i`/`-l` below them have none either:

```
 FLAGS ────────────────────────────────
 POSIX OPTIONS:GNU LONG OPTIONS: (STANDARD)
   -f progfile
   -F fs
   -v var=val
 SHORT OPTIONS:GNU LONG OPTIONS: (EXTENSIONS)
   -b, --characters-as-bytes
   ...
   -d, --dump-variables [file]
   -e 'program-text'
   -E file
```

**After** — every row pairs, and the value is carried once with its kind intact
(`[file]` still optional, `progfile` still required):

```
 FLAGS ────────────────────────────────
 POSIX OPTIONS:GNU LONG OPTIONS: (STANDARD)
   -f, --file progfile
   -F, --field-separator fs
   -v, --assign var=val
 SHORT OPTIONS:GNU LONG OPTIONS: (EXTENSIONS)
   -b, --characters-as-bytes
   ...
   -d, --dump-variables [file]
   -e, --source 'program-text'
   -E, --exec file
```

The second tool worth looking at is `ntfswipe`, where the long spelling was not
merely missing but **glued to the front of its own description**:

```console
$ ./target/release/mandible ntfswipe   # Tab, then scroll to -c
```

```
before:  -c num
             --count num Number of times to write(default = 1)
after:   -c, --count num
             Number of times to write(default = 1)
```

Screenshots were captured with `scripts/pty_screenshot.py` (no tty in the agent
sandbox); the "before" binary is built at `c8245de`.

## Honest caveats

- **Out of scope, unchanged, and still wrong.** `awk`'s multi-short rows
  (`-? -h --help`) — `mandible_core::Flag` has one `short: Option<char>` and no
  field to hold the second. And `awk`'s
  `POSIX options:\tGNU long options: (standard)` header is read as a section
  heading, becoming every flag's `group` and leaking into the root description;
  same family as `uconv`/`nano`, already queued.
- **The evidence is a census, not a sample.** 24 pairs over 2,301 captures is
  every instance on one Ubuntu 24.04 box. A layout that pairs two independent
  flags naming the same value token is *possible*; none exists in this corpus.
- **`corpus/awk/5.2.1` is `provenance = "agent"` with no `verdict_scope`.** Its
  snapshot freezes the tree; it does not assert a human judged it right. The
  seven long spellings were checked by hand against the raw capture in this PR,
  which is not the same as a recorded verdict.
- **The sweep is one box.** 2,254 tools on this machine's `PATH`; another
  distribution's `less`, `ntfsprogs` or `gawk` may print a different layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
