### PR TITLE
fix(help_text): read a glued `=value` as a value, not as part of the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **A single-dash long option carrying a glued `=value` was split into a
+  one-character short flag plus a mangled value.** `dbiprof` writes
+  `-number=N` and the tree held `-n` with `value_name: "umber=N"`;
+  `gcc` writes `-foffload=<targets>` and the tree held `-f` with
+  `value_name: "offload=<targets>"` — a real parser bug the human audit had
+  already confirmed on `corpus/gcc/13.3.0`. The value-less rows of the *same
+  tables* (`-reverse`, `-pipe`, `-help`) came out right, because
+  `help_text::sections::repair_single_dash_long_options` already existed for
+  them.
+
+  What that repair could not see is that `=` is a *boundary*: it asked
+  whether the whole swallowed run was an option name, and `umber=N` is a
+  name plus the value spec the tool glued onto it. The tail is now split at
+  the first `=` (`split_glued_value`) and the existing name-shape and case
+  predicates are applied to the name half; the glued value spec survives on
+  the flag it belongs to, so `-foffload` stays a value-taking flag named
+  `<targets>` rather than becoming a boolean. Splitting at the *first* `=`
+  is what makes `dbiprof`'s `-match=K=V` come out right.
+
+  **No predicate was loosened, and the discriminator is unchanged in
+  substance.** The rule that keeps the GCC/Clang glued-value convention safe
+  — no ASCII uppercase anywhere in the reconstructed token — now reads the
+  name half, which is exactly where that convention puts its shout:
+  Ghostscript's real `-sDEVICE=png16m` has the name token `-sDEVICE`,
+  `java`'s real `-D<name>=<value>` has `-D<name>`, `gcc`'s own
+  `-Wl,<options>` fails the name-shape test on the comma before case is
+  consulted. All three are still rejected, asserted by name in
+  `sections.rs`'s tests and in `xtask::single_dash_long`'s self-checks.
+  A **spaced** `key=value` argument (`-e var=value`) stores byte-for-byte
+  what `-number=N` stores, and is still separated from it by the raw-text
+  glued-occurrence scan alone.
+
+  Measured over the 2,301 frozen captures in `audit/queue-captures/`: the
+  shape reaches **40 tools and 2,196 flags**, overwhelmingly the GCC
+  toolchain and its cross-compiled aliases (`gcc`, `cpp`, `g++`, `as`,
+  `c89`/`c99`/`cc`, the `aarch64-linux-gnu-*` and `-13` variants) plus
+  `dbiprof` and two LLVM tools. A document-level "this tool uses single-dash
+  long options elsewhere" signal was evaluated as an alternative
+  discriminator and **rejected on the data**: it fires on 37 of the 40
+  true positives but also on 11 of the 13 tools in the false-positive-risk
+  population, so it corroborates and does not discriminate.
+
+  Knowingly still split, each declared and asserted rather than described:
+  uppercase-led names (`-Xassembler`, `-Wuninit-variable-checking`), names
+  carrying an underscore (`dbiprof`'s own `-case_sensitive`, in the very
+  table this repairs), bracketed optional values (`-fcompare-debug[=<opts>]`),
+  and a tail that ends at the `=` with nothing after it.
+
 - **Three shapes that are not headings were being read as section headings,
   polluting `group` on 197 tools and losing two real option rows.** The
   section scanner promotes a line to a heading on *indentation alone* — any

--- a/corpus/dbiprof/1.643/expected.snap
+++ b/corpus/dbiprof/1.643/expected.snap
@@ -1,0 +1,71 @@
+name: dbiprof
+description: dbiprof [options] [files]
+flags:
+- long: number
+  value_name: N
+  value_kind: Required
+  single_dash: true
+  description: show top N, defaults to 10
+  provenance:
+    sources:
+    - help-text
+- long: sort
+  value_name: S
+  value_kind: Required
+  single_dash: true
+  description: sort by S, defaults to total
+  provenance:
+    sources:
+    - help-text
+- long: reverse
+  single_dash: true
+  description: reverse the sort
+  provenance:
+    sources:
+    - help-text
+- long: match
+  value_name: K=V
+  value_kind: Required
+  single_dash: true
+  description: for filtering, see docs
+  provenance:
+    sources:
+    - help-text
+- long: exclude
+  value_name: K=V
+  value_kind: Required
+  single_dash: true
+  description: for filtering, see docs
+  provenance:
+    sources:
+    - help-text
+- short: 'c'
+  value_name: ase_sensitive
+  value_kind: Required
+  description: for -match and -exclude
+  provenance:
+    sources:
+    - help-text
+- long: delete
+  single_dash: true
+  description: rename files before reading then delete afterwards
+  provenance:
+    sources:
+    - help-text
+- long: version
+  single_dash: true
+  description: print version number and exit
+  provenance:
+    sources:
+    - help-text
+- long: help
+  single_dash: true
+  description: print this help
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/dbiprof/1.643/help.txt
+++ b/corpus/dbiprof/1.643/help.txt
@@ -1,0 +1,18 @@
+dbiprof [options] [files]
+
+Reads and merges DBI profile data from files and prints a summary.
+
+files: defaults to dbi.prof
+
+options:
+
+    -number=N        show top N, defaults to 10
+    -sort=S          sort by S, defaults to total
+    -reverse         reverse the sort
+    -match=K=V       for filtering, see docs
+    -exclude=K=V     for filtering, see docs
+    -case_sensitive  for -match and -exclude
+    -delete          rename files before reading then delete afterwards
+    -version         print version number and exit
+    -help            print this help
+

--- a/corpus/dbiprof/1.643/meta.toml
+++ b/corpus/dbiprof/1.643/meta.toml
@@ -1,0 +1,35 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "dbiprof"
+version = "1.643"
+platform = "ubuntu-24.04 (aarch64)"
+captured_with = "mandible 0.4.0"
+
+# A single-dash long-option specimen whose options carry a *glued* `=value`
+# (`-number=N`, `-sort=S`, `-match=K=V`), sitting in the same option table
+# as value-less single-dash longs (`-reverse`, `-delete`, `-version`,
+# `-help`). Before the `=`-aware split in
+# `help_text::sections::repair_single_dash_long_options`, the value-less
+# rows were repaired and the `=`-carrying rows were not: `-number=N` was
+# stored as short `-n` with `value_name: "umber=N"`.
+[[capture]]
+argv = ["dbiprof", "--help"]
+stdout = "help.txt"
+exit_code = 1
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+min_subcommands = 0
+# Bare words match `Flag::long` verbatim (see `xtask::corpus::flag_present`),
+# which is where a single-dash long option's name lives — `single_dash` only
+# decides how many dashes it renders with.
+must_contain_flags = ["number", "sort", "match", "exclude", "reverse", "help"]
+# The defect this fixture exists for, stated negatively: `-number=N` used to
+# come out as the short flag `-n` carrying `"umber=N"`, and each of these
+# characters is the first letter of a row this table writes as a long option.
+# `-c` is deliberately absent: `-case_sensitive` is the declared underscore
+# miss and *is* still stored as short `c`.
+must_not_contain_flags = ["-n", "-s", "-m", "-e", "-r", "-d", "-v", "-h"]

