### PR TITLE
fix(help_text): read `_` as a name character in a single-dash long option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **A single-dash long option whose name carries an underscore was split
+  into a one-character short flag plus the rest of its own name.**
+  `dbiprof` writes `-case_sensitive` and the tree held `-c` with
+  `value_name: "ase_sensitive"` — a short flag `dbiprof` does not document
+  anywhere. It sat in the same table as `-number=N`, `-reverse` and
+  `-version`, all of which the previous release already recovered; the one
+  thing that separated it from them was the `_`, which
+  `is_option_name_tail` rejected.
+
+  `_` separates words inside a name exactly as `-` does, and none of the
+  seven conditions that make this repair safe is measured on which
+  separator a name uses. Admitting it therefore moves nothing else:
+  `-DFOO_BAR` and `-oOUT_FILE` are still rejected by the uniform-lowercase
+  test, `-o out_file` is still rejected by the raw-text scan (it never
+  occurs glued), and `-d item_a[,...]` is still rejected by the name-shape
+  test's own punctuation rule. Each is asserted by name in `sections.rs`'s
+  tests and in `xtask::single_dash_long`'s self-checks.
+
+  Measured on a full-`PATH` sweep (2,254 tools, aarch64 Ubuntu 24.04) the
+  change moves **17 tools and 604 flag spellings** — `clang -fchar8_t` and
+  `-fno-char8_t`, `llvm-install-name-tool -add_rpath` and
+  `-delete_all_rpaths`, `llvm-lipo -verify_arch`, `llvm-otool
+  -chained_fixups`, `ffmpeg -pix_fmts` and `-filter_script`, `lto-dump
+  -fchar8_t`, and the whole of `ffplay`'s and `ffprobe`'s `AVOption`
+  tables. No tool appeared, disappeared, or changed status or tier, and
+  the field-level sweep diff reports **no flag lost anywhere**. Every one
+  of the 604 recovered names was checked against its own tool's raw
+  capture and every one occurs as the leading token of a row that tool
+  writes; there were no counter-examples.
+
+  `ffplay` and `ffprobe` are 97% of it, and their rows put the value spec
+  in a *space-separated* column (`-is_avc  <boolean>  .D.V..X....  is
+  avc`). Both that column and the capability column beside it are
+  untouched: they were never in `value_name` — the swallowed name half
+  was — and they live in the description, which this repair does not
+  write. `ffplay`'s tree keeps the same 1,136 flags and the same 1,135
+  descriptions byte for byte; 679 of them stop being fabricated shorts,
+  and the fabricated `-b`, `-c`, `-d`, `-g`, `-h`, `-k`, `-l`, `-m`, `-n`,
+  `-o`, `-p`, `-r`, `-u` and `-w` disappear while its real `-h`/`--help`,
+  `-i input_file`, `-x width`, `-v loglevel` and `-f fmt` stay.
+
 - **A single-dash long option carrying a glued `=value` was split into a
   one-character short flag plus a mangled value.** `dbiprof` writes
   `-number=N` and the tree held `-n` with `value_name: "umber=N"`;

--- a/corpus/dbiprof/1.643/expected.snap
+++ b/corpus/dbiprof/1.643/expected.snap
@@ -39,9 +39,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'c'
-  value_name: ase_sensitive
-  value_kind: Required
+- long: case_sensitive
+  single_dash: true
   description: for -match and -exclude
   provenance:
     sources:

--- a/corpus/ffmpeg/6.1.1/expected.snap
+++ b/corpus/ffmpeg/6.1.1/expected.snap
@@ -128,9 +128,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'p'
-  value_name: ix_fmts
-  value_kind: Required
+- long: pix_fmts
+  single_dash: true
   description: show available pixel formats
   provenance:
     sources:
@@ -141,9 +140,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 's'
-  value_name: ample_fmts
-  value_kind: Required
+- long: sample_fmts
+  single_dash: true
   description: show available audio sample formats
   provenance:
     sources:
@@ -197,9 +195,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'm'
-  value_name: ax_alloc
-  value_kind: Required
+- long: max_alloc
+  single_dash: true
   description: set maximum size of a single allocated block
   provenance:
     sources:
@@ -214,23 +211,20 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'i'
-  value_name: gnore_unknown
-  value_kind: Required
+- long: ignore_unknown
+  single_dash: true
   description: Ignore unknown stream types
   provenance:
     sources:
     - help-text
-- short: 'f'
-  value_name: ilter_threads
-  value_kind: Required
+- long: filter_threads
+  single_dash: true
   description: number of non-complex filter threads
   provenance:
     sources:
     - help-text
-- short: 'f'
-  value_name: ilter_complex_threads
-  value_kind: Required
+- long: filter_complex_threads
+  single_dash: true
   description: number of threads for -filter_complex
   provenance:
     sources:
@@ -241,9 +235,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'm'
-  value_name: ax_error_rate
-  value_kind: Required
+- long: max_error_rate
+  single_dash: true
   description: 'ratio of decoding errors (0.0: no errors, 1.0: 100% errors) above which ffmpeg returns an error instead of success.'
   provenance:
     sources:
@@ -274,9 +267,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'm'
-  value_name: ap_metadata
-  value_kind: Required
+- long: map_metadata
+  single_dash: true
   description: set metadata information of outfile from infile
   provenance:
     sources:
