### PR TITLE
fix: recover descriptions behind a bare `=` separator, and make sweep-diff able to see awk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ once it reaches a published 0.1.0 release.
   `coverage-scoreboard.ci.txt`, so unescaping is the identity function on
   every scoreboard on disk today.
 
+- **A flag row that separates its spec from its description with a bare `=`
+  token, instead of a column gap, either lost the description entirely or
+  kept a leaked `= ` prefix.** `update-xmlcatalog`'s `With:` block
+  (`--file <file>       = a local filename`) is column-aligned, so the split
+  itself worked, but the description kept its leading `= `; `wpa_supplicant`'s
+  `options:` block (`-b = optional bridge interface name`) has only single
+  spacing, so no 2+-space gap existed anywhere on the line and the whole row
+  fell into `grammar::parse_flag_spec` — the description was lost outright,
+  measured at "low confidence: 9% parsed" across its ~28 flags. Two new
+  functions in `mandible-extract/src/help_text/sections.rs`,
+  `find_equals_separator_gap` (a new fallback in `find_description_gap`,
+  ordered after the existing 2+-space/tab rule so every already-working
+  aligned split is untouched) and `strip_equals_separator` (applied at both
+  places a flag row's description is produced), fix both shapes with one
+  mechanism. Real `=` usage inside specs and descriptions
+  (`--opt=VALUE`, `ffprobe`'s "0 = disable, 1 = enable", `--enable-gvn-hoist`'s
+  "(default = off)", `systemd`'s `--dump-core[=BOOL]`) is left untouched —
+  covered by new regression tests for each measured instance.
+
 ## [0.4.0] - 2026-08-23
 
 **Breaking:** `CommandNode` gained a public `invocation_attested` field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`xtask sweep-diff`'s `#fp` fingerprint footer silently dropped tools whose
+  `value_name` contained one of the format's own separator characters** —
+  found on `awk`/`gawk`/`nawk`, whose `-L` flag documents `value_name`
+  `"fatal|invalid|no-ext"`. The old `fp_escape` scrubbed only tab and
+  newline, so that flag's rendered `#fp` line carried three unescaped `|`s
+  where the flag-list separator expected exactly one;
+  `parse_fingerprint_line` split on all three, the resulting bogus entries
+  had no `=`, and the entire `#fp awk` line — every flag on it — was
+  discarded. `fp_escape`/`fp_unescape` now backslash-escape and reverse
+  every separator the wire format uses (`\`, tab, newline, `|`, `,`, `=`,
+  `:`), so the escaped text is guaranteed free of raw separators and the
+  round trip is lossless. Backward compatible, measured: 0 backslashes
+  across 2,308 `#fp` lines in a full-`PATH` sweep capture and 0 in
+  `coverage-scoreboard.ci.txt`, so unescaping is the identity function on
+  every scoreboard on disk today.
+
 ## [0.4.0] - 2026-08-23
 
 **Breaking:** `CommandNode` gained a public `invocation_attested` field.

--- a/corpus/update-xmlcatalog/audit-seed2/meta.toml
+++ b/corpus/update-xmlcatalog/audit-seed2/meta.toml
@@ -17,15 +17,20 @@ exit_code = 255
 
 [contract]
 expected_framework = "generic"
-# Verified: the "= description" style (`--root  = the root XML catalog`)
-# leaks the leading "=" into every "With:" flag's description, and the
-# repeated `--add`/`--del` usage-synopsis lines get misread as flag
-# definitions, producing 6 duplicate/garbage `--id` entries. Most directly
-# testable without asserting on description *text* (no [contract] field
-# checks that): `--del` never becomes a real flag at all — only `--add`
-# survives, and only via the synopsis fallback.
+# Verified after the `=`-as-description-separator fix: the "= description"
+# style (`--root  = the root XML catalog`) no longer leaks its leading "="
+# into any "With:" flag's description (`--file`, `--id`, `--root`, `--type`,
+# `--verbose`, `--sort` all recover clean prose now, "the root XML catalog
+# (= /etc/xml/catalog)" included, second `=` intact). What remains broken is
+# unrelated: the repeated `--add`/`--del` usage-synopsis lines still get
+# misread as flag-table SECTION HEADERS (the uconv/nano section-header
+# family), producing 6 duplicate/garbage `--id` entries grouped under
+# fabricated headings like `update-xmlcatalog <options> --del --root ...`.
+# `--del` never becomes a real flag at all — only `--add` survives, and only
+# via the synopsis fallback. Most directly testable without asserting on
+# description *text* (no [contract] field checks that): `--del` is missing.
 must_contain_flags = ["--del"]
 
 [xfail]
 broken = true
-reason = "mostly looks fine, but not sure how to make sanitization on this one. Because this tool uses '=' to start the description of flag, which propogates to the tool"
+reason = "the `=`-as-description-separator bug is fixed (With: block descriptions are now clean); what remains is the unrelated uconv/nano section-header family: update-xmlcatalog's usage lines (`UPDATE-XMLCATALOG <OPTIONS> --DEL --ROOT ...`) are misread as flag-table section headers, so --del is absorbed into a group heading and never becomes its own flag"

--- a/corpus/wpa_supplicant/audit-seed4/expected.snap
+++ b/corpus/wpa_supplicant/audit-seed4/expected.snap
@@ -1,0 +1,158 @@
+name: wpa_supplicant
+description: This software may be distributed under the terms of the BSD license. See README for more details. This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)
+usage:
+- 'usage:'
+- wpa_supplicant [-BddhKLqqstuvW] [-P<pid file>] [-g<global ctrl>] \ [-G<group>] \
+flags:
+- short: 'i'
+  value_name: <ifname>
+  value_kind: Required
+  description: -c<config file> [-C<ctrl>] [-D<driver>] [-p<driver_param>] \
+  provenance:
+    sources:
+    - help-text
+- short: 'b'
+  description: optional bridge interface name
+  provenance:
+    sources:
+    - help-text
+- short: 'B'
+  description: run daemon in the background
+  provenance:
+    sources:
+    - help-text
+- short: 'c'
+  description: Configuration file
+  provenance:
+    sources:
+    - help-text
+- short: 'C'
+  description: ctrl_interface parameter (only used if -c is not)
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  description: increase debugging verbosity (-dd even more)
+  provenance:
+    sources:
+    - help-text
+- short: 'D'
+  description: 'driver name (can be multiple drivers: nl80211,wext)'
+  provenance:
+    sources:
+    - help-text
+- short: 'e'
+  description: entropy file
+  provenance:
+    sources:
+    - help-text
+- short: 'f'
+  description: log output to debug file instead of stdout
+  provenance:
+    sources:
+    - help-text
+- short: 'g'
+  description: global ctrl_interface
+  provenance:
+    sources:
+    - help-text
+- short: 'G'
+  description: global ctrl_interface group
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  description: show this help text
+  provenance:
+    sources:
+    - help-text
+- short: 'i'
+  description: interface name
+  provenance:
+    sources:
+    - help-text
+- short: 'I'
+  description: additional configuration file
+  provenance:
+    sources:
+    - help-text
+- short: 'K'
+  description: include keys (passwords, etc.) in debug output
+  provenance:
+    sources:
+    - help-text
+- short: 'L'
+  description: show license (BSD)
+  provenance:
+    sources:
+    - help-text
+- short: 'm'
+  description: Configuration file for the P2P Device interface
+  provenance:
+    sources:
+    - help-text
+- short: 'N'
+  description: start describing new interface
+  provenance:
+    sources:
+    - help-text
+- short: 'o'
+  description: override driver parameter for new interfaces
+  provenance:
+    sources:
+    - help-text
+- short: 'O'
+  description: override ctrl_interface parameter for new interfaces
+  provenance:
+    sources:
+    - help-text
+- short: 'p'
+  description: driver parameters
+  provenance:
+    sources:
+    - help-text
+- short: 'P'
+  description: PID file
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  description: decrease debugging verbosity (-qq even less)
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  description: log output to syslog instead of stdout
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  description: include timestamp in debug messages
+  provenance:
+    sources:
+    - help-text
+- short: 'T'
+  description: record to Linux tracing in addition to logging (records all messages regardless of debug verbosity)
+  provenance:
+    sources:
+    - help-text
+- short: 'u'
+  description: enable DBus control interface
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  description: show version
+  provenance:
+    sources:
+    - help-text
+- short: 'W'
+  description: wait for a control interface monitor before starting
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/wpa_supplicant/audit-seed4/help.stderr.txt
+++ b/corpus/wpa_supplicant/audit-seed4/help.stderr.txt
@@ -1,0 +1,1 @@
+/usr/sbin/wpa_supplicant: invalid option -- '-'

--- a/corpus/wpa_supplicant/audit-seed4/help.txt
+++ b/corpus/wpa_supplicant/audit-seed4/help.txt
@@ -1,0 +1,57 @@
+wpa_supplicant v2.10
+Copyright (c) 2003-2022, Jouni Malinen <j@w1.fi> and contributors
+
+This software may be distributed under the terms of the BSD license.
+See README for more details.
+
+This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit (http://www.openssl.org/)
+
+usage:
+  wpa_supplicant [-BddhKLqqstuvW] [-P<pid file>] [-g<global ctrl>] \
+        [-G<group>] \
+        -i<ifname> -c<config file> [-C<ctrl>] [-D<driver>] [-p<driver_param>] \
+        [-b<br_ifname>] [-e<entropy file>] [-f<debug file>] \
+        [-o<override driver>] [-O<override ctrl>] \
+        [-N -i<ifname> -c<conf> [-C<ctrl>] [-D<driver>] \
+        [-m<P2P Device config file>] \
+        [-p<driver_param>] [-b<br_ifname>] [-I<config file>] ...]
+
+drivers:
+  nl80211 = Linux nl80211/cfg80211
+  wext = Linux wireless extensions (generic)
+  wired = Wired Ethernet driver
+  macsec_linux = MACsec Ethernet driver for Linux
+  none = no driver (RADIUS server/WPS ER)
+options:
+  -b = optional bridge interface name
+  -B = run daemon in the background
+  -c = Configuration file
+  -C = ctrl_interface parameter (only used if -c is not)
+  -d = increase debugging verbosity (-dd even more)
+  -D = driver name (can be multiple drivers: nl80211,wext)
+  -e = entropy file
+  -f = log output to debug file instead of stdout
+  -g = global ctrl_interface
+  -G = global ctrl_interface group
+  -h = show this help text
+  -i = interface name
+  -I = additional configuration file
+  -K = include keys (passwords, etc.) in debug output
+  -L = show license (BSD)
+  -m = Configuration file for the P2P Device interface
+  -N = start describing new interface
+  -o = override driver parameter for new interfaces
+  -O = override ctrl_interface parameter for new interfaces
+  -p = driver parameters
+  -P = PID file
+  -q = decrease debugging verbosity (-qq even less)
+  -s = log output to syslog instead of stdout
+  -t = include timestamp in debug messages
+  -T = record to Linux tracing in addition to logging
+       (records all messages regardless of debug verbosity)
+  -u = enable DBus control interface
+  -v = show version
+  -W = wait for a control interface monitor before starting
+example:
+  wpa_supplicant -Dnl80211 -iwlan0 -c/etc/wpa_supplicant.conf

--- a/corpus/wpa_supplicant/audit-seed4/meta.toml
+++ b/corpus/wpa_supplicant/audit-seed4/meta.toml
@@ -1,0 +1,34 @@
+# Fixture for the `=`-as-description-separator fix
+# (mandible-extract/src/help_text/sections.rs, `find_equals_separator_gap`
+# / `strip_equals_separator`): wpa_supplicant's `options:` block writes
+# `-b = optional bridge interface name`, one space on each side of a bare
+# `=` and no aligned column gap anywhere on the line. Before the fix that
+# whole row fell into `grammar::parse_flag_spec` and lost its description
+# outright — measured on real `wpa_supplicant --help`: "low confidence: 9%
+# parsed" across its ~28 flags.
+
+# An agent generated this fixture; only a human may change the value
+# below (corpus/README.md's `[bless]` section). No `verdict_scope` is set
+# for the same reason: nobody human has judged this tree.
+[bless]
+provenance = "agent"
+
+[tool]
+name = "wpa_supplicant"
+version = "audit-seed4"
+captured_with = "xtask audit"
+
+[[capture]]
+argv = ["wpa_supplicant", "--help"]
+stdout = "help.txt"
+stderr = "help.stderr.txt"
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+min_subcommands = 0
+# Every one of these used to render with no description at all (the bare
+# `=` separator lost the whole line to the flag-spec grammar). Spot-check
+# both that the flags survive and that their descriptions come back clean,
+# with no leaked `=`.
+must_contain_flags = ["-b", "-B", "-c", "-d", "-h", "-v"]

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -3073,7 +3073,8 @@ fn split_aligned_spelling_entry(line: &str) -> (String, String) {
         Some(start) => line.chars().skip(start).collect::<String>(),
         None => String::new(),
     };
-    (spec, description.trim_end().to_string())
+    let description = strip_equals_separator(description.trim_end()).to_string();
+    (spec, description)
 }
 
 /// The original (pre-multi-column) way to split one flags-block entry line:
@@ -3084,6 +3085,11 @@ fn split_aligned_spelling_entry(line: &str) -> (String, String) {
 fn split_single_column_entry(line: &str) -> (String, String) {
     let gap = find_description_gap(line);
     let (spec, desc) = split_at_column(line, gap);
+    // `find_equals_separator_gap`/`find_multi_space_gap` may have cut at or
+    // before a lone `=` separator token, leaving it attached to the front
+    // of `desc` (`= be verbose`, `= a local filename`) — see
+    // `strip_equals_separator`.
+    let desc = strip_equals_separator(&desc).to_string();
     // A second column of *option spellings* is not a description (`awk
     // --help` prints POSIX short options beside their GNU long
     // equivalents) — see `is_synonym_not_description`. Blanked rather than
@@ -3734,6 +3740,14 @@ fn find_description_gap(line: &str) -> Option<usize> {
         return Some(col);
     }
     // Only ever consulted when the rule above found nothing anywhere in
+    // the line: a lone `=` token standing in for a column gap
+    // (`update-xmlcatalog`'s `--verbose = be verbose`, `wpa_supplicant`'s
+    // `-b = optional bridge interface name`) — see
+    // `find_equals_separator_gap`'s own doc comment.
+    if let Some(col) = find_equals_separator_gap(line) {
+        return Some(col);
+    }
+    // Only ever consulted when the rules above found nothing anywhere in
     // the line — see `find_placeholder_boundary_gap`'s own doc comment.
     if let Some(col) = find_placeholder_boundary_gap(line) {
         return Some(col);
@@ -3985,6 +3999,112 @@ fn find_multi_space_gap(line: &str) -> Option<usize> {
 /// placeholder, never a single space, so it fails the "immediately
 /// followed by exactly one space" test and scanning continues to the
 /// placeholder's real closing `>`.
+/// Fallback for a flag row with no aligned column at all, that separates
+/// spec from description with a lone `=` token instead of whitespace or a
+/// dash: `update-xmlcatalog`'s `--verbose = be verbose` and
+/// `wpa_supplicant`'s `-b = optional bridge interface name` (spec §6, the
+/// `=`-as-separator family). Before this fallback neither line has a 2+
+/// space gap anywhere, so the whole row fell into
+/// `grammar::parse_flag_spec` and the description was lost outright —
+/// measured on `wpa_supplicant`, whose ~28 flags dropped to 9% parsed.
+///
+/// **Only ever consulted when [`find_multi_space_gap`] found no gap
+/// anywhere in the line**, so an aligned row like `--file <file>       =
+/// a local filename` keeps taking that path unchanged; this function never
+/// even runs for it. That row's leftover `= ` prefix on the description is
+/// [`strip_equals_separator`]'s job, not this one's.
+///
+/// Restricted to flag rows (`line.trim_start()` starts with `-`) — a
+/// bare-word block using the same `name = description` shape
+/// (`wpa_supplicant`'s `drivers:` block, `nl80211 = Linux
+/// nl80211/cfg80211`) has no `-` anchor to key off of and is deliberately
+/// left alone: that block never reaches [`find_description_gap`] through
+/// this path anyway ([`scan_bare_block`] uses a different splitter), but
+/// the guard also protects the (untested) day this function gets reused
+/// from a different call site.
+///
+/// Scans tokens left to right. Every token before the `=` must satisfy
+/// [`is_value_spec_token`] — the same predicate [`find_sentence_start_gap`]
+/// uses to tell a still-open spec from prose — so `--file <file> = ...`
+/// qualifies (`<file>` is a placeholder) but `--foo Set X = Y` does not:
+/// `Set` is a bare lowercase-free word that stops the scan, and the
+/// function returns `None` rather than treating `Set`'s `=` as the
+/// separator. The candidate token itself must be **exactly** `=` — never
+/// `=x`, `x=`, or `x=y` — which the whitespace tokenizer guarantees is
+/// already surrounded by whitespace on both sides. Real in-spec and
+/// in-description `=` usage (`--opt=VALUE`, `ffplay`'s "0 = disable, 1 =
+/// enable", `bugpoint-18`'s "(default = off)") never reaches this function
+/// bare: either `find_multi_space_gap` already cut the line, or the `=`
+/// sits inside a token rather than standing alone as one.
+///
+/// Requires at least one non-whitespace character after the `=` — an
+/// empty tail (`--flag =`) returns `None`, leaving today's behaviour (no
+/// description) unchanged.
+///
+/// Returns the byte offset of the `=` character itself, so
+/// [`split_at_column`] yields `spec = "--verbose"` and
+/// `desc = "= be verbose"` — the leading `= ` is stripped afterward by
+/// [`strip_equals_separator`], the same function symptom 2 uses.
+fn find_equals_separator_gap(line: &str) -> Option<usize> {
+    if !line.trim_start().starts_with('-') {
+        return None;
+    }
+    let bytes = line.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b' ' || bytes[i] == b'\t' {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < bytes.len() && bytes[i] != b' ' && bytes[i] != b'\t' {
+            i += 1;
+        }
+        // `start` and `i` only ever land on ASCII space/tab boundaries or
+        // the ends of the string, so neither can fall inside a multi-byte
+        // character — `get` rather than `[..]` regardless (AGENTS.md §2).
+        let token = line.get(start..i)?;
+        if token == "=" {
+            let tail_has_content = line.get(i..).is_some_and(|rest| !rest.trim().is_empty());
+            return if tail_has_content { Some(start) } else { None };
+        }
+        if !is_value_spec_token(token) {
+            return None;
+        }
+    }
+    None
+}
+
+/// Strip a flag row description's leading `= ` separator token: if `desc`
+/// starts with `=` immediately followed by ASCII whitespace, drop the `=`
+/// and that whitespace; otherwise return it unchanged.
+///
+/// Two call sites need this, both symptoms of the same `=`-as-separator
+/// layout: [`find_equals_separator_gap`] deliberately returns the `=`
+/// character's own offset (so [`split_at_column`] keeps the separator
+/// attached to whichever side already worked), and a row whose column
+/// *is* aligned (`--file <file>       = a local filename`) already splits
+/// correctly at the space run **before** the `=` — [`find_multi_space_gap`]
+/// gets there first — leaving the same leading `= ` on the description.
+/// One strip serves both paths.
+///
+/// Only the separator token is removed. A second `=` inside the
+/// description proper is text, not punctuation, and is left alone:
+/// `--root              = the root XML catalog (= /etc/xml/catalog)`
+/// strips to `the root XML catalog (= /etc/xml/catalog)`, keeping the
+/// parenthetical's own `=`.
+///
+/// Apply this only where a flag row's description is produced — never to
+/// a bare-word block's entries, where `name = description` names the
+/// value itself (`wpa_supplicant`'s `drivers:` block) and stripping would
+/// fabricate a different name.
+fn strip_equals_separator(desc: &str) -> &str {
+    match desc.strip_prefix('=') {
+        Some(rest) if rest.starts_with(|c: char| c.is_ascii_whitespace()) => rest.trim_start(),
+        _ => desc,
+    }
+}
+
 fn find_placeholder_boundary_gap(line: &str) -> Option<usize> {
     let bytes = line.as_bytes();
     for (i, &b) in bytes.iter().enumerate() {
@@ -8046,5 +8166,284 @@ Options:
                 .any(|f| f.long.as_deref() == Some("beta")),
             "one row is not evidence of a column"
         );
+    }
+
+    /// Symptom 1 (`update-xmlcatalog`, `wpa_supplicant`): a bare `= `
+    /// separator with only one space on each side has no 2+-space gap
+    /// anywhere on the line, so before `find_equals_separator_gap` the
+    /// whole row fell into `grammar::parse_flag_spec` and the description
+    /// was lost outright. Measured on `wpa_supplicant --help`: "low
+    /// confidence: 9% parsed" across its ~28 flags.
+    #[test]
+    fn a_lone_equals_token_with_single_spacing_recovers_the_description() {
+        let help = "Options:\n    \
+                    --verbose = be verbose\n    \
+                    --sort = sorts the manipulated catalog content\n";
+        let parsed = parse(help);
+        assert_eq!(
+            flag_named(&parsed, "verbose")
+                .description
+                .as_ref()
+                .map(|d| d.as_str()),
+            Some("be verbose")
+        );
+        assert_eq!(
+            flag_named(&parsed, "sort")
+                .description
+                .as_ref()
+                .map(|d| d.as_str()),
+            Some("sorts the manipulated catalog content")
+        );
+        for flag in &parsed.flags {
+            let desc = flag.description.as_ref().map(|d| d.as_str()).unwrap_or("");
+            assert!(!desc.starts_with('='), "separator leaked into: {desc:?}");
+        }
+    }
+
+    /// Same shape, short-flag form (`wpa_supplicant`'s `options:` block):
+    /// `-b = optional bridge interface name`.
+    #[test]
+    fn a_lone_equals_token_recovers_a_short_flags_description() {
+        let help = "options:\n  \
+                    -b = optional bridge interface name\n  \
+                    -B = run daemon in the background\n";
+        let parsed = parse(help);
+        let b = parsed
+            .flags
+            .iter()
+            .find(|f| f.short == Some('b'))
+            .expect("-b must be recovered");
+        assert_eq!(
+            b.description.as_ref().map(|d| d.as_str()),
+            Some("optional bridge interface name")
+        );
+    }
+
+    /// Symptom 2 (`update-xmlcatalog`'s `With:` block): the column *is*
+    /// aligned, so `find_multi_space_gap` already cuts correctly, but the
+    /// description keeps its leading `= ` (`= a local filename`). This is
+    /// `strip_equals_separator`'s job, applied after the split rather than
+    /// changing where the split happens.
+    #[test]
+    fn an_aligned_column_still_strips_its_leading_equals_separator() {
+        let help = "With:\n    \
+                    --file <file>       = a local filename\n    \
+                    --id <id>           = catalog entry idenitifier\n";
+        let parsed = parse(help);
+        let file = parsed
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("file"))
+            .expect("--file must be recovered");
+        assert_eq!(
+            file.description.as_ref().map(|d| d.as_str()),
+            Some("a local filename")
+        );
+    }
+
+    /// Only the *separator* `=` is stripped; a second `=` inside the
+    /// description proper is text and must survive verbatim.
+    /// `update-xmlcatalog`: `--root ... = the root XML catalog (=
+    /// /etc/xml/catalog)`.
+    #[test]
+    fn a_second_equals_inside_the_description_is_left_alone() {
+        let help = "With:\n    \
+                    --root              = the root XML catalog (= /etc/xml/catalog)\n";
+        let parsed = parse(help);
+        let root = flag_named(&parsed, "root");
+        assert_eq!(
+            root.description.as_ref().map(|d| d.as_str()),
+            Some("the root XML catalog (= /etc/xml/catalog)")
+        );
+    }
+
+    /// `--flag =` with nothing after the separator keeps today's behaviour
+    /// (no description invented from an empty tail).
+    #[test]
+    fn an_equals_separator_with_an_empty_tail_invents_no_description() {
+        let help = "Options:\n  --flag =\n";
+        let parsed = parse(help);
+        let flag = flag_named(&parsed, "flag");
+        assert_eq!(flag.description, None);
+    }
+
+    /// Inverse case: `=` deep inside a description, not a separator at
+    /// all. `ffprobe --help`/`ffplay --help`:
+    /// `-http_seekable <boolean> .D... Use HTTP partial requests, 0 =
+    /// disable, 1 = enable, -1 = auto (default auto)`. A real aligned
+    /// column gap exists before any `=`, so `find_multi_space_gap` must
+    /// keep winning and `find_equals_separator_gap` must never run.
+    #[test]
+    fn equals_signs_inside_a_sentence_are_not_mistaken_for_a_separator() {
+        // `http_seekable`'s underscore keeps `repair_single_dash_long_options`
+        // from ever claiming it (condition 3 rejects `_` in the swallowed
+        // tail — see that function's own doc comment), so this stays a
+        // short `-h` carrying everything after it as one description. That
+        // is unrelated to and unchanged by this fix; what matters here is
+        // that the `=` signs inside the sentence survive untouched.
+        let help = "Options:\n  \
+                    -http_seekable     <boolean>    .D......... Use HTTP partial requests, 0 = disable, 1 = enable, -1 = auto (default auto)\n";
+        let parsed = parse(help);
+        let flag = parsed
+            .flags
+            .iter()
+            .find(|f| f.short == Some('h'))
+            .expect("-http_seekable must be recovered as a short flag");
+        assert_eq!(
+            flag.description.as_ref().map(|d| d.as_str()),
+            Some("<boolean> .D......... Use HTTP partial requests, 0 = disable, 1 = enable, -1 = auto (default auto)")
+        );
+    }
+
+    /// Inverse case: `llc-18`/`opt-18`/`bugpoint-18`'s
+    /// `--enable-gvn-hoist ... - Enable the GVN hoisting pass (default =
+    /// off)`. A huge aligned gap, then a ` - ` dash separator; the `=`
+    /// inside `(default = off)` is deep in the description and must not
+    /// move the cut.
+    #[test]
+    fn equals_signs_after_a_dash_separator_are_left_in_the_description() {
+        let help = "Options:\n  \
+                    --enable-gvn-hoist                                                    - Enable the GVN hoisting pass (default = off)\n";
+        let parsed = parse(help);
+        let flag = flag_named(&parsed, "enable-gvn-hoist");
+        assert_eq!(
+            flag.description.as_ref().map(|d| d.as_str()),
+            Some("- Enable the GVN hoisting pass (default = off)")
+        );
+    }
+
+    /// Inverse case: `ntfswipe --help`'s
+    /// `-c num   --count num   Number of times to write(default = 1)` —
+    /// an aligned multi-column row (two spellings, then description) whose
+    /// description itself contains `=`.
+    #[test]
+    fn equals_signs_in_a_two_column_rows_description_are_untouched() {
+        let help = "Options:\n    \
+                    -c num   --count num   Number of times to write(default = 1)\n    \
+                    -b list  --bytes list  List of values to write(default = 0)\n";
+        let parsed = parse(help);
+        let flag = flag_named(&parsed, "count");
+        let desc = flag.description.as_ref().map(|d| d.as_str()).unwrap_or("");
+        assert!(
+            desc.contains("(default = 1)"),
+            "description lost its own `=`: {desc:?}"
+        );
+    }
+
+    /// Inverse case: `lvmpolld --help`'s
+    /// `-t|--timeout     Time to wait in seconds before shutdown on idle
+    /// (missing or 0 = inifinite)`.
+    #[test]
+    fn equals_signs_in_a_piped_alias_rows_description_are_untouched() {
+        let help = "Options:\n   \
+                    -t|--timeout     Time to wait in seconds before shutdown on idle (missing or 0 = inifinite)\n";
+        let parsed = parse(help);
+        let desc = parsed
+            .flags
+            .iter()
+            .find_map(|f| f.description.as_ref().map(|d| d.as_str()))
+            .unwrap_or("");
+        assert!(
+            desc.contains("(missing or 0 = inifinite)"),
+            "description lost its own `=`: {desc:?}"
+        );
+    }
+
+    /// Inverse case: `systemd --help`'s `--dump-core[=BOOL]          Dump
+    /// core on crash` — the `=` is inside the spec's own bracket notation,
+    /// never a standalone token, and a real aligned gap follows it anyway.
+    #[test]
+    fn a_bracketed_equals_inside_the_spec_is_not_a_separator() {
+        let help = "Options:\n     \
+                    --dump-core[=BOOL]          Dump core on crash\n";
+        let parsed = parse(help);
+        let flag = flag_named(&parsed, "dump-core");
+        assert_eq!(flag.value_kind, ValueKind::Optional);
+        assert_eq!(
+            flag.description.as_ref().map(|d| d.as_str()),
+            Some("Dump core on crash")
+        );
+    }
+
+    /// `man --help`'s deeply-indented continuation line
+    /// (`corpus`/queue-capture `man/0.stdout`):
+    ///
+    /// ```text
+    ///   -X, --gxditview[=RESOLUTION]   use groff and display through gxditview
+    ///                              (X11):
+    ///                              -X = -TX75, -X100 = -TX100, -X100-12 = -TX100-12
+    ///   -Z, --ditroff              use groff and force it to produce ditroff
+    /// ```
+    ///
+    /// The `-X = -TX75, ...` line starts with `-` and would qualify for
+    /// `find_equals_separator_gap` in isolation, but `scan_flags_block`
+    /// never offers it that function: its indent (29) is far past
+    /// `-X, --gxditview`'s own entry indent (2) plus
+    /// `ENTRY_INDENT_TOLERANCE`, so it is read as a **continuation** line
+    /// and appended verbatim to `--gxditview`'s description
+    /// (`entries.last_mut()` in `scan_flags_block`) — it never reaches
+    /// `split_single_column_entry` or `find_description_gap` at all.
+    /// Confirmed unchanged by this fix: the continuation text, `=` signs
+    /// included, survives byte-for-byte in the recovered description both
+    /// before and after.
+    #[test]
+    fn mans_deeply_indented_continuation_line_is_unaffected() {
+        let help = "Options:\n  \
+                    -X, --gxditview[=RESOLUTION]   use groff and display through gxditview\n                             \
+                    (X11):\n                             \
+                    -X = -TX75, -X100 = -TX100, -X100-12 = -TX100-12\n  \
+                    -Z, --ditroff              use groff and force it to produce ditroff\n";
+        let parsed = parse(help);
+        let gxditview = flag_named(&parsed, "gxditview");
+        assert_eq!(
+            gxditview.description.as_ref().map(|d| d.as_str()),
+            Some(
+                "use groff and display through gxditview (X11): -X = -TX75, -X100 = -TX100, -X100-12 = -TX100-12"
+            ),
+            "the continuation text (and its own `=` signs) must survive verbatim"
+        );
+    }
+
+    #[test]
+    fn find_equals_separator_gap_unit_cases() {
+        assert_eq!(
+            find_equals_separator_gap("  --verbose = be verbose"),
+            Some("  --verbose ".len())
+        );
+        assert_eq!(
+            find_equals_separator_gap("  -b = optional bridge interface name"),
+            Some("  -b ".len())
+        );
+        // No content after the separator: unchanged behaviour.
+        assert_eq!(find_equals_separator_gap("  --flag ="), None);
+        // A token other than a bare spec/value-spec before the `=` stops
+        // the scan (`mariadb`-style prose before an `=`).
+        assert_eq!(find_equals_separator_gap("  --foo Set X = Y"), None);
+        // Not a flag row at all (no leading `-`): never matched here.
+        assert_eq!(
+            find_equals_separator_gap("nl80211 = Linux nl80211/cfg80211"),
+            None
+        );
+        // `=` glued to another character is not a lone separator token.
+        assert_eq!(find_equals_separator_gap("  --foo =bar"), None);
+        assert_eq!(find_equals_separator_gap("  --foo bar= baz"), None);
+    }
+
+    #[test]
+    fn strip_equals_separator_unit_cases() {
+        assert_eq!(strip_equals_separator("= be verbose"), "be verbose");
+        assert_eq!(strip_equals_separator("=\tbe verbose"), "be verbose");
+        assert_eq!(
+            strip_equals_separator("the root XML catalog (= /etc/xml/catalog)"),
+            "the root XML catalog (= /etc/xml/catalog)"
+        );
+        // No leading `=`: unchanged.
+        assert_eq!(
+            strip_equals_separator("no separator here"),
+            "no separator here"
+        );
+        // `=` not followed by whitespace is not the separator shape.
+        assert_eq!(strip_equals_separator("=bar"), "=bar");
+        assert_eq!(strip_equals_separator("="), "=");
     }
 }

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -362,22 +362,76 @@ fn build_fingerprint(root: Option<&mandible_core::CommandNode>) -> ToolFingerpri
     fp
 }
 
-/// Escape the one character ([`FP_FIELD_SEP`]) that would otherwise be
-/// ambiguous with the `#fp` line's own field separator — flag identities and
-/// subcommand paths never contain it by construction ([`flag_identity`]
-/// only ever emits `-`, `,`, `.`, `:`, `(`, `)` and the tool's own ASCII-
-/// overwhelming spellings), but `value_name` is free-form text lifted
-/// verbatim from a tool's own `--help` output and cannot be assumed clean.
+/// Backslash-escape every character the `#fp` wire format uses as
+/// structure, so the escaped output is guaranteed to contain **no raw
+/// separator character at all** — the read side ([`crate::transition`]'s
+/// `fp_unescape`) can then keep its existing plain `split`/`splitn` calls
+/// unchanged and only needs an unescape pass per field.
+///
+/// **Why every separator, not just [`FP_FIELD_SEP`].** An earlier version of
+/// this function only replaced the top-level field separator (tab) and
+/// newline with a space, on the theory that `flag_identity` only ever emits
+/// `-`, `,`, `.`, `:`, `(`, `)` and the tool's own spelling, and `value_name`
+/// — while free-form text lifted verbatim from a tool's own `--help` output
+/// — was assumed not to collide with the *other* separators this format
+/// uses ([`FP_FLAG_SEP`], [`FP_SUBCOMMAND_SEP`], [`FP_ID_SEP`],
+/// [`FP_ENTRY_SEP`]). That assumption is false, measurably: `awk`'s `-L`
+/// flag has `value_name` `"fatal|invalid|no-ext"` — real text from `awk
+/// --help`, not something this codebase invents. `fingerprint_lines`'s
+/// flag-list separator is also `|`, so the old `fp_escape` rendered a `#fp`
+/// line with three unescaped pipes where one flag-list separator was
+/// intended; `transition::parse_fingerprint_line` splits on every `|` it
+/// finds, so `"invalid"` and `"no-ext"` became bogus flag entries with no
+/// `=`, `split_once('=')` returned `None`, and the `?` on that line
+/// discarded the *entire* `#fp awk` line — every flag on it, not just `-L`.
+/// `awk`, `gawk` and `nawk` silently dropped out of every field-level
+/// `sweep-diff` comparison until this was found (PR #22, diffed by hand).
+///
+/// Escapes, per character: `\` -> `\\`, tab -> `\t`, newline -> `\n`,
+/// [`FP_FLAG_SEP`] (`|`) -> `\p`, [`FP_SUBCOMMAND_SEP`] (`,`) -> `\c`,
+/// [`FP_ID_SEP`] (`=`) -> `\e`, [`FP_ENTRY_SEP`] (`:`) -> `\s`. Everything
+/// else passes through unchanged.
 fn fp_escape(s: &str) -> String {
-    s.replace([FP_FIELD_SEP, '\n'], " ")
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            FP_FIELD_SEP => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            FP_FLAG_SEP => out.push_str("\\p"),
+            FP_SUBCOMMAND_SEP => out.push_str("\\c"),
+            FP_ID_SEP => out.push_str("\\e"),
+            FP_ENTRY_SEP => out.push_str("\\s"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
-/// Field separator inside one `#fp` line's flag-entry list. A literal tab:
-/// never legitimately present in a flag identity or a `value_name` lifted
-/// from help text (which is sanitized to a single line, spec §4.1), so it
-/// needs no escaping on the read side beyond [`fp_escape`] scrubbing it out
-/// of `value_name` before it's ever written.
+/// Top-level field separator inside one `#fp` line (`#fp <tool>\t<subs>\t<flags>`)
+/// — duplicated into `crate::transition` as its own `FP_FIELD_SEP` for the
+/// same reason [`EXTRACT_TIMEOUT_MS`] is duplicated rather than imported: a
+/// single well-known, stable character, re-measured in the same commit as
+/// the other side if it ever changes. Escaped out of every emitted piece by
+/// [`fp_escape`], same as the other three separators below.
 const FP_FIELD_SEP: char = '\t';
+
+/// Separator between flag entries inside one `#fp` line's flag-entry list
+/// (`<flag1>|<flag2>|...`) — mirrored in `crate::transition`.
+const FP_FLAG_SEP: char = '|';
+
+/// Separator between subcommand paths inside one `#fp` line's subcommand
+/// list (`<sub1>,<sub2>,...`) — mirrored in `crate::transition`.
+const FP_SUBCOMMAND_SEP: char = ',';
+
+/// Separator between one flag entry's id and its fields (`<id>=<fields>`) —
+/// mirrored in `crate::transition`.
+const FP_ID_SEP: char = '=';
+
+/// Separator between one flag entry's fields
+/// (`<has_desc>:<desc_hash>:<choices_hash>:<value_name>`) — mirrored in
+/// `crate::transition`.
+const FP_ENTRY_SEP: char = ':';
 
 /// Render every row's [`ToolFingerprint`] as `#fp` footer lines, one per
 /// tool, in the same tool-name order `rows` is already sorted in ([`run_over`])
@@ -400,9 +454,13 @@ const FP_FIELD_SEP: char = '\t';
 /// Line shape: `#fp <tool>\t<sub1>,<sub2>,...\t<flag1>|<flag2>|...` where
 /// each flag entry is `<id>=<has_desc:0/1>:<desc_hash-or-->:<choices_hash-or-->:<value_name-or-->`
 /// (hashes as lowercase hex), and either list may be empty (`#fp true\t\t`
-/// for a tool with no subcommands and no flags). Never mixed into
-/// `render_markdown`'s output: [`crate::transition::parse_scoreboard`] only
-/// ever reads a [`ScoreFormat::Text`] scoreboard (that module's own doc
+/// for a tool with no subcommands and no flags). `tool`, each subcommand
+/// path, each flag `id` and `value_name` are individually run through
+/// [`fp_escape`] before being written, so none of them can ever contain a
+/// raw `\t`, `\n`, `|`, `,`, `=` or `:` — see that function's doc comment for
+/// why every one of those needs escaping, not just the top-level `\t`. Never
+/// mixed into `render_markdown`'s output: [`crate::transition::parse_scoreboard`]
+/// only ever reads a [`ScoreFormat::Text`] scoreboard (that module's own doc
 /// comment), so there is nothing that would read a markdown copy of this
 /// section.
 fn fingerprint_lines(rows: &[Row]) -> String {
@@ -2739,6 +2797,158 @@ mod tests {
             assert_eq!(parsed_flag.choices_hash, live_flag.choices_hash);
             assert_eq!(parsed_flag.value_name, live_flag.value_name);
         }
+    }
+
+    /// **The awk regression, reproduced.** PR #22's real finding: `awk`'s
+    /// `-L` flag has `value_name` `"fatal|invalid|no-ext"` — free-form text
+    /// lifted verbatim from `awk --help`, not something this codebase
+    /// invents. `fingerprint_lines`'s flag-list separator is also `|`, so
+    /// pre-fix (`fp_escape` only scrubbing tab/newline) the rendered `#fp`
+    /// line contains three unescaped pipes where only one flag-list
+    /// separator was intended; `transition::parse_fingerprint_line` splits
+    /// on every `|` it sees, so `"invalid"` and `"no-ext"` become their own
+    /// bogus flag entries with no `=`, `split_once('=')` returns `None`, and
+    /// the `?` on that line discards the *entire* `#fp awk` line — every
+    /// flag on it, not just `-L`. `awk`/`gawk`/`nawk` silently vanish from
+    /// every field-level `sweep-diff` comparison. This test drives the exact
+    /// shape through the real pipeline (`build_fingerprint` ->
+    /// `fingerprint_lines` -> `transition::parse_scoreboard`) and asserts
+    /// the line survives and the value_name comes back byte-for-byte.
+    #[test]
+    fn fingerprint_footer_round_trips_a_value_name_containing_the_flag_list_separator() {
+        use mandible_core::{CommandNode, Flag, Provenance, Source};
+
+        let mut root = CommandNode::new("awk", Provenance::single(Source::HelpText));
+        let mut flag = Flag::long("L", Provenance::single(Source::HelpText));
+        flag.long = None;
+        flag.short = Some('L');
+        flag.value_name = Some("fatal|invalid|no-ext".to_string());
+        root.flags.push(flag);
+
+        let mut r = row("awk", 1, Some(0.0), "ok");
+        r.fingerprint = build_fingerprint(Some(&root));
+        let rows = vec![r];
+        let agg = compute_aggregate(&rows);
+        let text = render_text(&rows, &agg);
+
+        let parsed = crate::transition::parse_scoreboard(&text);
+        let fp = parsed.fingerprints.get("awk").expect(
+            "pre-fix this whole line is dropped by parse_fingerprint_line \
+             because value_name's unescaped `|`s are mistaken for extra \
+             flag-list entries",
+        );
+        assert_eq!(fp.flags.len(), 1, "the only flag on the line must survive");
+        let flag = fp.flags.values().next().unwrap();
+        assert_eq!(
+            flag.value_name.as_deref(),
+            Some("fatal|invalid|no-ext"),
+            "value_name must round-trip byte-for-byte, not be mangled or dropped"
+        );
+    }
+
+    /// **Every separator the `#fp` wire format uses, in one sweep**, plus
+    /// two defensive cases beyond `value_name`: a subcommand name carrying
+    /// the subcommand-list separator (`,`), and a flag long spelling
+    /// carrying the flag-list separator (`|`) — a badly-parsed flag can, in
+    /// principle, carry anything, and the escaping scheme is supposed to be
+    /// blind to *which* piece of text needs it, not special-cased to
+    /// `value_name` alone. Each value_name below embeds exactly one
+    /// character the wire format would otherwise misread as structure:
+    /// `,` (subcommand-list sep), `=` (id/fields sep), `:` (intra-entry
+    /// sep), a literal tab (top-level field sep), and a literal backslash
+    /// (the escape character itself, which must round-trip too).
+    #[test]
+    fn fingerprint_footer_round_trips_every_separator_character() {
+        use mandible_core::{CommandNode, Flag, Provenance, Source};
+
+        let mut root = CommandNode::new("demo", Provenance::single(Source::HelpText));
+
+        let mut comma_flag = Flag::long("comma-value", Provenance::single(Source::HelpText));
+        comma_flag.value_name = Some("a,b".to_string());
+        root.flags.push(comma_flag);
+
+        let mut equals_flag = Flag::long("equals-value", Provenance::single(Source::HelpText));
+        equals_flag.value_name = Some("a=b".to_string());
+        root.flags.push(equals_flag);
+
+        let mut colon_flag = Flag::long("colon-value", Provenance::single(Source::HelpText));
+        colon_flag.value_name = Some("a:b".to_string());
+        root.flags.push(colon_flag);
+
+        let mut tab_flag = Flag::long("tab-value", Provenance::single(Source::HelpText));
+        tab_flag.value_name = Some("a\tb".to_string());
+        root.flags.push(tab_flag);
+
+        let mut backslash_flag =
+            Flag::long("backslash-value", Provenance::single(Source::HelpText));
+        backslash_flag.value_name = Some("a\\b".to_string());
+        root.flags.push(backslash_flag);
+
+        // Defensive: a flag whose own long spelling (not just its
+        // value_name) carries the flag-list separator.
+        let pipe_id_flag = Flag::long("weird|name", Provenance::single(Source::HelpText));
+        root.flags.push(pipe_id_flag);
+
+        // Defensive: a subcommand name carrying the subcommand-list
+        // separator.
+        root.subcommands.push(CommandNode::new(
+            "sub,with,comma",
+            Provenance::single(Source::HelpText),
+        ));
+
+        let mut r = row("demo", 1, Some(0.0), "ok");
+        r.fingerprint = build_fingerprint(Some(&root));
+        let rows = vec![r];
+        let agg = compute_aggregate(&rows);
+        let text = render_text(&rows, &agg);
+
+        let parsed = crate::transition::parse_scoreboard(&text);
+        let fp = parsed
+            .fingerprints
+            .get("demo")
+            .expect("the #fp line must survive with every flag intact");
+        assert_eq!(fp.flags.len(), 6, "no flag entry may be lost or merged");
+
+        assert_eq!(
+            fp.flags
+                .get("(root)::--comma-value")
+                .and_then(|f| f.value_name.clone()),
+            Some("a,b".to_string())
+        );
+        assert_eq!(
+            fp.flags
+                .get("(root)::--equals-value")
+                .and_then(|f| f.value_name.clone()),
+            Some("a=b".to_string())
+        );
+        assert_eq!(
+            fp.flags
+                .get("(root)::--colon-value")
+                .and_then(|f| f.value_name.clone()),
+            Some("a:b".to_string())
+        );
+        assert_eq!(
+            fp.flags
+                .get("(root)::--tab-value")
+                .and_then(|f| f.value_name.clone()),
+            Some("a\tb".to_string())
+        );
+        assert_eq!(
+            fp.flags
+                .get("(root)::--backslash-value")
+                .and_then(|f| f.value_name.clone()),
+            Some("a\\b".to_string())
+        );
+        assert!(
+            fp.flags.contains_key("(root)::--weird|name"),
+            "a flag id carrying the flag-list separator must survive under its own key"
+        );
+
+        assert_eq!(fp.subcommands.len(), 1);
+        assert!(
+            fp.subcommands.contains("sub,with,comma"),
+            "a subcommand name carrying the subcommand-list separator must round-trip whole"
+        );
     }
 
     // `structure_sanity`'s own unit tests (fabricated names, empty nodes,

--- a/xtask/src/transition.rs
+++ b/xtask/src/transition.rs
@@ -206,7 +206,7 @@ static EMPTY_FINGERPRINT: ParsedFingerprint = ParsedFingerprint {
 /// this binary itself wrote.
 fn parse_fingerprint_line(rest: &str) -> Option<(String, ParsedFingerprint)> {
     let mut top = rest.splitn(3, FP_FIELD_SEP);
-    let tool = top.next()?.to_string();
+    let tool = fp_unescape(top.next()?);
     let subs_s = top.next().unwrap_or("");
     let flags_s = top.next().unwrap_or("");
 
@@ -214,18 +214,22 @@ fn parse_fingerprint_line(rest: &str) -> Option<(String, ParsedFingerprint)> {
     if !subs_s.is_empty() {
         for s in subs_s.split(',') {
             if !s.is_empty() {
-                fp.subcommands.insert(s.to_string());
+                fp.subcommands.insert(fp_unescape(s));
             }
         }
     }
     if !flags_s.is_empty() {
         for entry in flags_s.split('|') {
             let (id, rest) = entry.split_once('=')?;
+            let id = fp_unescape(id);
             // `splitn(4, ':')` so a `value_name` that itself contains a
-            // colon (free-form text lifted from real `--help` output, only
-            // `\t`/`\n` are escaped — see `coverage::fp_escape`) lands whole
-            // in the final piece instead of being truncated at its first
-            // colon.
+            // colon (free-form text lifted from real `--help` output) lands
+            // whole in the final piece instead of being truncated at its
+            // first colon. This still matters post-escaping: an *old*
+            // scoreboard's `value_name` can hold a raw, unescaped `:` (see
+            // `fp_unescape`'s doc comment on backward compatibility), and
+            // this `splitn` is exactly what already handles that case
+            // correctly, unchanged.
             let mut fields = rest.splitn(4, ':');
             let has_description = fields.next()? == "1";
             let description_hash = match fields.next()? {
@@ -238,10 +242,10 @@ fn parse_fingerprint_line(rest: &str) -> Option<(String, ParsedFingerprint)> {
             };
             let value_name = match fields.next()? {
                 "-" => None,
-                v => Some(v.to_string()),
+                v => Some(fp_unescape(v)),
             };
             fp.flags.insert(
-                id.to_string(),
+                id,
                 ParsedFlagFingerprint {
                     has_description,
                     description_hash,
@@ -254,12 +258,85 @@ fn parse_fingerprint_line(rest: &str) -> Option<(String, ParsedFingerprint)> {
     Some((tool, fp))
 }
 
+/// Reverse [`crate::coverage::fp_escape`] on one parsed piece (tool name,
+/// subcommand path, flag id, or `value_name`) of a `#fp` line.
+///
+/// `\\` -> `\`, `\t` -> a literal tab, `\n` -> a literal newline, `\p` -> `|`
+/// ([`FP_FLAG_SEP`]), `\c` -> `,` ([`FP_SUBCOMMAND_SEP`]), `\e` -> `=`
+/// ([`FP_ID_SEP`]), `\s` -> `:` ([`FP_ENTRY_SEP`]). Every other `\X` passes
+/// through **verbatim as `\X`** (an unrecognized escape is not an error —
+/// there is nothing else in this format that could have produced it), and a
+/// trailing lone `\` at the end of the field passes through as `\`.
+///
+/// **Backward compatible with every scoreboard this binary has ever
+/// written, measured, not assumed.** Before this task, `fp_escape` never
+/// emitted a backslash at all (it only replaced tab/newline with a space) —
+/// a direct count found **0 backslashes across all 2,308 `#fp` lines** in a
+/// full-`PATH` sweep capture (`tmp/sweep-before.txt`) and **0** in
+/// `coverage-scoreboard.ci.txt`. `fp_unescape` is therefore the identity
+/// function on every existing scoreboard: with no backslash present, every
+/// branch above is unreachable and the string comes back unchanged,
+/// including a raw `|`, `,`, `=` or `:` sitting in a `value_name` exactly
+/// where it always did (the pre-existing `splitn(4, ':')` in
+/// [`parse_fingerprint_line`] is what actually keeps a raw-colon
+/// `value_name` intact, unaffected by this function).
+///
+/// **The one theoretical incompatibility, and why it's a caveat rather than
+/// a blocker.** An old scoreboard whose `value_name` happened to hold a
+/// literal backslash immediately followed by one of the seven escape
+/// letters (`\`, `t`, `n`, `p`, `c`, `e`, `s`) would have that pair
+/// misread as an escape sequence instead of two literal characters. Neither
+/// measured corpus contains a single backslash of any kind, so this has
+/// never actually happened — it is recorded here as a known, measured-zero
+/// edge case, not a defect being silently accepted.
+fn fp_unescape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('\\') => out.push('\\'),
+            Some('t') => out.push('\t'),
+            Some('n') => out.push('\n'),
+            Some('p') => out.push(FP_FLAG_SEP),
+            Some('c') => out.push(FP_SUBCOMMAND_SEP),
+            Some('e') => out.push(FP_ID_SEP),
+            Some('s') => out.push(FP_ENTRY_SEP),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
 /// The literal tab [`coverage::fingerprint_lines`] separates a `#fp` line's
 /// three top-level fields with — duplicated from `coverage::FP_FIELD_SEP`
 /// (private to that module) for the same reason [`EXTRACT_TIMEOUT_MS`] is
 /// duplicated rather than imported: a single well-known, stable character,
 /// re-measured in the same commit as the other side if it ever changes.
 const FP_FIELD_SEP: char = '\t';
+
+/// Mirrors `coverage::FP_FLAG_SEP` — same duplication convention as
+/// [`FP_FIELD_SEP`] above.
+const FP_FLAG_SEP: char = '|';
+
+/// Mirrors `coverage::FP_SUBCOMMAND_SEP` — same duplication convention as
+/// [`FP_FIELD_SEP`] above.
+const FP_SUBCOMMAND_SEP: char = ',';
+
+/// Mirrors `coverage::FP_ID_SEP` — same duplication convention as
+/// [`FP_FIELD_SEP`] above.
+const FP_ID_SEP: char = '=';
+
+/// Mirrors `coverage::FP_ENTRY_SEP` — same duplication convention as
+/// [`FP_FIELD_SEP`] above.
+const FP_ENTRY_SEP: char = ':';
 
 /// True when `header` is (or resembles) a scoreboard's own header line,
 /// used only to decide whether it carries the `misattr` column added after
@@ -1856,6 +1933,113 @@ mod tests {
         assert_eq!(fd.flags_removed, vec!["(root)::--old"]);
         assert_eq!(fd.subcommands_added, vec!["new-sub"]);
         assert_eq!(fd.subcommands_removed, vec!["old-sub"]);
+    }
+
+    /// **The awk regression, at `sweep-diff` level.** `coverage.rs`'s own
+    /// test module proves the wire format round-trips a `|`-containing
+    /// value_name through the real rendering pipeline; this test proves the
+    /// *consumer* of that format — `sweep-diff`'s `diff` — actually uses the
+    /// recovered data instead of quietly losing the tool to the
+    /// "unmeasured" bucket. The `#fp` line below is hand-written in the
+    /// fixed wire format (`\p` standing in for the escaped `|` inside
+    /// `awk`'s real `fatal|invalid|no-ext` value_name — `coverage::fp_escape`
+    /// is private to that module, so the format's own fixed, documented
+    /// shape is pinned here directly rather than called into). Pre-fix,
+    /// `parse_fingerprint_line` has no unescaping step at all: it takes the
+    /// literal two characters `\` and `p` at face value, so nothing here
+    /// trips the *old* bug (splitting on a raw `|`) — instead it proves the
+    /// value_name comes back as literal `fatal\pinvalid\pno-ext` instead of
+    /// `fatal|invalid|no-ext`, and separately, `field_diff_unmeasured` and
+    /// `field_diffs` should have been produced correctly since no raw `|`
+    /// entered the line at all. Only the value_name assertion at the bottom
+    /// is expected to fail before `fp_unescape` exists; kept as one test
+    /// (rather than splitting the unescape check out) because the whole
+    /// point is that `sweep-diff` must report the change *and* recover the
+    /// right value_name, not one or the other.
+    #[test]
+    fn sweep_diff_reports_field_change_for_a_tool_whose_value_name_contains_a_flag_separator() {
+        let row = row_line("awk", "ok", 1, 20);
+        let before_text = format!(
+            "{}#fp awk\t\t(root)::-L=0:-:-:fatal\\pinvalid\\pno-ext\n",
+            sample_text(&[&row])
+        );
+        let after_text = format!(
+            "{}#fp awk\t\t(root)::-L=1:abc:-:fatal\\pinvalid\\pno-ext\n",
+            sample_text(&[&row])
+        );
+        let before = parse_scoreboard(&before_text);
+        let after = parse_scoreboard(&after_text);
+
+        let t = diff(&before, &after);
+        assert_eq!(
+            t.field_diff_unmeasured, 0,
+            "the #fp line must parse on both sides, not fall into the unmeasured bucket"
+        );
+        assert_eq!(t.field_diffs.len(), 1);
+        assert_eq!(t.field_diffs[0].tool, "awk");
+        assert_eq!(
+            t.field_diffs[0].description_changed,
+            vec!["(root)::-L"],
+            "the description change on awk's -L flag must be reported, not swallowed"
+        );
+
+        let fp = before
+            .fingerprints
+            .get("awk")
+            .expect("awk fingerprint present");
+        assert_eq!(
+            fp.flags
+                .get("(root)::-L")
+                .and_then(|f| f.value_name.clone()),
+            Some("fatal|invalid|no-ext".to_string()),
+            "value_name must unescape back to awk's real text, not stay literal escape codes"
+        );
+    }
+
+    /// **Backward compatibility, explicitly.** An OLD-format `#fp` line —
+    /// written before this task, with no backslash escaping at all, and a
+    /// `value_name` carrying a raw `:` the way `coverage::fp_escape` never
+    /// touched before now — must parse to exactly the same
+    /// [`ParsedFingerprint`] it always has. This is the measured claim: 0
+    /// backslashes appear across all 2,308 `#fp` lines in a full-PATH sweep
+    /// capture and 0 in `coverage-scoreboard.ci.txt`, so `fp_unescape` is
+    /// the identity function on every existing scoreboard, and a raw `:`
+    /// inside `value_name` (the pre-existing case `splitn(4, ':')` exists
+    /// for) still lands whole in the final field exactly as before. The
+    /// only theoretical incompatibility — an old scoreboard whose
+    /// `value_name` held a literal backslash immediately followed by one of
+    /// the seven escape letters (`\`, `t`, `n`, `p`, `c`, `e`, `s`) — is a
+    /// known, measured-zero caveat: `fp_unescape` would consume that
+    /// backslash-letter pair as an escape sequence instead of passing it
+    /// through as two literal characters. No such value_name exists in
+    /// either measured corpus.
+    #[test]
+    fn old_format_fp_line_without_backslashes_parses_unchanged() {
+        let line = "t\tsub-a,sub-b\t(root)::--time=1:1a2b:-:10:30|(root)::--verbose=0:-:-:-";
+        let (tool, fp) = parse_fingerprint_line(line).expect("old-format line parses");
+        assert_eq!(tool, "t");
+        assert_eq!(fp.subcommands.len(), 2);
+        assert!(fp.subcommands.contains("sub-a"));
+        assert!(fp.subcommands.contains("sub-b"));
+
+        let time = fp.flags.get("(root)::--time").expect("--time flag present");
+        assert!(time.has_description);
+        assert_eq!(time.description_hash, Some(0x1a2b));
+        assert_eq!(time.choices_hash, None);
+        assert_eq!(
+            time.value_name.as_deref(),
+            Some("10:30"),
+            "a raw colon inside value_name must still land whole via splitn(4, ':')"
+        );
+
+        let verbose = fp
+            .flags
+            .get("(root)::--verbose")
+            .expect("--verbose flag present");
+        assert!(!verbose.has_description);
+        assert_eq!(verbose.description_hash, None);
+        assert_eq!(verbose.choices_hash, None);
+        assert_eq!(verbose.value_name, None);
     }
 
     /// A tier or framework change on an otherwise field-identical tool is


### PR DESCRIPTION
Two ordered fixes on one branch. The first is the instrument the second is verified with.

---

## 1. `xtask sweep-diff` could not see `awk`, `gawk` or `nawk` at all

**Mechanism.** The scoreboard's `#fp` fingerprint footer is a flat text format:

```
#fp <tool>\t<sub1>,<sub2>,...\t<flag1>|<flag2>|...
```

with each flag entry `<id>=<has_desc>:<desc_hash>:<choices_hash>:<value_name>`. `value_name` is free-form text lifted verbatim from a tool's own `--help` output, but `fp_escape` only scrubbed tab and newline — the other four separators (`|`, `,`, `=`, `:`) were assumed never to collide.

That assumption is false, and `awk` is the counterexample. Its `-L` flag documents `value_name` `fatal|invalid|no-ext`, so the rendered line carried three unescaped pipes where the flag-list separator expected one:

```
#fp awk		(root)::-C=0:-:-:-|...|(root)::-L=0:-:-:fatal|invalid|no-ext|(root)::-M=0:-:-:-|...
```

`parse_fingerprint_line` splits on every `|`, the fragments `invalid` and `no-ext` have no `=`, `split_once('=')?` returns `None`, and the `?` discards **the entire `#fp awk` line** — every flag on it, not just `-L`. `awk`, `gawk` and `nawk` therefore dropped silently out of every field-level comparison. Found during PR #22, where those three had to be diffed by hand.

**Fix.** `fp_escape`/`fp_unescape` now backslash-escape and reverse every separator the format uses: `\`→`\\`, tab→`\t`, newline→`\n`, `|`→`\p`, `,`→`\c`, `=`→`\e`, `:`→`\s`. The escaped output is guaranteed to contain no raw separator at all, so the read side keeps its existing `split`/`splitn` calls unchanged and only adds an unescape pass per field.

**Old scoreboards stay readable.** `fp_escape` never emitted a backslash before this change — measured, not assumed: **0 backslashes across all 2,308 `#fp` lines** in a full-`PATH` sweep capture and **0** in `coverage-scoreboard.ci.txt`. `fp_unescape` is therefore the identity function on every scoreboard on disk today, and unknown escapes (`\X`) pass through verbatim rather than erroring. The format is not broken and pre-existing scoreboards remain comparable.

**Honest caveats.**
- An *old* scoreboard's `awk` line is still corrupt — it was written with raw pipes and nothing can recover it. Backward compatibility means old lines parse exactly as they always did, including the broken ones. Only sweeps taken from this commit forward carry `awk`/`gawk`/`nawk` through the diff.
- One theoretical incompatibility: an old `value_name` holding a literal backslash immediately followed by one of the seven escape letters would now be misread. Measured occurrences in both corpora: zero.

**Tests**, each proven to fail pre-fix (literal output captured before the fix landed):

```
FAILED coverage::tests::fingerprint_footer_round_trips_a_value_name_containing_the_flag_list_separator
  panicked: pre-fix this whole line is dropped by parse_fingerprint_line because
  value_name's unescaped `|`s are mistaken for extra flag-list entries
FAILED coverage::tests::fingerprint_footer_round_trips_every_separator_character
  panicked: the #fp line must survive with every flag intact
FAILED transition::tests::sweep_diff_reports_field_change_for_a_tool_whose_value_name_contains_a_flag_separator
  assertion `left == right` failed:
    left: Some("fatal\\pinvalid\\pno-ext")   right: Some("fatal|invalid|no-ext")
```

plus `old_format_fp_line_without_backslashes_parses_unchanged`, a compatibility guardrail that passes on both sides by design.

---

## 2. The `=` description separator

### First: the reported diagnosis was wrong, and the raw capture says so

This came in as a **deduplication bug** — "`--verbose` and `--sort` got parsed from usage, deduplicated, and lost their descriptions." That is not what happens, and it is worth correcting because it points at the wrong subsystem entirely.

`--verbose` appears **exactly once** in the whole of `update-xmlcatalog --help`:

```console
$ grep -c -- '--verbose' audit/queue-captures/update-xmlcatalog/0.stdout
1
$ grep -n -- '--verbose|--sort' audit/queue-captures/update-xmlcatalog/0.stdout
28:    --verbose = be verbose
29:    --sort = sorts the manipulated catalog content
```

There is nothing to deduplicate. Neither flag is mentioned in any usage line. Dedup never runs on them; the description was never *lost*, it was never *parsed*, and the reason is a description separator the grammar does not know about. (The instinct was reasonable — this tool *does* have a real synopsis-vs-flags collision, see the out-of-scope note below — but it is a different flag set and a different mechanism.)

### The actual mechanism — two symptoms, one cause

```
With:
    --file <file>       = a local filename
    --root              = the root XML catalog (= /etc/xml/catalog)

Options:
    --verbose = be verbose
    --sort = sorts the manipulated catalog content
```

1. **One space before `=`.** No 2+-space gap exists anywhere on the line, so `find_description_gap` returns `None`, the whole row is handed to `grammar::parse_flag_spec`, and the description is dropped outright. `--verbose` and `--sort` render with no description at all. `wpa_supplicant`, whose entire `options:` block is this shape, rendered at **"low confidence: 9% parsed"**.
2. **Aligned, then `=`.** The column split works, but the description keeps its leading `= `, so the pane shows `= a local filename` as the description text.

### The fix

One mechanism, wired into two entry points, in `mandible-extract/src/help_text/sections.rs`:

- **`find_equals_separator_gap`** — a new `find_description_gap` fallback, placed **after** `find_multi_space_gap` so every already-working aligned split is untouched, and before the existing placeholder/sentence fallbacks. It fires only when: the row starts with `-`; every token between the spelling and the separator satisfies the existing `is_value_spec_token`; the separator token is **exactly** the one-character string `"="`; and non-whitespace content follows it.
- **`strip_equals_separator`** — removes a leading `= ` from a flag row's description. This finishes symptom 1's split and is the whole of symptom 2's fix. Applied at both sites a flag row's description is produced (`split_single_column_entry` and `spelling_run`'s description slice).

Only the *separator* is stripped: `--root = the root XML catalog (= /etc/xml/catalog)` keeps its inner `=`.

### Family membership — 3 tools, not 17

The family was re-derived over all 2,301 frozen captures in `audit/queue-captures/`, matching a **lone `=` token immediately following a flag-spec run** (rather than any `=` on a flag row):

| tool | rows |
|---|---|
| `wpa_supplicant` | 28 |
| `update-xmlcatalog` | 8 |
| `wpa_cli` | 5 |

The earlier 17-tool estimate (`lto-dump` ×3, `twistd3`, `trial3`, `ld.bfd`, `systemd`, `cftp3`, `conch3`, `twist3`, …) conflated this shape with `--flag=VALUE`, where the `=` belongs to the *spec*, not the separator — `--param=lazy-modules=`, `-d, --rundir=`, `--sysroot=<DIRECTORY>`, `--bus-introspect=PATH`. None of those has a lone `=` token, and none of them changes here. Refining the pattern is what shrank 17 to 3, and the full-`PATH` sweep below confirms the refined number is the right one.

### The inverse case is the whole risk

`=` legitimately appears in flag syntax, in default columns, and inside descriptions. Every real instance the captures contain is left **byte-identical**, each with its own regression test:

| shape | real instance |
|---|---|
| `=` deep inside a description | `ffplay`/`ffprobe`: `-http_seekable <boolean> … 0 = disable, 1 = enable, -1 = auto` |
| `(default = off)` tail | `llc-18`, `opt-18`, `bugpoint-18`, `llvm-*-18` |
| `write(default = 1)` | `ntfswipe` |
| parenthetical `0 = inifinite` | `lvmpolld` |
| optional-value spec | `systemd`: `--dump-core[=BOOL]` |
| value containing `\|` | `awk`: `--lint[=fatal\|invalid\|no-ext]` |
| PR #22's valued-column pairing | `-v var=val` ↔ `--assign=var=val`, existing tests pass unchanged |

`man --help`'s deeply-indented `-X = -TX75, -X100 = -TX100, -X100-12 = -TX100-12` was the one line genuinely at risk. It turns out never to reach `find_description_gap` at all: it sits past `scan_flags_block`'s entry-indent tolerance and is classified as a continuation of `--gxditview`'s description, before and after. Verified with a dedicated test, and `man` does not appear in the sweep diff.

**Pre-fix failures** (fix wiring disabled, tests kept):

```
FAIL a_lone_equals_token_with_single_spacing_recovers_the_description
  left: None   right: Some("be verbose")
FAIL a_lone_equals_token_recovers_a_short_flags_description
  left: None   right: Some("optional bridge interface name")
FAIL a_second_equals_inside_the_description_is_left_alone
  left: Some("= the root XML catalog (= /etc/xml/catalog)")
  right: Some("the root XML catalog (= /etc/xml/catalog)")
FAIL an_aligned_column_still_strips_its_leading_equals_separator
  left: Some("= a local filename")   right: Some("a local filename")
```

---

## Evidence: full-`PATH` sweep, field by field

Both scoreboards were produced by the post-fix-1 `xtask` (2,308 tools each), so the field-level comparison is real on both sides:

```
overall: CHANGED
sweep transition: 2254 -> 2254 tools, 2254 matched, 0 appeared, 0 disappeared

# status transitions
  wpa_cli: low-confidence -> ok
  wpa_supplicant: low-confidence -> ok

# flag-count losses (the bar — never netted): 0 lost across 0 tool(s)
# flag-count gains: 0 gained across 0 tool(s)

# field-level changes: 3 tool(s)
  update-xmlcatalog: description changed: --file, --id, --local, --package, --root,
                     --sort, --type, --verbose; value_name changed: --sort, --verbose
  wpa_cli:           description changed: -B, -a, -h, -r, -v; value_name changed: same 5
  wpa_supplicant:    description changed: 26 flags; value_name changed: 28 flags
```

**Exactly the three family members change. Zero flags lost, zero gained, nothing appeared or disappeared.** Aggregate flags-carrying-text moved 94.64% → 95.60%.

*(Both sweeps exclude the same 23 tools near the 10s probe cap, unchanged between runs, and the same 54 truncated-tool-name rows are dropped on both sides — pre-existing, not introduced here.)*

## Corpus

- **`corpus/update-xmlcatalog/audit-seed2` stays `[xfail]`.** `--del` still never becomes a real flag, but for a *different* reason than the fixture claimed: its `[contract]` comment and `[xfail] reason` both described the `=`-separator bug, which is now fixed. Both were rewritten to name what actually remains — the section-header family swallowing the `--del` synopsis lines. Promoting it would have been wrong; the contract it fails is genuinely still failing.
- **New: `corpus/wpa_supplicant/audit-seed4`** — `ok`, snapshot match, `[bless] provenance = "agent"`, **no `verdict_scope`** (no human has judged this tree; per AGENTS.md §3.1 green means it stopped changing, not that it is right).
- `xtask corpus --bless` invented `expected.snap` for 14 unrelated `[xfail]` fixtures; all were deleted, only the new fixture's snapshot is committed.

## See it yourself

```console
$ cargo build --release
$ ./target/release/mandible update-xmlcatalog
```

In the detail pane under **FLAGS**, look for:
- `--verbose` and `--sort` now each carry a description (`be verbose`, `sorts the manipulated catalog content`). On `main` both render as a bare flag with nothing beside them.
- `--file <file>`, `--local`, `--package`, `--type` show `a local filename` etc. — **not** `= a local filename`.
- `--root` reads `the root XML catalog (= /etc/xml/catalog)`: the separator is gone, the parenthetical `=` is intact.

```console
$ ./target/release/mandible wpa_supplicant
```

- The status bar on `main` reads **`low confidence: 9% parsed`**. It should now be gone.
- Every short flag (`-b`, `-B`, `-c`, `-C`, `-d`, `-D`, …) carries its real description instead of being blank.

Headless equivalent (no tty needed):

```console
$ /tmp/ptyvenv/bin/python scripts/pty_screenshot.py 100 34 ./target/release/mandible wpa_supplicant
```

To reproduce the fingerprint fix directly:

```console
$ cargo xtask coverage --tools awk,gawk --out /tmp/probe.txt --format text
$ grep '^#fp awk' /tmp/probe.txt
```

The `-L` entry's `value_name` should read `fatal\pinvalid\pno-ext` (escaped) rather than splitting the line into fragments. Diff two sweeps taken with this binary and `awk`/`gawk`/`nawk` now participate instead of vanishing.

## Out of scope (reported, not fixed)

- **`update-xmlcatalog`'s usage lines rendered as section headers** — `UPDATE-XMLCATALOG <OPTIONS> --DEL --ROOT`, `--TYPE <TYPE> \`. This is the `uconv`/nano section-header family, already queued, and it is what actually keeps `--del` out of the tree.
- **Multi-short rows** (`-? -h --help`) — awaiting the 0.5.0 IR work.
- **`wpa_supplicant`'s `drivers:` bare-word block** (`nl80211 = Linux nl80211/cfg80211`) — the same `name = description` shape on rows with no `-` anchor. Deliberately left alone: the false-positive risk on bare-word blocks is unmeasured, and widening the predicate to catch it could degrade working tools. Confirmed it does not leak into `flags`.

## Gates

`cargo nextest run --workspace` (1094 passed) · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo fmt --all -- --check` · `cargo run -p xtask -- corpus` (99 fixtures: 83 ok, 16 xfail as expected, 0 failed) · `bash scripts/changelog_guard.sh`. CHANGELOG notes went under `## [Unreleased]`; `## [0.4.0]` is frozen.

## Caveat on the numbers

The 94.64% → 95.60% aggregate and the three changed tools are measured on the tools this change targets. Per AGENTS.md §3.1 that is train-on-test and is not a fleet accuracy estimate; the frozen queue exists for the unbiased draw. What the sweep *does* establish honestly is the negative result: across 2,254 matched tools, nothing else moved and no flag was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