--- a/corpus/gcc/13.3.0/expected.snap
+++ b/corpus/gcc/13.3.0/expected.snap
@@ -49,9 +49,10 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'f'
-  value_name: offload=<targets>
+- long: foffload
+  value_name: <targets>
   value_kind: Required
+  single_dash: true
   description: Specify offloading targets.
   provenance:
     sources:
@@ -68,16 +69,18 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'p'
-  value_name: rint-file-name=<lib>
+- long: print-file-name
+  value_name: <lib>
   value_kind: Required
+  single_dash: true
   description: Display the full path to library <lib>.
   provenance:
     sources:
     - help-text
-- short: 'p'
-  value_name: rint-prog-name=<prog>
+- long: print-prog-name
+  value_name: <prog>
   value_kind: Required
+  single_dash: true
   description: Display the full path to compiler component <prog>.
   provenance:
     sources:
@@ -166,9 +169,10 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 's'
-  value_name: ave-temps=<arg>
+- long: save-temps
+  value_name: <arg>
   value_kind: Required
+  single_dash: true
   description: Do not delete intermediate files.
   provenance:
     sources:
@@ -191,16 +195,18 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 's'
-  value_name: pecs=<file>
+- long: specs
+  value_name: <file>
   value_kind: Required
+  single_dash: true
   description: Override built-in specs with the contents of <file>.
   provenance:
     sources:
     - help-text
-- short: 's'
-  value_name: td=<standard>
+- long: std
+  value_name: <standard>
   value_kind: Required
+  single_dash: true
   description: Assume that the input sources are for <standard>.
   provenance:
     sources:

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -1112,16 +1112,58 @@ const MIN_SWALLOWED_NAME_CHARS: usize = 2;
 /// 1. it is **option-table-sourced** ([`Source::HelpText`], never
 ///    [`Source::HelpTextSynopsis`]);
 /// 2. it has a short spelling, no long name, and a `Required` value;
-/// 3. the swallowed text is **option-name-shaped**
-///    ([`is_option_name_tail`]);
-/// 4. at least [`MIN_SWALLOWED_NAME_CHARS`] characters were swallowed;
-/// 5. the whole reconstructed token is **uniformly lowercase**
+/// 3. the swallowed text's **name half** — everything before the first `=`,
+///    or the whole tail when there is no `=` ([`split_glued_value`]) — is
+///    **option-name-shaped** ([`is_option_name_tail`]);
+/// 4. that name half is at least [`MIN_SWALLOWED_NAME_CHARS`] characters;
+/// 5. the reconstructed **name token** is **uniformly lowercase**
 ///    ([`token_is_uniformly_lowercase`]);
 /// 6. the tail is not the flag's own character repeated — the
 ///    [`repair_repeated_character_flags`] family, handed off rather than
 ///    claimed twice;
-/// 7. the reconstructed token occurs glued and delimited in the tool's own
-///    raw text ([`token_occurs_glued`]).
+/// 7. the reconstructed token — name **and** glued value — occurs glued and
+///    delimited in the tool's own raw text ([`token_occurs_glued`]).
+///
+/// # The glued `=value` half, and why the first version missed it
+///
+/// `dbiprof` writes one option table and this parser used to repair half of
+/// it:
+///
+/// ```text
+///     -number=N        show top N, defaults to 10
+///     -sort=S          sort by S, defaults to total
+///     -reverse         reverse the sort
+///     -match=K=V       for filtering, see docs
+/// ```
+///
+/// `-reverse` came out right and `-number=N` came out as `-n` carrying
+/// `"umber=N"`, in the same table, on adjacent rows. The reason is entirely
+/// in condition 3: it asked whether the *whole* swallowed run was an option
+/// name, and `umber=N` is not one — it is an option name **plus the value
+/// spec the tool glued onto it**. `=` is the one character that says where
+/// the name stops, so the fix is to read the two halves separately rather
+/// than to admit `=` into [`is_option_name_tail`], which would also admit
+/// `-E var=value` and every other value spec that carries one.
+///
+/// **Condition 5 is unchanged in substance and is still the whole safety
+/// argument.** It is measured over the name token (`-number`) instead of
+/// the full token (`-number=N`) because the value half is now known to be a
+/// value half — and a value spec shouts (`-foffload=<targets>`,
+/// `-print-file-name=<lib>`) without saying anything about the flag. The
+/// population it must stay silent on is unmoved by that: Ghostscript's real
+/// `-sDEVICE=png16m` is a genuine glued short whose *name* token is
+/// `-sDEVICE`, `cpp`'s `-DMACRO=value` is `-DMACRO`, `-Wl,-rpath=…` is
+/// `-Wl,…` (rejected by condition 3 before case is even consulted) — every
+/// one of them shouts on the left of the `=`, which is exactly where the
+/// convention puts the argument, and every one is still rejected. What the
+/// change buys is the mirror-image population, whose name half is a
+/// lowercase *word*: `dbiprof`'s `-number`/`-sort`/`-match`/`-exclude`,
+/// `gcc`'s `-foffload`, `-print-file-name`, `-print-prog-name`, `-specs`,
+/// `-std` and `-save-temps=<arg>`.
+///
+/// Unlike the spaced-value case below, the value spec here is **kept**: the
+/// document wrote it on the same token, so `-foffload` stays a
+/// value-taking flag named `<targets>` rather than becoming a boolean.
 ///
 /// **Conditions 1 and 5 are the whole safety argument, and 5 is why this
 /// cannot be a change to [`parse_flag_spec`].** Conditions 2, 3, 4, 6 and 7
@@ -1157,12 +1199,18 @@ const MIN_SWALLOWED_NAME_CHARS: usize = 2;
 ///   `-hr: Set Honor Reservation bit`, so the tail is `"r:"` and condition
 ///   3 rejects it. No tail-shape rule can claim that without also admitting
 ///   every value spec that leaks punctuation.
-/// - **Glued value specs with `=` or brackets in them**, `-mtune=native`
-///   among them: condition 3 rejects `=`, `[`, `<`, `,`, `.`, `/` and `_`
-///   for the same reason the oracle does. `-mtune` really is a long option
-///   and recovering it would be a real gain, but not one this change is
-///   entitled to take as a side effect, and not by loosening the one
-///   predicate that keeps `-E var=value` and `-d item[,...]` out.
+/// - **Tails whose *name* half carries brackets or other value-spec
+///   punctuation.** Condition 3 still rejects `[`, `<`, `,`, `.`, `/` and
+///   `_` in the name half, for the same reason the oracle does — `-d
+///   item[,...]` and `-b{blocksize}` are value specs, not names. Only `=`
+///   is read structurally, and only as the boundary between the two halves.
+/// - **Names carrying an underscore**, `dbiprof`'s own `-case_sensitive`
+///   among them: condition 3 rejects `_`. It sits in the same table as the
+///   rows this change does repair and stays split, which is a knowingly
+///   incomplete result on that one document rather than a silent one.
+/// - **A tail that ends at the `=` with nothing after it** — refused
+///   outright by [`split_glued_value`], which has no evidence for either
+///   reading of it.
 /// - **One-character tails** ([`MIN_SWALLOWED_NAME_CHARS`]).
 ///
 /// The value a rewritten row's *real* spaced argument named (`-cpu model`