@@ -315,9 +307,8 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 's'
-  value_name: eek_timestamp
-  value_kind: Required
+- long: seek_timestamp
+  single_dash: true
   description: enable/disable seeking by timestamp with -ss
   provenance:
     sources:
@@ -364,16 +355,14 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'f'
-  value_name: ilter_script
-  value_kind: Required
+- long: filter_script
+  single_dash: true
   description: read stream filtergraph description from a file
   provenance:
     sources:
     - help-text
-- short: 'r'
-  value_name: einit_filter
-  value_kind: Required
+- long: reinit_filter
+  single_dash: true
   description: reinit filtergraph on input parameter changes
   provenance:
     sources:
@@ -422,23 +411,20 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'd'
-  value_name: isplay_rotation
-  value_kind: Required
+- long: display_rotation
+  single_dash: true
   description: set pure counter-clockwise rotation in degrees for stream(s)
   provenance:
     sources:
     - help-text
-- short: 'd'
-  value_name: isplay_hflip
-  value_kind: Required
+- long: display_hflip
+  single_dash: true
   description: set display horizontal flip for stream(s) (overrides any display rotation if it is not set)
   provenance:
     sources:
     - help-text
-- short: 'd'
-  value_name: isplay_vflip
-  value_kind: Required
+- long: display_vflip
+  single_dash: true
   description: set display vertical flip for stream(s) (overrides any display rotation if it is not set)
   provenance:
     sources:
@@ -569,16 +555,14 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'f'
-  value_name: ix_sub_duration
-  value_kind: Required
+- long: fix_sub_duration
+  single_dash: true
   description: fix subtitles duration
   provenance:
     sources:
     - help-text
-- short: 'c'
-  value_name: anvas_size
-  value_kind: Required
+- long: canvas_size
+  single_dash: true
   description: set canvas size (WxH or abbreviation)
   provenance:
     sources:

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -1183,6 +1183,69 @@ const MIN_SWALLOWED_NAME_CHARS: usize = 2;
 /// every other condition) — `parse_bundled_shorts` owns that shape from the
 /// synopsis, and the identical shape from an option table is this family.
 ///
+/// # Why `_` is a name character
+///
+/// Condition 3 used to reject `_`, on the theory that it "also appears in
+/// glued value placeholders". It does — and so does every letter of the
+/// alphabet. `_` is a **word separator inside a name**, the same job `-`
+/// does, and none of the conditions above is measured on which separator
+/// a name spells its word breaks with: `-DFOO_BAR` is still rejected by
+/// condition 5, `-oOUT_FILE` still by condition 5 read over the whole
+/// token, `-o out_file` still by condition 7 (it never occurs glued), and
+/// `-d item_a[,...]` still by condition 3's own punctuation test.
+///
+/// Measured on a full-`PATH` sweep of this machine (2,254 tools, aarch64
+/// Ubuntu 24.04), admitting `_` moves **17 tools and 604 flag spellings**,
+/// and moves nothing else: no tool appeared or disappeared, no tool
+/// changed status or tier, and no flag was lost — the field-level
+/// `sweep-diff` reports `0 lost across 0 tool(s)`. Every one of the 604
+/// recovered names was then checked against its own tool's raw capture,
+/// and **all 604 occur as the leading token of a row the tool itself
+/// writes** — `clang -fchar8_t`/`-fno-char8_t`, `llvm-install-name-tool
+/// -add_rpath`/`-delete_all_rpaths`, `llvm-lipo -verify_arch`,
+/// `llvm-otool -chained_fixups`, `ffmpeg -pix_fmts`/`-filter_script`,
+/// `dbiprof -case_sensitive`. There were no counter-examples.
+///
+/// **ffplay and ffprobe are 97% of it**, and they are the case worth
+/// stating explicitly because their rows carry a value spec in a
+/// *space-separated* column plus a capability column:
+///
+/// ```text
+///   -is_avc            <boolean>    .D.V..X.... is avc (default false)
+///   -grab_x            <int>        .D......... Initial x coordinate. (from 0 to INT_MAX)
+/// ```
+///
+/// Neither column is at risk, because neither was ever in `value_name` —
+/// the grammar stored the swallowed name half there (`-i` + `"s_avc"`)
+/// and both columns went into the *description*, which this repair does
+/// not touch. `ffplay`'s tree keeps the same 1,136 flags and the same
+/// 1,135 descriptions, byte for byte, before and after; 679 of them stop
+/// being fabricated shorts. The rows that were already recovered on the
+/// unmodified parser — `-idct`, `-threads`, `-debug`, whose names carry
+/// no underscore — have always read exactly this way, so this is the
+/// underscore rows joining them rather than a new behaviour.
+///
+/// # A rejected alternative: "is the candidate short documented?"
+///
+/// Recorded because it is the obvious next idea and it is **wrong**:
+/// allow the long reading only when the tool's help documents no bare row
+/// for the candidate short — `dbiprof` documents no `-c`, so `-c` is
+/// fabricated there and `-case_sensitive` wins.
+///
+/// It does not discriminate. Measured over the 604 spellings above it
+/// refuses 111 of them, and every single one of the 111 is a documented
+/// row token — a 100% false-refusal rate, buying nothing. `ffplay`
+/// documents `-f fmt` **and** `-filter_threads`; `-i input_file` **and**
+/// `-is_avc`. A tool documenting both a short and a long option that
+/// starts with the same letter is the ordinary case, not a suspicious
+/// one. Worse, as a general rule it would revert work already shipped:
+/// across those same 17 tools it refuses **632 of the 8,260** single-dash
+/// long options the parser already recovers, `ffplay -help` among them —
+/// the exact `-h` beside `-help` coexistence
+/// `xtask::single_dash_long`'s own doc comment opens with. What the idea
+/// is reaching for is already supplied, and supplied better, by
+/// conditions 5 and 7 together.
+///
 /// # What this deliberately does not claim
 ///
 /// Named here rather than discovered later, and each one is a place the

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -1200,14 +1200,10 @@ const MIN_SWALLOWED_NAME_CHARS: usize = 2;
 ///   3 rejects it. No tail-shape rule can claim that without also admitting
 ///   every value spec that leaks punctuation.
 /// - **Tails whose *name* half carries brackets or other value-spec
