### PR TITLE
fix(help_text): enter the usage block for unlabelled and name-prefixed synopses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,17 +42,44 @@ once it reaches a published 0.1.0 release.
   Measured on a full-`PATH` sweep: 16 tools move `verbatim` → `ok`, 20
   gain 124 flags fleet-wide, 0 flags are lost anywhere. Four systemd
   tools (`systemd-creds`, `systemd-sysext`, `systemd-confext`,
-  `varlinkctl`) lose their `Commands:`-derived subcommand stubs as a
-  side effect: their own `Commands:` heading is ANSI-corrupted
+  `varlinkctl`) initially lost their `Commands:`-derived subcommand
+  stubs as a side effect: their own `Commands:` heading is ANSI-corrupted
   (`\x1b[0mCommands:` reads as one alphanumeric run, `0mCommands`, to
   `mentions_commands_word`), and that heading's recognition was
   previously rescued only by accident, via the very description-leak
-  this fix removes. Left as an honest loss rather than patched by
-  widening the `command_mode` sticky chain to also seed from a usage
-  synopsis's own `COMMAND` word — measured and reverted: that seed
-  fabricated a subcommand literally named `v2.3.3` out of `containerd`'s
-  and `ctr`'s unrelated `VERSION:` block, the exact class of defect
-  [M-10] exists to prevent.
+  this fix removes. Not patched by widening the `command_mode` sticky
+  chain to also seed from a usage synopsis's own `COMMAND` word —
+  measured and reverted: that seed fabricated a subcommand literally
+  named `v2.3.3` out of `containerd`'s and `ctr`'s unrelated `VERSION:`
+  block, the exact class of defect [M-10] exists to prevent.
+
+  **Root-caused and fixed instead**: `mandible_core::strip_escapes`
+  (previously private to `Text::sanitize`, now exported) now runs once
+  over the whole raw `--help` document, in `help_text::sections`, before
+  any heading, indentation or column gap is computed from it — not only
+  per-field at final display time, which was too late for the layout
+  analysis that decides what's a heading at all. `systemd-creds` and
+  `varlinkctl` now recover their `Commands:` block through the ordinary
+  recognized-heading path (`heading_attested: true`, strictly better
+  evidence than the accidental stubs they had before). Measured on a
+  second full-`PATH` sweep isolating just this change: it moves exactly
+  these two tools and nothing else in the entire fleet — 0 other status
+  transitions, 0 other flag or subcommand changes, confirming escape
+  bytes were not silently distorting `leading_whitespace`/
+  `find_multi_space_gap` byte offsets for any other tool on this
+  machine's `PATH`.
+
+  `systemd-sysext` and `systemd-confext` remain a **known, named
+  residual regression**: their command rows sit directly under the
+  description prose with no `Commands:` heading at all (`systemd-sysext
+  [OPTIONS...] COMMAND` synopsis, then five unheaded rows), which is
+  categorically the shape spec §7 Tier B rule 1 forbids recognizing
+  ("a command block must be introduced by a recognized heading — layout
+  alone is never sufficient evidence"). Recovering it safely would need
+  a new, separately-measured recognizer restricted to a headingless,
+  column-aligned block immediately following the description with no
+  intervening heading and no `command_mode` stickiness; not attempted
+  here.
 
 - **Two headed command tables — one separated by ` = `, one carrying no
   separator at all — parsed to zero subcommands.** `wpa_cli`'s `commands:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **A usage synopsis with no `Usage:` label, or one whose `usage:` is
+  preceded by the tool's own name, was never entered — the whole synopsis
+  (and any flags documented only in it) fell through to the root
+  description or `unparsed`.** `wpa_cli --help` opens `wpa_cli
+  [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] ...` with no `Usage:`
+  line at all; `nfsidmap --help` writes the ordinary C `fprintf(stderr,
+  "%s: Usage: ...", argv[0])` idiom, `nfsidmap: Usage: nfsidmap [-vh]
+  ...`. `starts_with_usage_prefix` tests only a line's own start, so
+  neither shape was ever recognized as a usage block:
+  `extract_usage_flags` never ran on either line, `wpa_cli`'s root
+  description read as the tool's own invalid-option banner run straight
+  into its synopsis and entire `commands:` block, and `nfsidmap` reported
+  `verbatim` with zero flags.
+
+  Two new, narrowly-scoped recognizers in `help_text::sections`:
+  `starts_with_name_prefixed_usage` (the tool's own name, `": "`, then
+  `usage:`) and `looks_like_unlabeled_synopsis_line` (the tool's own name
+  at a word boundary, plus positive usage-grammar notation — `[`/`<`/`{`
+  — in the remainder, and not read as an English sentence), the latter
+  tried only when no labelled `usage:` line exists anywhere in the
+  document and only in the lines before the document's real body starts.
+  Neither loosens `starts_with_usage_prefix` itself or any existing entry
+  condition — a tool with a real `Usage:` line is unaffected. `wpa_cli`
+  gains six new, undescribed value-spec flags (`-p`, `-i`, `-P`, `-g`,
+  `-G`, `-s`); `-a`, `-h`, `-v`, `-B`, `-r` — already described by its
+  flag table — merge rather than duplicate, per
+  `flag_spelling_already_present`'s existing policy. `nfsidmap` goes from
+  `verbatim`/0 flags to `ok`/4 flags.
+
+  Measured on a full-`PATH` sweep: 16 tools move `verbatim` → `ok`, 20
+  gain 124 flags fleet-wide, 0 flags are lost anywhere. Four systemd
+  tools (`systemd-creds`, `systemd-sysext`, `systemd-confext`,
+  `varlinkctl`) lose their `Commands:`-derived subcommand stubs as a
+  side effect: their own `Commands:` heading is ANSI-corrupted
+  (`\x1b[0mCommands:` reads as one alphanumeric run, `0mCommands`, to
+  `mentions_commands_word`), and that heading's recognition was
+  previously rescued only by accident, via the very description-leak
+  this fix removes. Left as an honest loss rather than patched by
+  widening the `command_mode` sticky chain to also seed from a usage
+  synopsis's own `COMMAND` word — measured and reverted: that seed
+  fabricated a subcommand literally named `v2.3.3` out of `containerd`'s
+  and `ctr`'s unrelated `VERSION:` block, the exact class of defect
+  [M-10] exists to prevent.
+
 - **Two headed command tables — one separated by ` = `, one carrying no
   separator at all — parsed to zero subcommands.** `wpa_cli`'s `commands:`
   block writes each of its ~180 rows as `name [operands] = description`

--- a/corpus/dbiprof/1.643/expected.snap
+++ b/corpus/dbiprof/1.643/expected.snap
@@ -1,5 +1,6 @@
 name: dbiprof
-description: dbiprof [options] [files]
+usage:
+- dbiprof [options] [files]
 flags:
 - long: number
   value_name: N

--- a/corpus/nfsidmap/audit-seed/expected.snap
+++ b/corpus/nfsidmap/audit-seed/expected.snap
@@ -1,5 +1,5 @@
 name: nfsidmap
-description: '/usr/sbin/nfsidmap: invalid option -- ''-'''
+description: 'nfsidmap: invalid option -- ''-'''
 usage:
 - 'nfsidmap: Usage: nfsidmap [-vh] [-c || [-u|-g|-r key] || -d || -l || [-t timeout] key desc]'
 flags:

--- a/corpus/nfsidmap/audit-seed/help.txt
+++ b/corpus/nfsidmap/audit-seed/help.txt
@@ -1,0 +1,2 @@
+nfsidmap: invalid option -- '-'
+nfsidmap: Usage: nfsidmap [-vh] [-c || [-u|-g|-r key] || -d || -l || [-t timeout] key desc]

--- a/corpus/nfsidmap/audit-seed/meta.toml
+++ b/corpus/nfsidmap/audit-seed/meta.toml
@@ -1,0 +1,44 @@
+# Frozen capture supplied with the fix/usage-synopsis task brief (not
+# `xtask audit`): nfsidmap's whole `--help` output is two lines, an
+# invalid-option error followed by the C `fprintf(stderr, "%s: Usage: ...",
+# argv[0])` idiom's line. `starts_with_usage_prefix` tests a line's own
+# start, so a `usage:` preceded by the program's own name and `": "` was
+# previously invisible to it: status was `verbatim`, 0 flags, the whole
+# document landed in `unparsed`.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "nfsidmap"
+version = "audit-seed"
+captured_with = "frozen capture, fix/usage-synopsis task"
+
+[[capture]]
+argv = ["nfsidmap", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+# `starts_with_name_prefixed_usage` recognizes the `nfsidmap: Usage: ...`
+# line as a usage entry point despite the leading tool-name-and-colon
+# prefix. `extract_usage_flags` then mines the synopsis's bracket groups:
+# `-c`/`-d`/`-l` are bare short flags standing alone in the
+# `||`-separated alternation, and `-v` is recovered too, though not as a
+# clean boolean: `[-vh]` is only two characters, below
+# `help_text::grammar::parse_bundled_shorts`'s documented
+# `MIN_CLUSTER_MEMBERS = 3` floor for reading a cluster as a bundle of
+# switches (that floor is a pre-existing, general decision this fix does
+# not revisit — a two-character cluster is genuinely ambiguous
+# fleet-wide), so it falls through to the ordinary single-dash reading:
+# short `v` carrying `h` as a glued required value. `-h` itself is not a
+# separate flag here for that reason. (`-u`, `-g`, `-r` and `-t` sit
+# inside nested alternations that also carry a glued value word —
+# `[-u|-g|-r key]`, `[-t timeout]` — a shape `parse_flag_alternation`
+# refuses because not every member of the alternation is a *bare* flag
+# spelling; they are not recovered by this fix, and inventing a guess at
+# which alternative owns the value would be exactly the fabrication spec
+# §7 Tier B forbids.)
+must_contain_flags = ["-v", "-c", "-d", "-l"]
+must_not_contain_flags = ["-u", "-g", "-r", "-t"]

--- a/corpus/nfsidmap/audit-seed2/meta.toml
+++ b/corpus/nfsidmap/audit-seed2/meta.toml
@@ -22,7 +22,28 @@ exit_code = 1
 # verdict covers exactly the dimensions verdict_scope lists below, never
 # prose. expected.snap freezes descriptions too, but they were not part
 # of that review.
+#
+# fix/usage-synopsis (2026-08-23): that "correct" verdict judged the
+# *old* parser's `verbatim`/0-flags reading against this document — the
+# honest answer available at the time, not a claim that `verbatim` was
+# the ideal outcome forever. `nfsidmap`'s `Usage:` line is preceded by
+# the tool's own name and `": "` (the C `fprintf(stderr, "%s: Usage:
+# ...", argv[0])` idiom), which `starts_with_usage_prefix` — testing only
+# a line's own start — could never see. `starts_with_name_prefixed_usage`
+# now recognizes it, so this document reads as `ok` with real flags.
+# `verdict_scope` is left as-is rather than removed: per corpus/README.md
+# ("Human vs. agent") an `agent-then-human` fixture never asserts the
+# *current* tree was human-verified, only that a human looked at some
+# version of it and confirmed flags/subcommands — exactly this situation.
 verdict_scope = ["flags", "subcommands"]
 expected_framework = "generic"
-min_status = "verbatim"
+min_status = "ok"
 min_subcommands = 0
+# `-v` swallows `h` as a glued required value rather than splitting into
+# two switches: `[-vh]` is only two characters, and
+# `help_text::grammar::parse_bundled_shorts`'s own documented floor
+# (`MIN_CLUSTER_MEMBERS = 3`) deliberately declines a two-character
+# cluster as genuinely ambiguous fleet-wide (roughly half are real
+# collapses, the rest genuine multi-character single-dash flags) — a
+# pre-existing, general decision this fix does not revisit.
+must_contain_flags = ["-v", "-c", "-d", "-l"]

--- a/corpus/systemd-creds/ansi-heading/expected.snap
+++ b/corpus/systemd-creds/ansi-heading/expected.snap
@@ -1,0 +1,169 @@
+name: systemd-creds
+usage:
+- systemd-creds [OPTIONS...] COMMAND ...
+positionals:
+- name: COMMAND
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- short: 'h'
+  long: help
+  description: Show this help
+  provenance:
+    sources:
+    - help-text
+- long: version
+  description: Show package version
+  provenance:
+    sources:
+    - help-text
+- long: no-pager
+  description: Do not pipe output into a pager
+  provenance:
+    sources:
+    - help-text
+- long: no-legend
+  description: Do not show the headers and footers
+  provenance:
+    sources:
+    - help-text
+- long: json
+  value_name: pretty|short|off
+  value_kind: Required
+  description: Generate JSON output
+  provenance:
+    sources:
+    - help-text
+- long: system
+  description: Show credentials passed to system
+  provenance:
+    sources:
+    - help-text
+- long: transcode
+  value_name: base64|unbase64|hex|unhex
+  value_kind: Required
+  description: Transcode credential data
+  provenance:
+    sources:
+    - help-text
+- long: newline
+  value_name: auto|yes|no
+  value_kind: Required
+  description: Suffix output with newline
+  provenance:
+    sources:
+    - help-text
+- short: 'p'
+  long: pretty
+  description: Output as SetCredentialEncrypted= line
+  provenance:
+    sources:
+    - help-text
+- long: name
+  value_name: NAME
+  value_kind: Required
+  description: Override filename included in encrypted credential
+  provenance:
+    sources:
+    - help-text
+- long: timestamp
+  value_name: TIME
+  value_kind: Required
+  description: Include specified timestamp in encrypted credential
+  provenance:
+    sources:
+    - help-text
+- long: not-after
+  value_name: TIME
+  value_kind: Required
+  description: Include specified invalidation time in encrypted credential
+  provenance:
+    sources:
+    - help-text
+- long: with-key
+  value_name: host|tpm2|host+tpm2|tpm2-absent|auto|auto-initrd
+  value_kind: Required
+  description: Which keys to encrypt with
+  provenance:
+    sources:
+    - help-text
+- short: 'H'
+  description: Shortcut for --with-key=host
+  provenance:
+    sources:
+    - help-text
+- short: 'T'
+  description: Shortcut for --with-key=tpm2
+  provenance:
+    sources:
+    - help-text
+- long: tpm2-device
+  value_name: PATH
+  value_kind: Required
+  description: Pick TPM2 device
+  provenance:
+    sources:
+    - help-text
+- long: tpm2-pcrs
+  value_name: PCR1+PCR2+PCR3+…
+  value_kind: Required
+  description: Specify TPM2 PCRs to seal against (fixed hash)
+  provenance:
+    sources:
+    - help-text
+- long: tpm2-public-key
+  value_name: PATH
+  value_kind: Required
+  description: Specify PEM certificate to seal against
+  provenance:
+    sources:
+    - help-text
+- long: tpm2-public-key-pcrs
+  value_name: PCR1+PCR2+PCR3+…
+  value_kind: Required
+  description: Specify TPM2 PCRs to seal against (public key)
+  provenance:
+    sources:
+    - help-text
+- long: tpm2-signature
+  value_name: PATH
+  value_kind: Required
+  description: Specify signature for public key PCR policy
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quiet
+  description: Suppress output for 'has-tpm2' verb
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true
+subcommands:
+- name: list
+  summary: Show installed and available versions
+  group: 'Commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: setup
+  summary: Generate credentials host key, if not existing yet
+  group: 'Commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: has-tpm2
+  summary: Report whether TPM2 support is available
+  group: 'Commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true

--- a/corpus/systemd-creds/ansi-heading/help.txt
+++ b/corpus/systemd-creds/ansi-heading/help.txt
@@ -1,0 +1,48 @@
+systemd-creds [OPTIONS...] COMMAND ...
+
+Display and Process Credentials.
+
+[0mCommands:
+  list                    Show installed and available versions
+  cat CREDENTIAL...       Show specified credentials
+  setup                   Generate credentials host key, if not existing yet
+  encrypt INPUT OUTPUT    Encrypt plaintext credential file and write to
+                          ciphertext credential file
+  decrypt INPUT [OUTPUT]  Decrypt ciphertext credential file and write to
+                          plaintext credential file
+  has-tpm2                Report whether TPM2 support is available
+  -h --help               Show this help
+     --version            Show package version
+
+[0mOptions:
+     --no-pager           Do not pipe output into a pager
+     --no-legend          Do not show the headers and footers
+     --json=pretty|short|off
+                          Generate JSON output
+     --system             Show credentials passed to system
+     --transcode=base64|unbase64|hex|unhex
+                          Transcode credential data
+     --newline=auto|yes|no
+                          Suffix output with newline
+  -p --pretty             Output as SetCredentialEncrypted= line
+     --name=NAME          Override filename included in encrypted credential
+     --timestamp=TIME     Include specified timestamp in encrypted credential
+     --not-after=TIME     Include specified invalidation time in encrypted
+                          credential
+     --with-key=host|tpm2|host+tpm2|tpm2-absent|auto|auto-initrd
+                          Which keys to encrypt with
+  -H                      Shortcut for --with-key=host
+  -T                      Shortcut for --with-key=tpm2
+     --tpm2-device=PATH
+                          Pick TPM2 device
+     --tpm2-pcrs=PCR1+PCR2+PCR3+…
+                          Specify TPM2 PCRs to seal against (fixed hash)
+     --tpm2-public-key=PATH
+                          Specify PEM certificate to seal against
+     --tpm2-public-key-pcrs=PCR1+PCR2+PCR3+…
+                          Specify TPM2 PCRs to seal against (public key)
+     --tpm2-signature=PATH
+                          Specify signature for public key PCR policy
+  -q --quiet              Suppress output for 'has-tpm2' verb
+
+See the systemd-creds(1) man page for details.

--- a/corpus/systemd-creds/ansi-heading/meta.toml
+++ b/corpus/systemd-creds/ansi-heading/meta.toml
@@ -1,0 +1,51 @@
+# Frozen capture supplied with the fix/usage-synopsis task brief's
+# escape-stripping follow-up (byte-exact — the escape sequences ARE the
+# defect this fixture exists to pin, so no cleanup pass may touch them).
+#
+# `systemd-creds --help` writes its own `Commands:` heading with a
+# colorizing library's reset code glued directly onto it:
+# `\x1b[0mCommands:`. Left in the raw document at sectioning time (before
+# this fix, escape stripping ran only per-field at `Text::sanitize`
+# emission time, too late for layout analysis), the escape and the
+# heading's own first two characters read as one alphanumeric run,
+# `0mCommands`, to `mentions_commands_word` — no recognized heading word
+# anywhere in it — so the real six-command `Commands:` block was never
+# recognized as introducing a command list at all.
+#
+# `mandible_core::strip_escapes` (newly exported; previously private to
+# `Text::sanitize`) now runs over the whole raw document once, before
+# `help_text::sections` ever computes a heading, an indentation depth or
+# a column gap from it.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "systemd-creds"
+version = "ansi-heading"
+platform = "ubuntu-24.04"
+captured_with = "systemd 255 (255.4-1ubuntu8.17), frozen capture, fix/usage-synopsis task"
+
+[[capture]]
+argv = ["systemd-creds", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+# Three of the six real commands (list, setup, has-tpm2) recover cleanly
+# through the ordinary recognized-heading path once escape-stripping lets
+# `mentions_commands_word` see the heading's actual text. The other three
+# (cat, encrypt, decrypt) document an operand glued onto the command name
+# on the same physical line before the description column (`cat
+# CREDENTIAL...`, `encrypt INPUT OUTPUT`) — a pre-existing, separate gap
+# in `emit_subcommands`'s name extraction (it takes the whole field
+# before the column gap as the candidate name, which then fails
+# `is_command_name_shaped`'s `^[a-z][a-z0-9_.-]*$` test whole, rather than
+# isolating the row's leading token the way `scan_bare_command_table`'s
+# `leading_command_name` already does for a different call site) that
+# this fix does not touch. Recovering fewer than six is an honest partial
+# fix, not a fabrication: nothing here invents `cat`/`encrypt`/`decrypt`,
+# and nothing here loses a name that was previously recovered.
+min_subcommands = 3
+must_contain_flags = ["-h", "--version", "-p", "-H", "-T"]

--- a/corpus/wpa_cli/audit-seed/expected.snap
+++ b/corpus/wpa_cli/audit-seed/expected.snap
@@ -1,5 +1,7 @@
 name: wpa_cli
-description: 'wpa_cli: invalid option -- ''-'' wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] [-a<action file>] \ commands:'
+description: 'wpa_cli: invalid option -- ''-'' commands:'
+usage:
+- wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] [-a<action file>] [-P<pid file>] [-g<global ctrl>] [-G<ping interval>] [-s<wpa_client_socket_file_path>] [command..]
 flags:
 - short: 'h'
   description: help (show this usage text)
@@ -26,6 +28,42 @@ flags:
   provenance:
     sources:
     - help-text
+- short: 'p'
+  value_name: <path to ctrl sockets>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'i'
+  value_name: <ifname>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'P'
+  value_name: <pid file>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'g'
+  value_name: <global ctrl>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'G'
+  value_name: <ping interval>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 's'
+  value_name: <wpa_client_socket_file_path>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
 provenance:
   sources:
   - help-text

--- a/corpus/wpa_cli/audit-seed/meta.toml
+++ b/corpus/wpa_cli/audit-seed/meta.toml
@@ -36,4 +36,23 @@ min_subcommands = 150
 # above `commands:` (unrelated to this fixture's own bug, included so a
 # future change to `find_equals_separator_gap`'s flag-row path is caught
 # here too, not just in the recognized-heading commands block below it).
-must_contain_flags = ["-h", "-v", "-a", "-r", "-B"]
+#
+# fix/usage-synopsis (2026-08-23): `wpa_cli --help` opens with an
+# **unlabelled** synopsis — no `Usage:` line at all, just
+# `wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] ...` — which
+# `starts_with_usage_prefix` (testing only a line's own start) could never
+# enter. The whole synopsis, plus the tool's own `invalid option` banner
+# above it, was landing in the root `description` instead of `usage`, and
+# none of the seven value-spec flags synopsis-only flags were recovered.
+# `looks_like_unlabeled_synopsis_line` now recognizes this shape (tool's
+# own name at a word boundary, plus positive usage-grammar notation —
+# `[`/`<`/`{` — in the remainder, and not read as an English sentence),
+# restricted to the lines before the document's real body starts. `-a` is
+# already described by the table above and MERGES rather than duplicating
+# (`flag_spelling_already_present`); `-h`/`-v`/`-B`/`-r` are the same
+# story via the `[-hvBr]` bundle. The six new, undescribed flags below are
+# the ones no other block of this document names anywhere else.
+must_contain_flags = [
+  "-h", "-v", "-a", "-r", "-B",
+  "-p", "-i", "-P", "-g", "-G", "-s",
+]

--- a/mandible-core/src/lib.rs
+++ b/mandible-core/src/lib.rs
@@ -30,4 +30,4 @@ pub use snapshot::{
     to_snapshot, ConfessionSnapshot, ExampleSnapshot, FlagSnapshot, NodeSnapshot,
     PositionalSnapshot, ProvenanceSnapshot,
 };
-pub use text::{Text, MAX_TEXT_CHARS};
+pub use text::{strip_escapes, Text, MAX_TEXT_CHARS};

--- a/mandible-core/src/text.rs
+++ b/mandible-core/src/text.rs
@@ -203,7 +203,21 @@ impl<'de> Deserialize<'de> for Text {
 /// Strip ANSI CSI/OSC/DCS escape sequences and other `ESC`-prefixed
 /// sequences. Hand-written state machine rather than a regex crate
 /// dependency; the grammar is small and well-known.
-fn strip_escapes(input: &str) -> String {
+///
+/// `pub` (fix/usage-synopsis) so `help_text::sections` can run the same
+/// stripping over a whole raw `--help` document *before* sectioning, not
+/// only per-field at [`Text::sanitize`] emission time. Escapes reaching
+/// the sectioning pass corrupt layout analysis that has nothing to do
+/// with display: `systemd-creds --help` writes `[0mCommands:`, and
+/// with the escape still in the string `mentions_commands_word` sees one
+/// alphanumeric run, `0mCommands`, never `Commands` — the heading is
+/// never recognized as introducing a command list, and the whole block
+/// silently fails to become subcommands. AGENTS.md and
+/// `help_text::mod`'s re-export block both record what a second,
+/// drifting copy of a shared predicate has already cost this project, so
+/// this reuses the exact function [`Text::sanitize`] already calls rather
+/// than duplicating the state machine.
+pub fn strip_escapes(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
     while let Some(c) = chars.next() {

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -46,7 +46,8 @@ use super::grammar::{
 };
 use super::profile::{heading_matches_markers, FrameworkProfile};
 use mandible_core::{
-    is_command_name_shaped, CommandNode, Flag, Positional, Provenance, Source, Text, ValueKind,
+    is_command_name_shaped, strip_escapes, CommandNode, Flag, Positional, Provenance, Source, Text,
+    ValueKind,
 };
 
 /// Hard cap on distinct entries (subcommands, flags, or choices) accepted
@@ -196,6 +197,24 @@ pub fn parse_with_profile(
     profile: Option<&FrameworkProfile>,
     tool_name: Option<&str>,
 ) -> ParsedHelp {
+    // Strip terminal escape sequences over the *whole* document, once,
+    // before any layout analysis runs — never only per-field at
+    // `Text::sanitize` emission time, which is too late: headings,
+    // indentation and column gaps are all measured on this raw string,
+    // and an escape sequence still embedded in it corrupts every one of
+    // those measurements, not just what a user eventually reads.
+    // `systemd-creds --help` is the specimen this was measured against:
+    // it writes `[0mCommands:` (a colorizing library's reset code
+    // glued directly onto its own heading), and left in place that
+    // defeats `mentions_commands_word` — the escape and the heading's
+    // first two characters fuse into one alphanumeric run, `0mCommands`,
+    // which matches no recognized heading word, so the tool's real
+    // `Commands:` block (six real subcommands: `list`, `cat`, `setup`,
+    // `encrypt`, `decrypt`, `has-tpm2`) was never recognized as
+    // introducing a command list. Reuses `mandible_core::strip_escapes`
+    // rather than a second copy of the same state machine — see that
+    // function's own doc comment.
+    let raw = strip_escapes(raw);
     // A heading that shares its physical line with the first row of its
     // own table is rewritten into the two lines it means before the
     // engine below ever sees it — see `split_shared_heading_rows`. Doing
@@ -207,9 +226,9 @@ pub fn parse_with_profile(
     //
     // Structurally non-recursive: the rewrite is applied at most once,
     // and `parse_body` never calls back into this function.
-    match split_shared_heading_rows(raw) {
+    match split_shared_heading_rows(&raw) {
         Some(rewritten) => parse_body(&rewritten, profile, tool_name),
-        None => parse_body(raw, profile, tool_name),
+        None => parse_body(&raw, profile, tool_name),
     }
 }
 

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -310,10 +310,52 @@ fn parse_body(
     // fragment's own text is untouched, byte for byte; only the join
     // character between fragments is chosen, and a single space is what
     // the wrap itself removed by breaking the line there.
-    if let Some(start) = lines
-        .iter()
-        .position(|l| starts_with_usage_prefix(l.trim_start()))
-    {
+    // The usage block's entry point recognizes two labelled shapes and
+    // one unlabelled one, tried in this order:
+    //
+    // 1. An ordinary `usage:`/`Usage:` line, anywhere in the document —
+    //    unchanged from before this comment existed.
+    // 2. The C `fprintf(stderr, "%s: Usage: ...", argv[0])` idiom: the
+    //    tool's own name, a literal `": "`, then `usage:` — `nfsidmap`'s
+    //    `nfsidmap: Usage: nfsidmap [-vh] ...`. `starts_with_usage_prefix`
+    //    tests the line's *start*, so this shape is otherwise invisible to
+    //    it; see `starts_with_name_prefixed_usage`'s own doc comment for
+    //    why the match stays this tight (no scanning for `usage:` anywhere
+    //    inside a line).
+    // 3. Only when *neither* of the above appears anywhere in the
+    //    document — a tool with a real `Usage:` line is completely
+    //    unaffected by this arm — an **unlabelled synopsis**: a line that
+    //    opens with the tool's own name and reads as usage grammar rather
+    //    than prose (`looks_like_unlabeled_synopsis_line`'s own doc
+    //    comment has the two-part evidence test and why a name match
+    //    alone is not enough). Bounded to the lines before the document's
+    //    real body starts (its first flag row or section heading) so this
+    //    can only ever find a synopsis sitting where one actually belongs,
+    //    never something that merely happens to open with the tool's name
+    //    deep in the document.
+    let labelled_usage_start = lines.iter().position(|l| {
+        let t = l.trim_start();
+        starts_with_usage_prefix(t)
+            || tool_name.is_some_and(|name| starts_with_name_prefixed_usage(t, name))
+    });
+    let unlabelled_synopsis_start = if labelled_usage_start.is_none() {
+        tool_name.and_then(|name| {
+            let body_start = lines
+                .iter()
+                .position(|l| {
+                    let t = l.trim_start();
+                    !t.is_empty() && (looks_like_flag_start(t) || is_section_heading_line(t))
+                })
+                .unwrap_or(lines.len());
+            lines[..body_start]
+                .iter()
+                .position(|l| looks_like_unlabeled_synopsis_line(l.trim_start(), name))
+        })
+    } else {
+        None
+    };
+    let usage_start = labelled_usage_start.or(unlabelled_synopsis_start);
+    if let Some(start) = usage_start {
         i = start;
         let base_indent = leading_whitespace(lines[i]);
         usage_lines.push(lines[i].trim().to_string());
@@ -432,6 +474,19 @@ fn parse_body(
     // §13.1) parsing a degenerate multi-megabyte input in over two
     // minutes instead of milliseconds).
     let description_bound = i.max(leading_prose_bound(&lines));
+    // A column-0 line inside the recovered usage block's own line range
+    // (`usage_start..i`) is never description prose, whichever of the
+    // three entry shapes above found it — not just an ordinary `usage:`
+    // line. Checking the *range* rather than re-testing `starts_with_usage_prefix`
+    // here is what keeps this correct for the name-prefixed
+    // (`nfsidmap: Usage: ...`) and unlabelled (`wpa_cli [-p<path>] ...`)
+    // shapes too: neither line's text starts with `usage:`, so the old
+    // per-line text test alone would have let it leak into the
+    // description exactly the way it did before this fix — `wpa_cli`'s
+    // root description was the tool's own invalid-option banner run
+    // straight into its synopsis and its entire `commands:` block, because
+    // nothing about that text said "usage" at its own start.
+    let in_usage_block = |idx: usize| usage_start.is_some_and(|s| (s..i).contains(&idx));
     // Collected as *paragraphs* (blank-line-separated runs), not one flat
     // list, so a leading version/author/URL banner can be told apart from
     // the tool's real description — see `is_banner_paragraph` below. A
@@ -451,7 +506,7 @@ fn parse_body(
             }
         } else if leading_whitespace(l) == 0 {
             let t = l.trim_start();
-            if !starts_with_usage_prefix(t) {
+            if !starts_with_usage_prefix(t) && !in_usage_block(j) {
                 current.push(l);
             }
         }
@@ -493,6 +548,24 @@ fn parse_body(
     // keeps this from also lighting up on tar's `--occurrence` flag
     // description, which happens to say "one of the subcommands" deep in
     // prose describing something else entirely.
+    //
+    // Deliberately *not* also seeded from `result.usage`: a docopt-style
+    // `prog [OPTIONS] COMMAND ...` synopsis is an extremely common
+    // convention (cobra, urfave/cli, click, and plain GNU-argp tools all
+    // write it), and turning `command_mode` on for the rest of the
+    // document on that word alone reaches headings the synopsis says
+    // nothing about — measured on a full-`PATH` sweep: `containerd --help`
+    // and `ctr --help` (urfave/cli) both write `USAGE:\n   <tool> [global
+    // options] command [command options]`, and seeding from that alone
+    // turned their unrelated `VERSION:\n   v2.3.3` block into a fabricated
+    // subcommand literally named `v2.3.3` — the exact class of defect
+    // [M-10] exists to prevent. See this fix's PR description for the
+    // `systemd-creds`/`systemd-sysext`/`systemd-confext` regression this
+    // predicate would otherwise have repaired (their own `Commands:`
+    // heading is ANSI-corrupted — `\x1b[0mCommands:` reads as one alnum
+    // run, `0mCommands`, to `mentions_commands_word` — a separate,
+    // pre-existing gap left for a follow-up rather than fixed here by
+    // widening a sticky chain that a fleet sweep just showed fabricates).
     let mut command_mode = result
         .description
         .as_deref()
@@ -1832,6 +1905,70 @@ fn starts_with_tool_name(t: &str, name: &str) -> bool {
         Some(rest) => rest.is_empty() || rest.starts_with(char::is_whitespace),
         None => false,
     }
+}
+
+/// True if `t` (already trimmed of leading whitespace) is the C
+/// `fprintf(stderr, "%s: Usage: ...", argv[0])` idiom's line: the tool's
+/// own name, then a literal `": "`, then `usage:` case-insensitively —
+/// `nfsidmap`'s `nfsidmap: Usage: nfsidmap [-vh] [-c || ...]`.
+///
+/// [`starts_with_usage_prefix`] tests the line's *start*, so a `usage:`
+/// preceded by the program's own name (this ordinary `fprintf`
+/// convention, framework-general rather than per-tool) is invisible to
+/// it, and the whole document was previously rendered `verbatim` with
+/// zero flags recovered.
+///
+/// Kept deliberately tight, per this fix's own hazard warning: the
+/// `usage:` must be preceded by *only* the tool's own name and `": "` —
+/// not scanned for anywhere inside the line, and not satisfied by the
+/// name alone (an ordinary sentence starting `nfsidmap: ` followed by
+/// prose must never match).
+fn starts_with_name_prefixed_usage(t: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    t.strip_prefix(name)
+        .and_then(|rest| rest.strip_prefix(": "))
+        .is_some_and(starts_with_usage_prefix)
+}
+
+/// True if `t` (already trimmed of leading whitespace) opens with `name`
+/// at a word boundary and its remainder reads as usage-synopsis grammar
+/// rather than English prose — the **unlabelled** synopsis convention some
+/// tools use in place of any `Usage:` line at all: `wpa_cli --help` simply
+/// opens `wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] ...`,
+/// with no marker anywhere.
+///
+/// This predicate is the entire risk this fix carries (its own doc
+/// comment at the call site explains the guardrails around *where* it is
+/// tried). A name match alone is not evidence of a synopsis — `"tar is an
+/// archiving program that creates..."` starts with `tar` too — so two
+/// independent, purely notational signals are both required:
+///
+/// - The remainder must contain at least one of the docopt-style group
+///   delimiters spec §7 names (`[`, `<`, `{`) — the same notation
+///   [`looks_like_usage_fragment`] keys on for usage-block continuation.
+///   Prose describing a tool essentially never carries these characters;
+///   a synopsis is built almost entirely out of them.
+/// - The remainder must not read as an English sentence, reusing
+///   [`is_prose_sentence`]'s own test (period-terminated, several words,
+///   no multi-space column gap) — so a tool whose leading sentence
+///   happens to mention a bracketed aside is still refused.
+///
+/// Measured on a full-`PATH` sweep before landing (see this fix's PR
+/// description for the exact tool list this predicate moves).
+fn looks_like_unlabeled_synopsis_line(t: &str, name: &str) -> bool {
+    let Some(rest) = t.strip_prefix(name) else {
+        return false;
+    };
+    if !(rest.is_empty() || rest.starts_with(char::is_whitespace)) {
+        return false;
+    }
+    let rest = rest.trim_start();
+    if rest.is_empty() {
+        return false;
+    }
+    rest.contains(['[', '<', '{']) && !is_prose_sentence(rest)
 }
 
 /// True if `t` (already trimmed of leading whitespace) opens with one of

--- a/spec.md
+++ b/spec.md
@@ -1163,6 +1163,22 @@ The generic fallback parser (step 2) is built with `winnow`:
 - **A `Usage:` line grammar.** Usage lines have a learnable grammar — this is
   what `docopt` formalized: `[OPTIONS]`, `<required>`, `[optional]`, `...` for
   repetition, `|` for alternatives, `{a|b|c}` for choices.
+  The block is entered at any of three shapes (`help_text::sections`,
+  fix/usage-synopsis): an ordinary `usage:`/`Usage:` line anywhere in the
+  document; the C `fprintf(stderr, "%s: Usage: ...", argv[0])` idiom — the
+  tool's own name, `": "`, then `usage:` (`starts_with_name_prefixed_usage`;
+  `nfsidmap`'s `nfsidmap: Usage: nfsidmap [-vh] ...`); and, only when
+  neither of those appears anywhere in the document and only in the lines
+  before the document's real body starts, an **unlabelled** synopsis — the
+  tool's own name at a word boundary, plus positive usage-grammar notation
+  (one of the three group delimiters above) in the remainder, and not read
+  as an English sentence (`looks_like_unlabeled_synopsis_line`; `wpa_cli
+  --help` opens `wpa_cli [-p<path to ctrl sockets>] ...` with no label at
+  all). The third shape is the risky one — a name match alone is not
+  evidence of a synopsis (`"tar is an archiving program..."` also starts
+  with `tar`) — so it requires both signals together, and is bounded to
+  where a synopsis actually belongs rather than searched for anywhere in
+  the document.
 - **A layout-driven section parser** for `Options:`/`Flags:`/`Commands:` blocks.
   Group lines by leading-whitespace runs and indentation depth, so
   `-v, --verbose    Enable verbose output` tokenizes structurally as

--- a/spec.md
+++ b/spec.md
@@ -1179,6 +1179,31 @@ The generic fallback parser (step 2) is built with `winnow`:
   with `tar`) — so it requires both signals together, and is bounded to
   where a synopsis actually belongs rather than searched for anywhere in
   the document.
+
+  A related, general fix landed alongside this (fix/usage-synopsis):
+  `mandible_core::strip_escapes` — previously private, invoked only per
+  field inside `Text::sanitize` at final display time — is now also run
+  once over the *whole* raw document in `help_text::sections`, before any
+  heading, indentation or column gap is computed. An escape sequence
+  surviving into that layout analysis corrupts it in ways that have
+  nothing to do with display: `systemd-creds --help` writes its own
+  `Commands:` heading as `[0mCommands:` (a colorizing library's reset
+  code glued directly onto the heading text), and left in place the
+  escape and the heading's first two characters fuse into one
+  alphanumeric run, `0mCommands`, which `mentions_commands_word` (rule
+  1's literal heading test, above) never recognizes — the tool's real
+  six-command `Commands:` block silently failed to become subcommands at
+  all. Measured on a full-`PATH` sweep isolating this change alone: it
+  moves exactly two tools (`systemd-creds`, `varlinkctl`, both recovering
+  a `Commands:`/command list previously lost to this exact corruption)
+  and nothing else — 0 other status transitions, 0 other flag or
+  subcommand changes fleet-wide, so escape bytes were not otherwise
+  distorting `leading_whitespace`/`find_multi_space_gap` byte offsets for
+  any other tool on the measured machine's `PATH`. `systemd-sysext` and
+  `systemd-confext` remain unfixed by this: their command rows sit
+  directly under the description prose with no heading at all, which
+  rule 1 above forbids recognizing without a new, separately-measured
+  recognizer this change does not attempt.
 - **A layout-driven section parser** for `Options:`/`Flags:`/`Commands:` blocks.
   Group lines by leading-whitespace runs and indentation depth, so
   `-v, --verbose    Enable verbose output` tokenizes structurally as


### PR DESCRIPTION
## Mechanism

The parser refused to enter the usage block for two real shapes because `starts_with_usage_prefix` only tests a line's own *start*:

1. **Unlabelled synopsis.** `wpa_cli --help` opens `wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr] ...` with no `Usage:` line at all. The whole synopsis — plus the tool's own `invalid option` banner above it — fell into the root `description`, and the seven glued value-spec flags (`-p -i -a -P -g -G -s`) were never mined.
2. **Name-prefixed usage** (the C `fprintf(stderr, "%s: Usage: ...", argv[0])` idiom). `nfsidmap --help` writes `nfsidmap: Usage: nfsidmap [-vh] [-c || ...]`. The line's own start is `nfsidmap:`, not `usage:`, so the whole document rendered `verbatim` with zero flags.

Now: `starts_with_name_prefixed_usage` recognizes the tool's own name + `": "` + `usage:`. `looks_like_unlabeled_synopsis_line` recognizes the tool's own name at a word boundary whose remainder carries positive usage-grammar notation (`[`, `<`, `{`) and doesn't read as an English sentence — tried **only** when no labelled `usage:` line exists anywhere in the document, and **only** in the lines before the document's real body starts. Neither loosens `starts_with_usage_prefix` itself or any existing entry condition — a tool with a real `Usage:` line is completely unaffected.

A usage-derived flag that duplicates an already-described table flag **merges, never duplicates** (pre-existing `flag_spelling_already_present` policy, exercised here for the first time on these two shapes): `wpa_cli`'s `-a`, `-h`, `-v`, `-B`, `-r` are already described and are left alone; the six new flags (`-p`, `-i`, `-P`, `-g`, `-G`, `-s`) arrive undescribed, as [M-15] requires.

## uconv `-?` — confirmed out of scope

`uconv --help`'s usage line documents `-h, -?, --help` as one flag's three spellings. `mandible_core::Flag` has one `short` slot and one `long` slot, so `-?` has nowhere to go — recovering it would either overwrite `-h` or fabricate a second, spellingless entry. Confirmed: `uconv` doesn't move at all in the sweep (its `Usage:` line was already labelled, unaffected by this fix), and `-?` is silently and correctly dropped rather than guessed at. Tracked by issue #30 (0.5.0 spellings-vector schema). Nothing hacked around it here.

## Fleet numbers (full-`PATH` sweep, before vs. after)

- **16 tools** move `verbatim` → `ok`: `adduser`, `corepack`, `dbus-cleanup-sockets`, `dbus-daemon`, `delgroup`, `deluser`, `iscsiadm`, `jfr`, `lvconvert`, `lvcreate`, `lvextend`, `lvreduce`, `lvresize`, `nfsidmap`, `pydoc3`, `xfs_rtcp`.
- **20 tools gain flags, 124 flags total, 0 lost anywhere.** Biggest gains: `adduser` +22, `dbus-daemon` +15, `iscsiadm` +15, `deluser` +10, `lvreduce` +8, `wpa_cli` +6. Spot-checked several by hand against their real `--help` (`adduser`, `iscsiadm`, `jfr`, `pptpsetup`, `udevadm`) — every gained flag is a real spelling literally present in the tool's own unlabelled synopsis.
- **Every moved tool accounted for:**
  - The 16 `verbatim → ok` + 20 flag-gain tools are all this fix's mechanism firing on a real unlabelled or name-prefixed synopsis (`adduser`, `iscsiadm`, `jfr`, `pptpsetup`, `udevadm`, the `lv*`/`dbus-*` family, etc. — all genuinely unlabelled synopses).
  - **4 tools lose subcommand stubs**: `systemd-creds` (`has-tpm2`, `list`, `setup`), `systemd-sysext`/`systemd-confext` (`list`, `merge`, `refresh`, `status`, `unmerge`), `varlinkctl` (`help`). Root cause: their own `Commands:` heading is ANSI-corrupted in the real captured bytes (`\x1b[0mCommands:` reads as one alphanumeric run, `0mCommands`, to `mentions_commands_word`) — a separate, pre-existing gap. Before this fix, the bug being fixed here (the synopsis's `COMMAND` word leaking into the root `description`) was *accidentally* seeding `command_mode` and rescuing the block. I tried the "proper" companion fix — also seeding `command_mode` from the recovered `usage` entries — and reverted it after the sweep showed it fabricating a subcommand literally named `v2.3.3` out of `containerd`'s and `ctr`'s unrelated `VERSION:` block (both write the same `prog ... COMMAND ...` docopt convention in their own `USAGE:` line). Left as an honest, explained loss rather than shipped with a new fabrication path; the ANSI-corruption gap is a good candidate for a follow-up issue.
  - No other tool moved. (One further wobble, `ps: verbatim → ok`, appeared transiently between sweep runs and was confirmed **not** caused by this change — identical old/new binaries on the same captured bytes both report `ps` as `ok`; it was drift in the frozen `after-cmdtable.txt` baseline, not a real transition.)

## See it yourself

```console
$ ./target/release/mandible wpa_cli
# Before: DESCRIPTION pane reads "wpa_cli: invalid option -- '-' wpa_cli [-p<path to ctrl
#         sockets>] [-i<ifname>] [-hvBr] [-a<action file>] \ commands:" and FLAGS has only
#         5 rows (-h, -v, -a, -r, -B).
# After:  a USAGE pane appears with the full synopsis; FLAGS gains -p, -i, -P, -g, -G, -s
#         (undescribed, value-spec only); DESCRIPTION shrinks to just "commands:".

$ ./target/release/mandible nfsidmap
# Before: whole node renders "unparsed — showing raw --help output".
# After:  DESCRIPTION/USAGE/FLAGS panes appear; FLAGS has -v (carrying "h" as a glued
#         value — see meta.toml note), -c, -d, -l.

$ mandible --doctor wpa_cli    # flags: 5 -> 11
$ mandible --doctor nfsidmap   # verbatim, 0 flags -> ok, 4 flags
```

### `wpa_cli` — before

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (212) ──────────────────────────────────────────╮╭ wpa_cli ─────────────────────────────────────────────────╮
│▾ wpa_cli                                                 ││ DESCRIPTION ──────────────────────────────────────────── │
│    status               get current WPA/EAPOL/EAP status ││ wpa_cli [-p<path to ctrl sockets>] [-i<ifname>] [-hvBr]  │
│    ifname               get current interface name       ││ [-a<action file>] \ commands:                            │
│    ping                 pings wpa_supplicant             ││                                                          │
│    relog                re-open log-file (allow rolling… ││ FLAGS ────────────────────────────────────────────────── │
│    note                 add a note to wpa_supplicant…    ││   -h  help (show this usage text)                        │
│    mib                  get MIB variables (dot1x, dot11) ││   -v  shown version information                          │
│    help                 show usage help                  ││   -a  run in daemon mode executing the action file based │
│    interface            show interfaces/select interface ││       on events from wpa_supplicant                      │
│    level                change debug level               ││   -r  try to reconnect when client socket is             │
│    license              show full wpa_cli license        ││       disconnected. This is useful only when used with   │
│    quit                 exit wpa_cli                     ││       -a.                                                │
│    set                  set variables (shows list of…    ││   -B  run a daemon in the background                     │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

### `wpa_cli` — after

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (212) ──────────────────────────────────────────╮╭ wpa_cli ─────────────────────────────────────────────────╮
│▾ wpa_cli                                                 ││ DESCRIPTION ──────────────────────────────────────────── │
│    status               get current WPA/EAPOL/EAP status ││ commands:                                                │
│    ifname               get current interface name       ││                                                          │
│    ping                 pings wpa_supplicant             ││ USAGE ────────────────────────────────────────────────── │
│    relog                re-open log-file (allow rolling… ││   wpa_cli [-p<path to ctrl sockets>] [-i<ifname>]        │
│    note                 add a note to wpa_supplicant…    ││   [-hvBr] [-a<action file>] [-P<pid file>] [-g<global    │
│    mib                  get MIB variables (dot1x, dot11) ││   ctrl>] [-G<ping interval>]                             │
│    help                 show usage help                  ││   [-s<wpa_client_socket_file_path>] [command..]          │
│    interface            show interfaces/select interface ││                                                          │
│    level                change debug level               ││ FLAGS ────────────────────────────────────────────────── │
│    license              show full wpa_cli license        ││   -h                   help (show this usage text)       │
│    quit                 exit wpa_cli                     ││   -v                   shown version information         │
│    set                  set variables (shows list of…    ││   -a                   run in daemon mode executing the  │
│    dump                 dump config variables            ││                        action file based on events from  │
│    get                  get information                  ││                        wpa_supplicant                    │
│    driver_flags         list driver flags                ││   -r                   try to reconnect when client      │
│    logon                IEEE 802.1X EAPOL state machine… ││                        socket is disconnected. This is   │
│    logoff               IEEE 802.1X EAPOL state machine… ││                        useful only when used with -a.    │
│    pmksa                show PMKSA cache                 ││   -B                   run a daemon in the background    │
│    pmksa_flush          flush PMKSA cache entries        ││   -p  <path to ctrl sockets>                             │
│    pmksa_get            fetch all stored PMKSA cache…    ││   -i  <ifname>                                           │
│    pmksa_add            store PMKSA cache entry from…    ││   -P  <pid file>                                         │
│    mesh_pmksa_get       fetch all stored mesh PMKSA…     ││   -g  <global ctrl>                                      │
│    mesh_pmksa_add       store mesh PMKSA cache entry…    ││   -G  <ping interval>                                    │
│    reassociate          force reassociation              ││   -s  <wpa_client_socket_file_path>                      │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

### `nfsidmap` — before

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ nfsidmap ────────────────────────────────────────────────╮
│  nfsidmap                                                ││ unparsed — showing raw --help output                     │
│                                                          ││                                                          │
│                                                          ││ /usr/sbin/nfsidmap: invalid option -- '-'                │
│                                                          ││ nfsidmap: Usage: nfsidmap [-vh] [-c || [-u|-g|-r key] || │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

### `nfsidmap` — after

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ nfsidmap ────────────────────────────────────────────────╮
│  nfsidmap                                                ││ DESCRIPTION ──────────────────────────────────────────── │
│                                                          ││ /usr/sbin/nfsidmap: invalid option -- '-'                │
│                                                          ││                                                          │
│                                                          ││ USAGE ────────────────────────────────────────────────── │
│                                                          ││   nfsidmap: Usage: nfsidmap [-vh] [-c || [-u|-g|-r key]  │
│                                                          ││   || -d || -l || [-t timeout] key desc]                  │
│                                                          ││                                                          │
│                                                          ││ FLAGS ────────────────────────────────────────────────── │
│                                                          ││   -v  h                                                  │
│                                                          ││   -c                                                     │
│                                                          ││   -d                                                     │
│                                                          ││   -l                                                     │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` (Linux and `--target aarch64-apple-darwin`) — clean
- `cargo nextest run --workspace` — 1116 passed, 0 failed
- `cargo run -p xtask -- corpus` — 103 fixtures, 89 ok, 14 xfail (as expected), **0 failed**
- Full-`PATH` sweep before/after, `sweep-diff` — see fleet numbers above
- `cargo build --release`
- pty screenshots before/after — above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFin6DLho9duCAEy6ru6a2