@@ -1188,37 +1236,80 @@ fn repair_single_dash_long_options(flags: &mut [Flag], raw: &str) {
         let Some(tail) = flag.value_name.as_deref() else {
             continue;
         };
-        // 4. Enough tail to be a name rather than a character argument.
-        if tail.chars().count() < MIN_SWALLOWED_NAME_CHARS {
+        // 3a. Split the swallowed text at the first `=` — see
+        //     [`split_glued_value`]. Without a `=` the name half is the
+        //     whole tail and every condition below reads exactly as it did
+        //     before this split existed.
+        let Some((name_tail, glued_value)) = split_glued_value(tail) else {
+            continue;
+        };
+        // 4. Enough *name* to be a name rather than a character argument.
+        if name_tail.chars().count() < MIN_SWALLOWED_NAME_CHARS {
             continue;
         }
-        // 3. The tail is option-name-shaped.
-        if !is_option_name_tail(tail) {
+        // 3. The name half is option-name-shaped.
+        if !is_option_name_tail(name_tail) {
             continue;
         }
         // 6. Not the repeated-character family, which is the other repair's.
         if value_repeats_short(short, tail) {
             continue;
         }
-        let token = format!("-{short}{tail}");
+        let name_token = format!("-{short}{name_tail}");
         // 5. Uniformly lowercase — the only thing separating this from the
         //    glued-value convention. See this function's doc comment.
-        if !token_is_uniformly_lowercase(&token) {
+        if !token_is_uniformly_lowercase(&name_token) {
             continue;
         }
-        // 7. The token occurs, glued and delimited, in the raw text. Last
-        //    because it is the only condition that scans the document.
-        if !token_occurs_glued(raw, &token) {
+        // 7. The whole token — name *and* glued value — occurs, glued and
+        //    delimited, in the raw text. Last because it is the only
+        //    condition that scans the document.
+        if !token_occurs_glued(raw, &format!("-{short}{tail}")) {
             continue;
         }
-        // The name is the whole run, `long` holds it bare, and
+        // The name is the run up to the `=`, `long` holds it bare, and
         // `single_dash` is what puts one dash in front of it at display
         // time — see `mandible_core::Flag::single_dash`.
-        flag.long = Some(token[1..].to_string());
+        flag.long = Some(name_token[1..].to_string());
         flag.single_dash = true;
         flag.short = None;
-        flag.value_name = None;
-        flag.value_kind = ValueKind::None;
+        match glued_value {
+            // `-foffload=<targets>`: the document wrote the value spec
+            // itself, so it survives the repair on the flag it belongs to.
+            Some(value) => flag.value_name = Some(value.to_string()),
+            // `-cpu model`: the value was dropped on the floor by the
+            // grammar long before this ran, so the flag becomes the
+            // boolean it is correctly *named* rather than keeping a
+            // fabricated one. See this function's doc comment.
+            None => {
+                flag.value_name = None;
+                flag.value_kind = ValueKind::None;
+            }
+        }
+    }
+}
+
+/// Split a swallowed tail into the option-name half and the glued value
+/// half: `"umber=N"` → `("umber", Some("N"))`, `"elp"` → `("elp", None)`.
+///
+/// `None` — refuse the row entirely — when the tail ends at the `=` with
+/// nothing after it (`"oo="`). A `Required` value whose spec is the empty
+/// string is a shape nothing in the fleet was measured on, and inventing
+/// either reading of it (boolean, or a value named `""`) would be a claim
+/// this repair has no evidence for.
+///
+/// **Splitting at the *first* `=` is what makes `dbiprof`'s `-match=K=V`
+/// come out right**: the name ends at the first one and everything after it
+/// is the value spec the tool wrote, `=` included.
+///
+/// The twin of `xtask::single_dash_long::split_glued_value`, character for
+/// character, for the reason [`repair_single_dash_long_options`]'s doc
+/// comment gives.
+fn split_glued_value(tail: &str) -> Option<(&str, Option<&str>)> {
+    match tail.split_once('=') {
+        Some((_, "")) => None,
+        Some((name, value)) => Some((name, Some(value))),
+        None => Some((tail, None)),
     }
 }
 
@@ -1229,9 +1320,13 @@ fn repair_single_dash_long_options(flags: &mut [Flag], raw: &str) {
 /// for character. The letter requirement is what stops a glued *numeric*
 /// argument (`-b4096`, `-j8`) from riding in on a run that is technically
 /// alphanumeric. Everything else is rejected because a long option's name
-/// does not contain it: `=` (`-mtune=native`, `-E var=value`), `:`
-/// (`sg_emc_trespass`'s layout-mangled `-hr:`), `[`/`{`/`<`/`,`
-/// (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths), and `_`.
+/// does not contain it: `:` (`sg_emc_trespass`'s layout-mangled `-hr:`),
+/// `[`/`{`/`<`/`,` (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths),
+/// and `_` (`dbiprof`'s real `-case_sensitive`, left split).
+///
+/// `=` never reaches here: [`split_glued_value`] has already consumed it as
+/// the boundary between the name and its glued value spec, so what this
+/// sees is only ever the name half.
 fn is_option_name_tail(tail: &str) -> bool {
     tail.chars().any(|c| c.is_ascii_alphabetic())
         && tail.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
@@ -5375,11 +5470,158 @@ mod tests {
         }
     }
 
+    /// `dbiprof`'s real option table, byte-exact from
+    /// `corpus/dbiprof/1.643/help.txt` — the glued-`=value` rows and the
+    /// value-less rows in one table, which is the whole `=`-split problem
+    /// in five lines.
+    const DBIPROF_TABLE: &str = concat!(
+        "    -number=N        show top N, defaults to 10\n",
+        "    -sort=S          sort by S, defaults to total\n",
+        "    -reverse         reverse the sort\n",
+        "    -match=K=V       for filtering, see docs\n",
+        "    -exclude=K=V     for filtering, see docs\n",
+        "    -case_sensitive  for -match and -exclude\n",
+        "    -version         print version number and exit\n",
+    );
+
+    /// The defect the `=` split exists for: a single-dash long option
+    /// carrying a glued value came out as its own first character plus a
+    /// mangled value (`-number=N` → `-n` + `"umber=N"`), while the
+    /// value-less rows of the *same table* came out right.
+    #[test]
+    fn dbiprofs_glued_value_long_options_keep_their_real_names() {
+        let parsed = parse(DBIPROF_TABLE);
+        for (name, value) in [
+            ("number", "N"),
+            ("sort", "S"),
+            ("match", "K=V"),
+            ("exclude", "K=V"),
+        ] {
+            let flag = flag_named(&parsed, name);
+            assert!(flag.single_dash, "-{name} is spelled with one dash");
+            // `Flag::spelling` writes a required value with a space, the
+            // same repo-wide display convention that renders `--output=FILE`
+            // as `--output FILE`; what matters here is that the *name* is
+            // whole and the value is the tool's own.
+            assert_eq!(flag.spelling(), format!("-{name} {value}"));
+            assert_eq!(flag.short, None);
+            // The document wrote the value spec on the token, so unlike the
+            // spaced case it survives the repair. `-match=K=V` splits at the
+            // *first* `=` and keeps the rest verbatim.
+            assert_eq!(flag.value_name.as_deref(), Some(value));
+            assert_eq!(flag.value_kind, ValueKind::Required);
+        }
+        // The value-less rows in the same table are unchanged by the split.
+        for name in ["reverse", "version"] {
+            let flag = flag_named(&parsed, name);
+            assert!(flag.single_dash);
+            assert_eq!(flag.value_kind, ValueKind::None);
+        }
+    }
+
+    /// `gcc`'s `-foffload=<targets>`, stored as short `f` with `value_name`
+    /// `offload=<targets>` — a real parser bug the human audit confirmed on
+    /// `corpus/gcc/13.3.0`, and the same family as `dbiprof`'s. Carried as
+    /// gcc's own rows so the uppercase value spec is exercised: the case
+    /// test now reads the name half, and `<targets>` shouts on the other
+    /// side of the `=`.
+    #[test]
+    fn gccs_glued_value_long_options_keep_their_real_names() {
+        let parsed = parse(concat!(
+            "  -foffload=<targets>      Specify offloading targets.\n",
+            "  -print-file-name=<lib>   Display the full path to library <lib>.\n",
+            "  -std=<standard>          Assume that the input sources are for <standard>.\n",
+        ));
+        for (name, value) in [
+            ("foffload", "<targets>"),
+            ("print-file-name", "<lib>"),
+            ("std", "<standard>"),
+        ] {
+            let flag = flag_named(&parsed, name);
+            assert!(flag.single_dash, "-{name} is spelled with one dash");
+            assert_eq!(flag.short, None);
+            assert_eq!(flag.value_name.as_deref(), Some(value));
+        }
+    }
+
+    /// The inverse direction, and the reason condition 5 may look at the
+    /// name half alone: the glued-value convention puts its shout to the
+    /// **left** of the `=`, so every genuine glued short with a `key=value`
+    /// argument is still rejected on exactly the signal it always was.
+    /// Ghostscript's `-sDEVICE=` is the type specimen — a lowercase flag
+    /// letter, which is what makes it the hard case.
+    #[test]
+    fn the_glued_value_convention_is_never_repaired_when_it_carries_an_equals() {
+        for row in [
+            "  -sDEVICE=png16m   select the output device\n",
+            "  -sOutputFile=out.png   write output here\n",
+            "  -DMACRO=value     define a macro\n",
+            "  -Wl,-rpath=/usr/lib   pass to the linker\n",
+            "  -Ttext=0x100      set the text segment address\n",
+        ] {
+            let parsed = parse(row);
+            assert!(
+                parsed.flags.iter().all(|f| f.long.is_none()),
+                "a correct glued-value parse was destroyed by {row:?}: {:?}",
+                parsed
+                    .flags
+                    .iter()
+                    .map(|f| f.spelling())
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+
+    /// The separator is still the whole difference: a **spaced** `key=value`
+    /// argument stores byte-for-byte what `dbiprof`'s glued `-number=N`
+    /// stores, and only condition 7's scan of the raw text tells them
+    /// apart.
+    #[test]
+    fn a_spaced_key_value_argument_is_never_a_long_option() {
+        for row in [
+            "  -e var=value    set an environment variable\n",
+            "  -o key=val      set a mount option\n",
+            "  -v var=val      assign an awk variable\n",
+        ] {
+            let parsed = parse(row);
+            assert!(
+                parsed.flags.iter().all(|f| f.long.is_none()),
+                "a spaced value was glued into a name by {row:?}: {:?}",
+                parsed
+                    .flags
+                    .iter()
+                    .map(|f| f.spelling())
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+
     /// The two declared out-of-scope misses, asserted rather than
     /// described — a miss that is only written down in prose stops being
     /// checked the day the prose goes stale.
     #[test]
     fn the_declared_out_of_scope_misses_stay_missed() {
+        // A tail that ends at the `=` with nothing after it: refused
+        // outright rather than read as either a boolean or an empty value.
+        let parsed = parse("  -foo=   an empty value spec\n");
+        assert!(
+            parsed
+                .flags
+                .iter()
+                .all(|f| f.long.as_deref() != Some("foo")),
+            "an empty value spec has no measured reading"
+        );
+        // `dbiprof`'s own `-case_sensitive`: `_` is not an option-name
+        // character here, so it stays split even though it sits in the
+        // table this repair otherwise fixes.
+        let parsed = parse(DBIPROF_TABLE);
+        assert!(
+            parsed
+                .flags
+                .iter()
+                .all(|f| f.long.as_deref() != Some("case_sensitive")),
+            "the underscore miss is declared, not accidental"
+        );
         // `ip` writes a bracketed tail, so the grammar records
         // `ValueKind::Optional` — a value spec a human deliberately typed.
         let parsed = parse("OPTIONS := { -V[ersion] | -h[uman-readable] | -j[son] }\n");

--- a/xtask/src/single_dash_long.rs
+++ b/xtask/src/single_dash_long.rs
@@ -44,15 +44,20 @@
 //! 2. **It has a short spelling, no long name, and a `Required` value.** The
 //!    shared fingerprint. `Optional` means the raw text wrote brackets
 //!    (`ip`'s `-h[uman-readable]`), which is a value spec a human typed.
-//! 3. **The swallowed text is option-name-shaped**
+//! 3. **The swallowed text's *name half* is option-name-shaped**
 //!    ([`is_option_name_tail`]): ASCII alphanumerics and `-`, with at least
-//!    one letter. This rejects every value spec that leaks punctuation —
-//!    `qemu`'s own `-E var=value` and `-d item[,...]`, `sg_emc_trespass`'s
-//!    layout-mangled `-hr:` — and it is the condition that makes the claim
-//!    exact rather than approximate.
-//! 4. **At least [`MIN_SWALLOWED_CHARS`] characters are swallowed.** Two,
-//!    not one, and the lost recall is deliberate — see that constant.
-//! 5. **The whole token is uniformly lowercase**
+//!    one letter. The name half is everything before the first `=`, or the
+//!    whole tail when there is no `=` ([`split_glued_value`]) — a tail like
+//!    `qemu`'s `-number=N` → `"umber=N"` is a name **plus** the value spec
+//!    the tool glued onto it, and `=` is the character that says where the
+//!    name stops. Everything else is still rejected, so every value spec
+//!    that leaks other punctuation goes with it — `-d item[,...]`,
+//!    `sg_emc_trespass`'s layout-mangled `-hr:` — and it is the condition
+//!    that makes the claim exact rather than approximate.
+//! 4. **The name half carries at least [`MIN_SWALLOWED_CHARS`]
+//!    characters.** Two, not one, and the lost recall is deliberate — see
+//!    that constant.
+//! 5. **The reconstructed *name* token is uniformly lowercase**
 //!    ([`token_is_uniformly_lowercase`]). The discriminator against the
 //!    largest genuinely-correct population there is; see below.
 //! 6. **The swallowed text is not the flag's own character repeated**
@@ -74,7 +79,12 @@
 //! `cargo -Zscript`, `rpcgen -Dname`, `makewhatis -Tutf8`, `perl
 //! -Idirectory`, `find -Olevel`, `cc -oOUTFILE`, `gcc -DMACRO`. Every single
 //! one carries an **uppercase** letter, because the convention is what it is:
-//! the flag is a capital and the glued text is its argument.
+//! the flag is a capital and the glued text is its argument. The same holds
+//! when that argument is introduced by an `=` and condition 5 therefore only
+//! sees the left half: Ghostscript's real `-sDEVICE=png16m` has the name
+//! token `-sDEVICE`, `cpp`'s `-DMACRO=value` has `-DMACRO`. The convention
+//! puts the shout to the *left* of the `=`, which is exactly where this
+//! still looks.
 //!
 //! The real long options are the other way round and just as consistent —
 //! `-help`, `-cpu`, `-version`, `-strace`, `-seed`, `-trace`, `-perfmap`,
@@ -140,11 +150,15 @@ pub(crate) const MIN_SWALLOWED_CHARS: usize = 2;
 /// `-j8`) from riding in on a run that is technically alphanumeric, exactly
 /// as `bundling::MIN_ORDERED_LETTERS` stops the vacuous-ordering version of
 /// the same hazard. Everything else is rejected because a long option's name
-/// does not contain it: `=` (`-mtune=native`, `-E var=value`), `:`
-/// (`sg_emc_trespass`'s layout-mangled `-hr:`), `[`/`{`/`<`/`,`
-/// (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths), `_` (which no
-/// single-dash long option in the fleet uses, and which appears in glued
-/// value placeholders that do).
+/// does not contain it: `:` (`sg_emc_trespass`'s layout-mangled `-hr:`),
+/// `[`/`{`/`<`/`,` (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths),
+/// `_` (`dbiprof`'s real `-case_sensitive`, left split — the character also
+/// appears in glued value placeholders and nothing measured separates the
+/// two).
+///
+/// `=` never reaches here: [`split_glued_value`] has already consumed it as
+/// the boundary between the name and its glued value spec, so what this sees
+/// is only ever the name half.
 fn is_option_name_tail(tail: &str) -> bool {
     tail.chars().any(|c| c.is_ascii_alphabetic())
         && tail.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
@@ -222,30 +236,51 @@ fn split_token(flag: &Flag, raw: &str) -> Option<String> {
         return None;
     }
     let tail = flag.value_name.as_deref()?;
-    // 4. Enough tail to be a name rather than a character argument.
-    if tail.chars().count() < MIN_SWALLOWED_CHARS {
+    // 3a. Split the swallowed text at the first `=` — see
+    //     [`split_glued_value`].
+    let (name_tail, _value) = split_glued_value(tail)?;
+    // 4. Enough *name* to be a name rather than a character argument.
+    if name_tail.chars().count() < MIN_SWALLOWED_CHARS {
         return None;
     }
-    // 3. The tail is option-name-shaped.
-    if !is_option_name_tail(tail) {
+    // 3. The name half is option-name-shaped.
+    if !is_option_name_tail(name_tail) {
         return None;
     }
     // 6. Not the repeated-character family.
     if tail_repeats_short(short, tail) {
         return None;
     }
-    let token = format!("-{short}{tail}");
+    let name_token = format!("-{short}{name_tail}");
     // 5. Uniformly lowercase — the discriminator against the glued-value
     //    convention. See this module's doc comment.
-    if !token_is_uniformly_lowercase(&token) {
+    if !token_is_uniformly_lowercase(&name_token) {
         return None;
     }
-    // 7. The token occurs, glued and delimited, in the raw text. Last
-    //    because it is the only condition that scans the document.
-    if !spelling_occurs(raw, &token) {
+    // 7. The whole token — name and glued value — occurs, glued and
+    //    delimited, in the raw text. Last because it is the only condition
+    //    that scans the document.
+    if !spelling_occurs(raw, &format!("-{short}{tail}")) {
         return None;
     }
-    Some(token)
+    Some(name_token)
+}
+
+/// Split a swallowed tail into the option-name half and the glued value
+/// half: `"umber=N"` → `("umber", Some("N"))`, `"elp"` → `("elp", None)`.
+///
+/// `None` when the tail ends at the `=` with nothing after it. The twin of
+/// `mandible_extract::help_text::sections::split_glued_value`, character for
+/// character, and carried here rather than imported for the reason every
+/// other predicate in this module is: the oracle's rule must read completely
+/// in one place, and the assertion that the two agree is what the corpus and
+/// this module's tests are for.
+fn split_glued_value(tail: &str) -> Option<(&str, Option<&str>)> {
+    match tail.split_once('=') {
+        Some((_, "")) => None,
+        Some((name, value)) => Some((name, Some(value))),
+        None => Some((tail, None)),
+    }
 }
 
 fn walk(node: &CommandNode, path: &str, raw: &str, out: &mut Vec<Split>) {
@@ -317,6 +352,18 @@ const QEMU_TABLE: &str = concat!(
     "-cpu model           QEMU_CPU             select CPU (-cpu help for list)\n",
     "-one-insn-per-tb     QEMU_ONE_INSN_PER_TB run with one guest instruction per emulated TB\n",
     "-version             QEMU_VERSION         display version information and exit\n",
+);
+
+/// `dbiprof`'s real option table, byte-exact from
+/// `corpus/dbiprof/1.643/help.txt` — the glued-`=value` rows and the
+/// value-less rows in one table, which is the whole `=`-split problem in
+/// five lines.
+const DBIPROF_TABLE: &str = concat!(
+    "    -number=N        show top N, defaults to 10\n",
+    "    -sort=S          sort by S, defaults to total\n",
+    "    -reverse         reverse the sort\n",
+    "    -match=K=V       for filtering, see docs\n",
+    "    -case_sensitive  for -match and -exclude\n",
 );
 
 /// `ip`'s real bracketed-abbreviation token, carried here as the witness its
@@ -442,6 +489,72 @@ pub(crate) fn self_checks() -> Vec<crate::detector::SelfCheck> {
             expect: Expect::Silent,
             raw: "  -b4096   block size\n".to_string(),
             root: tree("t", vec![table_flag('b', Some("4096"))]),
+        },
+        SelfCheck {
+            name: "dbiprof's real option table, glued =value beside value-less rows",
+            why: "the shape the =-split exists for: -number=N and -reverse sit in one table and \
+                  only the = separates the row that used to be repaired from the one that did \
+                  not. -case_sensitive is the declared underscore miss and must stay split",
+            expect: Expect::Fires(4),
+            raw: DBIPROF_TABLE.to_string(),
+            root: tree(
+                "dbiprof",
+                vec![
+                    table_flag('n', Some("umber=N")),
+                    table_flag('s', Some("ort=S")),
+                    table_flag('r', Some("everse")),
+                    table_flag('m', Some("atch=K=V")),
+                    table_flag('c', Some("ase_sensitive")),
+                ],
+            ),
+        },
+        SelfCheck {
+            name: "gcc's real -foffload=<targets>",
+            why: "the human audit's confirmed parser bug on this family: a lowercase name half \
+                  with a shouting value spec on the right of the =",
+            expect: Expect::Fires(1),
+            raw: "  -foffload=<targets>      Specify offloading targets.\n".to_string(),
+            root: tree("gcc", vec![table_flag('f', Some("offload=<targets>"))]),
+        },
+        SelfCheck {
+            name: "ghostscript's real -sDEVICE=png16m",
+            why: "the inverse case that matters most: a genuine glued short whose argument is \
+                  introduced by =, and whose name half shouts exactly where the convention puts \
+                  the shout",
+            expect: Expect::Silent,
+            raw: "  -sDEVICE=png16m   select the output device\n".to_string(),
+            root: tree("gs", vec![table_flag('s', Some("DEVICE=png16m"))]),
+        },
+        SelfCheck {
+            name: "cpp's real -DMACRO=value",
+            why: "the same inverse, in the shape the whole no-uppercase rule was written for",
+            expect: Expect::Silent,
+            raw: "  -DMACRO=value   define a macro\n".to_string(),
+            root: tree("cpp", vec![table_flag('D', Some("MACRO=value"))]),
+        },
+        SelfCheck {
+            name: "a spaced key=value argument",
+            why: "-E var=value stores exactly what -number=N stores; only the raw text's space \
+                  tells them apart, and condition 7 is what reads it",
+            expect: Expect::Silent,
+            raw: "  -e var=value    set an environment variable\n".to_string(),
+            root: tree("t", vec![table_flag('e', Some("var=value"))]),
+        },
+        SelfCheck {
+            name: "a tail that ends at the = with nothing after it",
+            why: "split_glued_value refuses it outright rather than inventing either reading",
+            expect: Expect::Silent,
+            raw: "  -foo=   an empty value spec\n".to_string(),
+            root: tree("t", vec![table_flag('f', Some("oo="))]),
+        },
+        SelfCheck {
+            name: "gcc's real -Wl,<options>",
+            why: "cross-check that the = split changed nothing for tails with no =: the comma \
+                  still fails is_option_name_tail before case is consulted",
+            expect: Expect::Silent,
+            raw: "  -Wl,<options>            Pass comma-separated <options> on to the linker.\n"
+                .to_string(),
+            root: tree("gcc", vec![table_flag('W', Some("l,<options>"))]),
         },
     ];
 


### PR DESCRIPTION
## The defect

`dbiprof --help`, raw:

```
    -number=N        show top N, defaults to 10
    -sort=S          sort by S, defaults to total
    -reverse         reverse the sort
    -match=K=V       for filtering, see docs
    -case_sensitive  for -match and -exclude
```

`-reverse` came out right. `-number=N` came out as the short flag `-n` carrying
the value `"umber=N"`, and `-sort=S` as `-s` carrying `"ort=S"` — in the *same
table*, on adjacent rows. The reviewer's question was the right one: the
single-dash long-option repair already existed, so why did it not cover this?

## Why the earlier fix did not cover it

`help_text::sections::repair_single_dash_long_options` asks, as its condition 3,
whether the **whole** swallowed run is an option name (`is_option_name_tail`:
ASCII alphanumerics and `-`, at least one letter). For `-help` the swallowed run
is `elp` and that is a name. For `-number=N` the swallowed run is `umber=N`,
which is **a name plus the value spec the tool glued onto it** — and `=` is not
an option-name character, so the row was refused.

The predicate was not wrong. It was answering the wrong question about a tail
that carries two things.

## The mechanism

`split_glued_value` splits the tail at the **first** `=` into a name half and a
value half (no `=` → the whole tail is the name half, and every condition then
reads exactly as it did before). The existing name-shape, minimum-length and
case predicates are applied to the **name half**; the glued value spec survives
on the flag it belongs to, so `gcc -foffload=<targets>` stays a value-taking
flag named `<targets>` rather than becoming a boolean. Splitting at the *first*
`=` is what makes `dbiprof`'s `-match=K=V` come out right.

Condition 7 — the reconstructed token must occur glued and delimited in the
tool's own raw text — is still checked against the **whole** token, value
included, so the document has to have actually written the glued form.

## The discriminator, and why it cannot fire on a real glued short

**Nothing was loosened.** The instruction was explicit that the glued-short
predicate protects `cargo -Zscript` and must not be widened, and it has not
been: `is_option_name_tail` still rejects `=`, `:`, `[`, `{`, `<`, `,`, `.`,
`/` and `_`. `=` simply never reaches it any more, because it has already been
consumed as the boundary between the two halves.

The discriminator is the same one that was already load-bearing — **no ASCII
uppercase anywhere in the reconstructed token** — now read on the name half.
That is not a weakening, because **the GCC/Clang glued-value convention puts
its shout to the left of the `=`, which is exactly where this still looks**:

| real glued short | name token | rejected by |
|---|---|---|
| `gs -sDEVICE=png16m` | `-sDEVICE` | uppercase |
| `cpp -DMACRO=value` | `-DMACRO` | uppercase |
| `java -D<name>=<value>` | `-D<name>` | `<` is not a name character |
| `rpcgen -Dname[=value]` | `-Dname[` | `[` is not a name character |
| `gcc -Wl,-rpath=/usr/lib` | `-Wl,-rpath` | `,` is not a name character |
| `ld -Ttext=0x100` | `-Ttext` | uppercase |
| `cargo -Zscript` | (no `=` at all) | unchanged path |
| `tar -f archive`, `qemu -g port` | — | value is **spaced**; the glued token never occurs in the raw text |

Every one of those is asserted by name, in both directions, in
`sections.rs`'s tests and in `xtask::single_dash_long`'s promoted self-checks
(23 cases, all holding).

### The document-level discriminator I was asked to evaluate first — rejected on the data

The suggestion was: a document that contains unambiguous value-less single-dash
long options (`-reverse`, `-pipe`, `-version`) has declared its convention, so
`-number=N` in that document is the same convention. I measured it over all
2,301 frozen captures.

It **correlates** with the true positives — 37 of the 40 tools in the family
carry the signal — but it **does not discriminate**: **11 of the 13 tools in the
false-positive-risk population carry it too** (`clang`, `clang++`, `java`,
`javac`, `lto-dump`, and their variants all document bare single-dash longs
*and* real `-D<name>=<value>` macros in the same help text). It is evidence
that a *tool* uses the convention somewhere, not evidence that this *flag*
does. The case rule, applied to the name half, is what carries the precision,
so that is what shipped.

## Family size

Measured over the 2,301 frozen captures in `audit/queue-captures/`, replayed
through the real pipeline with zero subprocesses:

| shape | tools | flags |
|---|---|---|
| `short + no long + Required`, `value_name` contains `=` | 106 | 2,606 |
| ... of those, the glued token occurs in the raw text | 43 | 2,405 |
| ... of those, name half is name-shaped and lowercase (**the family**) | **40** | **2,196** |
| rejected by that last predicate (the risk population) | 13 | 209 |

It is dominated by the GCC toolchain and its clones (`gcc`, `cpp`, `g++`, `as`,
`c89`/`c99`/`cc`, the `aarch64-linux-gnu-*` and `-13` variants, `clang*`,
`lto-dump*`) plus `dbiprof`, `javax2jakarta`, `streamzip` and three LLVM tools.
The 13-tool risk population was eyeballed against its raw text: it is a genuine
mix of **correct parses that must not move** (`rpcgen -Dname[=value]`,
`java -D<name>=<value>`) and **declared out-of-scope misses**
(`-Wuninit-variable-checking=`, `-fRTS=`, `-fcompare-debug[=<opts>]`). None of
it moves.

## Evidence: full-PATH sweep, field by field

`before` = binary built at `792a800`; `after` = this branch. 2,254 tools matched.

- **flag-count losses: 0 across 0 tools.** The stop-the-line bar is clean.
- **status transitions: none.** Tools appeared: 0. Disappeared: 0.
- **flag-count gains: +8**, all on `lto-dump` and `lto-dump-13` (1747 → 1751).
- aggregate `%flags_text` unchanged at 95.62%; `suspicious` 0 → 0.
- **34 tools changed at field level.** `group` is not in the `#fp`
  fingerprint, so I checked separately: this change only ever rewrites
  `long`/`short`/`single_dash`/`value_name`/`value_kind` on a flag that already
  exists, never `group`, and the corpus snapshot diff (which does carry `group`)
  confirms it — `gcc` is the only pre-existing fixture that moved and its diff
  touches six flags and nothing else.

The 34, by shape:

- **21 GCC-family tools** (`gcc`, `gcc-13`, `g++`, `g++-13`, `c++`, `cpp`,
  `cpp-13`, `cc`, `c89`, `c89-gcc`, `c99`, `c99-gcc`, and the six
  `aarch64-linux-gnu-{gcc,g++,cpp}[-13]`): added `-foffload`,
  `-print-file-name`, `-print-prog-name`, `-specs`, `-std`; removed the
  fabricated `-f`, `-p`, `-s`; `-save-temps` value_name changed
  (`ave-temps=<arg>` → `<arg>`).
- **`as`, `aarch64-linux-gnu-as`**: added `-mabi`, `-march`, `-mcpu`; removed
  fabricated `-m`.
- **`clang`, `clang++`, `clang-18`, `clang++-18`, `clang-cpp-18`**: 178 flags
  added (`-std`, `-stdlib`, `-rtlib`, `-unwindlib`, `-march`, `-mcpu`, `-mtune`,
  the `-fsanitize*`/`-fprofile-*`/`-fxray-*` families, …); removed the
  fabricated `-r` and `-u`; `-f`, `-m`, `-s` still exist but now hold a
  *different* mangled row (see caveats).
- **`lto-dump`, `lto-dump-13`**: 104 flags added, fabricated `-i` removed, +4 net.
- **`dbiprof`**: added `-number`, `-sort`, `-match`, `-exclude`; removed
  fabricated `-n`, `-s`, `-m`, `-e`.
- **`javax2jakarta`** (`-exclude`, `-profile`), **`streamzip`**
  (`-member-name`, `-method`, `-zipfile`), **`llvm-addr2line-18`** and
  **`llvm-symbolizer-18`** (`-demangle`), **`llvm-dwp-18`**
  (`-continue-on-cu-index-overflow`), **`llvm-otool-18`** (`-mcpu`).

**Every removed short flag was verified fabricated** by grepping the tool's own
captured `--help` for a bare row: `clang` has no `-r` and no `-u` row, `as` has
no bare `-m`, `lto-dump` has no bare `-i`, `llvm-dwp-18` has no bare `-c`,
`llvm-addr2line-18` has no bare `-d`. Not one real flag was lost.

## Corpus

- `corpus/gcc/13.3.0` — the only pre-existing fixture that moved. Reviewed line
  by line: exactly six flags change, `-foffload`, `-print-file-name`,
  `-print-prog-name`, `-save-temps=<arg>`, `-specs`, `-std`, each from
  `short: 'X' / value_name: <mangled>` to `long: <real name> / single_dash: true
  / value_name: <the tool's own spec>`. Flag count 44 → 44, no description
  changed, nothing else in the file moved. This repairs a defect the human
  audit had already confirmed on this fixture.
- `corpus/dbiprof/1.643` — new fixture, `[bless] provenance = "agent"`, no
  `verdict_scope`. Its `[contract]` carries a negative claim
  (`must_not_contain_flags = ["-n", "-s", "-m", "-e", ...]`) so the defect
  cannot come back silently.
- 101 fixtures: 86 ok, 15 xfail as expected, 0 failed. `--bless` invented
  `expected.snap` for 13 `[xfail]` fixtures as warned; all 13 were deleted and
  `git status` is clean.

## Proving the tests fail pre-fix

Both new positive tests were run against a temporarily reverted
`split_glued_value` (`=` no longer a boundary), on the committed tree:

```
FAIL mandible-extract help_text::sections::tests::gccs_glued_value_long_options_keep_their_real_names
  no flag long=="foffload" in ["-f offload=<targets>", "-p rint-file-name=<lib>", "-s td=<standard>"]

FAIL mandible-extract help_text::sections::tests::dbiprofs_glued_value_long_options_keep_their_real_names
  no flag long=="number" in ["-n umber=N", "-s ort=S", "-reverse", "-m atch=K=V",
                             "-e xclude=K=V", "-c ase_sensitive", "-version"]
```

The two *inverse* tests (`..._never_repaired_when_it_carries_an_equals`,
`a_spaced_key_value_argument_is_never_a_long_option`) pass in both states, as
they must — they assert that nothing moves.

## See it yourself

```console
# 1. dbiprof, the reported tool
cargo build --release
./target/release/mandible dbiprof
```
Look at the FLAGS pane. Before this branch the first two rows read `-n umber=N`
and `-s ort=S`; they now read `-number N` and `-sort S`, and `-match K=V` /
`-exclude K=V` join them. `-c ase_sensitive` is still split — that one is the
declared underscore miss, see caveats.

```console
# 2. gcc, the audit-confirmed bug
./target/release/mandible gcc
```
Scroll to `-foffload`. Before: `-f offload=<targets>`. After:
`-foffload <targets>`. Same for `-print-file-name`, `-print-prog-name`,
`-specs`, `-std`.

```console
# 3. no tty? the pty harness renders the real screen as text
python3 -m venv /tmp/ptyvenv && /tmp/ptyvenv/bin/pip install pyte
/tmp/ptyvenv/bin/python scripts/pty_screenshot.py --keys '<tab>' 100 30 \
    ./target/release/mandible dbiprof

# 4. the inverse direction — these must NOT move
cargo run -p xtask --release -- detector self-check --detector single-dash-long
cargo run -p xtask --release -- corpus
```

### Captured screens

<details><summary><code>mandible dbiprof</code> — before (792a800) and after</summary>

```
##### BEFORE (mandible built at 792a800)
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────╮
│›                                                                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ──────────────────────────────────╮╭ dbiprof ───────────────────────────────────────╮
│  dbiprof                                       ││ DESCRIPTION ────────────────────────────────── │
│                                                ││ dbiprof [options] [files]                      │
│                                                ││                                                │
│                                                ││ FLAGS ──────────────────────────────────────── │
│                                                ││   -n umber=N                                   │
│                                                ││       show top N, defaults to 10               │
│                                                ││   -s ort=S                                     │
│                                                ││       sort by S, defaults to total             │
│                                                ││   -reverse                                     │
│                                                ││       reverse the sort                         │
│                                                ││   -m atch=K=V                                  │
│                                                ││       for filtering, see docs                  │
│                                                ││   -e xclude=K=V                                │
│                                                ││       for filtering, see docs                  │
│                                                ││   -c ase_sensitive                             │
│                                                ││       for -match and -exclude                  │
│                                                ││   -delete                                      │
│                                                ││       rename files before reading then delete  │
│                                                ││       afterwards                               │
│                                                ││   -version                                     │
│                                                ││       print version number and exit            │
│                                                ││   -help                                        │
│                                                ││       print this help                          │
│                                                ││                                                │
╰────────────────────────────────────────────────╯╰────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    ? help    ^C quit             help-text


##### AFTER (this branch)
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────╮
│›                                                                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ──────────────────────────────────╮╭ dbiprof ───────────────────────────────────────╮
│  dbiprof                                       ││ DESCRIPTION ────────────────────────────────── │
│                                                ││ dbiprof [options] [files]                      │
│                                                ││                                                │
│                                                ││ FLAGS ──────────────────────────────────────── │
│                                                ││   -number N                                    │
│                                                ││       show top N, defaults to 10               │
│                                                ││   -sort S                                      │
│                                                ││       sort by S, defaults to total             │
│                                                ││   -reverse                                     │
│                                                ││       reverse the sort                         │
│                                                ││   -match K=V                                   │
│                                                ││       for filtering, see docs                  │
│                                                ││   -exclude K=V                                 │
│                                                ││       for filtering, see docs                  │
│                                                ││   -c ase_sensitive                             │
│                                                ││       for -match and -exclude                  │
│                                                ││   -delete                                      │
│                                                ││       rename files before reading then delete  │
│                                                ││       afterwards                               │
│                                                ││   -version                                     │
│                                                ││       print version number and exit            │
│                                                ││   -help                                        │
│                                                ││       print this help                          │
│                                                ││                                                │
╰────────────────────────────────────────────────╯╰────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    ? help    ^C quit             help-text

```
</details>

<details><summary><code>mandible gcc</code> — before (792a800) and after</summary>

```
##### BEFORE
====================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────╮
│›                                                                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ──────────────────────────────────╮╭ gcc ───────────────────────────────────────────╮
│  gcc                                           ││ {common|optimizers|params|target|warnings|[^]{ │
│                                                ││ joined|separate|undocumented}}[,...].          │
│                                                ││       Display this information.                │
│                                                ││   --target-help                                │
│                                                ││       Display target specific command line     │
│                                                ││       options (including assembler and linker  │
│                                                ││       options).                                │
│                                                ││   --version                                    │
│                                                ││       Display compiler version information.    │
│                                                ││   -dumpspecs                                   │
│                                                ││       Display all of the built in spec         │
│                                                ││       strings.                                 │
│                                                ││   -dumpversion                                 │
│                                                ││       Display the version of the compiler.     │
│                                                ││   -dumpmachine                                 │
│                                                ││       Display the compiler's target processor. │
│                                                ││   -f offload=<targets>                         │
│                                                ││       Specify offloading targets.              │
│                                                ││   -print-search-dirs                           │
│                                                ││       Display the directories in the           │
│                                                ││       compiler's search path.                  │
│                                                ││   -print-libgcc-file-name                      │
│                                                ││       Display the name of the compiler's       │
│                                                ││       companion library.                       │
╰────────────────────────────────────────────────╯╰────────────────────────────────────────────────╯
  ? help    ^C quit          incomplete: this tool's help said more is available (`--help common`)

##### AFTER
====================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────╮
│›                                                                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ──────────────────────────────────╮╭ gcc ───────────────────────────────────────────╮
│  gcc                                           ││ {common|optimizers|params|target|warnings|[^]{ │
│                                                ││ joined|separate|undocumented}}[,...].          │
│                                                ││       Display this information.                │
│                                                ││   --target-help                                │
│                                                ││       Display target specific command line     │
│                                                ││       options (including assembler and linker  │
│                                                ││       options).                                │
│                                                ││   --version                                    │
│                                                ││       Display compiler version information.    │
│                                                ││   -dumpspecs                                   │
│                                                ││       Display all of the built in spec         │
│                                                ││       strings.                                 │
│                                                ││   -dumpversion                                 │
│                                                ││       Display the version of the compiler.     │
│                                                ││   -dumpmachine                                 │
│                                                ││       Display the compiler's target processor. │
│                                                ││   -foffload <targets>                          │
│                                                ││       Specify offloading targets.              │
│                                                ││   -print-search-dirs                           │
│                                                ││       Display the directories in the           │
│                                                ││       compiler's search path.                  │
│                                                ││   -print-libgcc-file-name                      │
│                                                ││       Display the name of the compiler's       │
│                                                ││       companion library.                       │
╰────────────────────────────────────────────────╯╰────────────────────────────────────────────────╯
  ? help    ^C quit          incomplete: this tool's help said more is available (`--help common`)

```
</details>

## Honest caveats and residuals

- **`Flag::spelling` renders a required value with a space**, so `-foffload`
  displays as `-foffload <targets>` even though gcc only accepts
  `-foffload=<targets>`. That is the pre-existing repo-wide display convention
  (`--output=FILE` has always rendered as `--output FILE`); the separator is
  not recorded anywhere in `Flag`. Out of scope here, and still strictly better
  than `-f offload=<targets>`. It probably belongs to the 0.5.0 IR work.
- **`dbiprof -case_sensitive` is still split** into `-c` + `ase_sensitive`, in
  the very table this repairs, because `_` is not an option-name character.
  Allowing it is a *separate* shape with its own safety argument (the character
  also appears in glued value placeholders) and I did not want to smuggle it in
  under this change's evidence. It is declared in the doc comments and asserted
  by a test, so it cannot rot silently.
- **gcc now carries two flags named `save-temps`** — a boolean and a
  value-taking one — because gcc's own help writes both rows with the same
  description. Previously the second one was the fabricated `-s`. This mirrors
  the document; it is not a regression, but it is visible.
- **clang's `-f`, `-m`, `-s` are still fabricated**, just from different rows
  now (`-fproc-stat-report<value>`, `-mbranches-within-32B-boundaries`,
  `-stdlib++-isystem`). Those are clang's bracket-glued and `+`-carrying
  shapes, outside this family. Pre-existing, count unchanged.
- **Uppercase-led single-dash longs are still split** (`-Xassembler`,
  `-Wuninit-variable-checking=`, `-fRTS=`) — the same declared exclusion the
  original repair carried, for the same reason: nothing separates them from
  `-Zscript`.
- **The full-PATH sweep ran `--allow-uncontained`** (Ubuntu's
  `apparmor_restrict_unprivileged_userns=1` blocks the namespace containment on
  this box, per AGENTS.md §4). Evidence-before-argv gating was still in effect.
- **The 2,196-flag family size is a *shape* count, not a repair count.** The
  authoritative measure of what actually moved is the sweep-diff above.
  Re-measuring accuracy on the tools this fixes would be train-on-test; no
  fleet-accuracy claim is made here.
- **Out of scope, reported not fixed** (all awaiting the 0.5.0 IR work):
  multi-short rows (`-? -h --help`), positionals, `ar` modifiers.

## Gates

| gate | result |
|---|---|
| `cargo nextest run --workspace` | 1107 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo run -p xtask -- corpus` | 101 fixtures: 86 ok, 15 xfail, 0 failed |
| `xtask detector self-check --detector single-dash-long` | 23/23 held |
| `bash scripts/changelog_guard.sh` | released sections match their tags |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