-///   punctuation.** Condition 3 still rejects `[`, `<`, `,`, `.`, `/` and
-///   `_` in the name half, for the same reason the oracle does — `-d
+///   punctuation.** Condition 3 still rejects `[`, `<`, `,`, `.` and `/`
+///   in the name half, for the same reason the oracle does — `-d
 ///   item[,...]` and `-b{blocksize}` are value specs, not names. Only `=`
 ///   is read structurally, and only as the boundary between the two halves.
-/// - **Names carrying an underscore**, `dbiprof`'s own `-case_sensitive`
-///   among them: condition 3 rejects `_`. It sits in the same table as the
-///   rows this change does repair and stays split, which is a knowingly
-///   incomplete result on that one document rather than a silent one.
 /// - **A tail that ends at the `=` with nothing after it** — refused
 ///   outright by [`split_glued_value`], which has no evidence for either
 ///   reading of it.
@@ -1314,22 +1310,29 @@ fn split_glued_value(tail: &str) -> Option<(&str, Option<&str>)> {
 }
 
 /// True when `tail` could be the rest of a single-dash long option's name:
-/// ASCII alphanumerics and `-`, with at least one ASCII letter in it.
+/// ASCII alphanumerics, `-` and `_`, with at least one ASCII letter in it.
 ///
 /// The twin of `xtask::single_dash_long::is_option_name_tail`, character
 /// for character. The letter requirement is what stops a glued *numeric*
 /// argument (`-b4096`, `-j8`) from riding in on a run that is technically
 /// alphanumeric. Everything else is rejected because a long option's name
 /// does not contain it: `:` (`sg_emc_trespass`'s layout-mangled `-hr:`),
-/// `[`/`{`/`<`/`,` (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths),
-/// and `_` (`dbiprof`'s real `-case_sensitive`, left split).
+/// `[`/`{`/`<`/`,` (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths).
+///
+/// `_` is admitted on the same footing as `-`, for the reason given in
+/// [`repair_single_dash_long_options`]'s "Why `_` is a name character"
+/// section: it separates words inside a name, and every condition that
+/// makes this repair safe is measured over the token, not over which
+/// separator the name happens to spell its word breaks with.
 ///
 /// `=` never reaches here: [`split_glued_value`] has already consumed it as
 /// the boundary between the name and its glued value spec, so what this
 /// sees is only ever the name half.
 fn is_option_name_tail(tail: &str) -> bool {
     tail.chars().any(|c| c.is_ascii_alphabetic())
-        && tail.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        && tail
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 /// True when `token` carries no ASCII uppercase letter at all — the
@@ -5596,6 +5599,141 @@ mod tests {
         }
     }
 
