### PR TITLE
release: 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-23
+
 ### Fixed
 
 - **A single-dash long option whose name carries an underscore was split

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arboard",
  "base64",
@@ -2362,7 +2362,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.4.0" }
-mandible-extract = { path = "mandible-extract", version = "0.4.0" }
-mandible-search = { path = "mandible-search", version = "0.4.0" }
-mandible-tui = { path = "mandible-tui", version = "0.4.0" }
+mandible-core = { path = "mandible-core", version = "0.4.1" }
+mandible-extract = { path = "mandible-extract", version = "0.4.1" }
+mandible-search = { path = "mandible-search", version = "0.4.1" }
+mandible-tui = { path = "mandible-tui", version = "0.4.1" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Cuts 0.4.1 from the five fixes merged since v0.4.0 (PRs #24-#28). No schema
change, nothing breaking — a patch release.

Every parser family in it was verified visually by the maintainer against
the real TUI (`dbiprof`, `gcc`, `uconv`, `wpa_cli`), not only by corpus
snapshots.

- bare `=` separator no longer hides a flag's description (3 tools)
- three shapes that are not headings stop naming groups (205 tools)
- single-dash long with a glued `=value` keeps its value (34 tools, incl.
  gcc `-foffload`)
- `_` reads as a name character in a single-dash long (17 tools, 604
  spellings)
- token index: ffplay 3.22s -> 0.43s, ffprobe 1.30s -> 0.24s, byte-identical
  output

Local gate before tagging: 1113 tests pass, `cargo fmt --check` clean,
`clippy -D warnings` clean, corpus 101 fixtures / 0 failed with nothing
blessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFin6DLho9duCAEy6ru6a2