### PR TITLE
fix(existence): teach the oracle three synopsis-entry shapes the parser already knows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- **The existence-fabrication oracle could not see three synopsis-entry
+  shapes the parser itself already recognized, and reported the operands
+  it correctly recovered from them as invented.** Measurement fix, not a
+  parser fix: `xtask/src/existence.rs`'s `synopsis_lines` learned the same
+  three entry points `mandible-extract`'s help-text tier already opens a
+  usage block on — the C `fprintf(stderr, "%s: Usage: ...", argv[0])`
+  idiom (`nfsidmap: Usage: nfsidmap [-vh] ...`), an **unlabelled** synopsis
+  with no `usage:` marker anywhere (`gh`'s bare `USAGE` heading followed by
+  `gh <command> <subcommand> [flags]`), and LVM's bare own-name line whose
+  notation sits on the *next* physical line instead (`vgextend VG PV ...`
+  followed by `[ -A|--autobackup y|n ]`) — by re-exporting and reusing the
+  parser's own predicates rather than restating them (`mandible-extract/
+  src/help_text/mod.rs`'s re-export block). Also fixed `existence::
+  option_list_slot`, whose position-only placeholder rule read a genuine
+  leading operand as invented the moment a synopsis's real flag-list
+  stand-in sat *last* rather than first (`gh`'s trailing `[flags]`): the
+  rule is now vocabulary-first (the parser's own `OPTION_LIST_PLACEHOLDERS`
+  five-word list, reused rather than restated), falling back to the
+  position rule only when nothing on the line already matched it. On a
+  full-`PATH` sweep this closed 103 of a 154-tool existence-fabrication
+  count down to 52 — below the round's own 66-tool starting point, since
+  14 tools flagged even before this round's parser work turned out to be
+  the same instrument gap — with zero remaining tools newly fabricating
+  relative to that starting point. `xtask detector self-check --detector
+  existence` (9 hand-built cases; this family has no labelled member in
+  the audit, so self-check is its only calibration evidence) and
+  `xtask corpus` both stay green.
+
 - **A short flag's abbreviation-continuation bracket (`ip --help`'s
   `-V[ersion]`, `-s[tatistics]`, `-f[amily]`, `-h[uman-readable]`, ...)
   was read as a fabricated optional value.** `-V[ersion]` came out as `-V`

--- a/mandible-extract/src/help_text/mod.rs
+++ b/mandible-extract/src/help_text/mod.rs
@@ -84,14 +84,78 @@ pub use sections::strip_optional_modifier_suffix;
 /// (`sections::parse_with_profile`); a second copy of "does this line say
 /// usage" would be one more predicate free to drift past a fix.
 ///
+/// Also carries the two entry shapes PR #32/#33 taught this tier to open a
+/// usage block on *without* an ordinary `usage:` marker anywhere on the
+/// line: [`sections::starts_with_name_prefixed_usage`] (the C
+/// `fprintf(stderr, "%s: Usage: ...", argv[0])` idiom — `nfsidmap: Usage:
+/// nfsidmap [-vh] ...`) and [`sections::looks_like_unlabeled_synopsis_line`]
+/// (a bare `USAGE` heading or no heading at all, with the synopsis itself
+/// opening with the tool's own name — `gh`'s `USAGE` / `  gh <command>
+/// <subcommand> [flags]`). Before this pair was added here, the oracle could
+/// not see the line either shape's operands came from, so a synopsis the
+/// parser now correctly recovers from one of them reported its own
+/// perfectly real operands as invented — measured fleet-wide as 94 tools on
+/// this task's own before/after sweep (`gh`, `busctl`, `journalctl`,
+/// `pidof`, ...), all false, all this exact instrument gap rather than a
+/// parser defect. Not reimplementing a second copy of either predicate is
+/// the whole point, per the same reasoning as the pair above.
+///
 /// What the oracle does **not** borrow is the block-continuation rule — how
 /// far past the marker line the synopsis runs. That is deliberately the
 /// oracle's own, wider, decision: it reads every indented line under a bare
 /// `Usage:` header, where this tier applies `looks_like_usage_fragment` and
 /// an indent ladder. A wider read can only *attest* more, i.e. report less,
 /// so the difference is safe in the one direction an oracle's difference has
