### PR TITLE
fix(help_text): recognize LVM's docopt bracket-group flag rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,56 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **LVM's docopt bracket-group flag rows (`vgck`, `vgextend`, `vgrename`,
+  and the whole `lv*`/`vg*`/`pv*` family) rendered `verbatim` with zero
+  flags.** LVM's own help emitter writes a *bare* invocation line with no
+  bracket notation of its own (`vgck` alone, or `vgextend VG PV ...`) and
+  puts every flag on a continuation row shaped `[ -x|--long value ]`, plus
+  a real `Common options for lvm:` heading whose rows are the identical
+  shape, tab-indented under a heading written with two spaces. Three
+  independent gaps combined to hide this entirely:
+
+  1. The unlabelled-synopsis entry point required notation evidence
+     (`[`, `<`, `{`) on the invocation line itself; LVM's evidence lives
+     only on the continuation row beneath it.
+  2. `grammar::looks_like_flag_start` (deliberately, per its own doc
+     comment — widening it would end `lsof`'s usage-block continuation one
+     line early and drop six flags documented only there) never recognized
+     a `[...]` group as a flag-table row, so the headed `Common options
+     for lvm:` block was invisible to the flags-table scanner.
+  3. `sections::leading_whitespace` counted raw characters, so a single
+     leading tab (LVM's own convention for its option rows) measured as
+     narrower than the heading's two leading spaces — the "is this content
+     indented more than its heading" gate failed structurally, independent
+     of (2).
+
+  Fixed with a new row-level predicate,
+  `grammar::{looks_like_bracket_flag_row, bracket_flag_row_content}` —
+  never folded into `looks_like_flag_start`, consulted only where a
+  flag-table row or a synopsis-continuation row is recognized — plus a
+  tab-stop-aware `leading_whitespace` (a leading tab now expands to the
+  next multiple of 8 columns, matching every terminal's own convention;
+  behaviour is byte-for-byte unchanged for the fleet's dominant
+  space-only-indentation case). A guard in `bracket_flag_row_content`
+  refuses a row whose apparent alias run doesn't actually end at its first
+  whitespace gap (`ethtool --help`'s `[ --all-groups | --groups [eth-phy]
+  ... ]` is an alternation between two *different* flags, not one flag
+  with aliases and a value, and reading it the LVM way would fabricate
+  `--all-groups`'s value from `--groups`'s operands while dropping
+  `--groups` outright).
+
+  Recovers all 19 flags for `vgck`, 30 for `vgextend`, 21 for `vgrename`,
+  and — via the same general, shape-keyed fix, no tool name ever consulted
+  — the entire `lv*`/`vg*`/`pv*` family (~1,400 flags fleet-wide). The tab-
+  stop correction also fixed a pre-existing, unrelated defect: a
+  deeply-tab-indented description continuation that happened to start with
+  a dash after trimming (`sotruss`'s `-o, --output`, `unsquashfs`'s
+  `-match`, `mksquashfs`'s compressor-option rows) was previously read as
+  a new, fabricated flag entry rather than a continuation of the row
+  above it, because its raw tab count fell inside
+  `scan_flags_block::ENTRY_INDENT_TOLERANCE`; the real terminal-column
+  count does not.
+
 - **A flag row that separates its spec from its description with a colon
   instead of whitespace or `=` had the colon (and, when glued, part of the
   spec itself) read as a fabricated required value.** `sg_emc_trespass

--- a/corpus/vgck/audit-seed2/expected.snap
+++ b/corpus/vgck/audit-seed2/expected.snap
@@ -1,0 +1,133 @@
+name: vgck
+usage:
+- vgck [ --reportformat basic|json ] [ COMMON_OPTIONS ] [ VG|Tag ... ]
+positionals:
+- name: COMMON_OPTIONS
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- short: 'd'
+  long: debug
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quiet
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: verbose
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  long: yes
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  long: test
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: commandprofile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: config
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: driverloaded
+  value_name: y|n
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nolocking
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: lockopt
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: longhelp
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: profile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: version
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devicesfile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devices
+  value_name: PV
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nohints
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: journal
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: reportformat
+  value_name: basic|json
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/vgck/audit-seed2/meta.toml
+++ b/corpus/vgck/audit-seed2/meta.toml
@@ -17,14 +17,23 @@ stderr = "help.stderr.txt"
 
 [contract]
 expected_framework = "generic"
-# The reviewer's note ("verbatim") names the actual status this fixture
-# gets: `CommandNode::unparsed` is non-empty (the whole raw text degraded
-# to spec §7 Tier B step 3's verbatim dump, verified by inspection), which
-# `xtask/src/status.rs`'s STATUS_LADDER ranks below "low-confidence". Once
-# this LVM-style bracketed-option text is genuinely structured into real
-# flags, status should clear at least that floor.
+# Was `[xfail] reason = "verbatim"`: `vgck`'s own emitter writes a *bare*
+# unlabelled synopsis (`vgck` alone, no bracket notation on its own line,
+# `--reportformat` documented only on the continuation row beneath it) and
+# a real `Common options for lvm:` heading whose 18 rows are each one
+# whole `[ -x|--long value ]` group, tab-indented under a heading written
+# with two spaces. Neither shape was recognized before this fix:
+# `grammar::looks_like_bracket_flag_row` (a row-level predicate, never
+# folded into `looks_like_flag_start` — see that function's own doc
+# comment for the `lsof` trap that widening it would spring) reads the
+# bracket rows as flag entries, `sections::leading_whitespace` now expands
+# a leading tab to the terminal's own tab-stop convention so the tab-
+# indented rows measure as more indented than their two-space heading, and
+# the unlabelled-synopsis entry point accepts a bare tool-name line whose
+# very next physical line is one of these bracket rows. All 19 real flags
+# (`--reportformat` plus the 18 common options) are now recovered.
 min_status = "low-confidence"
-
-[xfail]
-broken = true
-reason = "verbatim"
+must_contain_flags = ["-d", "--debug", "--reportformat", "--commandprofile"]
+# No `verdict_scope`: this bless is agent-reviewed (spot-checked against
+# `help.txt` above), not human-reviewed — see corpus/README.md's "What
+# `--bless` does and does not assert".

--- a/corpus/vgextend/audit-seed2/expected.snap
+++ b/corpus/vgextend/audit-seed2/expected.snap
@@ -1,0 +1,209 @@
+name: vgextend
+usage:
+- vgextend VG PV ... [ -A|--autobackup y|n ] [ -f|--force ] [ -Z|--zero y|n ] [ -M|--metadatatype lvm2 ] [ --labelsector Number ] [ --metadatasize Size[m|UNIT] ] [ --pvmetadatacopies 0|1|2 ] [ --metadataignore y|n ] [ --dataalignment Size[k|UNIT] ] [ --dataalignmentoffset Size[k|UNIT] ] [ --reportformat basic|json ] [ --restoremissing ] [ COMMON_OPTIONS ]
+positionals:
+- name: VG
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: PV
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: COMMON_OPTIONS
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- short: 'd'
+  long: debug
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quiet
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: verbose
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  long: yes
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  long: test
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: commandprofile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: config
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: driverloaded
+  value_name: y|n
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nolocking
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: lockopt
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: longhelp
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: profile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: version
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devicesfile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devices
+  value_name: PV
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nohints
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: journal
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'A'
+  long: autobackup
+  value_name: y|n
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'f'
+  long: force
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'Z'
+  long: zero
+  value_name: y|n
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- short: 'M'
+  long: metadatatype
+  value_name: lvm2
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: labelsector
+  value_name: Number
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: metadatasize
+  value_name: Size[m|UNIT]
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: pvmetadatacopies
+  value_name: 0|1|2
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: metadataignore
+  value_name: y|n
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: dataalignment
+  value_name: Size[k|UNIT]
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: dataalignmentoffset
+  value_name: Size[k|UNIT]
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: reportformat
+  value_name: basic|json
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text-synopsis
+- long: restoremissing
+  provenance:
+    sources:
+    - help-text-synopsis
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/vgextend/audit-seed2/meta.toml
+++ b/corpus/vgextend/audit-seed2/meta.toml
@@ -17,13 +17,16 @@ stderr = "help.stderr.txt"
 
 [contract]
 expected_framework = "generic"
-# The reviewer's note ("verbatim") names the actual status this fixture
-# gets: `CommandNode::unparsed` is non-empty (verified by inspection),
-# which `xtask/src/status.rs`'s STATUS_LADDER ranks below "low-confidence".
-# Once this LVM-style bracketed-option text is genuinely structured into
-# real flags, status should clear at least that floor.
+# Was `[xfail] reason = "verbatim"`. Same LVM emitter as `vgck` (see that
+# fixture's own comment for the mechanism): a bare `vgextend VG PV ...`
+# synopsis head with no bracket notation of its own, a run of continuation
+# rows carrying the tool's own flags — including the alias-vs-value
+# ambiguity (`-A|--autobackup y|n`) and a value with its own nested
+# brackets (`--metadatasize Size[m|UNIT]`) — and a `Common options for
+# lvm:` heading whose 18 rows are the identical bracket-group shape. All
+# recovered now.
 min_status = "low-confidence"
-
-[xfail]
-broken = true
-reason = "verbatim"
+must_contain_flags = ["-A", "--autobackup", "--metadatasize", "-d", "--debug"]
+# No `verdict_scope`: this bless is agent-reviewed (spot-checked against
+# `help.txt` above), not human-reviewed — see corpus/README.md's "What
+# `--bless` does and does not assert".

--- a/corpus/vgrename/audit-seed2/expected.snap
+++ b/corpus/vgrename/audit-seed2/expected.snap
@@ -1,0 +1,140 @@
+name: vgrename
+flags:
+- short: 'A'
+  long: autobackup
+  value_name: y|n
+  value_kind: Required
+  group: 'Common options for command:'
+  provenance:
+    sources:
+    - help-text
+- short: 'f'
+  long: force
+  group: 'Common options for command:'
+  provenance:
+    sources:
+    - help-text
+- long: reportformat
+  value_name: basic|json
+  value_kind: Required
+  group: 'Common options for command:'
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  long: debug
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quiet
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: verbose
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  long: yes
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  long: test
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: commandprofile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: config
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: driverloaded
+  value_name: y|n
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nolocking
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: lockopt
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: longhelp
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: profile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: version
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devicesfile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devices
+  value_name: PV
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nohints
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: journal
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/vgrename/audit-seed2/meta.toml
+++ b/corpus/vgrename/audit-seed2/meta.toml
@@ -17,13 +17,16 @@ stderr = "help.stderr.txt"
 
 [contract]
 expected_framework = "generic"
-# The reviewer's note ("verbatim") names the actual status this fixture
-# gets: `CommandNode::unparsed` is non-empty (verified by inspection),
-# which `xtask/src/status.rs`'s STATUS_LADDER ranks below "low-confidence".
-# Once this LVM-style bracketed-option text is genuinely structured into
-# real flags, status should clear at least that floor.
+# Was `[xfail] reason = "verbatim"`. Same LVM emitter as `vgck`/`vgextend`
+# (see `vgck`'s own comment for the mechanism). `vgrename`'s two synopsis
+# forms (`vgrename VG VG_new`, `vgrename String VG_new`) each continue
+# with only `[ COMMON_OPTIONS ]` — a cross-reference, correctly refused as
+# a flag (no dash) — so its real flags come entirely from two *headed*
+# blocks: `Common options for command:` (3 rows: `-A|--autobackup`,
+# `-f|--force`, `--reportformat`) and `Common options for lvm:` (the same
+# 18-row block `vgck`/`vgextend` carry). All 21 recovered now.
 min_status = "low-confidence"
-
-[xfail]
-broken = true
-reason = "verbatim"
+must_contain_flags = ["-A", "--autobackup", "-f", "--force", "-d", "--debug"]
+# No `verdict_scope`: this bless is agent-reviewed (spot-checked against
+# `help.txt` above), not human-reviewed — see corpus/README.md's "What
+# `--bless` does and does not assert".

--- a/mandible-extract/src/help_text/grammar.rs
+++ b/mandible-extract/src/help_text/grammar.rs
@@ -403,6 +403,127 @@ pub fn looks_like_flag_start(input: &str) -> bool {
     trimmed.starts_with('-') || parse_flag_alternation(trimmed).is_some_and(|alt| alt.open == '{')
 }
 
+// --- the docopt bracket-group flag row ----------------------------------
+//
+// LVM's own help emitter (`vgck`, `vgextend`, `vgrename`, and every other
+// `lv*`/`vg*`/`pv*` binary) writes one flag per physical line as a whole
+// `[...]` group, never a `-`-prefixed row and never a `{...}` alternation:
+//
+// ```text
+//   [ -d|--debug ]
+//   [    --commandprofile String ]
+//   [ -A|--autobackup y|n ]
+//   [ --metadatasize Size[m|UNIT] ]
+// ```
+//
+// This is a *third* row shape [`looks_like_flag_start`] cannot be widened
+// to cover — see that function's own doc comment and the trap recorded in
+// this fix's PR: `lsof`'s usage-block continuation lines also open with
+// `[` (`[-F [f]]`), and that predicate doubles as the usage block's own
+// terminator (`sections::parse_body`'s "a continuation that reads as a
+// flag row ends the block" guard). Widening it to accept `[` would make
+// `lsof`'s own continuation line satisfy it, ending the block one line in
+// and losing the six flags documented only in later continuation lines.
+//
+// So this is a **separate, row-level** predicate, consulted only at the
+// two places that ask "is this physical line a flag-table entry" —
+// `flags_block_start`/`scan_flags_block` for the headed `Common options
+// for lvm:` block, and `extract_usage_flags` for the bracket rows that
+// continue a bare, unlabelled `vgck`/`vgextend VG PV ...` synopsis line —
+// never the usage-block-continuation question above.
+
+/// The inner content of a [`looks_like_bracket_flag_row`] line — the
+/// cluster of `-`/`--` spellings plus, when present, the value spec that
+/// follows them — or `None` if `input` is not that shape.
+///
+/// Two conditions, both required:
+///
+/// 1. `input`, once trimmed, is *exactly one* bracket group: nothing
+///    before the `[`, nothing but whitespace after its matching `]`. A
+///    row with a description trailing the group, or with a second group,
+///    is not a shape this reads.
+/// 2. The group's content, trimmed, starts with `-`. This is what turns
+///    away every *operand* LVM writes in the identical notation —
+///    `[ COMMON_OPTIONS ]` (a cross-reference to this very block, no
+///    dash at all) and `[ VG|Tag ... ]` / `[ VG PV ... ]` (positionals) —
+///    while admitting every real flag row, because every one of LVM's
+///    flag rows opens with a dash and no operand row ever does.
+///
+/// The returned content is handed to [`parse_flag_spec`] unchanged by
+/// every caller: once the outer brackets are gone, `-d|--debug`,
+/// `--commandprofile String`, `-A|--autobackup y|n` and `--metadatasize
+/// Size[m|UNIT]` are all shapes that grammar already reads correctly —
+/// `|` is already an alias separator ([`is_alias_separator`]), and
+/// [`take_rest_value_token`]'s `alias_follows` check already keeps a
+/// value's own `|` (`y|n`, `Size[m|UNIT]`) from being misread as a second
+/// alias, which is the same hazard `sg_sanitize`'s `--count=OC|-c OC` is
+/// there for. No second value-vs-alias parser is written for this row
+/// shape; the existing one already closes the ambiguity spec [7] Tier B
+/// worries about here (`--color={always|never|auto}`), because
+/// `is_bare_flag_spelling` is never even consulted by this path — a
+/// leftover value spec becomes `value_name` exactly as it always has.
+pub fn bracket_flag_row_content(input: &str) -> Option<&str> {
+    let trimmed = input.trim();
+    if !trimmed.starts_with('[') {
+        return None;
+    }
+    let (content, rest) = split_at_matching_close(trimmed, '[', ']')?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    let content = content.trim();
+    if !content.starts_with('-') {
+        return None;
+    }
+    // Refuse a row whose alias run does not actually finish at the first
+    // whitespace gap — `ethtool --help`'s
+    // `[ --all-groups | --groups [eth-phy] [eth-mac] [eth-ctrl] [rmon] ]`
+    // is not LVM's shape at all: it is an alternation between *two
+    // different* flags, only one of which carries operands, glued into
+    // one bracket group. Every LVM row's aliases are unseparated by
+    // whitespace (`-A|--autobackup`, `-d|--debug`) with the value (if any)
+    // starting only *after* the alias run ends — so a `|` reappearing
+    // right after that first whitespace gap means the alias run never
+    // actually ended there, and what follows is a second alternative this
+    // function's single-flag reading cannot honestly attribute. Naively
+    // parsing this via `parse_flag_spec` reads `--all-groups` as carrying
+    // the value `eth-phy` and drops `--groups` entirely — a real flag
+    // lost to a fabricated one. Refusing the whole row is the same choice
+    // [`is_bare_flag_spelling`]'s own doc comment already makes for
+    // `[--count=OC|-c OC]`: missing beats invented.
+    if let Some(gap) = top_level_whitespace(content) {
+        if content[gap..].trim_start().starts_with('|') {
+            return None;
+        }
+    }
+    Some(content)
+}
+
+/// The byte index of the first whitespace character in `content` that
+/// sits outside any `[...]`/`{...}` nesting — the boundary between a
+/// bracket-group flag row's alias run and its value spec, when there is
+/// one. `None` when no such whitespace exists (a boolean row like
+/// `--nolocking`, or `-d|--debug`).
+fn top_level_whitespace(content: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, c) in content.char_indices() {
+        match c {
+            '[' | '{' => depth += 1,
+            ']' | '}' => depth -= 1,
+            c if c.is_whitespace() && depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// True if `input` is a [`bracket_flag_row_content`] row — a whole
+/// physical line consisting of exactly one `[...]` group whose content
+/// opens with a dash.
+pub fn looks_like_bracket_flag_row(input: &str) -> bool {
+    bracket_flag_row_content(input).is_some()
+}
+
 // --- the flag-alternation group ----------------------------------------
 //
 // A *delimited alternation of flag spellings* is one notation with three
@@ -1053,6 +1174,87 @@ mod tests {
     #[test]
     fn looks_like_flag_start_false_for_bare_word() {
         assert!(!looks_like_flag_start("clone     Clone a repository"));
+    }
+
+    // --- the docopt bracket-group flag row ------------------------------
+
+    #[test]
+    fn bracket_flag_row_reads_lvms_common_options() {
+        assert_eq!(
+            bracket_flag_row_content("[ -d|--debug ]"),
+            Some("-d|--debug")
+        );
+        assert_eq!(
+            bracket_flag_row_content("[    --commandprofile String ]"),
+            Some("--commandprofile String")
+        );
+        assert_eq!(
+            bracket_flag_row_content("[ -A|--autobackup y|n ]"),
+            Some("-A|--autobackup y|n")
+        );
+        assert_eq!(
+            bracket_flag_row_content("[ --metadatasize Size[m|UNIT] ]"),
+            Some("--metadatasize Size[m|UNIT]")
+        );
+        assert_eq!(
+            bracket_flag_row_content("[ -f|--force ]"),
+            Some("-f|--force")
+        );
+        assert_eq!(
+            bracket_flag_row_content("[ --nolocking ]"),
+            Some("--nolocking")
+        );
+    }
+
+    #[test]
+    fn bracket_flag_row_refuses_operand_rows() {
+        // No dash: a cross-reference to the common-options block, never a
+        // flag.
+        assert_eq!(bracket_flag_row_content("[ COMMON_OPTIONS ]"), None);
+        // Positionals, in the identical bracket notation.
+        assert_eq!(bracket_flag_row_content("[ VG|Tag ... ]"), None);
+        assert_eq!(bracket_flag_row_content("[ VG PV ... ]"), None);
+    }
+
+    #[test]
+    fn bracket_flag_row_refuses_trailing_text() {
+        // Not this row's shape: a description trails the group.
+        assert_eq!(
+            bracket_flag_row_content("[ -d|--debug ]  enable debugging"),
+            None
+        );
+    }
+
+    /// The content this predicate returns is handed straight to
+    /// `parse_flag_spec` by every caller — confirm that pipeline actually
+    /// reads the alias-vs-value ambiguity correctly, not just that the
+    /// brackets are stripped.
+    #[test]
+    fn bracket_flag_row_content_feeds_parse_flag_spec_correctly() {
+        let spec = parse_flag_spec(bracket_flag_row_content("[ -A|--autobackup y|n ]").unwrap());
+        assert_eq!(spec.short, Some('A'));
+        assert_eq!(spec.long.as_deref(), Some("autobackup"));
+        assert_eq!(spec.value_name.as_deref(), Some("y|n"));
+
+        let spec =
+            parse_flag_spec(bracket_flag_row_content("[ --metadatasize Size[m|UNIT] ]").unwrap());
+        assert_eq!(spec.long.as_deref(), Some("metadatasize"));
+        assert_eq!(spec.value_name.as_deref(), Some("Size[m|UNIT]"));
+
+        let spec = parse_flag_spec(bracket_flag_row_content("[ -d|--debug ]").unwrap());
+        assert_eq!(spec.short, Some('d'));
+        assert_eq!(spec.long.as_deref(), Some("debug"));
+        assert_eq!(spec.value_name, None);
+    }
+
+    #[test]
+    fn looks_like_flag_start_still_refuses_brackets() {
+        // The trap this whole row-level predicate exists to avoid:
+        // `looks_like_flag_start` must stay blind to `[`, or `lsof`'s
+        // usage-block continuation (`[-F [f]]`) would end that block one
+        // line in.
+        assert!(!looks_like_flag_start("[ -d|--debug ]"));
+        assert!(!looks_like_flag_start("[-F [f]]"));
     }
 
     // --- the bundled-short-flag cluster ---------------------------------

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -42,7 +42,8 @@
 //!    block is dropped rather than guessed at.
 
 use super::grammar::{
-    looks_like_flag_start, parse_bundled_shorts, parse_flag_alternation, parse_flag_spec, FlagSpec,
+    bracket_flag_row_content, looks_like_bracket_flag_row, looks_like_flag_start,
+    parse_bundled_shorts, parse_flag_alternation, parse_flag_spec, FlagSpec,
 };
 use super::profile::{heading_matches_markers, FrameworkProfile};
 use mandible_core::{
@@ -366,9 +367,35 @@ fn parse_body(
                     !t.is_empty() && (looks_like_flag_start(t) || is_section_heading_line(t))
                 })
                 .unwrap_or(lines.len());
-            lines[..body_start]
-                .iter()
-                .position(|l| looks_like_unlabeled_synopsis_line(l.trim_start(), name))
+            lines[..body_start].iter().enumerate().position(|(idx, l)| {
+                let t = l.trim_start();
+                looks_like_unlabeled_synopsis_line(t, name)
+                    // LVM's own emitter (`vgck`, `vgextend`, `vgrename`)
+                    // writes a *bare* invocation line — `vgck` alone, or
+                    // `vgextend VG PV ...` with no bracket notation at
+                    // all on the head line itself — and puts every bit of
+                    // docopt notation on the rows that continue it:
+                    //
+                    // ```text
+                    //   vgck
+                    //   \t[    --reportformat basic|json ]
+                    //   \t[ COMMON_OPTIONS ]
+                    // ```
+                    //
+                    // `looks_like_unlabeled_synopsis_line` alone can never
+                    // find this: its whole test is notation evidence *on
+                    // this line*, and this line has none. So a bare
+                    // own-name line is accepted too, but only when the
+                    // very next physical line is unambiguous flag-row
+                    // evidence ([`looks_like_bracket_flag_row`]) — a
+                    // narrow, structural signal (never "is this LVM") that
+                    // a name-only line's continuation really is usage
+                    // grammar and not, say, a one-word section title.
+                    || (starts_with_tool_name(t, name)
+                        && lines
+                            .get(idx + 1)
+                            .is_some_and(|next| looks_like_bracket_flag_row(next.trim_start())))
+            })
         })
     } else {
         None
@@ -1939,8 +1966,47 @@ fn looks_like_email(word: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-'))
 }
 
+/// The column a tab in leading whitespace advances to, from whatever
+/// column it started at — the ordinary terminal tab-stop convention.
+const TAB_STOP: usize = 8;
+
+/// A line's leading indentation, as a **visual column**, not a raw
+/// character count.
+///
+/// The two agree everywhere the fleet's overwhelming convention holds
+/// (indentation built entirely from spaces): a run of `n` leading spaces
+/// still measures `n` either way, so this is a byte-for-byte-identical
+/// answer for that case, and every caller of this function that was
+/// already correct for space-indented `--help` output stays exactly as
+/// correct.
+///
+/// They disagree when leading whitespace mixes tabs and spaces, which is
+/// where the plain character count actively lies: LVM's own emitter
+/// (`vgck`, `vgextend`, `vgrename`, ...) indents its `Common options for
+/// lvm:` heading two spaces and every flag row beneath it with **one
+/// tab**. A raw count reads the tab as *one* column — narrower than the
+/// heading's two spaces — so every "is this content indented more than
+/// its heading" check in this module answered "no" and the entire block
+/// (13+ flags per tool) was never even looked at as a candidate flags
+/// table, regardless of anything `looks_like_flag_start` does or does not
+/// accept. Expanding the tab to the next multiple of [`TAB_STOP`] (the
+/// universal terminal convention, not an LVM-specific number) reads it as
+/// column 8 — correctly deeper than the heading's column 2 — and every
+/// downstream decision in this file that already trusted
+/// `leading_whitespace`'s answer starts working for this shape too,
+/// without being touched.
 fn leading_whitespace(line: &str) -> usize {
-    line.len() - line.trim_start().len()
+    let mut col = 0usize;
+    for c in line.chars() {
+        if c == '\t' {
+            col = (col / TAB_STOP + 1) * TAB_STOP;
+        } else if c.is_whitespace() {
+            col += 1;
+        } else {
+            break;
+        }
+    }
+    col
 }
 
 /// True if `t` starts with `"usage:"`, case-insensitively.
@@ -3133,7 +3199,7 @@ fn flags_block_start(lines: &[&str], start: usize) -> Option<usize> {
     /// How many non-flag rows may precede the first flag row.
     const MAX_SKIPPED_LEADING_ROWS: usize = 3;
 
-    if looks_like_flag_start(lines[start]) {
+    if looks_like_flag_start(lines[start]) || looks_like_bracket_flag_row(lines[start]) {
         return Some(start);
     }
     let base = leading_whitespace(lines[start]);
@@ -3149,7 +3215,7 @@ fn flags_block_start(lines: &[&str], start: usize) -> Option<usize> {
         if indent < base {
             return None; // dedented out of the block
         }
-        if looks_like_flag_start(line) {
+        if looks_like_flag_start(line) || looks_like_bracket_flag_row(line) {
             return Some(offset);
         }
         // A row whose left token could not be *either* kind of entry does
@@ -3540,7 +3606,8 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
         let indent = leading_whitespace(line);
         let trimmed = line.trim_start();
 
-        let is_entry_start = looks_like_flag_start(trimmed)
+        let is_entry_start = (looks_like_flag_start(trimmed)
+            || looks_like_bracket_flag_row(trimmed))
             && min_entry_indent.is_none_or(|min| indent <= min + ENTRY_INDENT_TOLERANCE);
 
         if is_entry_start {
@@ -3593,6 +3660,19 @@ fn scan_flags_block<'a>(lines: &[&'a str], start: usize) -> (usize, Vec<(String,
     for row in rows {
         match row {
             FlagsBlockRow::Entry(line) => {
+                // A docopt bracket-group row (LVM's `[ -d|--debug ]`) is
+                // one flag and nothing else — no description column
+                // exists on the row at all. Neither the multi-column
+                // splitter nor the aligned-spelling-column splitter below
+                // is the right tool for a shape with no second column to
+                // find, so this row is read directly: the content inside
+                // the brackets is exactly what `split_single_column_entry`
+                // would otherwise try to recover by looking for a
+                // whitespace gap that isn't there.
+                if let Some(content) = bracket_flag_row_content(line.trim()) {
+                    entries.push((content.to_string(), String::new()));
+                    continue;
+                }
                 // `fields_in_line` can come back empty on a line
                 // `looks_like_flag_start` accepted (bare `-` test) but
                 // whose leading token isn't `is_flag_shaped` (a stricter,
@@ -5797,6 +5877,23 @@ fn extract_positionals(
 fn extract_usage_flags(usage_lines: &[String]) -> Vec<Flag> {
     let mut out: Vec<Flag> = Vec::new();
     for line in usage_lines {
+        // A whole line that is one docopt bracket-group flag row (LVM's
+        // `[ -A|--autobackup y|n ]`) is read directly by
+        // `bracket_flag_row_content` + `parse_flag_spec`, never by the
+        // generic segment walk below. `usage_segments` splits a group's
+        // content on every top-level `|` unconditionally
+        // (`split_top_level_pipe`), which is right for an alternation of
+        // whole flags (`{-v|--version}`) but wrong here: it would read
+        // `-A|--autobackup y|n` as three alternatives — `-A`,
+        // `--autobackup y`, `n` — losing `--autobackup`'s real value
+        // `y|n` down to just `y`. `parse_flag_spec` already resolves this
+        // exact alias-vs-value ambiguity correctly (see
+        // `bracket_flag_row_content`'s own doc comment), so this row
+        // shape is diverted to it before the segment walk ever sees it.
+        if let Some(content) = bracket_flag_row_content(line.trim()) {
+            push_usage_flag(&mut out, parse_flag_spec(content));
+            continue;
+        }
         for segment in usage_segments(line) {
             if out.len() >= MAX_RECOVERED_ENTRIES {
                 return out;
@@ -6400,6 +6497,233 @@ mod tests {
         "    -d                      (dry run) debug info\n",
         "    -dd                     (dry run) verbose debug info\n",
     );
+
+    // --- LVM's docopt bracket-group flag rows ---------------------------
+
+    /// `vgck --help`, byte-exact (minus the `WARNING: Running as a
+    /// non-root user` stderr banner, irrelevant here). A bare, unlabelled
+    /// synopsis (`vgck` alone, no bracket notation on its own line) whose
+    /// only flag — `--reportformat` — is documented on a continuation row,
+    /// plus a real `Common options for lvm:` heading whose 18 rows are
+    /// each one whole `[...]` group, tab-indented under a heading written
+    /// with two spaces.
+    const VGCK_HELP: &str = concat!(
+        "  vgck - Check the consistency of volume group(s)\n",
+        "\n",
+        "  Read and display information about a VG.\n",
+        "  vgck\n",
+        "\t[    --reportformat basic|json ]\n",
+        "\t[ COMMON_OPTIONS ]\n",
+        "\t[ VG|Tag ... ]\n",
+        "\n",
+        "  Rewrite VG metadata to correct problems.\n",
+        "  vgck --updatemetadata VG\n",
+        "\t[ COMMON_OPTIONS ]\n",
+        "\n",
+        "  Common options for lvm:\n",
+        "\t[ -d|--debug ]\n",
+        "\t[ -h|--help ]\n",
+        "\t[ -q|--quiet ]\n",
+        "\t[ -v|--verbose ]\n",
+        "\t[ -y|--yes ]\n",
+        "\t[ -t|--test ]\n",
+        "\t[    --commandprofile String ]\n",
+        "\t[    --config String ]\n",
+        "\t[    --driverloaded y|n ]\n",
+        "\t[    --nolocking ]\n",
+        "\t[    --lockopt String ]\n",
+        "\t[    --longhelp ]\n",
+        "\t[    --profile String ]\n",
+        "\t[    --version ]\n",
+        "\t[    --devicesfile String ]\n",
+        "\t[    --devices PV ]\n",
+        "\t[    --nohints ]\n",
+        "\t[    --journal String ]\n",
+        "\n",
+        "  Use --longhelp to show all options and advanced commands.\n",
+    );
+
+    #[test]
+    fn vgck_recovers_the_synopsis_continuation_flag() {
+        let parsed = parse_with_profile(VGCK_HELP, None, Some("vgck"));
+        let reportformat = flag_named(&parsed, "reportformat");
+        assert_eq!(reportformat.short, None);
+        assert_eq!(reportformat.value_name.as_deref(), Some("basic|json"));
+    }
+
+    #[test]
+    fn vgck_recovers_every_common_option_from_the_headed_bracket_table() {
+        let parsed = parse_with_profile(VGCK_HELP, None, Some("vgck"));
+        let debug = flag_named(&parsed, "debug");
+        assert_eq!(debug.short, Some('d'));
+        assert_eq!(debug.value_name, None);
+
+        let commandprofile = flag_named(&parsed, "commandprofile");
+        assert_eq!(commandprofile.short, None);
+        assert_eq!(commandprofile.value_name.as_deref(), Some("String"));
+
+        let driverloaded = flag_named(&parsed, "driverloaded");
+        assert_eq!(driverloaded.value_name.as_deref(), Some("y|n"));
+
+        // Every one of the 18 rows under `Common options for lvm:`, plus
+        // `--reportformat` from the synopsis continuation.
+        for long in [
+            "debug",
+            "help",
+            "quiet",
+            "verbose",
+            "yes",
+            "test",
+            "commandprofile",
+            "config",
+            "driverloaded",
+            "nolocking",
+            "lockopt",
+            "longhelp",
+            "profile",
+            "version",
+            "devicesfile",
+            "devices",
+            "nohints",
+            "journal",
+            "reportformat",
+        ] {
+            flag_named(&parsed, long);
+        }
+        assert_eq!(parsed.flags.len(), 19, "{:#?}", parsed.flags);
+    }
+
+    /// The operand cross-references LVM writes in the identical bracket
+    /// notation must never be read as flags: `[ COMMON_OPTIONS ]` names no
+    /// dash at all, and `[ VG|Tag ... ]` / `[ VG PV ... ]` are positionals.
+    #[test]
+    fn vgck_never_fabricates_a_flag_from_an_operand_bracket() {
+        let parsed = parse_with_profile(VGCK_HELP, None, Some("vgck"));
+        assert!(parsed
+            .flags
+            .iter()
+            .all(|f| f.long.as_deref() != Some("COMMON_OPTIONS")));
+        assert!(parsed.flags.iter().all(|f| f.long.as_deref() != Some("VG")));
+    }
+
+    /// `vgextend`'s richer synopsis head (`vgextend VG PV ...`, still no
+    /// bracket notation of its own) with the same value-vs-alias-vs-nested-
+    /// bracket shapes this fix's own doc comments name: `-A|--autobackup
+    /// y|n` (alias cluster plus a choice-list value) and `--metadatasize
+    /// Size[m|UNIT]` (a value carrying its own nested brackets).
+    #[test]
+    fn vgextend_reads_the_alias_choice_and_nested_bracket_value_rows() {
+        let raw = concat!(
+            "  vgextend - Add physical volumes to a volume group\n",
+            "\n",
+            "  vgextend VG PV ...\n",
+            "\t[ -A|--autobackup y|n ]\n",
+            "\t[ -f|--force ]\n",
+            "\t[    --metadatasize Size[m|UNIT] ]\n",
+            "\t[ COMMON_OPTIONS ]\n",
+        );
+        let parsed = parse_with_profile(raw, None, Some("vgextend"));
+
+        let autobackup = flag_named(&parsed, "autobackup");
+        assert_eq!(autobackup.short, Some('A'));
+        assert_eq!(autobackup.value_name.as_deref(), Some("y|n"));
+
+        let force = flag_named(&parsed, "force");
+        assert_eq!(force.short, Some('f'));
+        assert_eq!(force.value_name, None);
+
+        let metadatasize = flag_named(&parsed, "metadatasize");
+        assert_eq!(metadatasize.value_name.as_deref(), Some("Size[m|UNIT]"));
+    }
+
+    // --- the tab-stop leading-indentation fix ---------------------------
+
+    /// `sotruss --help`'s real specimen: a description that wraps onto a
+    /// physical continuation line indented with three tabs, and that
+    /// continuation's own trimmed text happens to start with a dash
+    /// (`-f is also used`, referring to a different flag in prose). Byte-
+    /// exact from a real capture.
+    ///
+    /// Before `leading_whitespace`'s tab-stop expansion, three raw tab
+    /// characters measured as indent `3` — inside
+    /// `scan_flags_block`'s `ENTRY_INDENT_TOLERANCE` (10) of the block's
+    /// own two-space entries — so this continuation line was read as a
+    /// **new** flag entry (`-f` carrying the fabricated value `is`)
+    /// instead of a continuation, and `-o, --output`'s own description
+    /// lost everything after "in case". Expanding the tabs to real
+    /// terminal columns (24) is well outside the tolerance, so the line
+    /// now correctly continues `-o`'s description and no phantom `-f`
+    /// entry is created.
+    const SOTRUSS_HELP: &str = concat!(
+        "Usage: sotruss [OPTION...] [--] EXECUTABLE [EXECUTABLE-OPTION...]\n",
+        "  -F, --from FROMLIST     Trace calls from objects on FROMLIST\n",
+        "  -T, --to TOLIST         Trace calls to objects on TOLIST\n",
+        "\n",
+        "  -e, --exit              Also show exits from the function calls\n",
+        "  -f, --follow            Trace child processes\n",
+        "  -o, --output FILENAME   Write output to FILENAME (or FILENAME. in case\n",
+        "\t\t\t  -f is also used) instead of standard error\n",
+        "\n",
+        "  -?, --help              Give this help list\n",
+        "      --usage             Give a short usage message\n",
+        "      --version           Print program version\n",
+    );
+
+    #[test]
+    fn tab_indented_continuation_does_not_fabricate_a_flag() {
+        let parsed = parse_with_profile(SOTRUSS_HELP, None, Some("sotruss"));
+        // No phantom `-f` carrying the value `is` — only the one real
+        // `-f, --follow` flag.
+        let f_flags: Vec<_> = parsed
+            .flags
+            .iter()
+            .filter(|f| f.short == Some('f'))
+            .collect();
+        assert_eq!(f_flags.len(), 1, "{:#?}", parsed.flags);
+        assert_eq!(f_flags[0].long.as_deref(), Some("follow"));
+        assert_eq!(f_flags[0].value_name, None);
+
+        // `-o, --output`'s description is now whole, not truncated at the
+        // point the continuation line used to be misread as a new entry.
+        let output = flag_named(&parsed, "output");
+        assert_eq!(
+            output.description.as_ref().map(|d| d.to_string()).as_deref(),
+            Some("Write output to FILENAME (or FILENAME. in case -f is also used) instead of standard error")
+        );
+    }
+
+    // --- the alternation-with-mismatched-operands hazard ----------------
+
+    /// `ethtool --help`'s real row: an alternation between two *different*
+    /// flags, only one of which carries its own bracketed operands. Not
+    /// LVM's shape at all — LVM's alias run never has a bare flag
+    /// spelling reappear after the first whitespace gap — so
+    /// `bracket_flag_row_content` must refuse the whole row rather than
+    /// read `--all-groups` as carrying `--groups`'s operand and losing
+    /// `--groups` outright (the exact fabrication this fix's own doc
+    /// comment on `bracket_flag_row_content` names).
+    #[test]
+    fn bracket_row_with_a_second_alternatives_operands_is_refused() {
+        assert_eq!(
+            bracket_flag_row_content(
+                "[ --all-groups | --groups [eth-phy] [eth-mac] [eth-ctrl] [rmon] ]"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn ethtool_keeps_both_alternatives_unread_rather_than_fabricating() {
+        let raw = concat!(
+            "  ethtool DEVNAME\n",
+            "\t[ --all-groups | --groups [eth-phy] [eth-mac] [eth-ctrl] [rmon] ]\n",
+        );
+        let parsed = parse_with_profile(raw, None, Some("ethtool"));
+        assert!(parsed
+            .flags
+            .iter()
+            .all(|f| f.long.as_deref() != Some("all-groups")));
+    }
 
     fn flag_named(parsed: &ParsedHelp, long: &str) -> Flag {
         parsed

--- a/spec.md
+++ b/spec.md
@@ -1246,6 +1246,73 @@ The generic fallback parser (step 2) is built with `winnow`:
   `device` instead of reporting it invented. Fleet existence-fabrication
   count on a full-`PATH` sweep of this machine: 130 → 124 tools, zero
   flags or subcommands lost anywhere.
+- **A docopt bracket-group flag row** (fix/lvm-bracket-rows). LVM's own help
+  emitter (`vgck`, `vgextend`, `vgrename`, and the whole `lv*`/`vg*`/`pv*`
+  family) writes one flag per physical line as a whole `[...]` group —
+  `[ -d|--debug ]`, `[    --commandprofile String ]`, `[ -A|--autobackup
+  y|n ]`, `[ --metadatasize Size[m|UNIT] ]` — never a `-`-prefixed row and
+  never a `{...}` alternation, with a bare, unlabelled synopsis head (`vgck`
+  alone, or `vgextend VG PV ...`) carrying no bracket notation of its own;
+  every bit of notation evidence lives on the rows that continue it. Three
+  gaps combined to leave the whole family `verbatim`:
+  - The unlabelled-synopsis entry point (previous bullet) requires notation
+    evidence on the invocation line itself, which a bare `vgck` line never
+    has. `looks_like_unlabeled_synopsis_line`'s check is now supplemented,
+    only at this one call site, by a lookahead: a bare own-name line
+    followed immediately by a `[ -x|--long ... ]`-shaped row also starts
+    the block.
+  - `grammar::looks_like_flag_start` deliberately never accepts a leading
+    `[` — widening it would end `lsof`'s usage-block continuation
+    (`[-F [f]]`) one line early and lose the six flags documented only
+    there, since that same predicate doubles as the usage block's own
+    terminator. A new, narrower, row-level predicate,
+    `grammar::looks_like_bracket_flag_row` /
+    `bracket_flag_row_content` — a whole physical line that is exactly one
+    `[...]` group whose content starts with `-` — is consulted only where
+    a flag-table row or a synopsis-continuation row is recognized
+    (`flags_block_start`, `scan_flags_block`, `extract_usage_flags`),
+    never at the usage-block-continuation call site. The recovered content
+    is handed to the existing `parse_flag_spec` unchanged: `|` is already
+    an alias separator, and its own alias-vs-value hazard guard
+    (`take_rest_value_token`'s `alias_follows` check, built for
+    `sg_sanitize`'s `--count=OC|-c OC`) already reads `-A|--autobackup
+    y|n`'s value as the whole choice list `y|n`, not three fabricated
+    alternatives.
+  - `sections::leading_whitespace` counted raw characters, so a single
+    leading tab (LVM's own indentation convention for these rows) measured
+    narrower than a heading written with two leading spaces — the
+    "content indented more than its heading" gate failed independently of
+    the point above. Now expands a leading tab to the next multiple of 8
+    columns (the ordinary terminal tab-stop convention), unchanged for the
+    fleet's dominant space-only-indentation case.
+
+  A fourth guard closes a hazard measured during review: not every
+  `[...]` row naming two flags is LVM's shape. `ethtool --help` writes
+  `[ --all-groups | --groups [eth-phy] [eth-mac] [eth-ctrl] [rmon] ]` — an
+  alternation between two *different* flags, only one of which carries its
+  own operands, not one flag with an alias list and a shared value.
+  `bracket_flag_row_content` refuses any row whose apparent alias run does
+  not actually end at its first whitespace gap (a bare `|` reappearing
+  there means the row is this shape), rather than fabricate
+  `--all-groups`'s value from `--groups`'s bracketed operands while
+  dropping `--groups` outright.
+
+  Recovers 19 flags for `vgck`, 30 for `vgextend`, 21 for `vgrename`, and
+  ~1,400 fleet-wide across the `lv*`/`vg*`/`pv*` family on a full-`PATH`
+  sweep, purely from the shape above — no tool name is ever consulted. The
+  tab-stop correction is general rather than LVM-specific and, measured on
+  the same sweep, also repaired a pre-existing, unrelated defect in three
+  `squashfs-tools` binaries and `sotruss`: a deeply-tab-indented
+  description-continuation line that happened to start with a dash after
+  trimming (`sotruss`'s `-o, --output` continuation literally reads `-f is
+  also used`) fell inside `scan_flags_block::ENTRY_INDENT_TOLERANCE` under
+  raw character counting and was misread as a new, fabricated flag entry;
+  the real terminal-column count does not. LVM's own help text never
+  describes an individual flag inline (only `--longhelp`/the man page
+  does), so every one of these tools' status honestly reads
+  `low-confidence` rather than `ok` once their real, correctly-spelled
+  flags are counted against that fact — a change in what the status ladder
+  can see, not a parsing regression.
 - **A layout-driven section parser** for `Options:`/`Flags:`/`Commands:` blocks.
   Group lines by leading-whitespace runs and indentation depth, so
   `-v, --verbose    Enable verbose output` tokenizes structurally as


### PR DESCRIPTION
## Summary

`vgck`, `vgextend`, `vgrename` (and the whole `lv*`/`vg*`/`pv*` LVM family)
rendered `verbatim` with zero flags. LVM's own help emitter writes a bare,
unlabelled synopsis head with no bracket notation of its own (`vgck` alone,
or `vgextend VG PV ...`) whose flags live entirely on continuation rows
shaped `[ -x|--long value ]`, plus a real `Common options for lvm:` heading
whose rows are the same shape, tab-indented under a two-space heading.

### Mechanism (three independent gaps, all fixed)

1. **Unlabelled-synopsis entry point required notation on the head line
   itself.** A bare `vgck` line carries none. Supplemented — only at this
   one call site — by a lookahead: a bare own-name line immediately
   followed by a `[ -x|--long ... ]`-shaped row also starts the block.
2. **`grammar::looks_like_flag_start` deliberately never accepts a leading
   `[`** — it doubles as the usage block's own continuation terminator, and
   widening it would end `lsof`'s usage continuation (`[-F [f]]`) one line
   early, losing six flags documented only there. A new, narrower,
   row-level predicate — `grammar::looks_like_bracket_flag_row` /
   `bracket_flag_row_content` — is consulted only where a flag-table row or
   a synopsis-continuation row is recognized (`flags_block_start`,
   `scan_flags_block`, `extract_usage_flags`), never at the
   usage-block-continuation call site. The recovered content is handed to
   the *existing* `parse_flag_spec` unchanged — no new value/alias parser
   was written; `|` is already an alias separator and its existing
   `alias_follows` guard (built for `sg_sanitize`'s `--count=OC|-c OC`)
   already reads `-A|--autobackup y|n`'s value as the whole choice list
   `y|n`, not three fabricated alternatives.
3. **`sections::leading_whitespace` counted raw characters**, so a single
   leading tab (LVM's own indentation convention for these rows) measured
   *narrower* than a heading written with two leading spaces — the "content
   indented more than its heading" gate failed structurally, independent of
   (2). Now expands a leading tab to the next multiple of 8 columns (the
   ordinary terminal tab-stop convention); byte-for-byte unchanged for the
   fleet's dominant space-only-indentation case.

A fourth guard closes a hazard found during review: `ethtool --help` writes
`[ --all-groups | --groups [eth-phy] [eth-mac] [eth-ctrl] [rmon] ]` — an
alternation between two *different* flags, only one of which carries
operands, not LVM's "one flag, aliases, one shared value" shape. Naively
parsing it reads `--all-groups` as carrying `eth-phy` and drops `--groups`
outright. `bracket_flag_row_content` now refuses any row whose alias run
doesn't actually end at its first whitespace gap (a bare `|` reappearing
there means it's this shape), so nothing is fabricated — the row is simply
left unread, exactly as before this PR.

### Fleet numbers

Full-`PATH` sweep, before → after (`after-colon2.txt` → fresh sweep):

- **verbatim**: 298 → 262 (−36; the task's stated starting figure of 314 is
  from an earlier baseline before the colon-separator PR landed)
- **low-confidence**: 50 → 97 (+47)
- **ok**: 1936 → 1925 (−11, see below)
- **total flags fleet-wide**: 50,564 → 51,965 (**+1,401 net**)
- **flag-count losses: 0 real losses.** 7 flags "lost" across 4 tools
  (`unsquashfs` −3, `mksquashfs` −2, `sotruss` −1, `sqfstar` −1) — every one
  is a **duplicate/garbled entry disappearing**, not information lost. All
  four wrap a flag's description onto a tab-indented continuation line that
  happens to start with a dash after trimming (e.g. `sotruss`'s `-o,
  --output`'s description continues "`-f is also used) instead of...`").
  Under raw-character tab counting this fell inside
  `scan_flags_block::ENTRY_INDENT_TOLERANCE` and was misread as a **new,
  fabricated flag** (`sotruss` had a phantom `-f` carrying the literal value
  `is`); the real terminal-column count puts it well outside tolerance, so
  it now correctly continues the previous entry's description instead. The
  real `-f, --follow` flag is untouched in both states; `-o, --output`'s
  description is now the *complete* text instead of truncated at "in case".
  Verified by direct before/after parse comparison for `sotruss` and
  `unsquashfs`; `mksquashfs`/`sqfstar` are the same codebase
  (squashfs-tools) and show the identical shape. A regression test
  (`tab_indented_continuation_does_not_fabricate_a_flag`) locks this in.
- **`ethtool`: fully back to baseline (48 → 48), not in the diff at all.**
  Its `--all-groups`/`--groups` row is now refused outright rather than
  fabricating one flag's value from the other's operands — this was a real
  regression during development, fixed before this PR (see guard above,
  and `bracket_row_with_a_second_alternatives_operands_is_refused` /
  `ethtool_keeps_both_alternatives_unread_rather_than_fabricating`).
- **`lsof`: unchanged at 39 flags** — confirmed the shared-predicate trap
  was avoided (`looks_like_flag_start` was never widened).
- **`ok` → `low-confidence` for 11 tools** (`adduser`, `c++filt`, `dmsetup`,
  `dmstats`, `gpgrt-config`, `libgcrypt-config`, `lvconvert`, `lvcreate`,
  `lvextend`, `lvreduce`, `lvresize`) **is honest, not a defect.** All 11
  *gain* real, correctly-spelled flags (e.g. `lvcreate` 3→138,
  `lvconvert` 4→117) and lose none. LVM's own emitter — and, for
  `c++filt`/`dmsetup`/etc., the same general bracket-row shape recovered in
  binutils/other tools — never documents an individual flag's description
  inline (only `--longhelp`/the man page does), so once these newly-real
  flags are counted against `pct_flags_with_text`, the coarse status ladder
  correctly reports `low-confidence` (< 50% described) instead of the
  previous *vacuous* `ok` (0 describable flags before, so the ratio didn't
  exist to fail). This is the status ladder seeing more of the truth, not
  the parser getting less correct — no flag identity, spelling, alias, or
  value was lost for any of these 11 tools. Whether `STATUS_LADDER` should
  treat a source-verified absence of description differently from an
  unattributed one is a scoring-policy question outside this PR's scope
  (AGENTS.md's own "fix the scoring, not the check" principle, applied to
  the flip side here).
- Existence-fabrication count: I did not find a dedicated counter emitted
  by `xtask coverage`/`sweep-diff` to quote a before/after number for. By
  construction this fix cannot raise it: the two operand cross-references
  LVM writes in the identical bracket notation (`[ COMMON_OPTIONS ]`, no
  dash at all; `[ VG|Tag ... ]` / `[ VG PV ... ]`, positionals) are
  correctly refused by `bracket_flag_row_content`'s "content must start
  with `-`" rule and never read as flags — asserted directly by
  `vgck_never_fabricates_a_flag_from_an_operand_bracket`.

### Corpus

`corpus/vgck/audit-seed2`, `corpus/vgextend/audit-seed2`,
`corpus/vgrename/audit-seed2` already existed as `[xfail] reason =
"verbatim"` fixtures from an earlier audit. Promoted (removed `[xfail]`,
added `expected.snap`, spot-check `must_contain_flags`, `min_status =
"low-confidence"` — matching the honest status explanation above, not
`"ok"`). `xtask corpus`: 104 fixtures, 94 ok, 10 xfail (as expected), 0
failed.

## See it yourself

```console
# Before this branch (main @ ae1be33): verbatim, 0 flags
$ mandible --doctor vgck
...
tiers:
  help_text                    ok
nodes:      1
flags:      0 (— flags with text)

# After this branch
$ mandible --doctor vgck
...
flags:      19 (0.0% flags with text)
$ mandible --doctor vgextend
...
flags:      30 (0.0% flags with text)
$ mandible --doctor vgrename
...
flags:      21 (0.0% flags with text)

# Full flag list, grouped correctly under "Common options for lvm:"
$ mandible vgck
$ mandible vgextend

# ethtool did not regress
$ mandible --doctor ethtool   # flags: 48, unchanged

# lsof did not regress (the shared-predicate trap this fix explicitly avoids)
$ mandible --doctor lsof      # flags: 39, unchanged

# Tests
$ cargo nextest run -p mandible-extract
$ cargo run -p xtask -- corpus
```

What to look for in `mandible vgck`/`mandible vgextend`: the FLAGS pane
lists `--reportformat basic|json` (recovered from the synopsis
continuation) and then, under a `COMMON OPTIONS FOR LVM` group heading, all
18 rows from that block — `-d, --debug`, `--commandprofile String`,
`--driverloaded y|n`, etc. — each with the right short/long spelling and
value shape, none of them carrying a description (LVM's `--help` never
supplies one for these).

## Screenshots

### Before (main @ ae1be33) — `mandible vgck`

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ vgck ────────────────────────────────────────────────────╮
│  vgck                                                    ││ unparsed — showing raw --help output                     │
│                                                          ││                                                          │
│                                                          ││ vgck - Check the consistency of volume group(s)          │
│                                                          ││                                                          │
│                                                          ││ Read and display information about a VG.                 │
│                                                          ││ vgck                                                     │
│                                                          ││ [ --reportformat basic|json ]                            │
│                                                          ││ [ COMMON_OPTIONS ]                                       │
│                                                          ││ [ VG|Tag ... ]                                           │
│                                                          ││                                                          │
│                                                          ││ Rewrite VG metadata to correct problems.                 │
│                                                          ││ vgck --updatemetadata VG                                 │
│                                                          ││ [ COMMON_OPTIONS ]                                       │
│                                                          ││                                                          │
│                                                          ││ Common options for lvm:                                  │
│                                                          ││ [ -d|--debug ]                                           │
│                                                          ││ [ -h|--help ]                                            │
│                                                          ││ [ -q|--quiet ]                                           │
│                                                          ││ [ -v|--verbose ]                                         │
│                                                          ││ [ -y|--yes ]                                             │
│                                                          ││ [ -t|--test ]                                            │
│                                                          ││ [ --commandprofile String ]                              │
│                                                          ││ [ --config String ]                                      │
│                                                          ││ [ --driverloaded y|n ]                                   │
│                                                          ││ [ --nolocking ]                                          │
│                                                          ││ [ --lockopt String ]                                     │
│                                                          ││ [ --longhelp ]                                           │
│                                                          ││ [ --profile String ]                                     │
│                                                          ││ [ --version ]                                            │
│                                                          ││ [ --devicesfile String ]                                 │
│                                                          ││ [ --devices PV ]                                         │
│                                                          ││ [ --nohints ]                                            │
│                                                          ││ [ --journal String ]                                     │
│                                                          ││                                                          │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

### After — `mandible vgck`

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ vgck ────────────────────────────────────────────────────╮
│  vgck                                                    ││ USAGE ────────────────────────────────────────────────── │
│                                                          ││   vgck [ --reportformat basic|json ] [ COMMON_OPTIONS ]  │
│                                                          ││   [ VG|Tag ... ]                                         │
│                                                          ││                                                          │
│                                                          ││ FLAGS ────────────────────────────────────────────────── │
│                                                          ││   --reportformat basic|json                              │
│                                                          ││ COMMON OPTIONS FOR LVM                                   │
│                                                          ││   -d, --debug                                            │
│                                                          ││   -h, --help                                             │
│                                                          ││   -q, --quiet                                            │
│                                                          ││   -v, --verbose                                          │
│                                                          ││   -y, --yes                                              │
│                                                          ││   -t, --test                                             │
│                                                          ││   --commandprofile String                                │
│                                                          ││   --config String                                        │
│                                                          ││   --driverloaded y|n                                     │
│                                                          ││   --nolocking                                            │
│                                                          ││   --lockopt String                                       │
│                                                          ││   --longhelp                                             │
│                                                          ││   --profile String                                       │
│                                                          ││   --version                                              │
│                                                          ││   --devicesfile String                                   │
│                                                          ││   --devices PV                                           │
│                                                          ││   --nohints                                              │
│                                                          ││   --journal String                                       │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
│                                                          ││                                                          │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

### After — `mandible vgextend`

```
========================================================================================================================
### startup
========================================================================================================================
╭ search [names]  (/ switches) ────────────────────────────────────────────────────────────────────────────────────────╮
│›                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (1) ────────────────────────────────────────────╮╭ vgextend ────────────────────────────────────────────────╮
│  vgextend                                                ││ USAGE ────────────────────────────────────────────────── │
│                                                          ││   vgextend VG PV ... [ -A|--autobackup y|n ] [           │
│                                                          ││   -f|--force ] [ -Z|--zero y|n ] [ -M|--metadatatype     │
│                                                          ││   lvm2 ] [ --labelsector Number ] [ --metadatasize       │
│                                                          ││   Size[m|UNIT] ] [ --pvmetadatacopies 0|1|2 ] [          │
│                                                          ││   --metadataignore y|n ] [ --dataalignment Size[k|UNIT]  │
│                                                          ││   ] [ --dataalignmentoffset Size[k|UNIT] ] [             │
│                                                          ││   --reportformat basic|json ] [ --restoremissing ] [     │
│                                                          ││   COMMON_OPTIONS ]                                       │
│                                                          ││                                                          │
│                                                          ││ FLAGS ────────────────────────────────────────────────── │
│                                                          ││   -A, --autobackup y|n                                   │
│                                                          ││   -f, --force                                            │
│                                                          ││   -Z, --zero y|n                                         │
│                                                          ││   -M, --metadatatype lvm2                                │
│                                                          ││   --labelsector Number                                   │
│                                                          ││   --metadatasize Size[m|UNIT]                            │
│                                                          ││   --pvmetadatacopies 0|1|2                               │
│                                                          ││   --metadataignore y|n                                   │
│                                                          ││   --dataalignment Size[k|UNIT]                           │
│                                                          ││   --dataalignmentoffset Size[k|UNIT]                     │
│                                                          ││   --reportformat basic|json                              │
│                                                          ││   --restoremissing                                       │
│                                                          ││ COMMON OPTIONS FOR LVM                                   │
│                                                          ││   -d, --debug                                            │
│                                                          ││   -h, --help                                             │
│                                                          ││   -q, --quiet                                            │
│                                                          ││   -v, --verbose                                          │
│                                                          ││   -y, --yes                                              │
│                                                          ││   -t, --test                                             │
│                                                          ││   --commandprofile String                                │
│                                                          ││   --config String                                        │
│                                                          ││   --driverloaded y|n                                     │
│                                                          ││   --nolocking                                            │
│                                                          ││   --lockopt String                                       │
│                                                          ││   --longhelp                                             │
│                                                          ││   --profile String                                       │
│                                                          ││   --version                                              │
│                                                          ││   --devicesfile String                                   │
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    Esc back    y copy    ? help    ^C quit           help-text
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiH6dj1daVzcgyprKa39Nf