+    /// `_` separates words inside an option name exactly as `-` does, and
+    /// `dbiprof` proves it in one table: `-case_sensitive` sits between
+    /// `-exclude=K=V` and `-version`, both of which this repair already
+    /// recovered, and came out as `-c` carrying `"ase_sensitive"` — a
+    /// short flag `dbiprof` does not document at all.
+    #[test]
+    fn an_underscored_name_is_recovered_from_the_table_it_shares() {
+        let parsed = parse(DBIPROF_TABLE);
+        let flag = parsed
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("case_sensitive"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "-case_sensitive was not recovered: {:?}",
+                    parsed
+                        .flags
+                        .iter()
+                        .map(|f| f.spelling())
+                        .collect::<Vec<_>>()
+                )
+            });
+        assert!(flag.single_dash, "it is spelled with one dash");
+        assert_eq!(flag.short, None, "the fabricated -c is gone");
+        assert_eq!(flag.value_kind, ValueKind::None);
+        assert_eq!(
+            flag.description.as_ref().map(|d| d.as_str()),
+            Some("for -match and -exclude")
+        );
+        // The fabricated short must not survive under any other flag.
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.short == Some('c') && f.long.is_none()),
+            "the invented -c is not left behind"
+        );
+    }
+
+    /// The ffmpeg `AVOption` table is 97% of this widening's population,
+    /// and the thing that has to survive it is the **value spec**: these
+    /// rows write `<int>`/`<flags>`/`<string>` in a space-separated column
+    /// of their own, followed by a `.D.V..X....` capability column. Both
+    /// already live in the *description* — the grammar never stored them
+    /// in `value_name`, which held the swallowed name half instead — so
+    /// the repair must move the name and leave the description untouched.
+    ///
+    /// Rows quoted byte-for-byte from `ffplay --help` (6.1.1-3ubuntu5).
+    #[test]
+    fn an_avoption_row_keeps_its_value_spec_and_capability_column() {
+        const AVOPTIONS: &str = concat!(
+            "AVCodecContext AVOptions:\n",
+            "  -is_avc            <boolean>    .D.V..X.... is avc (default false)\n",
+            "  -skip_top          <int>        .D.V....... number of macroblock rows at the top which are skipped (from INT_MIN to INT_MAX) (default 0)\n",
+            "  -threads           <int>        ED.VA...... set the number of threads (from 0 to INT_MAX) (default 1)\n",
+        );
+        let parsed = parse(AVOPTIONS);
+        for (name, spec) in [
+            ("is_avc", "<boolean> .D.V..X.... is avc (default false)"),
+            (
+                "skip_top",
+                "<int> .D.V....... number of macroblock rows at the top which are skipped (from INT_MIN to INT_MAX) (default 0)",
+            ),
+            // The control: no underscore, so this row is recovered on the
+            // parser as it stands. Its description is what the two above
+            // must now look like.
+            (
+                "threads",
+                "<int> ED.VA...... set the number of threads (from 0 to INT_MAX) (default 1)",
+            ),
+        ] {
+            let flag = parsed
+                .flags
+                .iter()
+                .find(|f| f.long.as_deref() == Some(name))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "-{name} was not recovered: {:?}",
+                        parsed
+                            .flags
+                            .iter()
+                            .map(|f| f.spelling())
+                            .collect::<Vec<_>>()
+                    )
+                });
+            assert!(flag.single_dash);
+            assert_eq!(
+                flag.description.as_ref().map(|d| d.as_str()),
+                Some(spec),
+                "-{name} lost its value spec or capability column"
+            );
+        }
+    }
+
+    /// The inverse, in the direction that matters: an underscore in the
+    /// *swallowed* text is not on its own a licence to read a long option.
+    /// Every one of these is a correct parse the widening must leave
+    /// standing, and each is refused by a different condition.
+    #[test]
+    fn an_underscore_alone_never_buys_the_long_reading() {
+        for (row, refused) in [
+            // Condition 5: the GCC/Clang glued-value convention shouts,
+            // and an underscored macro name shouts with it.
+            ("  -DFOO_BAR         define a macro\n", "DFOO_BAR"),
+            ("  -DMAX_PATH=4096   define a macro\n", "DMAX_PATH"),
+            // Condition 5 again, via the whole token: only the argument
+            // shouts, and that is exactly the `-oOUTFILE` shape.
+            ("  -oOUT_FILE        write output here\n", "oOUT_FILE"),
+            // Condition 7: a *spaced* underscored value stores the same
+            // bytes a glued one would, and the raw text is what tells
+            // them apart — `-o out_file` never occurs glued.
+            ("  -o out_file       write output here\n", "out_file"),
+            // Condition 3: the name half still may not carry value-spec
+            // punctuation just because it also carries an underscore.
+            ("  -d item_a[,...]   a list\n", "item_a"),
+            ("  -b some_path/name a path\n", "some_path/name"),
+            // Condition 4: one character of name is still not a name.
+            ("  -s_               a stray\n", "s_"),
+        ] {
+            let parsed = parse(row);
+            assert!(
+                parsed
+                    .flags
+                    .iter()
+                    .all(|f| f.long.as_deref() != Some(refused)),
+                "{row:?} was read as the long option -{refused}: {:?}",
+                parsed
+                    .flags
+                    .iter()
+                    .map(|f| f.spelling())
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+
     /// The two declared out-of-scope misses, asserted rather than
     /// described — a miss that is only written down in prose stops being
     /// checked the day the prose goes stale.
@@ -5610,17 +5748,6 @@ mod tests {
                 .iter()
                 .all(|f| f.long.as_deref() != Some("foo")),
             "an empty value spec has no measured reading"
-        );
-        // `dbiprof`'s own `-case_sensitive`: `_` is not an option-name
-        // character here, so it stays split even though it sits in the
-        // table this repair otherwise fixes.
-        let parsed = parse(DBIPROF_TABLE);
-        assert!(
-            parsed
-                .flags
-                .iter()
-                .all(|f| f.long.as_deref() != Some("case_sensitive")),
-            "the underscore miss is declared, not accidental"
         );
         // `ip` writes a bracketed tail, so the grammar records
         // `ValueKind::Optional` — a value spec a human deliberately typed.
@@ -5701,8 +5828,17 @@ mod tests {
         assert!(is_option_name_tail("elp"));
         assert!(is_option_name_tail("one-insn-per-tb"));
         assert!(is_option_name_tail("utf8"));
+        // `_` is a word separator inside a name, on the same footing as
+        // `-`: `dbiprof`'s `-case_sensitive`, ffmpeg's `-pix_fmts`.
+        assert!(is_option_name_tail("ase_sensitive"));
+        assert!(is_option_name_tail("ix_fmts"));
+        // Leading, trailing and doubled separators are still names — the
+        // shape test is about the character set, and every other
+        // condition is what makes the repair safe.
+        assert!(is_option_name_tail("_err_detect"));
         // No letter at all is a glued numeric argument, not a name.
         assert!(!is_option_name_tail("4096"));
+        assert!(!is_option_name_tail("_42"));
         assert!(!is_option_name_tail(""));
         // Every punctuation character a value spec leaks.
         for tail in [
@@ -5713,7 +5849,6 @@ mod tests {
             "a<b>",
             "path/name",
             "file.txt",
-            "some_name",
             "a,b",
         ] {
             assert!(!is_option_name_tail(tail), "{tail:?} is not an option name");
@@ -8804,20 +8939,21 @@ Options:
     /// keep winning and `find_equals_separator_gap` must never run.
     #[test]
     fn equals_signs_inside_a_sentence_are_not_mistaken_for_a_separator() {
-        // `http_seekable`'s underscore keeps `repair_single_dash_long_options`
-        // from ever claiming it (condition 3 rejects `_` in the swallowed
-        // tail — see that function's own doc comment), so this stays a
-        // short `-h` carrying everything after it as one description. That
-        // is unrelated to and unchanged by this fix; what matters here is
-        // that the `=` signs inside the sentence survive untouched.
+        // `-http_seekable` is one of the underscored single-dash long
+        // options `repair_single_dash_long_options` recovers, so the name
+        // is whole and the whole value-spec column stays in the
+        // description. What matters *here* is orthogonal to both: the `=`
+        // signs inside the sentence must not be mistaken for the glued
+        // `=value` separator and cut the row short.
         let help = "Options:\n  \
                     -http_seekable     <boolean>    .D......... Use HTTP partial requests, 0 = disable, 1 = enable, -1 = auto (default auto)\n";
         let parsed = parse(help);
         let flag = parsed
             .flags
             .iter()
-            .find(|f| f.short == Some('h'))
-            .expect("-http_seekable must be recovered as a short flag");
+            .find(|f| f.long.as_deref() == Some("http_seekable"))
+            .expect("-http_seekable must be recovered as one single-dash long option");
+        assert!(flag.single_dash);
         assert_eq!(
             flag.description.as_ref().map(|d| d.as_str()),
             Some("<boolean> .D......... Use HTTP partial requests, 0 = disable, 1 = enable, -1 = auto (default auto)")

--- a/xtask/src/single_dash_long.rs
+++ b/xtask/src/single_dash_long.rs
@@ -115,6 +115,14 @@
 //!   `sg_emc_trespass` writes `-hr: Set Honor Reservation bit` with no space
 //!   before the colon, so the tree stores `-h` + `"r:"` and condition 3
 //!   rejects it. Also a labelled member, also declared.
+//! - Once, but no longer: **names carrying an underscore**. Condition 3
+//!   rejected `_` on the theory that it also appears in glued value
+//!   placeholders; so does every letter of the alphabet, and `_` is a word
+//!   separator inside a name exactly as `-` is. A full-`PATH` sweep put the
+//!   population at 17 tools and 604 flag spellings, every one of them a
+//!   token its own tool writes at the head of a row, with no counter-example
+//!   — see `help_text::sections::repair_single_dash_long_options`'s "Why
+//!   `_` is a name character".
 //! - **One-character tails** ([`MIN_SWALLOWED_CHARS`]) — `rpcgen -Ss`,
 //!   `xxd -ps`, `sg_map -st`, `mandoc -ac`, `which -as`. The same
 //!   two-character population `bundling::MIN_BUNDLED_MEMBERS` already

--- a/xtask/src/single_dash_long.rs
+++ b/xtask/src/single_dash_long.rs
@@ -45,8 +45,8 @@
 //!    shared fingerprint. `Optional` means the raw text wrote brackets
 //!    (`ip`'s `-h[uman-readable]`), which is a value spec a human typed.
 //! 3. **The swallowed text's *name half* is option-name-shaped**
-//!    ([`is_option_name_tail`]): ASCII alphanumerics and `-`, with at least
-//!    one letter. The name half is everything before the first `=`, or the
+//!    ([`is_option_name_tail`]): ASCII alphanumerics, `-` and `_`, with at
+//!    least one letter. The name half is everything before the first `=`, or the
 //!    whole tail when there is no `=` ([`split_glued_value`]) — a tail like
 //!    `qemu`'s `-number=N` → `"umber=N"` is a name **plus** the value spec
 //!    the tool glued onto it, and `=` is the character that says where the
@@ -144,24 +144,27 @@ use mandible_core::{CommandNode, Flag, Provenance, Source, ValueKind};
 pub(crate) const MIN_SWALLOWED_CHARS: usize = 2;
 
 /// True when `tail` could be the rest of a single-dash long option's name:
-/// ASCII alphanumerics and `-`, with at least one ASCII letter in it.
+/// ASCII alphanumerics, `-` and `_`, with at least one ASCII letter in it.
 ///
 /// The letter requirement is what stops a glued numeric argument (`-b4096`,
 /// `-j8`) from riding in on a run that is technically alphanumeric, exactly
 /// as `bundling::MIN_ORDERED_LETTERS` stops the vacuous-ordering version of
 /// the same hazard. Everything else is rejected because a long option's name
 /// does not contain it: `:` (`sg_emc_trespass`'s layout-mangled `-hr:`),
-/// `[`/`{`/`<`/`,` (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths),
-/// `_` (`dbiprof`'s real `-case_sensitive`, left split — the character also
-/// appears in glued value placeholders and nothing measured separates the
-/// two).
+/// `[`/`{`/`<`/`,` (`-d item[,...]`, `-b{blocksize}`), `.` and `/` (paths).
+///
+/// `_` is admitted, on the same footing as `-`: it is a **word separator**
+/// in an option name, not value-spec punctuation. See this module's
+/// "Why `_` is a name character" section for the measurement.
 ///
 /// `=` never reaches here: [`split_glued_value`] has already consumed it as
 /// the boundary between the name and its glued value spec, so what this sees
 /// is only ever the name half.
 fn is_option_name_tail(tail: &str) -> bool {
     tail.chars().any(|c| c.is_ascii_alphabetic())
-        && tail.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        && tail
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 /// True when `token` carries no ASCII uppercase letter at all — the
@@ -494,8 +497,9 @@ pub(crate) fn self_checks() -> Vec<crate::detector::SelfCheck> {
             name: "dbiprof's real option table, glued =value beside value-less rows",
             why: "the shape the =-split exists for: -number=N and -reverse sit in one table and \
                   only the = separates the row that used to be repaired from the one that did \
-                  not. -case_sensitive is the declared underscore miss and must stay split",
-            expect: Expect::Fires(4),
+                  not. -case_sensitive rides in on the same rule now that _ is a name \
+                  character, which is why this counts five and not four",
+            expect: Expect::Fires(5),
             raw: DBIPROF_TABLE.to_string(),
             root: tree(
                 "dbiprof",
@@ -546,6 +550,40 @@ pub(crate) fn self_checks() -> Vec<crate::detector::SelfCheck> {
             expect: Expect::Silent,
             raw: "  -foo=   an empty value spec\n".to_string(),
             root: tree("t", vec![table_flag('f', Some("oo="))]),
+        },
+        SelfCheck {
+            name: "ffplay's real AVOption row, the underscore family's bulk",
+            why: "97% of the underscore population is this one table shape; the name is what the \
+                  document writes at the head of the row and the value spec sits in a \
+                  space-separated column the grammar never stored in value_name",
+            expect: Expect::Fires(1),
+            raw: "  -is_avc            <boolean>    .D.V..X.... is avc (default false)\n"
+                .to_string(),
+            root: tree("ffplay", vec![table_flag('i', Some("s_avc"))]),
+        },
+        SelfCheck {
+            name: "cpp's real -DFOO_BAR",
+            why: "the inverse the underscore widening had to survive: an underscore inside a \
+                  glued macro name buys nothing, because condition 5 still reads the shout",
+            expect: Expect::Silent,
+            raw: "  -DFOO_BAR   define a macro\n".to_string(),
+            root: tree("cpp", vec![table_flag('D', Some("FOO_BAR"))]),
+        },
+        SelfCheck {
+            name: "a lowercase flag letter with a shouting underscored argument",
+            why: "the -oOUTFILE shape wearing an underscore: only the whole-token case test \
+                  rejects it, and it is why condition 5 is not measured on the tail alone",
+            expect: Expect::Silent,
+            raw: "  -oOUT_FILE   write output here\n".to_string(),
+            root: tree("t", vec![table_flag('o', Some("OUT_FILE"))]),
+        },
+        SelfCheck {
+            name: "a spaced underscored value",
+            why: "-o out_file stores byte-for-byte what a glued -oout_file would; condition 7's \
+                  scan of the raw text is the only thing that tells them apart",
+            expect: Expect::Silent,
+            raw: "  -o out_file   write output here\n".to_string(),
+            root: tree("t", vec![table_flag('o', Some("out_file"))]),
         },
         SelfCheck {
             name: "gcc's real -Wl,<options>",
@@ -712,8 +750,14 @@ mod tests {
         assert!(!is_option_name_tail("var=value"));
         assert!(!is_option_name_tail("item[,...]"));
         assert!(!is_option_name_tail("c[vbuf]"));
-        assert!(!is_option_name_tail("a_b"));
         assert!(!is_option_name_tail(""));
+        // `_` is a word separator inside a name, on the same footing as
+        // `-` — `dbiprof`'s `-case_sensitive`, ffmpeg's `-pix_fmts`.
+        assert!(is_option_name_tail("a_b"));
+        assert!(is_option_name_tail("ase_sensitive"));
+        assert!(is_option_name_tail("_err_detect"));
+        // Still no letter, still a glued numeric argument.
+        assert!(!is_option_name_tail("_42"));
     }
 
     #[test]


### PR DESCRIPTION
`is_option_name_tail` rejected `_`, so a single-dash long option whose name
carries an underscore was read as a short flag with the rest of its own name
glued on as a value. `dbiprof` writes `-case_sensitive` and the tree held
`-c` carrying `"ase_sensitive"` — a short flag `dbiprof` documents nowhere.
It sat in the same table as `-number=N`, `-reverse` and `-version`, all of
which #26 recovered; the only thing separating it from them was the `_`.
#26 deliberately declined to widen the predicate inside a PR about something
else. This is that PR, and the widening is its whole subject.

## Why `_` is a name character

The predicate is ring-fenced for a good reason: it is what stops a real
glued short (`cargo -Zscript`, `cpp -DFOO=bar`) from being read as a long
option. But `_` is not value-spec punctuation — it is a **word separator
inside a name**, doing the same job `-` already does. None of the seven
conditions that make this repair safe is measured on which separator a name
spells its word breaks with, so admitting `_` moves nothing else. Each
inverse is asserted by name, in both the parser's tests and the oracle's
self-checks:

| Row | Still refused by |
|---|---|
| `-DFOO_BAR`, `-DMAX_PATH=4096` | condition 5 — the token shouts |
| `-oOUT_FILE` | condition 5 read over the **whole** token (only the argument shouts) |
| `-o out_file` | condition 7 — it never occurs glued in the raw text |
| `-d item_a[,...]`, `-b some_path/name` | condition 3's own punctuation test |
| `-s_` | condition 4 — one character of name is not a name |

## What it measured

Full-`PATH` sweep, 2,254 tools, aarch64 Ubuntu 24.04, `xtask sweep-diff`
field-level (before = a binary built at c7bc28d):

- **0 flags lost**, 0 gained, 0 tools appeared or disappeared, **0 status or
  tier transitions**.
- **17 tools, 604 flag spellings** move. Three of them
  (`aarch64-linux-gnu-lto-dump`, `-13`, `llvm-install-name-tool-18`) do not
  appear in `sweep-diff`'s field-level section because their names are too
  long for the scoreboard's tool column and the row is dropped
  (`# dropped (truncated tool name): 54 before, 54 after`); their `#fp`
  lines were diffed by hand. That gap is a real reporting hole in
  `sweep-diff`, not in this change.

| tool | spellings added | bare shorts removed |
|---|---|---|
| ffprobe | 292 | 14 |
| ffplay | 270 | 14 |
| ffmpeg | 16 | 3 |
| llvm-install-name-tool-18 | 4 | 3 |
| llvm-libtool-darwin-18 | 4 | 4 |
| clang, clang++, clang++-18, clang-18, clang-cpp-18 | 2 each | 0 |
| llvm-otool-18 | 2 | 1 |
| llvm-lipo-18 | 1 | 1 |
| lto-dump, lto-dump-13, aarch64-linux-gnu-lto-dump, `-13` | 1 each | 0 |
| dbiprof | 1 | 1 |

`json_pp` was in an earlier worker's list of 18 and is **not** in the family:
its `#fp` line is byte-identical before and after, and the only column that
moved on its row was `ms`.

### The counter-example hunt, redone

Every one of the 604 recovered names was checked against its own tool's raw
capture. **All 604 occur as the leading token of a row the tool itself
writes.** No counter-examples. Of the 41 removed bare shorts, the only one
that is documented is `-h` on ffplay/ffprobe — and that is the *fabricated*
`-h` key; the real one survives, as `-h`/`--help` (`#fp` before:
`-h`, `-h\c--help`, `-help`; after: `-h\c--help`, `-help`).

## ffplay/ffprobe: names recovered **and** value specs kept

Their rows are the ffmpeg AVOption table, with a space-separated value spec
and a capability column:

```
  -is_avc            <boolean>    .D.V..X.... is avc (default false)
  -skip_top          <int>        .D.V....... number of macroblock rows at the top which are skipped
```

An earlier worker warned this "would recover names but drop 1,380
`<string>`/`<int>` value specs". **That is not what happens, and the reason
is checkable**: neither column was ever in `value_name` — the grammar stored
the swallowed *name half* there (`-i` + `"s_avc"`) and put both columns in
the **description**, which this repair does not write. The rows already
recovered on unmodified `main` — `-idct`, `-threads`, `-debug`, whose names
carry no underscore — have always read exactly this way; the underscore rows
are joining them.

Field by field on `ffplay`'s tree, before vs. after:

| field | before | after |
|---|---|---|
| flags | 1136 | 1136 |
| descriptions | 1135 | 1135, **identical as a set, byte for byte** |
| `group` values | 1061 | 1061, unchanged on every changed flag |
| flags whose name/value fields changed | — | 679 |

679 flags go from a fabricated short + fabricated value to a documented
single-dash long name; the capability column and `<int>`/`<flags>` spec ride
along in the description untouched. The fabricated `-b -c -d -g -k -l -m -n
-o -p -r -u -w` disappear; the real `-h/--help`, `-i input_file`, `-x width`,
`-v loglevel`, `-f fmt` stay.

`corpus/ffmpeg/6.1.1` moves 16 flags, reviewed line by line against the
capture: `-pix_fmts`, `-sample_fmts`, `-max_alloc`, `-ignore_unknown`,
`-filter_threads`, `-filter_complex_threads`, `-max_error_rate`,
`-map_metadata`, `-seek_timestamp`, `-filter_script`, `-reinit_filter`,
`-display_rotation`, `-display_hflip`, `-display_vflip`,
`-fix_sub_duration`, `-canvas_size` — every one a row ffmpeg writes.
`corpus/dbiprof/1.643` moves one, `-case_sensitive`. No other fixture moves.

## The "is the candidate short documented?" discriminator — measured, and rejected

The suggested rule was: allow the long reading only when the tool's help
contains no bare row documenting the candidate short. It does not
discriminate, on two independent measurements:

1. **On this PR's new population** it refuses **111 of the 604** spellings
   (173 of ffplay's 679 flag instances), and **every one of the 111 is a
   documented row token** — a 100% false-refusal rate, buying nothing.
   `ffplay` documents `-f fmt` *and* `-filter_threads`; `-i input_file` *and*
   `-is_avc`, the example row itself. A tool documenting both a short and a
   long option starting with the same letter is the ordinary case.
2. **As a general rule it would revert shipped work.** Across those same 17
   tools it refuses **632 of the 8,260** single-dash long options the parser
   already recovers — `ffplay -help` and `ffprobe -help` among them, i.e.
   exactly the `-h` beside `-help` coexistence
   `xtask::single_dash_long`'s doc comment opens with, and `clang
   -gdwarf-5`, `lto-dump -ggdb`, `ffmpeg -formats`.

What the idea reaches for — "was the short fabricated?" — is already
supplied, and supplied better, by condition 5 (case) and condition 7 (the
token occurs glued and delimited in the tool's own text) together. The
rejection is recorded in `repair_single_dash_long_options`'s doc comment so
it does not get re-proposed.

## See it yourself

```console
$ cargo build --release
$ python3 -m venv /tmp/ptyvenv && /tmp/ptyvenv/bin/pip install pyte

# dbiprof: `-c ase_sensitive` becomes `-case_sensitive`
$ /tmp/ptyvenv/bin/python scripts/pty_screenshot.py 100 34 ./target/release/mandible dbiprof

# ffplay: type `/fmts` in the search box — `-p ix_fmts` becomes `-pix_fmts`
$ /tmp/ptyvenv/bin/python scripts/pty_screenshot.py \
      --keys '<tab>,<tab>,<tab>,<tab>,/,fmts' 100 34 ./target/release/mandible ffplay
```

`dbiprof` — before / after:

```
│   -exclude K=V                    │      │   -exclude K=V                    │
│       for filtering, see docs     │      │       for filtering, see docs     │
│   -c ase_sensitive                │  ->  │   -case_sensitive                 │
│       for -match and -exclude     │      │       for -match and -exclude     │
```

`ffplay`, search `fmts` — before / after:

```
│   -p ix_fmts                      │      │   -pix_fmts                       │
│       show available pixel formats│  ->  │       show available pixel formats│
│   -avioflags                      │      │   -layouts                        │
│       <flags> ED......... (defa…  │      │       show standard channel layou…│
│   -probesize                      │      │   -sample_fmts                    │
│       <int64> .D......... set pr… │      │       show available audio sample…│
```

## Every new test proven to fail pre-fix

Reverting only the predicate (`|| c == '_'`) and running the suite:

```
FAIL mandible-extract help_text::sections::tests::an_avoption_row_keeps_its_value_spec_and_capability_column
FAIL mandible-extract help_text::sections::tests::an_underscored_name_is_recovered_from_the_table_it_shares
FAIL mandible-extract help_text::sections::tests::equals_signs_inside_a_sentence_are_not_mistaken_for_a_separator
FAIL mandible-extract help_text::sections::tests::is_option_name_tail_rejects_every_value_spec_shape
FAIL xtask::bin/xtask single_dash_long::tests::every_promoted_self_check_case_holds
FAIL xtask::bin/xtask single_dash_long::tests::is_option_name_tail_needs_a_letter_and_rejects_value_punctuation
Summary: 1110 tests run: 1104 passed, 6 failed
```

`an_underscore_alone_never_buys_the_long_reading` (the inverse cases) passes
on both sides, which is the point of it.

## Gates

`cargo nextest run --workspace` 1110/1110 · `cargo clippy --workspace
--all-targets -- -D warnings` clean · `cargo fmt --check` clean · `cargo run
-p xtask -- corpus` 101 fixtures, 86 ok / 15 xfail / **0 failed** ·
`scripts/changelog_guard.sh` clean. No version bump. `--bless` invented 12
stray `expected.snap` files for `[xfail]` fixtures; all 12 were deleted, and
`git status` is clean apart from the two intended snapshots.

## Residuals

- **`ffplay` extraction went 1405ms → 3166ms and `ffprobe` 628ms → 1314ms.**
  Real and explainable: condition 7 scans the whole raw document per
  candidate, and 679/701 more candidates now reach it on a 752KB, 11.6k-line
  document. Nothing crossed the sweep's 10s cap (the 19 excluded tools are
  the same 19 before and after) and no other tool moved beyond machine
  noise, but `token_occurs_glued`'s cost model is worth a look on its own.
- **No `ffplay`/`ffprobe` corpus fixture was added**, deliberately: the
  capture is 752KB (the whole corpus is 2.3MB) and it parses in 2.9s, 29×
  the corpus harness's 100ms ceiling. It would double the corpus and log a
  permanent slow-parse warning. The AVOption shape is covered instead by
  `an_avoption_row_keeps_its_value_spec_and_capability_column`, quoting
  ffplay rows byte for byte, and by the oracle self-check on `-is_avc`.
- **`sweep-diff` silently drops tools whose name exceeds the scoreboard's
  column width** — 54 of 2,254 here, three of them in this change's family.
  Pre-existing, reported not fixed.
- Still out of reach, unchanged: one-character tails (`ffplay -fs`, `-an`,
  `-vf`, `-ec`, `-ar`) and uppercase-led single-dash longs.
- `corpus/ffmpeg/6.1.1` and `corpus/dbiprof/1.643` carry `provenance =
  "agent"` and no `verdict_scope`; the snapshots were read against their
  captures but nobody has signed a human verdict on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