-/// to be safe in.
-pub use sections::{starts_with_or_marker, starts_with_usage_prefix};
+/// to be safe in. The same argument extends to the unlabelled shape: the
+/// oracle does not bound its search to the lines before the document's body
+/// starts the way this tier's own `unlabelled_synopsis_start` does — a
+/// match found later in the document can only add an attested operand
+/// position, never remove one, so skipping that bound is safe in the same
+/// direction.
+pub use sections::{
+    looks_like_unlabeled_synopsis_line, starts_with_name_prefixed_usage, starts_with_or_marker,
+    starts_with_tool_name, starts_with_usage_prefix,
+};
+
+/// Re-exported for `xtask/src/existence.rs`, alongside
+/// [`looks_like_unlabeled_synopsis_line`] above: LVM's own emitter
+/// (`vgck`, `vgextend`, `vgrename`, and every other `vg*`/`lv*`/`pv*`
+/// command) writes a *bare* invocation line with no docopt notation on it
+/// at all — `vgextend VG PV ...`, no `[`, `<` or `{` anywhere — so
+/// `looks_like_unlabeled_synopsis_line`'s own notation test can never find
+/// it; every bit of bracket notation is on the *next* line instead
+/// (`\t[ -A|--autobackup y|n ]`). This tier's own usage-block entry point
+/// accepts a bare own-name line on exactly that evidence — the following
+/// physical line reading as unambiguous flag-row notation
+/// (`grammar::looks_like_bracket_flag_row`) — and the oracle has to open on
+/// the identical evidence, or every one of this family's real operands
+/// (`VG`, `PV`, ...) is invisible to it the same way `gh`'s were before
+/// `starts_with_name_prefixed_usage`/`looks_like_unlabeled_synopsis_line`
+/// were re-exported: measured fleet-wide as 29 tools on this task's own
+/// before/after sweep, the entire `vg*`/`lv*`/`pv*` family, all false.
+pub use grammar::looks_like_bracket_flag_row;
+
+/// Re-exported for `xtask/src/existence.rs`'s `option_list_slot`, and for
+/// the same drift reason as the block above: `sections::extract_positionals`
+/// excludes a token from the tree wherever in a synopsis line it sits, by
+/// this exact vocabulary (`sections::OPTION_LIST_PLACEHOLDERS`) — not only
+/// when it happens to be the line's first slot. The oracle's own
+/// `option_list_slot` additionally applies a *positional* shape rule (its
+/// own doc comment has the reasoning for why an oracle prefers shape over
+/// vocabulary as its primary signal), but a shape rule alone disagreed with
+/// this tier the moment an unlabelled synopsis put a real leading operand
+/// where the shape rule expected a placeholder: `gh`'s `<command>
+/// <subcommand> [flags]` names its actual flag stand-in *last*
+/// (`[flags]`, this exact vocabulary), not first, and the shape rule alone
+/// read `command` as the placeholder and `flags` as a real operand —
+/// backwards on both counts. Layering this vocabulary check on top (never in
+/// place of the shape rule, which still fires unconditionally for a
+/// non-vocabulary word like `pkgconf`'s `OPTIONS`) closes exactly that gap
+/// without asking the oracle to agree with the parser everywhere: a
+/// fabrication spelled with a word outside this five-word list is still
+/// caught by the shape rule or by the oracle's ordinary "does it occur at
+/// all" check, whichever applies.
+pub use sections::is_option_list_placeholder;
 
 use crate::errors::ExtractError;
 use crate::exec::{ExecOutput, InertArgv, LiveProbe, Probe};

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -2062,7 +2062,7 @@ pub fn starts_with_or_marker(t: &str) -> bool {
 /// Word-boundary checked (via `str::strip_prefix`, not a raw byte slice)
 /// so a tool named `git` doesn't also claim a line that happens to start
 /// with `gitk` or `git-foo`.
-fn starts_with_tool_name(t: &str, name: &str) -> bool {
+pub fn starts_with_tool_name(t: &str, name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
@@ -2088,7 +2088,7 @@ fn starts_with_tool_name(t: &str, name: &str) -> bool {
 /// not scanned for anywhere inside the line, and not satisfied by the
 /// name alone (an ordinary sentence starting `nfsidmap: ` followed by
 /// prose must never match).
-fn starts_with_name_prefixed_usage(t: &str, name: &str) -> bool {
+pub fn starts_with_name_prefixed_usage(t: &str, name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
@@ -2122,7 +2122,7 @@ fn starts_with_name_prefixed_usage(t: &str, name: &str) -> bool {
 ///
 /// Measured on a full-`PATH` sweep before landing (see this fix's PR
 /// description for the exact tool list this predicate moves).
-fn looks_like_unlabeled_synopsis_line(t: &str, name: &str) -> bool {
+pub fn looks_like_unlabeled_synopsis_line(t: &str, name: &str) -> bool {
     let Some(rest) = t.strip_prefix(name) else {
         return false;
     };
@@ -5678,7 +5678,7 @@ pub(super) const OPTION_LIST_PLACEHOLDERS: &[&str] =
 
 /// True when `name` (already unwrapped from its notation) is one of
 /// [`OPTION_LIST_PLACEHOLDERS`].
-fn is_option_list_placeholder(name: &str) -> bool {
+pub fn is_option_list_placeholder(name: &str) -> bool {
     OPTION_LIST_PLACEHOLDERS
         .iter()
         .any(|p| name.eq_ignore_ascii_case(p))

--- a/spec.md
+++ b/spec.md
@@ -1313,6 +1313,49 @@ The generic fallback parser (step 2) is built with `winnow`:
   `low-confidence` rather than `ok` once their real, correctly-spelled
   flags are counted against that fact — a change in what the status ladder
   can see, not a parsing regression.
+- **The existence oracle learned the three synopsis-entry shapes the three
+  fixes above taught the parser** (fix/oracle-unlabeled-synopsis). A
+  measurement fix, not a parser fix: `xtask/src/existence.rs`'s
+  `synopsis_lines` scanned for only an ordinary `usage:`/`or:` marker, so
+  every operand the parser now correctly recovers from a line without one
+  — the C `"%s: Usage: ..."` idiom, an unlabelled synopsis opening with the
+  tool's own name, and LVM's bare own-name line whose notation sits on the
+  next physical line — was reported as invented, exactly the gap the
+  `fix/colon-separator` bullet above named by hand
+  (`dbus-cleanup-sockets`/`dbus-run-session`/`lvreduce`, "the oracle cannot
+  yet attest"). The oracle now re-exports and reuses the parser's own three
+  predicates (`starts_with_name_prefixed_usage`,
+  `looks_like_unlabeled_synopsis_line`, `starts_with_tool_name` +
+  `looks_like_bracket_flag_row`) rather than a second, drifting copy of
+  each — `mandible-extract/src/help_text/mod.rs`'s re-export block carries
+  the rationale each time, the same discipline this project has already
+  paid once for skipping (spec §13.1c's K2 table).
+
+  A second, independent bug surfaced only once these lines became visible:
+  `option_list_slot`'s placeholder rule looked only at a synopsis's *first*
+  slot, which is where every previously-measured tool's flag-list stand-in
+  happened to sit. `gh`'s unlabelled `<command> <subcommand> [flags]` puts
+  its stand-in *last* — the rule would have excluded the genuine leading
+  operand `command` as a *second*, wrong placeholder had it fired
+  unconditionally alongside the correct exclusion of `flags`. Fixed by
+  trying the parser's own five-word vocabulary
+  (`sections::OPTION_LIST_PLACEHOLDERS`, reused via a new
+  `is_option_list_placeholder` re-export) first, regardless of position,
+  and falling back to the positional rule only when nothing on the line
+  already matched it — never both at once.
+
+  Measured on a full-`PATH` sweep: 154 → 52 existence-fabrication tools,
+  below the round's own 66-tool starting point (14 tools flagged even
+  before `fix/usage-synopsis`/`fix/colon-separator`/`fix/lvm-bracket-rows`
+  landed turned out to be the identical instrument gap), with the tool set
+  newly fabricating relative to that starting point empty — every
+  fabrication this round's parser work appeared to add was this gap, not a
+  real invention. Zero flag, subcommand, or status movement on the same
+  sweep, as expected of a change confined to `xtask`. This detector has no
+  labelled member in the audit (spec §13.1e: "not one reviewer reported a
+  fabricated subcommand or flag spelling"), so its 9 hand-built self-check
+  cases (`xtask detector self-check --detector existence`) are its only
+  calibration evidence, not a fleet-wide confusion matrix.
 - **A layout-driven section parser** for `Options:`/`Flags:`/`Commands:` blocks.
   Group lines by leading-whitespace runs and indentation depth, so
   `-v, --verbose    Enable verbose output` tokenizes structurally as

--- a/xtask/src/detector.rs
+++ b/xtask/src/detector.rs
@@ -1401,6 +1401,39 @@ const TAR_SYNOPSIS: &str = "Usage: tar [OPTION...] [FILE]...\n";
 const UOBJNEW_SYNOPSIS: &str =
     "usage: uobjnew [-h] [-l {c,java,ruby,tcl}] [-C TOP_COUNT] [-v] pid [interval]\n";
 
+/// `gh --help`'s real shape, byte-exact: a bare `USAGE` heading (no colon,
+/// so it is never a labelled `usage:` marker) followed by a line that opens
+/// with the tool's own name and reads as usage grammar with no marker
+/// anywhere — the **unlabelled** synopsis this task's own fix taught the
+/// oracle to enter. Its trailing `[flags]` is also the anchor case for the
+/// vocabulary fallback in `existence::option_list_slot`: the real flag
+/// stand-in sits *last* here, not first, which is exactly the shape that
+/// would have tripped the position rule into also excluding the genuine
+/// leading operand `command` if the two rules ran unconditionally instead
+/// of one gating the other.
+const GH_UNLABELLED_SYNOPSIS: &str = "USAGE\n  gh <command> <subcommand> [flags]\n";
+
+/// `nfsidmap --help`'s real shape, byte-exact: the C `fprintf(stderr, "%s:
+/// Usage: ...", argv[0])` idiom, which repeats the tool's own name twice on
+/// one line (once as the `fprintf` prefix, once again as the invocation's
+/// own program name) with no ordinary `usage:`-prefixed line anywhere else
+/// in the document.
+const NFSIDMAP_NAME_PREFIXED_SYNOPSIS: &str = "nfsidmap: Usage: nfsidmap [-vh] [-c || -d] path\n";
+
+/// `vgextend --help`'s real shape, byte-exact: LVM's own bare-own-name
+/// convention (the whole `vg*`/`lv*`/`pv*` family shares it) — no docopt
+/// notation anywhere on the invocation line itself, only on the line right
+/// after it. The entire family (29 tools) was newly flagged on this task's
+/// own before/after sweep until this shape was added, every one of them
+/// false.
+const VGEXTEND_BARE_OWN_NAME_SYNOPSIS: &str = concat!(
+    "  vgextend - Add physical volumes to a volume group\n",
+    "\n",
+    "  vgextend VG PV ...\n",
+    "\t[ -A|--autobackup y|n ]\n",
+    "\t[ COMMON_OPTIONS ]\n",
+);
+
 /// A root carrying `positionals` with the given names, all help-text-sourced.
 fn positional_node(name: &str, positionals: &[&str]) -> CommandNode {
     let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
@@ -1467,6 +1500,56 @@ fn existence_self_checks() -> Vec<SelfCheck> {
             expect: Expect::Fires(1),
             raw: TAR_SYNOPSIS.to_string(),
             root: positional_node("tar", &["TELEPORT"]),
+        },
+        SelfCheck {
+            name: "gh's two real operands from its unlabelled synopsis",
+            why: "this task's own worked example: `command` and `subcommand` are real, occur \
+                  literally in gh's own output, and sit one slot from `flags` — gh's own flag-list \
+                  stand-in, written *last* rather than first. Before this fix the line was entirely \
+                  invisible to the oracle (no `usage:` marker anywhere on it), so both were reported \
+                  as invented; after it, both must go silent and `flags` must not itself become an \
+                  attested operand hiding a genuine fabrication spelled the same way",
+            expect: Expect::Silent,
+            raw: GH_UNLABELLED_SYNOPSIS.to_string(),
+            root: positional_node("gh", &["command", "subcommand"]),
+        },
+        SelfCheck {
+            name: "an operand named nowhere beside gh's real unlabelled synopsis",
+            why: "the same base claim as tar's TELEPORT case, replayed against the new unlabelled \
+                  entry point: recognizing gh's synopsis line must not turn into a blanket amnesty \
+                  for anything claimed beside it",
+            expect: Expect::Fires(1),
+            raw: GH_UNLABELLED_SYNOPSIS.to_string(),
+            root: positional_node("gh", &["command", "teleport"]),
+        },
+        SelfCheck {
+            name: "nfsidmap's real operand from the name-prefixed usage idiom",
+            why: "the C `\"%s: Usage: ...\"` convention (`nfsidmap: Usage: nfsidmap ...`), the \
+                  other synopsis-entry shape this task's fix adds: the tool's own name occurs \
+                  twice on one line, and `path` — the real operand — must still attest correctly \
+                  once both copies are accounted for",
+            expect: Expect::Silent,
+            raw: NFSIDMAP_NAME_PREFIXED_SYNOPSIS.to_string(),
+            root: positional_node("nfsidmap", &["path"]),
+        },
+        SelfCheck {
+            name: "vgextend's two real operands from its bare own-name line",
+            why: "LVM's own convention: the invocation line carries no docopt notation at all, so \
+                  the unlabelled shape above can never find it — only the next physical line's \
+                  bracketed flag row proves it is usage grammar. Newly flagged the whole `vg*`/ \
+                  `lv*`/`pv*` family (29 tools) on this task's own before/after sweep until this \
+                  shape was added, every one of them false",
+            expect: Expect::Silent,
+            raw: VGEXTEND_BARE_OWN_NAME_SYNOPSIS.to_string(),
+            root: positional_node("vgextend", &["VG", "PV"]),
+        },
+        SelfCheck {
+            name: "an operand named nowhere beside vgextend's real bare own-name line",
+            why: "the same base claim replayed a third time: recognizing this entry shape must not \
+                  turn into a blanket amnesty for anything claimed beside it",
+            expect: Expect::Fires(1),
+            raw: VGEXTEND_BARE_OWN_NAME_SYNOPSIS.to_string(),
+            root: positional_node("vgextend", &["VG", "TELEPORT"]),
         },
     ]
 }

--- a/xtask/src/existence.rs
+++ b/xtask/src/existence.rs
@@ -553,9 +553,30 @@ struct SynopsisLine<'a> {
     opens_with_program_name: bool,
 }
 
+/// True when some physical line of `raw` opens a **labelled** usage block —
+/// an ordinary `usage:` marker, or the C `"%s: Usage: ..."` idiom
+/// (`starts_with_name_prefixed_usage`) — anywhere in the document.
+///
+/// Mirrors `sections::parse_with_profile`'s own `labelled_usage_start`
+/// exactly, including what it deliberately leaves out: `starts_with_or_marker`
+/// (`or:`) is not tested here, because an `or:` line is only ever a
+/// *continuation* of an already-open block, never itself evidence that a
+/// labelled block exists somewhere in the document. This is the gate that
+/// decides whether [`synopsis_lines`] may fall back to an **unlabelled**
+/// synopsis line at all — a tool with a real `usage:`/name-prefixed line
+/// anywhere is completely unaffected by that fallback, exactly as the tier
+/// itself is unaffected.
+fn has_labelled_usage_start(raw: &str, root_name: &str) -> bool {
+    use mandible_extract::help_text::{starts_with_name_prefixed_usage, starts_with_usage_prefix};
+    raw.lines().any(|l| {
+        let t = l.trim_start();
+        starts_with_usage_prefix(t) || starts_with_name_prefixed_usage(t, root_name)
+    })
+}
+
 /// The physical lines of `raw` that are a synopsis.
 ///
-/// Three shapes, all real and all in this project's own corpus:
+/// Five shapes, all real and all in this project's own corpus:
 ///
 /// * the marker and the synopsis on one line — `Usage: tar [OPTION...]
 ///   [FILE]...`, `  or:  du [OPTION]... --files0-from=F`;
@@ -568,23 +589,56 @@ struct SynopsisLine<'a> {
 ///   ([`is_bracketed`], the same three bytes the tier's own
 ///   `looks_like_usage_fragment` tests), which is what keeps the ordinary
 ///   indented *prose* under a usage line — `du`'s "Summarize device usage
-///   of the set of FILEs..." — from being read as more synopsis; and
+///   of the set of FILEs..." — from being read as more synopsis;
 /// * a bare `Usage:` header with the synopsis indented beneath it, which is
 ///   util-linux's house style (`setsid`, `wall`, `fsck`) and `zoxide`'s.
 ///   Every consecutive indented non-empty line under such a header is
 ///   taken, delimiter or not, because the continuation there begins with
-///   the tool's own name rather than with notation.
+///   the tool's own name rather than with notation; and
+/// * two shapes with **no `usage:` marker anywhere on their own line**,
+///   taught to `mandible-extract` by PR #32/#33 and, until now, invisible
+///   to this module entirely: the C `"%s: Usage: ..."` idiom
+///   (`starts_with_name_prefixed_usage` — `nfsidmap: Usage: nfsidmap [-vh]
+///   ...`) and an **unlabelled** synopsis, a line that simply opens with the
+///   tool's own name and reads as usage grammar
+///   (`looks_like_unlabeled_synopsis_line` — `gh`'s bare `USAGE` heading
+///   followed by `  gh <command> <subcommand> [flags]`). The unlabelled
+///   shape is only ever tried when [`has_labelled_usage_start`] finds no
+///   ordinary labelled block anywhere in the document, matching the tier's
+///   own precedence exactly. Unlike the tier, this module does not further
+///   bound the unlabelled search to the lines before the document's body
+///   starts — a match found later can only *add* an attested operand
+///   position, never remove one, so the narrower bound is safe to skip (see
+///   the re-export's own doc comment in `mandible-extract/src/help_text/
+///   mod.rs`); and
+/// * a **bare own-name line whose notation sits on the next line instead**:
+///   LVM's own emitter (`vgck`, `vgextend`, `vgrename`, and the rest of the
+///   `vg*`/`lv*`/`pv*` family) writes `vgextend VG PV ...` with no `[`, `<`
+///   or `{` anywhere on that line at all, so `looks_like_unlabeled_synopsis_
+///   line`'s own notation test can never find it — every bit of bracket
+///   notation (`\t[ -A|--autobackup y|n ]`) is on the line right after.
+///   Recognized on the same evidence the tier itself requires
+///   (`starts_with_tool_name` plus [`looks_like_bracket_flag_row`] on the
+///   very next physical line), tried only under the same `try_unlabelled`
+///   gate as the shape above — never merely because some line, anywhere,
+///   happens to open with the tool's own name.
 ///
-/// The marker test itself is `mandible_extract::help_text`'s own
-/// (`starts_with_usage_prefix`/`starts_with_or_marker`, re-exported for this
-/// module) rather than a second copy — see that re-export's doc comment. The
-/// continuation rule *is* this module's own, and is deliberately wider than
-/// the tier's: every line this admits can only add to the attested set
-/// ([`attested_operand_positions`]), and a wider attested set can only make
-/// this oracle report less. An oracle may differ from the parser in that
-/// direction and not the other.
-fn synopsis_lines(raw: &str) -> Vec<SynopsisLine<'_>> {
-    use mandible_extract::help_text::{starts_with_or_marker, starts_with_usage_prefix};
+/// The marker tests themselves are `mandible_extract::help_text`'s own
+/// (`starts_with_usage_prefix`/`starts_with_or_marker`/
+/// `starts_with_name_prefixed_usage`/`looks_like_unlabeled_synopsis_line`/
+/// `starts_with_tool_name`/`looks_like_bracket_flag_row`, re-exported for
+/// this module) rather than a second copy — see that re-export's doc
+/// comment. The continuation rule *is* this module's own,
+/// and is deliberately wider than the tier's: every line this admits can
+/// only add to the attested set ([`attested_operand_positions`]), and a
+/// wider attested set can only make this oracle report less. An oracle may
+/// differ from the parser in that direction and not the other.
+fn synopsis_lines<'a>(raw: &'a str, root_name: &str) -> Vec<SynopsisLine<'a>> {
+    use mandible_extract::help_text::{
+        looks_like_bracket_flag_row, looks_like_unlabeled_synopsis_line,
+        starts_with_name_prefixed_usage, starts_with_or_marker, starts_with_tool_name,
+        starts_with_usage_prefix,
+    };
 
     /// What an indented line under an open usage block has to look like
     /// before it counts as more synopsis.
@@ -599,11 +653,33 @@ fn synopsis_lines(raw: &str) -> Vec<SynopsisLine<'_>> {
         NotationOnly,
     }
 
+    let try_unlabelled = !has_labelled_usage_start(raw, root_name);
+    let lines: Vec<&str> = raw.lines().collect();
     let mut out = Vec::new();
     let mut open = Continuation::None;
-    for line in raw.lines() {
+    for (idx, &line) in lines.iter().enumerate() {
         let trimmed = line.trim_start();
-        if starts_with_usage_prefix(trimmed) || starts_with_or_marker(trimmed) {
+        // LVM's own emitter (`vgck`, `vgextend`, `vgrename`, and the rest
+        // of the `vg*`/`lv*`/`pv*` family) writes a *bare* invocation line
+        // with no docopt notation on it at all (`vgextend VG PV ...`), so
+        // `looks_like_unlabeled_synopsis_line`'s own notation test can never
+        // find it — every bit of bracket notation is on the line that
+        // follows instead. Mirrors the tier's own fallback exactly: a bare
+        // own-name line is accepted only when the very next physical line
+        // is unambiguous flag-row evidence, never merely because a line
+        // happens to start with the tool's own name somewhere later in the
+        // document.
+        let is_bare_own_name_with_flag_row_next = try_unlabelled
+            && starts_with_tool_name(trimmed, root_name)
+            && lines
+                .get(idx + 1)
+                .is_some_and(|next| looks_like_bracket_flag_row(next.trim_start()));
+        let opens_block = starts_with_usage_prefix(trimmed)
+            || starts_with_or_marker(trimmed)
+            || starts_with_name_prefixed_usage(trimmed, root_name)
+            || (try_unlabelled && looks_like_unlabeled_synopsis_line(trimmed, root_name))
+            || is_bare_own_name_with_flag_row_next;
+        if opens_block {
             out.push(SynopsisLine {
                 text: line,
                 opens_with_program_name: true,
@@ -653,9 +729,29 @@ fn synopsis_lines(raw: &str) -> Vec<SynopsisLine<'_>> {
 /// genuine `PATTERN` operand immediately after a bracketed `[-e]`, and a
 /// value-consuming reader attests `PATTERN` nowhere and reports a real
 /// operand as invented.
-fn usage_operands<'a>(line: &SynopsisLine<'a>) -> (Vec<(&'a str, bool)>, bool) {
-    use mandible_extract::help_text::{starts_with_or_marker, starts_with_usage_prefix};
-    let trimmed = line.text.trim_start();
+///
+/// `root_name` is needed for exactly one shape: the C `"%s: Usage: ..."`
+/// idiom (`nfsidmap: Usage: nfsidmap [-vh] ...`), whose line carries the
+/// tool's own name *twice* — once as the `fprintf` prefix, once again after
+/// the embedded `usage:` marker, as a real invocation would repeat it. The
+/// prefix is stripped off first (`"<name>: "`, byte for byte, the exact
+/// substring [`mandible_extract::help_text::starts_with_name_prefixed_usage`]
+/// matched), which leaves an ordinary `Usage: nfsidmap [-vh] ...` line for
+/// every rule below to read unchanged — one strip rather than a parallel
+/// three-token consumption rule that would have to be kept in sync with it.
+fn usage_operands<'a>(line: &SynopsisLine<'a>, root_name: &str) -> (Vec<(&'a str, bool)>, bool) {
+    use mandible_extract::help_text::{
+        starts_with_name_prefixed_usage, starts_with_or_marker, starts_with_usage_prefix,
+    };
+    let trimmed_full = line.text.trim_start();
+    let trimmed = if starts_with_name_prefixed_usage(trimmed_full, root_name) {
+        trimmed_full
+            .strip_prefix(root_name)
+            .and_then(|rest| rest.strip_prefix(": "))
+            .unwrap_or(trimmed_full)
+    } else {
+        trimmed_full
+    };
     let mut tokens = trimmed.split_whitespace().peekable();
     if starts_with_usage_prefix(trimmed) || starts_with_or_marker(trimmed) {
         // The marker may be glued to the program name (`usage:git`) or
@@ -709,16 +805,17 @@ fn usage_operands<'a>(line: &SynopsisLine<'a>) -> (Vec<(&'a str, bool)>, bool) {
 /// — and this oracle saw every one of them and said nothing, because it did
 /// not look at positionals at all.
 ///
-/// # Why a shape rule and not a word list
+/// # Why a shape rule first, and a word list only on top
 ///
 /// The tier's own fix names the shape by its vocabulary
 /// (`sections::OPTION_LIST_PLACEHOLDERS`), which is the right call *there*:
 /// a parser deciding whether to emit must decide, and those five words are
 /// the ones the frameworks in the fleet actually use. An oracle must not
-/// share that list. A word list cannot tell you whether the parser is
-/// wrong, only whether it disagreed with the same list — and a fabrication
-/// spelled with a sixth word would be attested by both. So the rule here is
-/// positional, and it reads only shape:
+/// rely on that list *alone*: it cannot tell you whether the parser is
+/// wrong, only whether it disagreed with the same list — a fabrication
+/// spelled with a sixth word would be attested by both, and the primary
+/// rule below still has to cover that case on its own. So the primary rule
+/// here is positional, and it reads only shape:
 ///
 /// > On a synopsis line that writes **no literal flag of its own**, the
 /// > **first** slot is the option list — provided it is written in
@@ -749,12 +846,84 @@ fn usage_operands<'a>(line: &SynopsisLine<'a>) -> (Vec<(&'a str, bool)>, bool) {
 /// [FILE]...`) by clause 1. Both are under-reports, deliberately: this
 /// oracle's own standing rule is that a permissive miss costs a defect
 /// unfound while a false alarm blocks a working tool.
-fn option_list_slot<'a>(slots: &[(&'a str, bool)], has_literal_flag: bool) -> Option<&'a str> {
-    if has_literal_flag || slots.len() < 2 {
-        return None;
+///
+/// # The vocabulary addendum, and why it is additive rather than a rewrite
+///
+/// The positional rule above assumes the placeholder sits *first*, true of
+/// every case measured before this task and false of `gh`'s unlabelled
+/// `<command> <subcommand> [flags]` — a shape [`crate::existence`]'s own
+/// synopsis-entry fix (`mandible_extract::help_text::
+/// looks_like_unlabeled_synopsis_line`) only just made visible to this
+/// oracle at all. `gh`'s real flag stand-in is the *last* slot, and reading
+/// the positional rule alone would have excluded `command` (a real operand)
+/// as if it were the placeholder, while leaving `flags` (the actual
+/// placeholder) attested as if it were real — backwards on both counts.
+///
+/// So this function tries two tests, in a fixed order, not a blind union:
+///
+/// 1. A **vocabulary** test, applied regardless of position:
+///    [`mandible_extract::help_text::is_option_list_placeholder`], the exact
+///    five-word list `sections::extract_positionals` itself excludes on
+///    (`option`, `options`, `flag`, `flags`, `arguments`), re-used rather
+///    than restated for the drift reason that re-export's own doc comment
+///    gives. Scoped to a notation-written slot (`bracketed`) on purpose:
+///    this vocabulary family's whole reason to exist is a word that *looks*
+///    like a bare operand name while notation marks it as a placeholder
+///    instead, so a bare, unbracketed occurrence of one of these words is
+///    left alone as the ordinary operand it would otherwise be (nothing in
+///    the fleet measurement contradicts this; the anchor case, `vim`'s
+///    `[arguments]`, is always written bracketed).
+/// 2. Only when the vocabulary test found **nothing at all** on the line:
+///    the **positional** shape rule above (this function's own doc comment
+///    up to this point) — the first slot, when the line writes no literal
+///    flag of its own, it is written in notation, and something follows it.
+///
+/// The ordering is load-bearing, not cosmetic. Running both unconditionally
+/// double-counts the moment a real operand happens to sit first on a line
+/// whose *actual* placeholder is further along: `gh`'s unlabelled
+/// `<command> <subcommand> [flags]` has its real flag stand-in *last*
+/// (`flags`, caught by rule 1), but rule 2 alone would also read the
+/// genuine first operand `command` as *a second, wrong* placeholder if it
+/// ran unconditionally — reporting a real operand as invented is exactly
+/// the failure this whole module exists to prevent. Gating rule 2 on "rule
+/// 1 found nothing" is what keeps the two from ever answering the same
+/// question twice: every case measured in the fleet before this task
+/// (`tar`'s `OPTION`, `pkgconf`'s `OPTIONS`, `rmiregistry`'s `options`, ...)
+/// already matches the vocabulary case-insensitively, so rule 2 is pure
+/// insurance for a placeholder spelled with a word outside the five-word
+/// list — it has never yet had to fire *and* disagree with rule 1 on the
+/// same line, and this ordering guarantees it never will.
+///
+/// Returns every excluded slot's word, not just one, since a line can
+/// legitimately carry more than one vocabulary hit (rare, unmeasured, but
+/// nothing forbids a synopsis from repeating the word).
+fn option_list_slot<'a>(slots: &[(&'a str, bool)], has_literal_flag: bool) -> HashSet<&'a str> {
+    let mut placeholders = HashSet::new();
+    for (word, bracketed) in slots {
+        if *bracketed && mandible_extract::help_text::is_option_list_placeholder(word) {
+            placeholders.insert(*word);
+        }
     }
-    let (first, bracketed) = slots[0];
-    bracketed.then_some(first)
+    // The positional rule is a *fallback*, tried only when nothing on the
+    // line already matched the vocabulary above — never run unconditionally
+    // alongside it. Every real fleet case this rule was written for
+    // (`tar`'s `OPTION`, `pkgconf`'s `OPTIONS`, `vim`'s `arguments`, ...)
+    // already matches the vocabulary case-insensitively, so this branch is
+    // pure insurance against a placeholder spelled with a sixth word the
+    // vocabulary doesn't have — never a second vote alongside a vocabulary
+    // match that already named a *different* slot. Without this ordering,
+    // `gh`'s `<command> <subcommand> [flags]` triggers both rules at once:
+    // the vocabulary rule correctly excludes `flags` (the real placeholder,
+    // last), while the position rule — blind to which slot the vocabulary
+    // already answered for — would *also* exclude `command` (the first
+    // slot, and a genuine operand), reporting it as invented.
+    if placeholders.is_empty() && !has_literal_flag && slots.len() >= 2 {
+        let (first, bracketed) = slots[0];
+        if bracketed {
+            placeholders.insert(first);
+        }
+    }
+    placeholders
 }
 
 /// Every position in `raw` at which a genuine positional operand is
@@ -778,13 +947,13 @@ fn option_list_slot<'a>(slots: &[(&'a str, bool)], has_literal_flag: bool) -> Op
 /// nobody has bounded. The subtraction as written costs `du`'s `OPTION` a
 /// report whenever a second `or:` line re-attests it, and that is the trade
 /// this module takes every time.
-fn attested_operand_positions(raw: &str) -> HashSet<&str> {
+fn attested_operand_positions<'a>(raw: &'a str, root_name: &str) -> HashSet<&'a str> {
     let mut out = HashSet::new();
-    for line in synopsis_lines(raw) {
-        let (slots, has_literal_flag) = usage_operands(&line);
-        let placeholder = option_list_slot(&slots, has_literal_flag);
+    for line in synopsis_lines(raw, root_name) {
+        let (slots, has_literal_flag) = usage_operands(&line, root_name);
+        let placeholders = option_list_slot(&slots, has_literal_flag);
         for (word, _) in &slots {
-            if Some(*word) != placeholder {
+            if !placeholders.contains(word) {
                 out.insert(*word);
             }
         }
@@ -1103,7 +1272,7 @@ fn walk(
 /// checked like any other node's.
 pub fn detect(raw: &str, root: &CommandNode) -> ExistenceReport {
     let attested = attested_name_positions(raw, &root.name);
-    let operands = attested_operand_positions(raw);
+    let operands = attested_operand_positions(raw, &root.name);
     let mut fabrications = Vec::new();
     walk(
         root,
@@ -2054,7 +2223,7 @@ mod tests {
     #[test]
     fn the_option_list_slot_is_never_an_attested_operand() {
         for (raw, placeholder, operand) in PLACEHOLDER_PAIRS {
-            let attested = attested_operand_positions(raw);
+            let attested = attested_operand_positions(raw, "");
             assert!(
                 !attested.contains(placeholder),
                 "{placeholder:?} must not be attested by {raw:?}: {attested:?}"
@@ -2153,7 +2322,7 @@ mod tests {
     #[test]
     fn a_bare_usage_header_opens_a_synopsis_block() {
         let raw = "Usage:\n wall [options] [<file> | <message>]\n\nWrite a message to all users.\n";
-        let attested = attested_operand_positions(raw);
+        let attested = attested_operand_positions(raw, "wall");
         assert!(attested.contains("file"), "{attested:?}");
         assert!(attested.contains("message"), "{attested:?}");
         assert!(!attested.contains("options"), "{attested:?}");
@@ -2192,7 +2361,7 @@ mod tests {
             "  or:  du [OPTION]... --files0-from=F\n",
             "  Summarize device usage of the set of FILEs, recursively for directories.\n",
         );
-        let attested = attested_operand_positions(raw);
+        let attested = attested_operand_positions(raw, "du");
         assert!(!attested.contains("device"), "{attested:?}");
         assert!(!attested.contains("recursively"), "{attested:?}");
         assert!(attested.contains("FILE"), "{attested:?}");
@@ -2292,5 +2461,158 @@ mod tests {
         let root = help_text_node("nothing");
         let report = detect(probe.root_help_text().unwrap_or_default().as_str(), &root);
         assert_eq!(report.fabrication_count(), 0);
+    }
+
+    // --- unlabelled and name-prefixed synopses (this task's own fix) -----
+
+    /// `gh --help`'s real shape, byte-exact: a bare `USAGE` heading (no
+    /// colon, so `starts_with_usage_prefix` never matches it) followed by an
+    /// indented line that simply opens with the tool's own name and reads as
+    /// usage grammar. Before this fix, this line was entirely invisible to
+    /// `synopsis_lines`, so both of `gh`'s real operands were reported as
+    /// invented despite occurring literally in the tool's own output — this
+    /// task's own worked example.
+    const GH_USAGE: &str = "USAGE\n  gh <command> <subcommand> [flags]\n";
+
+    #[test]
+    fn an_unlabelled_synopsis_opening_with_the_tools_own_name_is_recognized() {
+        let attested = attested_operand_positions(GH_USAGE, "gh");
+        assert!(attested.contains("command"), "{attested:?}");
+        assert!(attested.contains("subcommand"), "{attested:?}");
+        // `flags` is gh's own flag-list stand-in (vocabulary-matched, see
+        // `option_list_slot`) and must not itself be an attested operand.
+        assert!(!attested.contains("flags"), "{attested:?}");
+    }
+
+    #[test]
+    fn detect_does_not_flag_ghs_real_operands_from_its_unlabelled_synopsis() {
+        let mut root = help_text_node("gh");
+        root.positionals.push(help_text_positional("command"));
+        root.positionals.push(help_text_positional("subcommand"));
+        let report = detect(GH_USAGE, &root);
+        assert_eq!(
+            report.fabrication_count(),
+            0,
+            "gh's own real operands must not be flagged: {:?}",
+            report
+                .fabrications
+                .iter()
+                .map(|f| &f.name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// A labelled `usage:` line anywhere in the document must still take
+    /// precedence: the unlabelled fallback is only ever tried when
+    /// [`has_labelled_usage_start`] finds nothing, exactly mirroring the
+    /// tier's own `labelled_usage_start`/`unlabelled_synopsis_start`
+    /// precedence.
+    #[test]
+    fn a_real_labelled_usage_line_suppresses_the_unlabelled_fallback() {
+        let raw = "Usage: gh [flags]\nEXTRA\n  gh <command> <subcommand> [flags]\n";
+        assert!(has_labelled_usage_start(raw, "gh"));
+        let attested = attested_operand_positions(raw, "gh");
+        // The unlabelled fallback line never opens a block here, so its
+        // `command`/`subcommand` are not attested via that path — only
+        // whatever the real labelled block itself carries (nothing, in this
+        // synthetic example, since its only slot is the option list).
+        assert!(!attested.contains("command"), "{attested:?}");
+    }
+
+    /// The C `"%s: Usage: ..."` idiom: the tool's own name, a literal
+    /// `": "`, then `usage:` — `nfsidmap`'s real shape. The tool's name
+    /// occurs *twice* on this one line (the `fprintf` prefix, then again as
+    /// the invocation's own program name), and both copies must be
+    /// consumed before the remaining tokens are read as operands.
+    const NFSIDMAP_USAGE: &str = "nfsidmap: Usage: nfsidmap [-vh] [-c || -d] [-l] path\n";
+
+    #[test]
+    fn a_name_prefixed_usage_idiom_line_is_recognized() {
+        let attested = attested_operand_positions(NFSIDMAP_USAGE, "nfsidmap");
+        assert!(attested.contains("path"), "{attested:?}");
+    }
+
+    #[test]
+    fn detect_does_not_flag_nfsidmaps_real_operand_from_the_name_prefixed_idiom() {
+        let mut root = help_text_node("nfsidmap");
+        root.positionals.push(help_text_positional("path"));
+        let report = detect(NFSIDMAP_USAGE, &root);
+        assert_eq!(
+            report.fabrication_count(),
+            0,
+            "nfsidmap's own real operand must not be flagged: {:?}",
+            report
+                .fabrications
+                .iter()
+                .map(|f| &f.name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// [`option_list_slot`]'s own regression: the vocabulary rule and the
+    /// positional shape rule must never both fire on the same line. `gh`'s
+    /// synopsis puts its real flag stand-in *last* (`flags`, vocabulary-
+    /// matched) while a genuine operand (`command`) sits first — exactly
+    /// the shape that would trip the position rule into treating `command`
+    /// as *a second* excluded placeholder if the two rules ran
+    /// unconditionally instead of the vocabulary rule gating the fallback.
+    #[test]
+    fn a_trailing_vocabulary_placeholder_does_not_also_trigger_the_leading_position_rule() {
+        let slots = vec![("command", true), ("subcommand", true), ("flags", true)];
+        let placeholders = option_list_slot(&slots, false);
+        assert_eq!(placeholders, HashSet::from(["flags"]));
+    }
+
+    /// `vgextend --help`'s real shape, byte-exact: LVM's own bare-own-name
+    /// convention. The invocation line carries no docopt notation at all
+    /// (`vgextend VG PV ...`, no `[`, `<` or `{` anywhere on it), so
+    /// `looks_like_unlabeled_synopsis_line` alone can never find it — the
+    /// evidence that it is usage grammar is entirely on the *next* physical
+    /// line, an unambiguous bracketed flag row.
+    const VGEXTEND_USAGE: &str = concat!(
+        "  vgextend - Add physical volumes to a volume group\n",
+        "\n",
+        "  vgextend VG PV ...\n",
+        "\t[ -A|--autobackup y|n ]\n",
+        "\t[ -f|--force ]\n",
+        "\t[ COMMON_OPTIONS ]\n",
+    );
+
+    #[test]
+    fn a_bare_own_name_line_followed_by_a_bracket_flag_row_is_recognized() {
+        let attested = attested_operand_positions(VGEXTEND_USAGE, "vgextend");
+        assert!(attested.contains("VG"), "{attested:?}");
+        assert!(attested.contains("PV"), "{attested:?}");
+    }
+
+    #[test]
+    fn detect_does_not_flag_vgextends_real_operands_from_its_bare_own_name_line() {
+        let mut root = help_text_node("vgextend");
+        root.positionals.push(help_text_positional("VG"));
+        root.positionals.push(help_text_positional("PV"));
+        let report = detect(VGEXTEND_USAGE, &root);
+        assert_eq!(
+            report.fabrication_count(),
+            0,
+            "vgextend's own real operands must not be flagged: {:?}",
+            report
+                .fabrications
+                .iter()
+                .map(|f| &f.name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// A bare own-name line whose *next* line is ordinary prose, not a
+    /// bracketed flag row, must not open a synopsis block — the same
+    /// discipline `starts_with_tool_name` alone would otherwise blur: a
+    /// sentence that happens to open with the tool's own name is not usage
+    /// grammar.
+    #[test]
+    fn a_bare_own_name_line_without_a_flag_row_next_does_not_open_a_block() {
+        let raw = "vgextend is a tool for extending volume groups.\nIt takes no further arguments here.\n";
+        let attested = attested_operand_positions(raw, "vgextend");
+        assert!(!attested.contains("is"), "{attested:?}");
+        assert!(!attested.contains("tool"), "{attested:?}");
     }
 }


### PR DESCRIPTION
## Summary

**This is a measurement fix, not a parser fix.** No file under `mandible-extract`'s parsing logic changes behavior — the two `fn` → `pub fn` visibility changes and the re-exports in `mandible-extract/src/help_text/{sections,mod}.rs` change nothing about what gets parsed. Every substantive change is in `xtask/src/existence.rs` (the existence-fabrication oracle) and `xtask/src/detector.rs` (its self-check cases).

### The defect

Across the recent round of parser work (`fix/usage-synopsis`, `fix/colon-separator`, `fix/lvm-bracket-rows`), the fleet existence-fabrication count went from 66 tools to 154. The diagnosis: `xtask/src/existence.rs`'s `synopsis_lines` found a synopsis using only `starts_with_usage_prefix`/`starts_with_or_marker` — an ordinary `usage:`/`or:` marker. The parser itself had already learned three additional entry shapes that carry no such marker:

1. The C `fprintf(stderr, "%s: Usage: ...", argv[0])` idiom (`nfsidmap: Usage: nfsidmap [-vh] ...`).
2. An **unlabelled** synopsis with no marker anywhere — `gh`'s bare `USAGE` heading followed by `gh <command> <subcommand> [flags]`.
3. LVM's bare own-name line whose notation sits on the *next* physical line (`vgextend VG PV ...` / `[ -A|--autobackup y|n ]`) — the entire `vg*`/`lv*`/`pv*` family (29 tools).

Every operand the parser correctly recovered from one of these lines was invisible to the oracle and reported as invented.

### The fix

- Made the parser's own predicates `pub` and re-exported them for `xtask` (`starts_with_name_prefixed_usage`, `looks_like_unlabeled_synopsis_line`, `starts_with_tool_name`, `looks_like_bracket_flag_row`), rather than reimplementing any of them — same discipline the existing re-export block already documents (spec §13.1c's K2 table: a second, drifting copy of a shared predicate has cost this project before).
- `synopsis_lines` now opens a synopsis block on all three shapes above, gated the same way the parser gates them (the unlabelled/bare-own-name shapes only tried when no labelled `usage:` marker exists anywhere in the document).
- **A second, independent bug**, surfaced only once `gh`'s line became visible: `option_list_slot` excluded a synopsis's *first* slot unconditionally whenever the line wrote no literal flag — safe while every previously-measured tool's flag-list placeholder happened to sit first. `gh`'s `<command> <subcommand> [flags]` puts its placeholder *last*; the position rule would also have excluded the genuine leading operand `command` as a second, wrong placeholder. Fixed by trying the parser's own five-word vocabulary (`OPTION_LIST_PLACEHOLDERS`, reused via a new `is_option_list_placeholder` re-export) first, regardless of position, and falling back to the position rule only when nothing on the line already matched.

### Calibration harness result (spec §13.1e)

This detector has **no labelled member in the audit** — "not one reviewer reported a fabricated subcommand or flag spelling" — so `xtask detector calibrate --detector existence` correctly reports **NOT CALIBRATABLE**, exactly as before this change. Its self-check is the only calibration evidence, and it now carries 9 hand-built cases (up from 4): the original 4 plus one pair each for the three new shapes (gh's unlabelled synopsis, nfsidmap's name-prefixed idiom, vgextend's bare own-name line), each a `Fires`/`Silent` pair proving the fix recovers the real operand without opening a blanket amnesty.

```
$ cargo run -p xtask -- detector self-check --detector existence
SELF-CHECK EVIDENCE — the detector's own hand-built cases, re-run just now (9 declared):
  [held  ] must fire 1x     tar's OPTION operand
  [held  ] must stay silent tar's FILE operand alone
  [held  ] must stay silent uobjnew's two real operands
  [held  ] must fire 1x     an operand named nowhere
  [held  ] must stay silent gh's two real operands from its unlabelled synopsis
  [held  ] must fire 1x     an operand named nowhere beside gh's real unlabelled synopsis
  [held  ] must stay silent nfsidmap's real operand from the name-prefixed usage idiom
  [held  ] must stay silent vgextend's two real operands from its bare own-name line
  [held  ] must fire 1x     an operand named nowhere beside vgextend's real bare own-name line
```

All other registered detectors' self-checks and calibrations are unaffected (verified full `detector self-check`/`detector calibrate` runs; the one calibration finding printed — `verbatim-fallback`'s `vgck`/`vgextend`/`vgrename` miss — reproduces identically on `main` before this branch, confirmed with `git stash`).

### Before/after fabrication count

| sweep | existence-fabrication tools |
|---|---|
| baseline (before this round's parser work) | 66 |
| after this round's parser work, before this fix | 154 |
| **after this fix** | **52** |

The final count (52) is *below* the round's own 66-tool starting point: 14 tools flagged even at baseline turned out to be the identical instrument gap (unrelated to the recent parser work), not something the recent round introduced.

**Real invention vs. instrument gap — the honest split asked for:** a full tool-by-tool set comparison (parsed from the fixed-width scoreboard's `exist` column) shows **zero** tools newly fabricating relative to the 66-tool baseline. Every one of the 154-tool figure's growth over baseline, and then some, was this instrument gap. No real parser-introduced fabrication remains to name.

### Hand-verification (4+ tools, real `--help` output)

- **`gh`**: `USAGE` / `  gh <command> <subcommand> [flags]` — `command` and `subcommand` occur literally; `flags` is gh's own flag-list stand-in. Oracle now reports `exist=0` (was `exist=1` after only the synopsis-entry fix, `exist=2` before any fix — the `option_list_slot` bug is what closed the gap from 1 to 0).
- **`busctl`**, **`journalctl`**, **`pidof`**: same "flag count unchanged, `exist` newly non-zero" signature as `gh`; all now `exist=0` on a real sweep.
- **`nfsidmap`**: `nfsidmap: Usage: nfsidmap [-vh] [-c || -d] [-l] path` — `path` occurs literally after both copies of the tool's own name are accounted for. `exist=0`.
- **`vgextend`/`vgck`/`pvcreate`/`lvs`**: LVM's bare own-name convention (`vgextend VG PV ...` / `\t[ -A|--autobackup y|n ]`). All four now `exist=0` on a real sweep (verified with `cargo run --release -p xtask -- coverage --tools vgextend,vgck,pvcreate,lvs`).

### Zero flag/subcommand/status movement

`sweep-diff` between the pre-fix and post-fix full-`PATH` sweeps shows the identical set of ~19 changed tools in both runs (`dnf`, `dockerd-rootless.sh`, `lxc`/`lxd`, `pro`/`ua`, `e2scrub*`, `login`, `luksformat`, `mpathpersist`, `purge-old-kernels`, `ps`) — all package-manager/daemon/PAM-dependent tools whose output depends on runtime system state, not on this diff (this change touches zero lines of `mandible-extract`'s parsing). Confirmed identical, tool-for-tool and count-for-count, between the two post-fix sweeps taken ~30 minutes apart, which is consistent with environment drift between captures rather than anything in this diff. No flag, subcommand, or status change is attributable to this commit.

### No pty screenshots

This changes no rendering and no parse — it only changes what a diagnostic counter reports. No see-it-yourself steps or screenshots are included, per this project's own visual-verification convention, because there is nothing visual to verify.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --target aarch64-apple-darwin -- -D warnings`
- [x] `cargo nextest run --workspace` (1147 passed, 0 skipped)
- [x] `cargo run -p xtask -- corpus` (107 fixtures: 97 ok, 10 xfail as expected, 0 failed) — green, no `--bless` needed
- [x] `cargo build --release`
- [x] `cargo run -p xtask -- detector self-check` (all detectors, all cases held)
- [x] `cargo run -p xtask -- detector calibrate` (existence correctly reports NOT CALIBRATABLE; no other detector regressed)
- [x] Full-`PATH` sweep before/after + `sweep-diff` (zero flag/subcommand/status movement; existence-fabrication 154 → 52)
- [x] Hand-verified `gh`, `busctl`, `journalctl`, `pidof`, `nfsidmap`, `vgextend`, `vgck`, `pvcreate`, `lvs` against real `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiH6dj1daVzcgyprKa39Nf