### PR TITLE
release: 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-24
+
 ### Fixed
 
 - **The existence-fabrication oracle could not see three synopsis-entry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "base64",
@@ -2362,7 +2362,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.4.1" }
-mandible-extract = { path = "mandible-extract", version = "0.4.1" }
-mandible-search = { path = "mandible-search", version = "0.4.1" }
-mandible-tui = { path = "mandible-tui", version = "0.4.1" }
+mandible-core = { path = "mandible-core", version = "0.4.2" }
+mandible-extract = { path = "mandible-extract", version = "0.4.2" }
+mandible-search = { path = "mandible-search", version = "0.4.2" }
+mandible-tui = { path = "mandible-tui", version = "0.4.2" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Cuts 0.4.2 from the six PRs merged since v0.4.1 (#31-#36). Non-breaking patch release; every family was verified visually by the maintainer (verdicts recorded in #11) before this cut.

Fleet: +1,531 flags across 66 tools; verbatim 314→262; existence-fabrication 66→52 (after #36 fixed the oracle's own blindness).

Local gate: 1147 tests pass, fmt clean, clippy -D warnings clean, corpus 107 fixtures / 0 failed, no stray blessed snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFin6DLho9duCAEy6ru6a2