### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ over a 2,254-tool sweep.
 
 ### Added
 
+- **The README states the measured accuracy, not just the coverage badge.** A green
+  `framework support` tick says CI passed; it says nothing about how often a parsed
+  tree is right. The "Is it actually universal?" section now carries seed 5's
+  human-reviewed figure — 58.1% [43.3%, 71.6%] overall, 80.0% [60.9%, 91.1%] on the
+  `ok` stratum — with the test-retest agreement (11/16) beside it, so a reader can see
+  both the number and how much to trust it.
+
 - **The aligned multi-column option table: a row's long spelling is no longer
   eaten as the start of its own description.** A tool that lays its options
   out in columns — short spelling, long spelling, and (sometimes) a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-23
+
+**Breaking:** `CommandNode` gained a public `invocation_attested` field.
+The struct is not `#[non_exhaustive]`, so any downstream struct-literal
+construction must be updated. Everything else in this release is additive
+parser accuracy: no flag, description, subcommand or usage line that
+0.3.2 parsed correctly is parsed differently now, verified field-by-field
+over a 2,254-tool sweep.
+
 ### Added
 
 - **The aligned multi-column option table: a row's long spelling is no longer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "base64",
@@ -2362,7 +2362,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.3.2" }
-mandible-extract = { path = "mandible-extract", version = "0.3.2" }
-mandible-search = { path = "mandible-search", version = "0.3.2" }
-mandible-tui = { path = "mandible-tui", version = "0.3.2" }
+mandible-core = { path = "mandible-core", version = "0.4.0" }
+mandible-extract = { path = "mandible-extract", version = "0.4.0" }
+mandible-search = { path = "mandible-search", version = "0.4.0" }
+mandible-tui = { path = "mandible-tui", version = "0.4.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ prose. A metric that improves when the tool gets worse is worse than no metric.
 CI gates every change against a fixed tool list, and sweeps the whole `PATH`
 separately for the broad picture.
 
+Coverage is not accuracy, though, and the honest number is lower than a green badge
+suggests. A frozen, randomly drawn queue of real tools gets reviewed by a human against
+each tool's own `--help` text — the sample is committed before any verdict is recorded,
+so it cannot be redrawn once the results look bad. The most recent draw (seed 5,
+43 tools judged) puts the parser at **58.1% fully correct, 95% CI [43.3%, 71.6%]**;
+tools the pipeline itself rates `ok` score 80.0% [60.9%, 91.1%]. Repeat-review of the
+same tools agreed 11 times in 16, so treat any single figure as approximate, and any
+trend between draws as partly reviewer drift.
+
+mandible is useful today and wrong often enough that you should check anything
+surprising against the tool's own `--help`.
+
 
 > [!TIP]
 > Something parses wrong? Run `mandible --report <tool>` and paste the output


### PR DESCRIPTION
Cuts 0.4.0 from everything merged since 0.3.2. **Not tagged yet** — this PR is the review gate.

## Why 0.4.0 and not 0.3.3

`CommandNode` gained a public `invocation_attested` field (from the headingless-table work), and the struct is not `#[non_exhaustive]`. Under semver that breaks any downstream struct-literal construction, and `mandible-core` is published — shipping it as a patch would break a `mandible-core = "0.3"` dependant on a routine `cargo update`.

That is the *only* breaking change. Everything else is additive parser accuracy, verified field-by-field over a 2,254-tool sweep rather than by flag counts: **nothing 0.3.2 parsed correctly parses differently now.**

## What users get

**Parser accuracy — ~110 tools measurably better:**
- **Aligned multi-column option tables** (51 tools): the long spelling in column 2 was being read as description text and discarded. `nano`/`pico`/`editor` 54 → 106 spellings, `rnano` 46 → 90, `wget` 154 → 193, `patch` 38 → 62, plus the `iptables`/`ip6tables`/`ebtables` family.
- **Valued cells in those tables** (`awk`/`gawk`/`nawk`, `less`, `pager`, `zstdless`, `ntfsmove`, `ntfswipe`): `-f progfile` now pairs with `--file=progfile`. 25 flags gained a long spelling, 3 descriptions repaired.
- **Descriptions one space after the spec** (60 tools incl. clang/gcc/ld, curl, systemctl, node, mariadb): fleet-wide 94.64% → 95.54% of flags carry text.
- **Prose-paragraph descriptions** (jdeprscan): a flag whose description is written below the table now finds it.
- **Headingless command tables**: `btrfs` goes from 1 node to 87 — `balance`, `subvolume`, `device` and friends are navigable. Recovered nodes are deliberately **not probe-eligible**.
- **A flag description no longer swallows the command table below it** (btrfs).
- **False alias merges undone**: `--allow-multiple-definition` vs `-z muldefs` and three pre-existing collisions in `as`, `lto-dump`, `gold`.

**Infrastructure:**
- PATH-sweep CI shards write their scoreboard again (they had been dying `EACCES` inside namespace containment, all 16 shards, with the summary staying green); the summary now fails on zero shards.
- arm64 `.deb`/`.rpm` packages, built and install-tested natively.
- `xtask sweep-diff` compares per-field, not per-count — it exists because a count-only diff missed a real regression.
- Every corpus fixture records `[bless] provenance` (human / agent-then-human / agent). Current corpus: 98 fixtures, **0 human-blessed trees**, 39 agent-then-human, 43 agent.
- 12 fixtures added from the seed-4 audit; `xtask audit report` now names skipped tools instead of only counting them.

## Honest accuracy

The seed-5 audit — a frozen-queue draw, human-reviewed in the TUI, committed before any verdict was recorded — puts the parser at **58.1% [43.3%, 71.6%]** overall, **80.0%** on the `ok` stratum. The gap is mostly one cohort: 14 tools promoted by an unaudited heuristic scored **2/14**. Test-retest against seed 4 was 11/16, with 4 of 5 disagreements moving stricter, so cross-seed trends are confounded by reviewer drift and should not be read as parser regression.

## Not in this release

`#[non_exhaustive]` on the public types. It forbids struct-literal construction across crate boundaries — 61 sites in this workspace — and the IR-entities migration rewrites those same sites, so both land together in 0.5.0 as one pass.

Positionals, `ar` modifiers, env vars and multi-short rows (`-? -h --help`) all await that same IR work; roughly a third of the seed-5 defects are structurally unreachable until then.

## Gates

`cargo nextest run` 1077/1077 · clippy `-D warnings` clean · fmt clean · corpus 98 fixtures (82 ok / 16 xfail / 0 failed) · changelog guard clean · `mandible --version` → `0.4.0` · all five crate versions bumped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJWGGJ4FTA41EYRQ6W5zUm