### PR TITLE
feat(help_text): recover headed command tables with ` = ` separators or no separator at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,56 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two headed command tables — one separated by ` = `, one carrying no
+  separator at all — parsed to zero subcommands.** `wpa_cli`'s `commands:`
+  block writes each of its ~180 rows as `name [operands] = description`
+  (`status [verbose] = get current WPA/EAPOL/EAP status`); the generic
+  engine's column-gap-or-dash entry splitter found neither shape, so a
+  row's whole line became its candidate "name," failed the name-shape
+  test, and was dropped as unattributable. `apt-ftparchive`'s `Commands:`
+  heading is worse off still: its first row (`packages binarypath
+  [overridefile [pathprefix]]`) shares the heading's own physical line, so
+  it was never scanned as content at all — the whole line, plus every
+  aligned continuation row beneath it, was absorbed into the root
+  description/group text instead.
+
+  Two new recognizers in `help_text::sections` — `scan_bare_command_table`
+  (the ` = `/no-separator row shape) and `split_heading_inline_row` (a
+  heading sharing its physical line with the table's first row) — recover
+  a row's name as only its **leading name-shaped token**, never a run:
+  `apt-ftparchive`'s `sources srcpath` must name one command, `sources`,
+  with `srcpath` as its own positional operand, not a second command or a
+  grandchild. Every recovered node is `invocation_attested: true,
+  heading_attested: false` (never `--help`-probe argv) — these tables
+  belong to daemon-control clients (`wpa_cli terminate`, `wpa_cli quit`)
+  whose "commands" are runtime verbs a probe could act on, so the rows are
+  strong existence evidence and deliberately weak safety evidence, the
+  same split spec §6 already draws for the headingless-invocation-table
+  recognizer.
+
+  Both recognizers are gated on the *current* heading being directly
+  recognized (never a `command_mode` chain) and refuse any block already
+  carrying a real column gap or ` - ` separator, plus a floor of at least
+  two *distinct* recovered names — three guards added after two real
+  fabrications turned up mid-development on the live fleet: a heading's
+  `command_mode` staying stuck on let `fail2ban-client`'s wrapped
+  continuation prose ("...restarting of the server, the / option
+  '--restart' activates...") read as commands named `of`, `the`, `option`;
+  and `trash-put`'s closing sentence "use one of these commands:" (a real,
+  if misleading, hit of the existing generic `mentions_commands_word`
+  test) followed by a two-line usage example turned one repeated example
+  invocation, `trash`, into a fabricated subcommand of `trash-put`.
+
+  Measured, full PATH (2,254 tools, aarch64 Ubuntu 24.04): exactly three
+  tools move, all by gaining subcommands only — `wpa_cli` (+211,
+  deduplicated from ~180 rows, some of which alias one name across several
+  operand shapes), `apt-ftparchive` (+6, its full real command list), and
+  `dpkg-maintscript-helper` (+5, the same generic recognizer catching a
+  second, previously-unmeasured real fixture). Zero flags lost or gained
+  anywhere, zero status transitions, zero unexplained movement.
+
 ## [0.4.1] - 2026-08-23
 
 ### Fixed

--- a/corpus/apt-ftparchive/audit-seed2/expected.snap
+++ b/corpus/apt-ftparchive/audit-seed2/expected.snap
@@ -61,3 +61,34 @@ provenance:
   - help-text
   confidence: 0.5
 children_filled: true
+subcommands:
+- name: packages
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: sources
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: contents
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: release
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: generate
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: clean
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true

--- a/corpus/apt-ftparchive/audit-seed2/meta.toml
+++ b/corpus/apt-ftparchive/audit-seed2/meta.toml
@@ -18,19 +18,25 @@ stdout = "help.txt"
 expected_framework = "generic"
 # "Commands: packages binarypath ... / sources srcpath ... / contents
 # path / release path / generate config [groups] / clean config" lists 6
-# real subcommands. Verified the whole "Commands:" block gets absorbed
-# into the root `description` instead; zero subcommands currently.
-# Conservative floor, not the real count (6).
-min_subcommands = 1
-
-[xfail]
-broken = true
-# Still broken, and for the reason above only: the "Commands:" block.
-# The *descriptions* are fixed — `--md5 Control MD5 generation` and
-# `--no-delink Enable delinking debug mode` write their description one
-# space after the spec, and used to be read as `value_name: Control` /
-# `value_name: Enable` with the rest of the sentence discarded
-# (`find_sentence_start_gap`). `expected.snap` is committed while `[xfail]`
-# so that gain cannot silently regress before the commands bug is fixed and
-# this fixture is promoted.
-reason = "missing commands, I can see in help text, but not parsed"
+# real subcommands. Promoted (fix/command-table): the first row shares its
+# physical line with the `Commands:` heading itself
+# (`split_heading_inline_row`), and the remaining five are recovered by
+# `scan_bare_command_table` — each row is a name followed only by its own
+# positional operands (`sources srcpath [overridefile [pathprefix]]`), no
+# description at all, so every recovered node's `summary` is honestly
+# `None` rather than an invented description built from operand text.
+# `srcpath`, itself name-shaped, is deliberately never promoted to a
+# second command or a grandchild — see `leading_command_name`'s doc
+# comment. All six are `invocation_attested`, never `heading_attested`
+# (spec §6's "A second attestation bit exists now"): this heading's own
+# wording is generic ("Commands:") and carries no evidence beyond layout
+# that these six words are safe to send as `--help` probe argv.
+# The exact six, by name (no `must_contain_subcommands` field exists in
+# `[contract]`'s schema — `min_subcommands` is the only normative
+# subcommand check today — so this is prose, verified against `help.txt`
+# and `expected.snap` directly): packages, sources, contents, release,
+# generate, clean. None of `srcpath`, `binarypath`, `overridefile`,
+# `pathprefix`, `config`, `groups` or the bare `path` (each command's own
+# positional operand) appear anywhere in `expected.snap`'s subcommand
+# list.
+min_subcommands = 6

--- a/corpus/wpa_cli/audit-seed/expected.snap
+++ b/corpus/wpa_cli/audit-seed/expected.snap
@@ -1,0 +1,1297 @@
+name: wpa_cli
+description: 'wpa_cli: invalid option -- ''-'' wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] [-a<action file>] \ commands:'
+flags:
+- short: 'h'
+  description: help (show this usage text)
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  description: shown version information
+  provenance:
+    sources:
+    - help-text
+- short: 'a'
+  description: run in daemon mode executing the action file based on events from wpa_supplicant
+  provenance:
+    sources:
+    - help-text
+- short: 'r'
+  description: try to reconnect when client socket is disconnected. This is useful only when used with -a.
+  provenance:
+    sources:
+    - help-text
+- short: 'B'
+  description: run a daemon in the background
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true
+subcommands:
+- name: status
+  summary: get current WPA/EAPOL/EAP status
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: ifname
+  summary: get current interface name
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: ping
+  summary: pings wpa_supplicant
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: relog
+  summary: re-open log-file (allow rolling logs)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: note
+  summary: add a note to wpa_supplicant debug log
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mib
+  summary: get MIB variables (dot1x, dot11)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: help
+  summary: show usage help
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interface
+  summary: show interfaces/select interface
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: level
+  summary: change debug level
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: license
+  summary: show full wpa_cli license
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: quit
+  summary: exit wpa_cli
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: set
+  summary: set variables (shows list of variables when run without arguments)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dump
+  summary: dump config variables
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: get
+  summary: get information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: driver_flags
+  summary: list driver flags
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: logon
+  summary: IEEE 802.1X EAPOL state machine logon
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: logoff
+  summary: IEEE 802.1X EAPOL state machine logoff
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: pmksa
+  summary: show PMKSA cache
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: pmksa_flush
+  summary: flush PMKSA cache entries
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: pmksa_get
+  summary: fetch all stored PMKSA cache entries
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: pmksa_add
+  summary: store PMKSA cache entry from external storage
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_pmksa_get
+  summary: fetch all stored mesh PMKSA cache entries
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_pmksa_add
+  summary: store mesh PMKSA cache entry from external storage
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: reassociate
+  summary: force reassociation
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: reattach
+  summary: force reassociation back to the same BSS
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: preauthenticate
+  summary: force preauthentication
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: identity
+  summary: configure identity for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: password
+  summary: configure password for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: new_password
+  summary: change password for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: pin
+  summary: configure pin for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: otp
+  summary: configure one-time-password for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: psk_passphrase
+  summary: configure PSK/passphrase for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: passphrase
+  summary: configure private key passphrase for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: sim
+  summary: report SIM operation result
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: bssid
+  summary: set preferred BSSID for an SSID
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: bssid_ignore
+  summary: add a BSSID to the list of temporarily ignored BSSs
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: blacklist
+  summary: deprecated alias for bssid_ignore
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: log_level
+  summary: update the log level/timestamp
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: list_networks
+  summary: list configured networks
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: select_network
+  summary: select a network (disable others)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: enable_network
+  summary: enable a network
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: disable_network
+  summary: disable a network
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: add_network
+  summary: add a network
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: remove_network
+  summary: remove a network
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: set_network
+  summary: set network variables (shows list of variables when run without arguments)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: get_network
+  summary: get network variables
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dup_network
+  summary: duplicate network variables
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: list_creds
+  summary: list configured credentials
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: add_cred
+  summary: add a credential
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: remove_cred
+  summary: remove a credential
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: set_cred
+  summary: set credential variables
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: get_cred
+  summary: get credential variables
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: save_config
+  summary: save the current configuration
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: disconnect
+  summary: disconnect and wait for reassociate/reconnect command before connecting
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: reconnect
+  summary: like reassociate, but only takes effect if already disconnected
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: scan
+  summary: request new BSS scan
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: scan_results
+  summary: get latest scan results
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: abort_scan
+  summary: request ongoing scan to be aborted
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: bss
+  summary: get detailed scan result info
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: get_capability
+  summary: get capabilities
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: reconfigure
+  summary: force wpa_supplicant to re-read its configuration file
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: terminate
+  summary: terminate wpa_supplicant
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interface_add
+  summary: <bridge_name> <create> <type> = adds new interface, all parameters but <ifname> are optional. Supported types are station ('sta') and AP ('ap')
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interface_remove
+  summary: removes the interface
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interface_list
+  summary: list available interfaces
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: ap_scan
+  summary: set ap_scan parameter
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: scan_interval
+  summary: set scan_interval parameter (in seconds)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: bss_expire_age
+  summary: set BSS expiration age parameter
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: bss_expire_count
+  summary: set BSS expiration scan count parameter
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: bss_flush
+  summary: set BSS flush age (0 by default)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: ft_ds
+  summary: request over-the-DS FT with <addr>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_pbc
+  summary: 'start Wi-Fi Protected Setup: Push Button Configuration'
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_pin
+  summary: start WPS PIN method (returns PIN, if not hardcoded)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_check_pin
+  summary: verify PIN checksum
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_cancel
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_nfc
+  summary: 'start Wi-Fi Protected Setup: NFC'
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_nfc_config_token
+  summary: build configuration token
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_nfc_token
+  summary: create password token
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_nfc_tag_read
+  summary: report read NFC tag with WPS data
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: nfc_get_handover_req
+  summary: create NFC handover request
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: nfc_get_handover_sel
+  summary: create NFC handover select
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: nfc_report_handover
+  summary: report completed NFC handover
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_reg
+  summary: start WPS Registrar to configure an AP
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_ap_pin
+  summary: enable/disable AP PIN
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_start
+  summary: start Wi-Fi Protected Setup External Registrar
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_stop
+  summary: stop Wi-Fi Protected Setup External Registrar
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_pin
+  summary: add an Enrollee PIN to External Registrar
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_pbc
+  summary: accept an Enrollee PBC using External Registrar
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_learn
+  summary: learn AP configuration
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_set_config
+  summary: set AP configuration for enrolling
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_config
+  summary: configure AP
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wps_er_nfc_config_token
+  summary: build NFC configuration token
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: ibss_rsn
+  summary: request RSN authentication with <addr> in IBSS
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: sta
+  summary: get information about an associated station (AP)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: all_sta
+  summary: get information about all associated stations (AP)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: list_sta
+  summary: list all stations (AP)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: deauthenticate
+  summary: deauthenticate a station
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: disassociate
+  summary: disassociate a station
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: chan_switch
+  summary: CSA parameters
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: update_beacon
+  summary: update Beacon frame contents
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: suspend
+  summary: notification of suspend/hibernate
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: resume
+  summary: notification of resume/thaw
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: roam
+  summary: roam to the specified BSS
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_interface_add
+  summary: Create a new mesh interface
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_group_add
+  summary: join a mesh network (disable others)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_group_remove
+  summary: Remove mesh group interface
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_peer_remove
+  summary: Remove a mesh peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_peer_add
+  summary: Add a mesh peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mesh_link_probe
+  summary: Probe a mesh link for a given peer by injecting a frame.
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_find
+  summary: find P2P Devices for up-to timeout seconds
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_stop_find
+  summary: stop P2P Devices search
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_asp_provision
+  summary: provision with a P2P ASP Device
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_asp_provision_resp
+  summary: provision with a P2P ASP Device
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_connect
+  summary: connect to a P2P Device
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_listen
+  summary: listen for P2P Devices for up-to timeout seconds
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_group_remove
+  summary: remove P2P group interface (terminate group if GO)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_group_add
+  summary: add a new P2P group (local end as GO)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_group_member
+  summary: Get peer interface address on local GO using peer Device Address
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_prov_disc
+  summary: request provisioning discovery
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_get_passphrase
+  summary: get the passphrase for a group (GO only)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_serv_disc_req
+  summary: schedule service discovery request
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_serv_disc_cancel_req
+  summary: cancel pending service discovery request
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_serv_disc_resp
+  summary: service discovery response
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_service_update
+  summary: indicate change in local services
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_serv_disc_external
+  summary: set external processing of service discovery
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_service_flush
+  summary: remove all stored service entries
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_service_add
+  summary: add a local service
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_service_rep
+  summary: replace local ASP service
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_service_del
+  summary: remove a local service
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_reject
+  summary: reject connection attempts from a specific peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_invite
+  summary: invite peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_peers
+  summary: list known (optionally, only fully discovered) P2P peers
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_peer
+  summary: show information about known P2P peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_set
+  summary: set a P2P parameter
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_flush
+  summary: flush P2P state
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_cancel
+  summary: cancel P2P group formation
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_unauthorize
+  summary: unauthorize a peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_presence_req
+  summary: request GO presence
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_ext_listen
+  summary: set extended listen timing
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_remove_client
+  summary: remove a peer from all groups
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: vendor_elem_add
+  summary: 'add vendor specific IEs to frame(s) 0: Probe Req (P2P), 1: Probe Resp (P2P) , 2: Probe Resp (GO), 3: Beacon (GO), 4: PD Req, 5: PD Resp, 6: GO Neg Req, 7: GO Neg Resp, 8: GO Neg Conf, 9: Inv Req, 10: Inv Resp, 11: Assoc Req (P2P), 12: Assoc Resp (P2P)'
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: vendor_elem_get
+  summary: 'get vendor specific IE(s) to frame(s) 0: Probe Req (P2P), 1: Probe Resp (P2P) , 2: Probe Resp (GO), 3: Beacon (GO), 4: PD Req, 5: PD Resp, 6: GO Neg Req, 7: GO Neg Resp, 8: GO Neg Conf, 9: Inv Req, 10: Inv Resp, 11: Assoc Req (P2P), 12: Assoc Resp (P2P)'
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: vendor_elem_remove
+  summary: 'remove vendor specific IE(s) in frame(s) 0: Probe Req (P2P), 1: Probe Resp (P2P) , 2: Probe Resp (GO), 3: Beacon (GO), 4: PD Req, 5: PD Resp, 6: GO Neg Req, 7: GO Neg Resp, 8: GO Neg Conf, 9: Inv Req, 10: Inv Resp, 11: Assoc Req (P2P), 12: Assoc Resp (P2P)'
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wfd_subelem_set
+  summary: set Wi-Fi Display subelement
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wfd_subelem_get
+  summary: get Wi-Fi Display subelement
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: fetch_anqp
+  summary: fetch ANQP information for all APs
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: stop_fetch_anqp
+  summary: stop fetch_anqp operation
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interworking_select
+  summary: perform Interworking network selection
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interworking_connect
+  summary: connect using Interworking credentials
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: interworking_add_network
+  summary: connect using Interworking credentials
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: anqp_get
+  summary: request ANQP information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: gas_request
+  summary: GAS request
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: gas_response_get
+  summary: Fetch last GAS response
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: hs20_anqp_get
+  summary: request HS 2.0 ANQP information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: nai_home_realm_list
+  summary: get HS20 nai home realm list
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: hs20_icon_request
+  summary: get Hotspot 2.0 OSU icon
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: fetch_osu
+  summary: fetch OSU provider information from all APs
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: cancel_fetch_osu
+  summary: cancel fetch_osu command
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: sta_autoconnect
+  summary: disable/enable automatic reconnection
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: tdls_discover
+  summary: request TDLS discovery with <addr>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: tdls_setup
+  summary: request TDLS setup with <addr>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: tdls_teardown
+  summary: tear down TDLS with <addr>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: tdls_link_status
+  summary: TDLS link status with <addr>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wmm_ac_addts
+  summary: add WMM-AC traffic stream
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wmm_ac_delts
+  summary: delete WMM-AC traffic stream
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wmm_ac_status
+  summary: show status for Wireless Multi-Media Admission-Control
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: tdls_chan_switch
+  summary: enable channel switching with TDLS peer
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: tdls_cancel_chan_switch
+  summary: disable channel switching with TDLS peer <addr>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: signal_poll
+  summary: get signal parameters
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: signal_monitor
+  summary: set signal monitor parameters
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: pktcnt_poll
+  summary: get TX/RX packet counters
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: reauthenticate
+  summary: trigger IEEE 802.1X/EAPOL reauthentication
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: autoscan
+  summary: Set or unset (if none) autoscan parameters
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wnm_sleep
+  summary: enter/exit WNM-Sleep mode
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: wnm_bss_query
+  summary: Send BSS Transition Management Query
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: raw
+  summary: Sent unprocessed command
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: flush
+  summary: flush wpa_supplicant state
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: radio_work
+  summary: radio_work <show/add/done>
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: vendor
+  summary: Send vendor command
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: neighbor_rep_request
+  summary: 'Trigger request to AP for neighboring AP report (with optional given SSID in hex or enclosed in double quotes, default: current SSID; with optional LCI and location civic request)'
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: twt_setup
+  summary: Send TWT Setup frame
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: twt_teardown
+  summary: Send TWT Teardown frame
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: erp_flush
+  summary: flush ERP keys
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mac_rand_scan
+  summary: scan MAC randomization
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: get_pref_freq_list
+  summary: retrieve preferred freq list for the specified interface type
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_lo_start
+  summary: start P2P listen offload
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: p2p_lo_stop
+  summary: stop P2P listen offload
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_qr_code
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_bootstrap_gen
+  summary: generate DPP bootstrap information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_bootstrap_remove
+  summary: remove DPP bootstrap information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_bootstrap_get_uri
+  summary: get DPP bootstrap URI
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_bootstrap_info
+  summary: show DPP bootstrap information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_bootstrap_set
+  summary: set DPP configurator parameters
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_auth_init
+  summary: initiate DPP bootstrapping
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_listen
+  summary: start DPP listen
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_stop_listen
+  summary: stop DPP listen
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_configurator_add
+  summary: add DPP configurator
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_configurator_remove
+  summary: remove DPP configurator
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_configurator_get_key
+  summary: Get DPP configurator's private key
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_configurator_sign
+  summary: generate self DPP configuration
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_pkex_add
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_pkex_remove
+  summary: remove DPP pkex information
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_controller_start
+  summary: start DPP controller
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_controller_stop
+  summary: stop DPP controller
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_chirp
+  summary: start DPP chirp
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dpp_stop_chirp
+  summary: stop DPP chirp
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: all_bss
+  summary: list all BSS entries (scan results)
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: mscs
+  summary: Configure MSCS request
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: scs
+  summary: Send SCS request
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dscp_resp
+  summary: Send DSCP response
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true
+- name: dscp_query
+  summary: Send DSCP Query
+  provenance:
+    sources:
+    - help-text
+  invocation_attested: true

--- a/corpus/wpa_cli/audit-seed/help.txt
+++ b/corpus/wpa_cli/audit-seed/help.txt
@@ -1,0 +1,236 @@
+wpa_cli: invalid option -- '-'
+wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] [-a<action file>] \
+        [-P<pid file>] [-g<global ctrl>] [-G<ping interval>] \
+        [-s<wpa_client_socket_file_path>] [command..]
+  -h = help (show this usage text)
+  -v = shown version information
+  -a = run in daemon mode executing the action file based on events from
+       wpa_supplicant
+  -r = try to reconnect when client socket is disconnected.
+       This is useful only when used with -a.
+  -B = run a daemon in the background
+  default path: /var/run/wpa_supplicant
+  default interface: first interface found in socket path
+commands:
+  status [verbose] = get current WPA/EAPOL/EAP status
+  ifname = get current interface name
+  ping = pings wpa_supplicant
+  relog = re-open log-file (allow rolling logs)
+  note <text> = add a note to wpa_supplicant debug log
+  mib = get MIB variables (dot1x, dot11)
+  help [command] = show usage help
+  interface [ifname] = show interfaces/select interface
+  level <debug level> = change debug level
+  license = show full wpa_cli license
+  quit = exit wpa_cli
+  set = set variables (shows list of variables when run without arguments)
+  dump = dump config variables
+  get <name> = get information
+  driver_flags = list driver flags
+  logon = IEEE 802.1X EAPOL state machine logon
+  logoff = IEEE 802.1X EAPOL state machine logoff
+  pmksa = show PMKSA cache
+  pmksa_flush = flush PMKSA cache entries
+  pmksa_get <network_id> = fetch all stored PMKSA cache entries
+  pmksa_add <network_id> <BSSID> <PMKID> <PMK> <reauth_time in seconds> <expiration in seconds> <akmp> <opportunistic> = store PMKSA cache entry from external storage
+  mesh_pmksa_get <peer MAC address | any> = fetch all stored mesh PMKSA cache entries
+  mesh_pmksa_add <BSSID> <PMKID> <PMK> <expiration in seconds> = store mesh PMKSA cache entry from external storage
+  reassociate = force reassociation
+  reattach = force reassociation back to the same BSS
+  preauthenticate <BSSID> = force preauthentication
+  identity <network id> <identity> = configure identity for an SSID
+  password <network id> <password> = configure password for an SSID
+  new_password <network id> <password> = change password for an SSID
+  pin <network id> <pin> = configure pin for an SSID
+  otp <network id> <password> = configure one-time-password for an SSID
+  psk_passphrase <network id> <PSK/passphrase> = configure PSK/passphrase for an SSID
+  passphrase <network id> <passphrase> = configure private key passphrase
+    for an SSID
+  sim <network id> <pin> = report SIM operation result
+  bssid <network id> <BSSID> = set preferred BSSID for an SSID
+  bssid_ignore <BSSID> = add a BSSID to the list of temporarily ignored BSSs
+  bssid_ignore clear = clear the list of temporarily ignored BSSIDs
+  bssid_ignore = display the list of temporarily ignored BSSIDs
+  blacklist = deprecated alias for bssid_ignore
+  log_level <level> [<timestamp>] = update the log level/timestamp
+  log_level = display the current log level and log options
+  list_networks = list configured networks
+  select_network <network id> = select a network (disable others)
+  enable_network <network id> = enable a network
+  disable_network <network id> = disable a network
+  add_network = add a network
+  remove_network <network id> = remove a network
+  set_network <network id> <variable> <value> = set network variables (shows
+    list of variables when run without arguments)
+  get_network <network id> <variable> = get network variables
+  dup_network <src network id> <dst network id> <variable> = duplicate network variables
+  list_creds = list configured credentials
+  add_cred = add a credential
+  remove_cred <cred id> = remove a credential
+  set_cred <cred id> <variable> <value> = set credential variables
+  get_cred <cred id> <variable> = get credential variables
+  save_config = save the current configuration
+  disconnect = disconnect and wait for reassociate/reconnect command before
+    connecting
+  reconnect = like reassociate, but only takes effect if already disconnected
+  scan = request new BSS scan
+  scan_results = get latest scan results
+  abort_scan = request ongoing scan to be aborted
+  bss <<idx> | <bssid>> = get detailed scan result info
+  get_capability <eap/pairwise/group/key_mgmt/proto/auth_alg/channels/freq/modes> = get capabilities
+  reconfigure = force wpa_supplicant to re-read its configuration file
+  terminate = terminate wpa_supplicant
+  interface_add <ifname> <confname> <driver> <ctrl_interface> <driver_param>
+    <bridge_name> <create> <type> = adds new interface, all parameters but
+    <ifname> are optional. Supported types are station ('sta') and AP ('ap')
+  interface_remove <ifname> = removes the interface
+  interface_list = list available interfaces
+  ap_scan <value> = set ap_scan parameter
+  scan_interval <value> = set scan_interval parameter (in seconds)
+  bss_expire_age <value> = set BSS expiration age parameter
+  bss_expire_count <value> = set BSS expiration scan count parameter
+  bss_flush <value> = set BSS flush age (0 by default)
+  ft_ds <addr> = request over-the-DS FT with <addr>
+  wps_pbc [BSSID] = start Wi-Fi Protected Setup: Push Button Configuration
+  wps_pin <BSSID> [PIN] = start WPS PIN method (returns PIN, if not hardcoded)
+  wps_check_pin <PIN> = verify PIN checksum
+  wps_cancel Cancels the pending WPS operation
+  wps_nfc [BSSID] = start Wi-Fi Protected Setup: NFC
+  wps_nfc_config_token <WPS|NDEF> = build configuration token
+  wps_nfc_token <WPS|NDEF> = create password token
+  wps_nfc_tag_read <hexdump of payload> = report read NFC tag with WPS data
+  nfc_get_handover_req <NDEF> <WPS> = create NFC handover request
+  nfc_get_handover_sel <NDEF> <WPS> = create NFC handover select
+  nfc_report_handover <role> <type> <hexdump of req> <hexdump of sel> = report completed NFC handover
+  wps_reg <BSSID> <AP PIN> = start WPS Registrar to configure an AP
+  wps_ap_pin [params..] = enable/disable AP PIN
+  wps_er_start [IP address] = start Wi-Fi Protected Setup External Registrar
+  wps_er_stop = stop Wi-Fi Protected Setup External Registrar
+  wps_er_pin <UUID> <PIN> = add an Enrollee PIN to External Registrar
+  wps_er_pbc <UUID> = accept an Enrollee PBC using External Registrar
+  wps_er_learn <UUID> <PIN> = learn AP configuration
+  wps_er_set_config <UUID> <network id> = set AP configuration for enrolling
+  wps_er_config <UUID> <PIN> <SSID> <auth> <encr> <key> = configure AP
+  wps_er_nfc_config_token <WPS/NDEF> <UUID> = build NFC configuration token
+  ibss_rsn <addr> = request RSN authentication with <addr> in IBSS
+  sta <addr> = get information about an associated station (AP)
+  all_sta = get information about all associated stations (AP)
+  list_sta = list all stations (AP)
+  deauthenticate <addr> = deauthenticate a station
+  disassociate <addr> = disassociate a station
+  chan_switch <cs_count> <freq> [sec_channel_offset=] [center_freq1=] [center_freq2=] [bandwidth=] [blocktx] [ht|vht] = CSA parameters
+  update_beacon = update Beacon frame contents
+  suspend = notification of suspend/hibernate
+  resume = notification of resume/thaw
+  roam <addr> = roam to the specified BSS
+  mesh_interface_add [ifname] = Create a new mesh interface
+  mesh_group_add <network id> = join a mesh network (disable others)
+  mesh_group_remove <ifname> = Remove mesh group interface
+  mesh_peer_remove <addr> = Remove a mesh peer
+  mesh_peer_add <addr> [duration=<seconds>] = Add a mesh peer
+  mesh_link_probe <addr> [payload=<hex dump of payload>] = Probe a mesh link for a given peer by injecting a frame.
+  p2p_find [timeout] [type=*] = find P2P Devices for up-to timeout seconds
+  p2p_stop_find = stop P2P Devices search
+  p2p_asp_provision <addr> adv_id=<adv_id> conncap=<conncap> [info=<infodata>] = provision with a P2P ASP Device
+  p2p_asp_provision_resp <addr> adv_id=<adv_id> [role<conncap>] [info=<infodata>] = provision with a P2P ASP Device
+  p2p_connect <addr> <"pbc"|PIN> [ht40] = connect to a P2P Device
+  p2p_listen [timeout] = listen for P2P Devices for up-to timeout seconds
+  p2p_group_remove <ifname> = remove P2P group interface (terminate group if GO)
+  p2p_group_add [ht40] = add a new P2P group (local end as GO)
+  p2p_group_member <dev_addr> = Get peer interface address on local GO using peer Device Address
+  p2p_prov_disc <addr> <method> = request provisioning discovery
+  p2p_get_passphrase = get the passphrase for a group (GO only)
+  p2p_serv_disc_req <addr> <TLVs> = schedule service discovery request
+  p2p_serv_disc_cancel_req <id> = cancel pending service discovery request
+  p2p_serv_disc_resp <freq> <addr> <dialog token> <TLVs> = service discovery response
+  p2p_service_update = indicate change in local services
+  p2p_serv_disc_external <external> = set external processing of service discovery
+  p2p_service_flush = remove all stored service entries
+  p2p_service_add <bonjour|upnp|asp> <query|version> <response|service> = add a local service
+  p2p_service_rep asp <auto> <adv_id> <svc_state> <svc_string> [<svc_info>] = replace local ASP service
+  p2p_service_del <bonjour|upnp> <query|version> [|service] = remove a local service
+  p2p_reject <addr> = reject connection attempts from a specific peer
+  p2p_invite <cmd> [peer=addr] = invite peer
+  p2p_peers [discovered] = list known (optionally, only fully discovered) P2P peers
+  p2p_peer <address> = show information about known P2P peer
+  p2p_set <field> <value> = set a P2P parameter
+  p2p_flush = flush P2P state
+  p2p_cancel = cancel P2P group formation
+  p2p_unauthorize <address> = unauthorize a peer
+  p2p_presence_req [<duration> <interval>] [<duration> <interval>] = request GO presence
+  p2p_ext_listen [<period> <interval>] = set extended listen timing
+  p2p_remove_client <address|iface=address> = remove a peer from all groups
+  vendor_elem_add <frame id> <hexdump of elem(s)> = add vendor specific IEs to frame(s)
+    0: Probe Req (P2P), 1: Probe Resp (P2P) , 2: Probe Resp (GO), 3: Beacon (GO), 4: PD Req, 5: PD Resp, 6: GO Neg Req, 7: GO Neg Resp, 8: GO Neg Conf, 9: Inv Req, 10: Inv Resp, 11: Assoc Req (P2P), 12: Assoc Resp (P2P)
+  vendor_elem_get <frame id> = get vendor specific IE(s) to frame(s)
+    0: Probe Req (P2P), 1: Probe Resp (P2P) , 2: Probe Resp (GO), 3: Beacon (GO), 4: PD Req, 5: PD Resp, 6: GO Neg Req, 7: GO Neg Resp, 8: GO Neg Conf, 9: Inv Req, 10: Inv Resp, 11: Assoc Req (P2P), 12: Assoc Resp (P2P)
+  vendor_elem_remove <frame id> <hexdump of elem(s)> = remove vendor specific IE(s) in frame(s)
+    0: Probe Req (P2P), 1: Probe Resp (P2P) , 2: Probe Resp (GO), 3: Beacon (GO), 4: PD Req, 5: PD Resp, 6: GO Neg Req, 7: GO Neg Resp, 8: GO Neg Conf, 9: Inv Req, 10: Inv Resp, 11: Assoc Req (P2P), 12: Assoc Resp (P2P)
+  wfd_subelem_set <subelem> [contents] = set Wi-Fi Display subelement
+  wfd_subelem_get <subelem> = get Wi-Fi Display subelement
+  fetch_anqp = fetch ANQP information for all APs
+  stop_fetch_anqp = stop fetch_anqp operation
+  interworking_select [auto] = perform Interworking network selection
+  interworking_connect <BSSID> = connect using Interworking credentials
+  interworking_add_network <BSSID> = connect using Interworking credentials
+  anqp_get <addr> <info id>[,<info id>]... = request ANQP information
+  gas_request <addr> <AdvProtoID> [QueryReq] = GAS request
+  gas_response_get <addr> <dialog token> [start,len] = Fetch last GAS response
+  hs20_anqp_get <addr> <subtype>[,<subtype>]... = request HS 2.0 ANQP information
+  nai_home_realm_list <addr> <home realm> = get HS20 nai home realm list
+  hs20_icon_request <addr> <icon name> = get Hotspot 2.0 OSU icon
+  fetch_osu = fetch OSU provider information from all APs
+  cancel_fetch_osu = cancel fetch_osu command
+  sta_autoconnect <0/1> = disable/enable automatic reconnection
+  tdls_discover <addr> = request TDLS discovery with <addr>
+  tdls_setup <addr> = request TDLS setup with <addr>
+  tdls_teardown <addr> = tear down TDLS with <addr>
+  tdls_link_status <addr> = TDLS link status with <addr>
+  wmm_ac_addts <uplink/downlink/bidi> <tsid=0..7> <up=0..7> [nominal_msdu_size=#] [mean_data_rate=#] [min_phy_rate=#] [sba=#] [fixed_nominal_msdu] = add WMM-AC traffic stream
+  wmm_ac_delts <tsid> = delete WMM-AC traffic stream
+  wmm_ac_status = show status for Wireless Multi-Media Admission-Control
+  tdls_chan_switch <addr> <oper class> <freq> [sec_channel_offset=] [center_freq1=] [center_freq2=] [bandwidth=] [ht|vht] = enable channel switching with TDLS peer
+  tdls_cancel_chan_switch <addr> = disable channel switching with TDLS peer <addr>
+  signal_poll = get signal parameters
+  signal_monitor = set signal monitor parameters
+  pktcnt_poll = get TX/RX packet counters
+  reauthenticate = trigger IEEE 802.1X/EAPOL reauthentication
+  autoscan [params] = Set or unset (if none) autoscan parameters
+  wnm_sleep <enter/exit> [interval=#] = enter/exit WNM-Sleep mode
+  wnm_bss_query <query reason> [list] [neighbor=<BSSID>,<BSSID information>,<operating class>,<channel number>,<PHY type>[,<hexdump of optional subelements>] = Send BSS Transition Management Query
+  raw <params..> = Sent unprocessed command
+  flush = flush wpa_supplicant state
+  radio_work = radio_work <show/add/done>
+  vendor <vendor id> <command id> [<hex formatted command argument>] = Send vendor command
+  neighbor_rep_request [ssid=<SSID>] [lci] [civic] = Trigger request to AP for neighboring AP report (with optional given SSID in hex or enclosed in double quotes, default: current SSID; with optional LCI and location civic request)
+  twt_setup [dialog=<token>] [exponent=<exponent>] [mantissa=<mantissa>] [min_twt=<Min TWT>] [setup_cmd=<setup-cmd>] [twt=<u64>] [requestor=0|1] [trigger=0|1] [implicit=0|1] [flow_type=0|1] [flow_id=<3-bit-id>] [protection=0|1] [twt_channel=<twt chanel id>] [control=<control-u8>] = Send TWT Setup frame
+  twt_teardown [flags=<value>] = Send TWT Teardown frame
+  erp_flush = flush ERP keys
+  mac_rand_scan <scan|sched|pno|all> enable=<0/1> [addr=mac-address mask=mac-address-mask] = scan MAC randomization
+  get_pref_freq_list <interface type> = retrieve preferred freq list for the specified interface type
+  p2p_lo_start <freq> <period> <interval> <count> = start P2P listen offload
+  p2p_lo_stop = stop P2P listen offload
+  dpp_qr_code report a scanned DPP URI from a QR Code
+  dpp_bootstrap_gen type=<qrcode> [chan=..] [mac=..] [info=..] [curve=..] [key=..] = generate DPP bootstrap information
+  dpp_bootstrap_remove *|<id> = remove DPP bootstrap information
+  dpp_bootstrap_get_uri <id> = get DPP bootstrap URI
+  dpp_bootstrap_info <id> = show DPP bootstrap information
+  dpp_bootstrap_set <id> [conf=..] [ssid=<SSID>] [ssid_charset=#] [psk=<PSK>] [pass=<passphrase>] [configurator=<id>] [conn_status=#] [akm_use_selector=<0|1>] [group_id=..] [expiry=#] [csrattrs=..] = set DPP configurator parameters
+  dpp_auth_init peer=<id> [own=<id>] = initiate DPP bootstrapping
+  dpp_listen <freq in MHz> = start DPP listen
+  dpp_stop_listen = stop DPP listen
+  dpp_configurator_add [curve=..] [key=..] = add DPP configurator
+  dpp_configurator_remove *|<id> = remove DPP configurator
+  dpp_configurator_get_key <id> = Get DPP configurator's private key
+  dpp_configurator_sign conf=<role> configurator=<id> = generate self DPP configuration
+  dpp_pkex_add add PKEX code
+  dpp_pkex_remove *|<id> = remove DPP pkex information
+  dpp_controller_start [tcp_port=<port>] [role=..] = start DPP controller
+  dpp_controller_stop = stop DPP controller
+  dpp_chirp own=<BI ID> iter=<count> = start DPP chirp
+  dpp_stop_chirp = stop DPP chirp
+  all_bss = list all BSS entries (scan results)
+  mscs <add|remove|change> [up_bitmap=<hex byte>] [up_limit=<integer>] [stream_timeout=<in TUs>] [frame_classifier=<hex bytes>] = Configure MSCS request
+  scs [scs_id=<decimal number>] <add|remove|change> [scs_up=<0-7>] [classifier_type=<4|10>] [classifier params based on classifier type] [tclas_processing=<0|1>] [scs_id=<decimal number>] ... = Send SCS request
+  dscp_resp <[reset]>/<[solicited] [policy_id=1 status=0...]> [more] = Send DSCP response
+  dscp_query wildcard/domain_name=<string> = Send DSCP Query

--- a/corpus/wpa_cli/audit-seed/meta.toml
+++ b/corpus/wpa_cli/audit-seed/meta.toml
@@ -1,0 +1,39 @@
+# Frozen capture supplied with the fix/command-table task brief (not
+# `xtask audit`), reviewed line-by-line against help.txt before blessing:
+# every recovered subcommand's name and (where present) description was
+# checked against the row it came from.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "wpa_cli"
+version = "audit-seed"
+captured_with = "frozen capture, fix/command-table task"
+
+[[capture]]
+argv = ["wpa_cli", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+# `wpa_cli`'s `commands:` block is ~180 rows of `name [operands] =
+# description` (a handful carry no ` = ` at all — a real inconsistency in
+# the tool's own `--help` text, e.g. `wps_cancel Cancels the pending WPS
+# operation` — and those rows come through with no `summary` rather than a
+# guessed one). Before fix/command-table: 0 subcommands, every row dropped
+# as unattributable (the whole line failed `is_command_name_shaped`, and
+# some rows containing `]` accidentally split there, leaving a
+# description that still began with a literal `= `). Now:
+# `scan_bare_command_table` recovers 211 distinct names (some rows collapse
+# — `bssid_ignore` and `log_level` each appear three/two times with
+# different trailing operands, and only the first is kept, same dedup
+# `emit_subcommands` already applies everywhere else). 150 is a
+# conservative floor, not the exact count, so a future rewording of a
+# handful of rows can't turn a real regression into CI noise.
+min_subcommands = 150
+# The five real root flags, described from the `-h = help ...` block
+# above `commands:` (unrelated to this fixture's own bug, included so a
+# future change to `find_equals_separator_gap`'s flag-row path is caught
+# here too, not just in the recognized-heading commands block below it).
+must_contain_flags = ["-h", "-v", "-a", "-r", "-B"]

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -694,6 +694,50 @@ fn parse_body(
             continue;
         }
 
+        // A headed command table whose first row sits on the heading's own
+        // physical line (`apt-ftparchive`'s
+        // `Commands: packages binarypath [overridefile [pathprefix]]`),
+        // with the remaining rows column-aligned beneath it. This row's
+        // text never becomes "content indented below the heading" in the
+        // engine's own sense — it trails the heading on the very same
+        // line — so without this it vanishes whole into the `heading`
+        // string above and never reaches any scanner as data: today
+        // `mandible apt-ftparchive` reports zero subcommands and a group
+        // literally named `"Commands: packages binarypath [overridefile
+        // [pathprefix]]"`. See `split_heading_inline_row` and
+        // `scan_bare_command_table`'s doc comments for the admission
+        // rules, and `emit_headed_command_table`'s for why these nodes
+        // are `invocation_attested` rather than `heading_attested`.
+        //
+        // Gated on `is_recognized_command_heading(label, ...)` for *this*
+        // heading directly, never a `command_mode` chain — see the other
+        // `scan_bare_command_table` call site below (the ` = `-separator
+        // one) for the fabrication a sticky chain enables: it can reach an
+        // unrelated wrapped-prose block where ordinary English words pass
+        // every other guard this recognizer has.
+        if let Some((label, inline_row)) = split_heading_inline_row(line.trim()) {
+            if !is_ignorable_heading(&heading)
+                && is_recognized_command_heading(label, profile)
+                && !profile.is_some_and(|p| {
+                    heading_matches_markers(&label.to_lowercase(), p.non_command_heading_markers)
+                })
+            {
+                if let Some(first_name) = leading_command_name(inline_row) {
+                    if let Some((end, mut entries)) = scan_bare_command_table(&lines, i) {
+                        entries.insert(0, (first_name, None));
+                        i = end;
+                        command_mode = true;
+                        let raw_tokens = command_table_token_index(raw);
+                        let (seen, clean) =
+                            emit_headed_command_table(entries, &raw_tokens, &mut result);
+                        total_entries += seen;
+                        clean_entries += clean;
+                        continue;
+                    }
+                }
+            }
+        }
+
         // Peek the first content lines to decide flags vs. bare-word. Not
         // just the *first*: some tools document a positional at the top of
         // their options table, and keying the whole decision off row one
@@ -797,6 +841,60 @@ fn parse_body(
         // already (spec [M-10]), just via the column-gap rule instead of
         // this one.
         let allow_dash_separator = (recognized || command_mode) && !is_declared_non_command;
+
+        // A headed command table whose rows use ` = ` as a separator
+        // instead of a column gap, or (some rows) no separator at all
+        // (`wpa_cli`'s `commands:` block: `status [verbose] = get current
+        // WPA/EAPOL/EAP status`, `wps_cancel Cancels the pending WPS
+        // operation`).
+        //
+        // Gated on `recognized` **alone** — deliberately narrower than
+        // `allow_dash_separator` just above, which also accepts a
+        // `command_mode` chain. That extra breadth is exactly what turned
+        // this into a fabrication path during development: `fail2ban-
+        // client`'s `Command:` block nests dozens of column-aligned rows
+        // whose own descriptions wrap across several more-indented lines
+        // (`"reload [--restart]...     reloads the configuration
+        // without\n     restarting of the server, the\n     option
+        // '--restart' activates\n..."`). The engine's own "not actually a
+        // heading, rewind" path (this file's `i = heading_idx + 1;
+        // continue;`) re-examines each such row as a fresh pseudo-heading
+        // once `command_mode` is already stuck on from the real `Command:`
+        // heading many rows earlier, and when a wrapped continuation block
+        // ends up reachable on its own (disconnected from the row it
+        // actually describes), every one of `scan_bare_command_table`'s
+        // safeguards — no column gap, no dash, a name-shaped leading token,
+        // more than one token on the line — is satisfied by ordinary
+        // English (`"restarting of the server"`, `"option '--restart'
+        // activates"`), because a lowercase word is indistinguishable from
+        // a command name by shape alone. Measured: `of`, `the`, `for`,
+        // `back`, `adds`, `sets`, `calls`, `otherwise` and a dozen more
+        // English words became `invocation_attested` "subcommands" this
+        // way. `recognized` — true only when *this exact heading's own
+        // text* mentions "command(s)" — is false for every one of those
+        // pseudo-headings (`"reload [--restart]...     reloads the
+        // configuration without"` names no command), so requiring it
+        // directly (never inherited through the sticky chain) closes this
+        // off while still admitting both real fixtures: `wpa_cli`'s
+        // `commands:` and `apt-ftparchive`'s `Commands:` are each
+        // literally recognized at the exact point this is tried, with no
+        // `command_mode` inheritance needed. `!is_declared_non_command`
+        // guards the same framework override `allow_dash_separator` does,
+        // for the same reason. See `scan_bare_command_table`'s own doc
+        // comment for the column-gap/dash bail-out that separately keeps
+        // this from ever overriding an already-working column- or
+        // dash-separated table.
+        if recognized && !is_declared_non_command {
+            if let Some((end, entries)) = scan_bare_command_table(&lines, i) {
+                i = end;
+                command_mode = true;
+                let raw_tokens = command_table_token_index(raw);
+                let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, &mut result);
+                total_entries += seen;
+                clean_entries += clean;
+                continue;
+            }
+        }
 
         // Busybox's applet list (spec issue #1) is a single flat,
         // comma-separated run under one heading — structurally distinct
@@ -2368,6 +2466,91 @@ fn emit_subcommands(
     (seen, clean)
 }
 
+/// Emit a headed command table's rows — `wpa_cli`'s ` = `-separated
+/// `commands:` block and `apt-ftparchive`'s operand-only `Commands:` table
+/// (see [`scan_bare_command_table`] and `split_heading_inline_row`'s call
+/// site) — as subcommand stubs with `invocation_attested: true,
+/// heading_attested: false`, rather than routing through
+/// [`emit_subcommands`], which always sets `heading_attested: true`.
+///
+/// # Why the weaker attestation bit (spec §6, "A second attestation bit
+/// exists now")
+///
+/// `heading_attested` is spec §6 rule 0's gate for exactly one question:
+/// is this word safe to send as `<tool> <word> --help` probe argv? These
+/// two tables belong to C daemons and daemon-control clients whose
+/// "commands" are runtime control verbs, not argv subcommands in the
+/// clap/cobra sense — `wpa_cli terminate`, `wpa_cli quit`,
+/// `wpa_cli reconfigure` act on a *running* `wpa_supplicant` the instant
+/// they are invoked, and programs in this family commonly ignore a
+/// trailing `--help` and just execute the verb. Probing
+/// `wpa_cli terminate --help` therefore risks tearing down a real
+/// supplicant rather than printing usage — exactly the risk
+/// `invocation_attested` exists to flag as unproven, per
+/// [`scan_headingless_invocation_table`]'s own precedent. The rows are
+/// still strong *existence* evidence (each name is checked against
+/// [`command_table_token_index`] below — the same whole-token existence
+/// test [`token_occurs_literally`] makes, answered from one pass over the
+/// raw text rather than one rescan per candidate, since a headed command
+/// table can carry on the order of a hundred rows where
+/// `scan_headingless_invocation_table`'s callers see a few dozen at most
+/// — see that function's own doc comment, which the earlier commit
+/// history of this file already applied to `help_text`'s glued-token
+/// check for exactly this reason), just weak *safety* evidence, which is
+/// the whole reason the bit is split rather than reused. And today these
+/// tables yield nothing at all — every row is currently dropped as
+/// unattributable — so withholding probe-eligibility costs no existing
+/// behaviour: nothing that used to be probed stops being probed.
+/// A headed command table's rows, already split into `(name,
+/// description)` pairs by [`split_bare_command_table_row`] — named
+/// because the plain tuple-of-tuple spelling trips clippy's
+/// `type_complexity` lint at every one of this shape's several call
+/// sites ([`scan_bare_command_table`], [`emit_headed_command_table`]).
+type CommandTableEntries<'a> = Vec<(&'a str, Option<String>)>;
+
+fn emit_headed_command_table(
+    entries: CommandTableEntries<'_>,
+    raw_tokens: &std::collections::HashSet<&str>,
+    out: &mut ParsedHelp,
+) -> (usize, usize) {
+    let mut seen = 0usize;
+    let mut clean = 0usize;
+    for (name, desc) in entries {
+        seen += 1;
+        // `is_command_name_shaped` is true by construction here (every
+        // name was produced by `leading_command_name`, which already
+        // checked it), but spec [M-10]'s lesson is to check explicitly
+        // rather than trust construction — same posture
+        // `scan_headingless_invocation_table` takes for the identical
+        // reason.
+        if !is_command_name_shaped(name) || !raw_tokens.contains(name) {
+            out.saw_unattributable_content = true;
+            continue;
+        }
+        clean += 1;
+        let mut node = CommandNode::new(name, Provenance::single(Source::HelpText));
+        node.summary = desc.and_then(|d| non_empty_text(&d));
+        node.invocation_attested = true;
+        node.heading_attested = false;
+        out.try_push_subcommand(node);
+    }
+    (seen, clean)
+}
+
+/// One-pass tokenization of `raw` into the maximal runs of
+/// [`is_command_name_shaped`]'s own character class — the whole-token
+/// existence index [`emit_headed_command_table`] checks each recovered
+/// name against, built once per headed-command-table block rather than
+/// re-scanning `raw` (as [`token_occurs_literally`] does) once per
+/// candidate name. Same split predicate as that function; the two must
+/// keep agreeing on what "occurs literally" means; a set entry here is
+/// exactly a `true` answer there.
+fn command_table_token_index(raw: &str) -> std::collections::HashSet<&str> {
+    raw.split(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-')))
+        .filter(|w| !w.is_empty())
+        .collect()
+}
+
 /// Strip trailing bracketed optional-modifier groups from a command entry's
 /// name token: `m[ab]` names the command `m`, `r[ab][f][u]` names `r`.
 ///
@@ -2402,6 +2585,64 @@ pub fn strip_optional_modifier_suffix(name: &str) -> &str {
     } else {
         name
     }
+}
+
+/// Leading name from a headed command table row's name field — only the
+/// row's very first whitespace token can ever be the command's name,
+/// never a "run" of further name-shaped tokens.
+///
+/// This is deliberately capped at one token, unlike
+/// [`invocation_table_row_run`]'s up-to-two-token run: `apt-ftparchive`'s
+/// `sources srcpath [overridefile [pathprefix]]` row names one command,
+/// `sources`, with `srcpath` as its first *operand* — and `srcpath` is
+/// itself [`is_command_name_shaped`], so a "run of name-shaped tokens"
+/// rule would wrongly promote it to a second command or a grandchild.
+/// Taking only the first token sidesteps that ambiguity entirely: it is
+/// always correct for a table whose rows carry no description at all
+/// (there is nothing else the token stream could mean), and it is what
+/// spec's headed-command-table subsection (§7 Tier B) requires.
+///
+/// Strips a trailing `:` and any `[...]` optional-modifier suffix first,
+/// same as [`emit_subcommands`].
+fn leading_command_name(field: &str) -> Option<&str> {
+    let first = field.split_whitespace().next()?;
+    let name = first.trim_end_matches(':');
+    let name = strip_optional_modifier_suffix(name);
+    is_command_name_shaped(name).then_some(name)
+}
+
+/// Split a heading line that carries its section table's **first row on
+/// the heading's own physical line** (`apt-ftparchive`'s
+/// `Commands: packages binarypath [overridefile [pathprefix]]`) into the
+/// heading label (without its trailing colon) and the trailing row text.
+///
+/// Unlike [`split_shared_heading_row`] (which recovers the same shared-
+/// line shape for a *flag* row and requires a real
+/// [`MIN_COLUMN_GAP_SPACES`]-wide column gap after the colon, because a
+/// flag table is column-aligned), this table's rows are single-spaced —
+/// `apt-ftparchive` puts exactly one space after `Commands:` — so this
+/// asks only for *some* non-empty text following the colon, and leaves it
+/// to the call site's own [`is_recognized_command_heading`] /
+/// [`leading_command_name`] checks to decide whether that text is really
+/// a command row rather than an ordinary sentence that happens to contain
+/// a colon.
+///
+/// [`is_section_heading_line`] is still the gate that keeps this from
+/// firing on a colon buried in prose (`"Note: see the manual for
+/// details"`) — a real section label is short and plain-worded, a
+/// sentence generally is not. Returns `None` when no colon exists, the
+/// text up to it doesn't read as a heading label, or nothing follows.
+fn split_heading_inline_row(line: &str) -> Option<(&str, &str)> {
+    let colon = line.find(':')?;
+    let label = &line[..=colon];
+    if !is_section_heading_line(label) || starts_with_usage_prefix(label) {
+        return None;
+    }
+    let suffix = line[colon + 1..].trim_start();
+    if suffix.is_empty() {
+        return None;
+    }
+    Some((&line[..colon], suffix))
 }
 
 /// Route an unrecognized bare-word block into the `choices` of whichever
@@ -4302,6 +4543,221 @@ fn split_at_dash(line: &str, dash_idx: usize) -> (&str, String) {
     let spec = line[..dash_idx].trim_end();
     let desc = line[dash_idx + 1..].trim_start().to_string();
     (spec, desc)
+}
+
+/// Find the byte offset of a ` = ` (space-equals-space) entry separator in
+/// `line`, if any — [`find_dash_separator`]'s twin for a headed command
+/// table that uses `=` instead of `-` (`wpa_cli`'s `commands:` block:
+/// `status [verbose] = get current WPA/EAPOL/EAP status`). Same shape,
+/// same reasoning: a token's own internal `=` (`payload=<hex dump of
+/// payload>`, `dialog=<token>`) never matches, because it has no space on
+/// at least one side, so only a genuine surrounding-space separator is
+/// found. Distinct from [`find_equals_separator_gap`], which is
+/// deliberately restricted to flag rows and a stricter "every token
+/// before `=` is value-spec-shaped" test — see that function's doc
+/// comment for why a bare-word block must never reach it. This one is
+/// reached only from [`scan_bare_command_table`], itself gated on already
+/// being headed for command emission (see that function's own doc
+/// comment for the gate).
+fn find_bare_equals_separator_gap(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut i = 1;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'=' && bytes[i - 1] == b' ' && bytes[i + 1] == b' ' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split `line` at a ` = ` separator found by [`find_bare_equals_separator_gap`]:
+/// `eq_idx` is the `=`'s own byte offset, so the name field is everything
+/// before the space preceding it and the description is everything after
+/// the space following it — mirrors [`split_at_dash`] exactly, substituting
+/// the separator character.
+fn split_at_bare_equals(line: &str, eq_idx: usize) -> (&str, String) {
+    let name_field = line[..eq_idx].trim_end();
+    let desc = line[eq_idx + 1..].trim_start().to_string();
+    (name_field, desc)
+}
+
+/// Split one row of a headed command table into `(name, description)`:
+/// [`find_bare_equals_separator_gap`]'s ` = ` separator when present
+/// (`wpa_cli`'s ordinary row shape), otherwise the row's leading token as
+/// the name with no description at all (`apt-ftparchive`'s
+/// `sources srcpath [overridefile [pathprefix]]`, and the handful of
+/// `wpa_cli` rows that carry no `=` at all — `wps_cancel Cancels the
+/// pending WPS operation` — a real inconsistency in that tool's own
+/// `--help` text, not something this parser should paper over by guessing
+/// where the name ends and prose begins).
+///
+/// The no-separator branch deliberately never treats trailing words as a
+/// description: for `apt-ftparchive` those words are the command's own
+/// positional operands (`binarypath [overridefile [pathprefix]]`), and
+/// reading them as prose would fabricate a description the tool never
+/// wrote — the exact §1 violation this project exists to refuse. Losing
+/// three real `wpa_cli` descriptions to the same rule is the honest price
+/// of not being able to tell the two shapes apart from a single line.
+///
+/// `None` when the leading token isn't [`is_command_name_shaped`] — the
+/// per-row refusal [`scan_bare_command_table`] relies on to skip a stray
+/// line without rejecting the whole table.
+fn split_bare_command_table_row(line: &str) -> Option<(&str, Option<String>)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match find_bare_equals_separator_gap(trimmed) {
+        Some(eq_idx) => {
+            let (name_field, desc) = split_at_bare_equals(trimmed, eq_idx);
+            let name = leading_command_name(name_field)?;
+            let desc = if desc.trim().is_empty() {
+                None
+            } else {
+                Some(desc)
+            };
+            Some((name, desc))
+        }
+        None => {
+            let name = leading_command_name(trimmed)?;
+            Some((name, None))
+        }
+    }
+}
+
+/// Scan a headed command table whose rows carry no column-aligned
+/// description at all — `wpa_cli`'s `commands:` block and
+/// `apt-ftparchive`'s `Commands:` table (spec §7 Tier B, the
+/// headed-command-table subsection). Reuses [`bare_block_end`] to find
+/// the block, same as [`scan_bare_block`], but splits each row with
+/// [`split_bare_command_table_row`] instead of [`split_entry_line`], and
+/// its emission ([`emit_headed_command_table`]) is `invocation_attested`
+/// rather than `heading_attested` — see that function's doc comment for
+/// why.
+///
+/// # The column-gap/dash bail-out
+///
+/// Bails (`None`) outright — before reading a single row — if *any*
+/// non-blank line in the block has a real column gap
+/// ([`find_multi_space_gap`]) or a ` - ` separator ([`find_dash_separator`]).
+/// Both are already-working shapes: a column-aligned table is read
+/// correctly today via [`split_entry_line`]'s ordinary column-gap path,
+/// and a dash-separated one via `allow_dash_separator`. Without this
+/// guard, this function would compete with both — worse, it would *win*
+/// by running first, silently discarding a working column-gap or dash
+/// description in favor of this function's own "leading token, no
+/// description" fallback. This is also what keeps this recognizer away
+/// from `wpa_supplicant`'s own `drivers:` block (`nl80211 = Linux
+/// nl80211/cfg80211`) even on the rare tool where that heading *would*
+/// otherwise be recognized as a command list: a description-bearing
+/// `name = description` bare block reads as a column gap the instant its
+/// values line up, and the moment it doesn't, [`find_equals_separator_gap`]'s
+/// own doc comment already explains why that block must be read as
+/// `(name, value)`, never split apart here.
+///
+/// # Why bare single-word rows are excluded from the admission floor
+///
+/// A row that is just one bare word (no `=`, no further tokens) already
+/// parses correctly through the ordinary heading-recognized path with
+/// `heading_attested: true` — the strictly *more* trustworthy bit. Only
+/// rows that are demonstrably not working today (an `=` separator, or
+/// more than one token on the name side) count toward
+/// [`MIN_INVOCATION_TABLE_ROWS`]'s floor, so this recognizer never fires
+/// for a block that the existing engine already reads correctly, even
+/// though a fired scan still emits every row it can (a single-word row
+/// caught up in an otherwise-qualifying block is still worth recovering,
+/// just with the weaker attestation bit, rather than being dropped
+/// outright).
+///
+/// # The floor counts distinct names, not qualifying rows
+///
+/// Two rows that qualify but share one name do not meet the floor —
+/// `trash-put --help`'s own "use one of these commands:" sentence (a real
+/// false hit of `mentions_commands_word`/`is_recognized_command_heading`,
+/// which read no further than "does the word 'commands' appear") followed
+/// by the worked example `trash -- -foo` / `trash ./-foo`, two invocations
+/// of one *different* program, not two commands of `trash-put`. Both rows
+/// qualify by every other rule here (no column gap, no dash, a
+/// name-shaped leading token, more than one token on the line), and
+/// without this a distinct guard would have fabricated `trash` as a
+/// subcommand of `trash-put`. A real command table lists several
+/// *different* commands — that is the entire evidentiary point of
+/// requiring repetition at all — so this is not a new restriction, only a
+/// more precise statement of the one already documented above.
+fn scan_bare_command_table<'a>(
+    lines: &[&'a str],
+    start: usize,
+) -> Option<(usize, CommandTableEntries<'a>)> {
+    let end = bare_block_end(lines, start);
+    let block = &lines[start..end];
+
+    if block.iter().any(|l| {
+        !l.trim().is_empty()
+            && (find_multi_space_gap(l).is_some() || find_dash_separator(l).is_some())
+    }) {
+        return None;
+    }
+
+    let non_blank: Vec<&&str> = block.iter().filter(|l| !l.trim().is_empty()).collect();
+    if non_blank.is_empty() {
+        return None;
+    }
+    let baseline = non_blank
+        .iter()
+        .map(|l| leading_whitespace(l))
+        .min()
+        .unwrap_or(0);
+
+    let mut entries: CommandTableEntries<'a> = Vec::new();
+    let mut qualifying_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for &line in block {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = leading_whitespace(line);
+        if indent <= baseline + 1 {
+            let Some((name, desc)) = split_bare_command_table_row(line) else {
+                continue;
+            };
+            if desc.is_some() || line.split_whitespace().count() > 1 {
+                qualifying_names.insert(name);
+            }
+            entries.push((name, desc));
+        } else if let Some(last) = entries.last_mut() {
+            // A deeper-indented continuation of the previous row's
+            // description — same rule `split_entries` uses to fold
+            // wrapped description lines. Never invents a description
+            // where the entry row had none (an `apt-ftparchive` row is
+            // never followed by a continuation line in the first place,
+            // since none of its rows wrap), it simply starts one from
+            // whatever real text the tool printed on the continuation
+            // line.
+            let cont = line.trim();
+            match &mut last.1 {
+                Some(d) => {
+                    d.push(' ');
+                    d.push_str(cont);
+                }
+                None => last.1 = Some(cont.to_string()),
+            }
+        }
+    }
+
+    // Distinct names, not raw qualifying rows: a real command table lists
+    // several *different* commands, which is the whole point of it being a
+    // table. Two rows sharing one name is exactly the shape a worked usage
+    // example produces instead (`trash-put`'s own "use one of these
+    // commands:" sentence — itself a false hit of `mentions_commands_word`,
+    // not a real heading — followed by `trash -- -foo` / `trash ./-foo`,
+    // two alternative invocations of one *different* program's example),
+    // and admitting it fabricated `trash` as a "subcommand" of
+    // `trash-put`. Requiring distinct names costs nothing on either real
+    // fixture (`wpa_cli`'s ~180 rows and `apt-ftparchive`'s six are all
+    // distinct) and closes this off structurally rather than by trying to
+    // out-guess every future sentence that happens to contain "commands:".
+    (qualifying_names.len() >= MIN_INVOCATION_TABLE_ROWS && !entries.is_empty())
+        .then_some((end, entries))
 }
 
 /// Find the byte offset of the first column gap in `line`, if any, after
@@ -8593,6 +9049,206 @@ Options:
         let raw = "    mytool frob start <path>\n        Start frobbing\n";
         let parsed = parse_named(raw, "mytool");
         assert!(parsed.subcommands.is_empty());
+    }
+
+    /// `wpa_cli`'s real defect: a recognized `commands:` heading whose rows
+    /// separate name and description with ` = ` instead of a column gap,
+    /// with a couple of rows (a real inconsistency in the tool's own text)
+    /// carrying no separator at all. Before this recognizer: 0 subcommands
+    /// — every multi-word row failed [`is_command_name_shaped`] whole, and
+    /// `note <text>`'s row happened to split at the placeholder boundary,
+    /// leaving a description that still began with a literal `= `.
+    #[test]
+    fn bare_command_table_admits_the_wpa_cli_equals_shape() {
+        let raw = "commands:\n  \
+                    status [verbose] = get current WPA/EAPOL/EAP status\n  \
+                    ifname = get current interface name\n  \
+                    note <text> = add a note to wpa_supplicant debug log\n  \
+                    log_level <level> [<timestamp>] = update the log level/timestamp\n  \
+                    pmksa_add <network_id> <BSSID> <PMKID> <PMK> = store PMKSA cache entry\n  \
+                    wps_cancel Cancels the pending WPS operation\n";
+        let parsed = parse(raw);
+
+        let status = find_subcommand(&parsed.subcommands, "status");
+        assert!(status.invocation_attested);
+        assert!(!status.heading_attested);
+        assert_eq!(
+            status.summary.as_ref().map(|t| t.as_str()),
+            Some("get current WPA/EAPOL/EAP status"),
+            "the `[verbose]` operand must never survive into the name or the description"
+        );
+
+        let log_level = find_subcommand(&parsed.subcommands, "log_level");
+        assert_eq!(
+            log_level.summary.as_ref().map(|t| t.as_str()),
+            Some("update the log level/timestamp")
+        );
+
+        let pmksa_add = find_subcommand(&parsed.subcommands, "pmksa_add");
+        assert_eq!(
+            pmksa_add.summary.as_ref().map(|t| t.as_str()),
+            Some("store PMKSA cache entry")
+        );
+
+        // No ` = ` at all on this row — the name is still recovered, but
+        // never with a guessed description built from the trailing prose.
+        let wps_cancel = find_subcommand(&parsed.subcommands, "wps_cancel");
+        assert!(
+            wps_cancel.summary.is_none(),
+            "a row with no separator must come out honestly undescribed, not guessed at"
+        );
+
+        // The `= ` separator itself must never survive as description text.
+        for name in ["status", "ifname", "note", "log_level", "pmksa_add"] {
+            let node = find_subcommand(&parsed.subcommands, name);
+            if let Some(summary) = &node.summary {
+                assert!(
+                    !summary.as_str().starts_with("= "),
+                    "{name}'s summary still carries the separator: {summary:?}"
+                );
+            }
+        }
+    }
+
+    /// The exact hazard `find_equals_separator_gap`'s own doc comment
+    /// warns about, now guarding a second call site: a bare-word block
+    /// that legitimately uses `name = description` for something that is
+    /// *not* a command list (`wpa_supplicant`'s own `drivers:` block) must
+    /// never be read by [`scan_bare_command_table`] — its heading isn't
+    /// recognized and nothing put the parser in `command_mode`, so the
+    /// gate at the call site refuses to even try.
+    #[test]
+    fn bare_command_table_never_touches_an_unrecognized_equals_block() {
+        let raw = "drivers:\n  \
+                    nl80211 = Linux nl80211/cfg80211\n  \
+                    wext = Linux wireless extensions (generic)\n";
+        let parsed = parse(raw);
+        assert!(
+            parsed.subcommands.is_empty(),
+            "an unrecognized heading's `name = description` block must never become commands: \
+             {:?}",
+            parsed.subcommands
+        );
+    }
+
+    /// Found on the real fleet while validating this recognizer (not a
+    /// synthetic worry): `fail2ban-client --help`'s real `Command:` table
+    /// is column-aligned throughout, but several rows' descriptions wrap
+    /// entirely onto their own more-indented lines with nothing on the
+    /// name row itself, and one row's own name-side text is itself
+    /// column-gapped. The generic engine's "not actually a heading,
+    /// rewind" path re-treats every such row as a fresh pseudo-heading
+    /// once `command_mode` is stuck on — and a wrapped continuation block
+    /// that ends up reachable on its own passes every guard
+    /// [`scan_bare_command_table`] has (no column gap, no dash, a
+    /// name-shaped leading token, more than one word) purely because
+    /// ordinary English is indistinguishable from a command name by shape
+    /// alone. Gating on `recognized` alone (never inherited through
+    /// `command_mode`) closes this: none of these pseudo-headings
+    /// themselves mention "command".
+    #[test]
+    fn bare_command_table_does_not_leak_through_a_sticky_command_mode_chain() {
+        // The `BASIC` sub-heading is load-bearing: at indent 45 immediately
+        // above rows at indent 4, it makes `bare_block_end` end the block
+        // after `BASIC` alone (the real shape `fail2ban-client --help`
+        // prints), which is what fragments the rest of the table into the
+        // engine's row-by-row "not actually a heading, rewind" recursion —
+        // without it, the whole block is read in one `scan_bare_block`
+        // pass and this test does not exercise the hazard at all.
+        let raw = "Command:\n                                             \
+                    BASIC\n    \
+                    start                                    starts the server and the jails\n    \
+                    reload [--restart] [--unban] [--all]     reloads the configuration without\n                                             \
+                    restarting of the server, the\n                                             \
+                    option activates completely\n    \
+                    stop                                     stops all jails and terminate the\n";
+        let parsed = parse_named(raw, "fail2ban-client");
+        for bogus in ["restarting", "option", "completely", "of", "the"] {
+            assert!(
+                parsed.subcommands.iter().all(|n| n.name != bogus),
+                "{bogus:?} is a fragment of wrapped prose, never a command: {:?}",
+                parsed.subcommands
+            );
+        }
+    }
+
+    /// Found on the real fleet: `trash-put --help` closes with "To remove
+    /// a file whose name starts with a '-' ... use one of these
+    /// commands:" — an ordinary sentence, not a section heading, that
+    /// happens to satisfy `mentions_commands_word` because "commands"
+    /// appears in it as a whole word. The two lines beneath it are a
+    /// worked example of invoking a *different* program (`trash`, not
+    /// `trash-put`) twice, not a table of `trash-put`'s own subcommands.
+    /// Both example lines qualify by every other rule
+    /// [`scan_bare_command_table`] has, but they share one name, and the
+    /// distinct-names floor refuses to treat one repeated example as
+    /// repetition evidence.
+    #[test]
+    fn bare_command_table_refuses_one_name_repeated_by_a_worked_example() {
+        let raw = "use one of these commands:\n\n    \
+                    trash -- -foo\n\n    \
+                    trash ./-foo\n";
+        let parsed = parse_named(raw, "trash-put");
+        assert!(
+            parsed.subcommands.is_empty(),
+            "two invocations of one program are not two commands: {:?}",
+            parsed.subcommands
+        );
+    }
+
+    /// `apt-ftparchive`'s real defect: `Commands:` carries its first row on
+    /// its own physical line, and the remaining rows are pure `name
+    /// operand...` with no description at all. Before this recognizer: 0
+    /// subcommands, and the whole line (including every continuation row)
+    /// was absorbed into the root description/group text.
+    #[test]
+    fn heading_inline_row_admits_the_apt_ftparchive_shape() {
+        let raw = "Usage: apt-ftparchive [options] command\n\
+                    Commands: packages binarypath [overridefile [pathprefix]]\n          \
+                    sources srcpath [overridefile [pathprefix]]\n          \
+                    contents path\n          \
+                    release path\n          \
+                    generate config [groups]\n          \
+                    clean config\n";
+        let parsed = parse(raw);
+
+        let mut names: Vec<&str> = parsed.subcommands.iter().map(|n| n.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["clean", "contents", "generate", "packages", "release", "sources"],
+            "all six real commands, and nothing else, must be recovered: {names:?}"
+        );
+
+        // `sources srcpath` must never promote `srcpath` — itself
+        // name-shaped — to a second command or a grandchild.
+        assert!(
+            parsed.subcommands.iter().all(|n| n.subcommands.is_empty()),
+            "no row's operand may become a child command"
+        );
+        for name in [
+            "srcpath",
+            "binarypath",
+            "overridefile",
+            "pathprefix",
+            "groups",
+        ] {
+            assert!(
+                parsed.subcommands.iter().all(|n| n.name != name),
+                "{name} is an operand, never a command"
+            );
+        }
+
+        for node in &parsed.subcommands {
+            assert!(node.invocation_attested, "{}", node.name);
+            assert!(!node.heading_attested, "{}", node.name);
+            assert!(
+                node.summary.is_none(),
+                "{}'s row carries only operands, never a description: {:?}",
+                node.name,
+                node.summary
+            );
+        }
     }
 
     /// pngfix's real near-miss (`corpus/pngfix/1.6.43/help.stderr.txt`):

--- a/spec.md
+++ b/spec.md
@@ -1288,6 +1288,77 @@ Every node this recognizer produces is `invocation_attested: true`,
 `heading_attested: false` — see rule 0's closing paragraph above (§6) for
 why the two are kept separate and what each one governs.
 
+**Headed command tables with no column-gap or dash separator.** Rule 1
+requires a recognized heading; the two shapes above additionally require a
+column gap or a ` - ` separator to split a row into name and description.
+Two real tools' command tables have a recognized heading but neither: `wpa_cli
+--help`'s `commands:` block separates name and description with ` = `
+instead (`status [verbose] = get current WPA/EAPOL/EAP status`, and a
+handful of rows — a real inconsistency in the tool's own text — with no
+separator at all), and `apt-ftparchive --help`'s `Commands:` table has no
+description per row at all, just the command name followed by its own
+positional operands (`sources srcpath [overridefile [pathprefix]]`), with
+its first row sharing the heading's own physical line
+(`corpus/apt-ftparchive/audit-seed2`, promoted from `[xfail]`).
+
+`help_text::sections::scan_bare_command_table` reads a row's name as only
+its **leading name-shaped token**, never a run of them (unlike the
+headingless recognizer's two-token run above): `apt-ftparchive`'s `sources
+srcpath` names one command, `sources`, with `srcpath` — itself
+name-shaped — as its own operand, never a second command or a
+grandchild. A ` = ` separator (found the same way `find_dash_separator`
+finds ` - `) gives the description; its absence leaves the node honestly
+undescribed rather than guessing where the name ends and prose begins.
+`split_heading_inline_row` recovers the special case of a heading sharing
+its own line with the table's first row, using
+`is_section_heading_line` to tell a real (if unconventional) heading
+label from an ordinary sentence that merely ends in a colon.
+
+Three admission guards, each added after a real fabrication surfaced
+during development against the live fleet, not written down in advance:
+
+1. **The bail-out.** Refuses (`None`) the whole block outright if any row
+   has a real column gap or a ` - ` separator — both already-working
+   shapes this recognizer must never compete with, let alone win against
+   by running first. This is also what keeps a bare-word block that
+   legitimately uses `name = value` for something that is not a command
+   list (`wpa_supplicant`'s own `drivers:` block, `nl80211 = Linux
+   nl80211/cfg80211` — see `find_equals_separator_gap`'s own doc comment)
+   safe on the rare tool where that heading would otherwise qualify.
+2. **`recognized`, never `command_mode`.** Gated on the *current* heading
+   itself mentioning "command(s)", not on inheriting a `command_mode`
+   chain the way `allow_dash_separator` (issue #3) deliberately does.
+   `fail2ban-client --help`'s real `Command:` table nests column-aligned
+   rows whose descriptions wrap onto their own more-indented lines; the
+   engine's "not actually a heading, rewind" path re-examines each such
+   row as a fresh pseudo-heading once `command_mode` is stuck on from the
+   real heading many rows earlier, and a wrapped continuation block that
+   ends up reachable on its own passes every other guard here purely
+   because ordinary English is indistinguishable from a command name by
+   shape alone — `of`, `the`, `restarting`, `option` all became
+   "subcommands" of `fail2ban-client` this way before this guard was
+   added. None of those pseudo-headings themselves mention "command", so
+   requiring `recognized` directly closes it while still admitting both
+   real fixtures (each literally recognized at the point this is tried).
+3. **The floor counts distinct names, not qualifying rows.** `trash-put
+   --help` closes with an ordinary sentence, "...use one of these
+   commands:", that satisfies the generic `mentions_commands_word` test
+   exactly as written (the word "commands" does appear), followed by a
+   two-line worked example of invoking a *different* program twice
+   (`trash -- -foo`, `trash ./-foo`). Both lines pass every guard above,
+   but they name the same thing, and a real command table's whole
+   evidentiary claim is that it lists several *different* commands — so
+   the floor is distinct qualifying names, not raw qualifying rows.
+
+Every node this recognizer produces is `invocation_attested: true,
+heading_attested: false`, for the same reason as the headingless table
+above — with an extra note specific to this shape: these tables belong to
+C daemons and daemon-control clients whose "commands" are runtime control
+verbs (`wpa_cli terminate`, `wpa_cli quit`) rather than argv subcommands in
+the clap/cobra sense, and such programs commonly ignore a trailing
+`--help` and just execute the verb, so even a correctly-attested name here
+is a `heading_attested`-shaped risk rule 0's gate exists to withhold.
+
 ### Tier C — completion script structural parsing
 
 For tools not in a catalog that support `<tool> completion bash|zsh|fish`


### PR DESCRIPTION
## Summary

Two real tools print a headed command table the parser recovered nothing from:

- **`wpa_cli`** — the parser refused `commands:` rows because it only knew how to split a row at a 2+-space column gap or a ` - ` separator; `wpa_cli` uses ` = ` instead (`status [verbose] = get current WPA/EAPOL/EAP status`), and a handful of rows use no separator at all. The whole row's text became the candidate "name," failed the name-shape test, and was dropped. Now `scan_bare_command_table` reads a row's name as only its **leading name-shaped token**, taking the ` = ` text (when present) as the description and leaving `summary: None` honestly when there isn't one.
- **`apt-ftparchive`** — the parser refused the `Commands:` table because its first row (`packages binarypath [overridefile [pathprefix]]`) shares the heading's own physical line; the entire line, plus every aligned continuation row beneath it, was absorbed into the root `description` instead of ever being scanned as data. Now `split_heading_inline_row` recovers that shared-line row using the same leading-token rule, so `sources srcpath` never promotes `srcpath` (itself name-shaped) to a second command.

Both recognizers emit `invocation_attested: true, heading_attested: false` — never sent as `--help` probe argv — because these tables belong to daemon-control clients (`wpa_cli terminate`, `wpa_cli quit`) whose "commands" are runtime verbs a probe could actually trigger, the same split spec §6 already draws for the headingless-invocation-table recognizer (`btrfs`).

## Two real fabrications found and closed mid-development

Both recognizers are gated on the **current heading being directly recognized**, never a `command_mode` chain, and require a floor of **distinct** recovered names, not just qualifying rows. Neither guard was theoretical — both came from running the new code against the live fleet:

- `fail2ban-client --help`'s real `Command:` table wraps several descriptions onto their own more-indented lines. The engine's "not actually a heading, rewind" path re-treats each row as a fresh pseudo-heading once `command_mode` is stuck on from the real heading many rows earlier, and a wrapped continuation block that ends up reachable on its own (`"...restarting of the server, the / option '--restart' activates..."`) passed every other guard — ordinary English is indistinguishable from a command name by shape alone. `of`, `the`, `option`, `restarting` and a dozen more became fabricated "subcommands." Fixed by requiring the *literal current heading* to say "command(s)", never inheriting that through the sticky chain.
- `trash-put --help` closes with "...use one of these commands:" — an ordinary sentence that legitimately trips the existing generic `mentions_commands_word` test — followed by a two-line worked example of invoking a *different* program (`trash -- -foo`, `trash ./-foo`). Both lines passed every other guard, but they name the same thing twice; requiring **distinct** qualifying names (not just row count) refuses this.

## Fleet numbers (full PATH, 2,254 tools, aarch64 Ubuntu 24.04)

Base scoreboard: 95.60% of flags carry text, 2308 tools joined, 1 with no tier, 0 suspicious, 314 verbatim, 66 existence-fabrication.

After this change, the aggregate flags dimension is **byte-identical** to base (95.60%, 314 verbatim, 66 existence-fabrication — this change touches subcommand recovery only). The sweep diff:

```
sweep transition: 2254 -> 2254 tools, 2254 matched, 0 appeared, 0 disappeared, 19 excluded (near 10s cap)

# status transitions
(none)

# flag-count losses (the bar — never netted): 0 lost across 0 tool(s)
# flag-count gains: 0 gained across 0 tool(s)

# field-level changes: 3 tool(s)
  apt-ftparchive: subcommands added: clean, contents, generate, packages, release, sources
  dpkg-maintscript-helper: subcommands added: dir_to_symlink, mv_conffile, rm_conffile, supports, symlink_to_dir
  wpa_cli: subcommands added: (211 names — the near-complete real command list)
```

**Every moved tool accounted for:**
- `wpa_cli`: +211 subcommands (deduplicated from ~180 raw rows — a few names like `bssid_ignore` and `log_level` repeat across multiple operand shapes and dedup to one node each, same as `emit_subcommands` everywhere else).
- `apt-ftparchive`: +6 subcommands — its complete, real command list.
- `dpkg-maintscript-helper`: +5 subcommands — the same generic recognizer catching a second, previously-unmeasured real fixture (a genuine `Commands:` table, `supports`/`rm_conffile`/`mv_conffile`/`symlink_to_dir`/`dir_to_symlink`).

The 19 "excluded, near 10s cap" tools are pre-existing near-timeout entries (ms jitter only, same tools both sides — nothing about this change touches probe timing).

No flag was lost anywhere. No tool changed status or tier. No other tool's subcommand tree changed at all.

## See it yourself

```
$ cargo build --release
$ ./target/release/mandible wpa_cli        # before this branch: "commands (1)" — just the root, 0 subcommands
                                            # after: "commands (212)" — the full ~180-command tree, each with
                                            # its real description ("status" → "get current WPA/EAPOL/EAP status")
$ ./target/release/mandible apt-ftparchive # before: "commands (1)" — root only, description reads
                                            #   "apt 2.8.3 (arm64) Commands: packages binarypath [overridefile [pathprefix]]"
                                            # after: "commands (7)" — packages, sources, contents, release,
                                            #   generate, clean, each a real (undescribed, by design) leaf
```

## PTY screenshots

**`wpa_cli` — before:**
```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ wpa_cli ─────────────────────────────────────────────────╮
│  wpa_cli                                                 ││ DESCRIPTION ──────────────────────────────────────────── │
│                                                          ││ wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr]  │
│                                                          ││ [-a<action file>] \ commands:                            │
│                                                          ││                                                          │
│                                                          ││ FLAGS ────────────────────────────────────────────────── │
│                                                          ││   -h  help (show this usage text)                        │
│                                                          ││   -v  shown version information                          │
│                                                          ││   -a  run in daemon mode executing the action file based │
│                                                          ││       on events from wpa_supplicant                      │
│                                                          ││   -r  try to reconnect when client socket is             │
│                                                          ││       disconnected. This is useful only when used with   │
│                                                          ││       -a.                                                │
│                                                          ││   -B  run a daemon in the background                     │
│                                                          ││                                                          │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    ? help    ^C quit     low confidence: 2% parsed
```

**`wpa_cli` — after:**
```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (212) ──────────────────────────────────────────╮╭ wpa_cli ─────────────────────────────────────────────────╮
│▾ wpa_cli                                                 ││ DESCRIPTION ──────────────────────────────────────────── │
│    status               get current WPA/EAPOL/EAP status ││ wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr]  │
│    ifname               get current interface name       ││ [-a<action file>] \ commands:                            │
│    ping                 pings wpa_supplicant             ││                                                          │
│    relog                re-open log-file (allow rolling… ││ FLAGS ────────────────────────────────────────────────── │
│    note                 add a note to wpa_supplicant…    ││   -h  help (show this usage text)                        │
│    mib                  get MIB variables (dot1x, dot11) ││   -v  shown version information                          │
│    help                 show usage help                  ││   -a  run in daemon mode executing the action file based │
│    interface            show interfaces/select interface ││       on events from wpa_supplicant                      │
│    level                change debug level               ││   -r  try to reconnect when client socket is             │
│    license              show full wpa_cli license        ││       disconnected. This is useful only when used with   │
│    quit                 exit wpa_cli                     ││       -a.                                                │
│    set                  set variables (shows list of…    ││   -B  run a daemon in the background                     │
│    dump                 dump config variables            ││                                                          │
│    get                  get information                  ││                                                          │
│    driver_flags         list driver flags                ││                                                          │
│    logon                IEEE 802.1X EAPOL state machine… ││                                                          │
│    logoff               IEEE 802.1X EAPOL state machine… ││                                                          │
│    pmksa                show PMKSA cache                 ││                                                          │
│    pmksa_flush          flush PMKSA cache entries        ││                                                          │
│    pmksa_get            fetch all stored PMKSA cache…    ││                                                          │
│    pmksa_add            store PMKSA cache entry from…    ││                                                          │
│    mesh_pmksa_get       fetch all stored mesh PMKSA…     ││                                                          │
│    mesh_pmksa_add       store mesh PMKSA cache entry…    ││                                                          │
│    reassociate          force reassociation              ││                                                          │
│    reattach             force reassociation back to the… ││                                                          │
│    preauthenticate      force preauthentication          ││                                                          │
│    identity             configure identity for an SSID   ││                                                          │
│    password             configure password for an SSID   ││                                                          │
│    new_password         change password for an SSID      ││                                                          │
│    pin                  configure pin for an SSID        ││                                                          │
│    otp                  configure one-time-password for… ││                                                          │
│    psk_passphrase       configure PSK/passphrase for an… ││                                                          │
│    passphrase           configure private key…           ││                                                          │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

**`apt-ftparchive` — before:**
```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ apt-ftparchive ──────────────────────────────────────────╮
│  apt-ftparchive                                          ││ DESCRIPTION ──────────────────────────────────────────── │
│                                                          ││ apt 2.8.3 (arm64) Commands: packages binarypath          │
│                                                          ││ [overridefile [pathprefix]]                              │
│                                                          ││                                                          │
│                                                          ││ USAGE ────────────────────────────────────────────────── │
│                                                          ││   apt-ftparchive [options] command                       │
│                                                          ││                                                          │
│                                                          ││ FLAGS ────────────────────────────────────────────────── │
│                                                          ││   -h              This help text                         │
│                                                          ││   --md5           Control MD5 generation                 │
│                                                          ││   -s           ?  Source override file                   │
│                                                          ││   -q              Quiet                                  │
│                                                          ││   -d           ?  Select the optional caching database   │
│                                                          ││   --no-delink     Enable delinking debug mode            │
│                                                          ││   --contents      Control contents file generation       │
│                                                          ││   -c           ?  Read this configuration file           │
│                                                          ││   -o           ?  Set an arbitrary configuration option  │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

**`apt-ftparchive` — after:**
```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (7) ────────────────────────────────────────────╮╭ apt-ftparchive ──────────────────────────────────────────╮
│▾ apt-ftparchive                                          ││ DESCRIPTION ──────────────────────────────────────────── │
│    packages                                              ││ apt 2.8.3 (arm64) Commands: packages binarypath          │
│    sources                                               ││ [overridefile [pathprefix]]                              │
│    contents                                              ││                                                          │
│    release                                               ││ USAGE ────────────────────────────────────────────────── │
│    generate                                              ││   apt-ftparchive [options] command                       │
│    clean                                                 ││                                                          │
│                                                          ││ FLAGS ────────────────────────────────────────────────── │
│                                                          ││   -h              This help text                         │
│                                                          ││   --md5           Control MD5 generation                 │
│                                                          ││   -s           ?  Source override file                   │
│                                                          ││   -q              Quiet                                  │
│                                                          ││   -d           ?  Select the optional caching database   │
│                                                          ││   --no-delink     Enable delinking debug mode            │
│                                                          ││   --contents      Control contents file generation       │
│                                                          ││   -c           ?  Read this configuration file           │
│                                                          ││   -o           ?  Set an arbitrary configuration option  │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

(Both `apt-ftparchive` captures are of the real system binary, `apt 2.8.3 (arm64)` — the same version as the frozen `corpus/apt-ftparchive/audit-seed2` fixture, so the six recovered commands line up exactly. `wpa_cli`'s screenshot is also the real system binary; its live `--help` text matches the shape of the frozen `corpus/wpa_cli/audit-seed` capture used for the corpus fixture.)

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (also checked against `aarch64-apple-darwin` per AGENTS.md)
- `cargo nextest run --workspace` — 1116/1116 passed
- `cargo run -p xtask -- corpus` — 88 ok, 14 xfail (as expected), 0 failed. Promotes `corpus/apt-ftparchive/audit-seed2` out of `[xfail]`; adds `corpus/wpa_cli/audit-seed`.
- `cargo build --release` — clean
- Full-PATH sweep before/after + `sweep-diff` — see fleet numbers above.

## Not done / open question

None — this closes both defects in the brief. The `dpkg-maintscript-helper` gain was an unplanned but verified-correct bonus from the same generic recognizer (not tool-specific logic; no per-tool code was added anywhere).
