### PR TITLE
fix(tui): wrap unverified-subcommand notices inside the detail pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Long unverified-subcommand notices now wrap inside the detail pane instead
+  of being clipped in the raw-help view.
+
 ## [0.4.2] - 2026-08-24
 
 ### Fixed

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -188,8 +188,9 @@ fn render_raw_mode(frame: &mut Frame, inner: Rect, app: &App, raw: &crate::app::
 /// per entry, labelled so it reads as "the author's own text", not a
 /// mandible parse.
 ///
-/// Deliberately **not** run through [`wrap_words`] and **not** given
-/// `Paragraph::wrap` the way every other block in this pane is (see this
+/// Tool-authored body lines are deliberately **not** run through
+/// [`wrap_words`] and are not given `Paragraph::wrap` the way every other
+/// block in this pane is (see this
 /// module's top doc comment on why the rest of the pane pre-wraps
 /// everything itself) — this is preformatted output, and re-wrapping it
 /// would silently edit the tool author's own text. Without `Wrap`,
@@ -207,7 +208,9 @@ fn render_raw_mode(frame: &mut Frame, inner: Rect, app: &App, raw: &crate::app::
 /// (`mandible-extract`'s `help_text::raw_help*`) — both of which guarantee
 /// no embedded control characters or newlines reach here; they differ only
 /// in whether whitespace/indentation is collapsed, never in that safety
-/// property.
+/// property. The heading and the recognizable unverified-subcommand notice
+/// prefix are different: they are prose owned by mandible, so they wrap at the
+/// current inner width while the tool lines after them stay untouched.
 fn render_verbatim(
     frame: &mut Frame,
     inner: Rect,
@@ -216,18 +219,76 @@ fn render_verbatim(
     body: impl Iterator<Item = String>,
 ) {
     let mut lines: Vec<Line<'static>> = Vec::new();
-    lines.push(Line::from(Span::styled(
-        heading.to_string(),
-        style::muted_bold(app.color_enabled),
-    )));
+    let width = inner.width as usize;
+    for chunk in wrap_words(heading, width) {
+        lines.push(Line::from(Span::styled(
+            chunk,
+            style::muted_bold(app.color_enabled),
+        )));
+    }
     lines.push(Line::default());
-    for text in body {
-        lines.push(Line::from(text));
+    let body: Vec<String> = body.collect();
+    let wrapped_prefix_lines = unverified_notice_prefix_len(&body);
+    for (index, text) in body.into_iter().enumerate() {
+        if index < wrapped_prefix_lines {
+            push_wrapped_notice(&mut lines, &text, width);
+        } else {
+            lines.push(Line::from(text));
+        }
     }
     app.set_detail_extent(lines.len(), inner.height as usize);
     let scroll = app.clamped_detail_scroll() as u16;
     let paragraph = Paragraph::new(lines).scroll((scroll, 0));
     frame.render_widget(paragraph, inner);
+}
+
+/// Recognize only the display-only prose prepended by `not_attested_fallback`.
+///
+/// The first sentence is always present. A successful safe root-help fallback
+/// adds a blank, mandible's explanatory label, and another blank before the
+/// tool-authored bytes. Keeping this recognition here avoids changing the raw
+/// help API or tree model solely to carry presentation metadata.
+fn unverified_notice_prefix_len(body: &[String]) -> usize {
+    const PREFIX: &str = "mandible could not verify \"";
+
+    if !body.first().is_some_and(|line| line.starts_with(PREFIX)) {
+        return 0;
+    }
+
+    if body.get(1).is_some_and(String::is_empty)
+        && body.get(2).is_some_and(|line| {
+            line == "Showing the tool's own root --help instead, labelled below:"
+        })
+        && body.get(3).is_some_and(String::is_empty)
+    {
+        4
+    } else {
+        1
+    }
+}
+
+/// Add one mandible-authored notice paragraph with a stable block indent.
+///
+/// The raw-help body after this prefix is intentionally preformatted; only
+/// prose created by mandible takes this path. [`wrap_words`] supplies the
+/// display-width-aware long-token splitting used by the structured detail
+/// pane, so CJK and emoji cannot turn a character count into a border overrun.
+fn push_wrapped_notice(lines: &mut Vec<Line<'static>>, text: &str, width: usize) {
+    if text.is_empty() {
+        lines.push(Line::default());
+        return;
+    }
+
+    const INDENT: &str = "  ";
+    let indent = if width > display_width(INDENT) {
+        INDENT
+    } else {
+        ""
+    };
+    let available = width.saturating_sub(display_width(indent)).max(1);
+    for chunk in wrap_words(text, available) {
+        lines.push(Line::from(format!("{indent}{chunk}")));
+    }
 }
 
 /// The rendered detail-pane content plus where a search-targeted flag

--- a/mandible-tui/tests/unverified_notice_wrap.rs
+++ b/mandible-tui/tests/unverified_notice_wrap.rs
@@ -1,0 +1,185 @@
+//! Regression for the display-only refusal surfaced by the raw-help view.
+//!
+//! `mandible apt-ftparchive`, followed by `jjjj,t`, reaches a `release`
+//! node that is invocation-attested but deliberately not heading-attested.
+//! The probe refusal is correct. Its explanatory notice is mandible-authored
+//! prose, though, so it must wrap even while the root tool output that follows
+//! it remains preformatted.
+
+use mandible_core::{CommandNode, Provenance, Source, Text};
+use mandible_tui::app::{App, RawHelp};
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::Terminal;
+use unicode_width::UnicodeWidthStr;
+
+const NOTICE: &str = "mandible could not verify \"release\" as a real subcommand name: it came from a source the probe-safety gate does not accept as evidence a word is safe to run (a native/cobra artifact scan, or a headingless invocation table's layout evidence — neither is a recognized --help heading), so it was never sent as an argument. This is a known limitation of the gate, not something already worked around.";
+const CONTROL_USAGE: &str = "Usage: apt [options]";
+const END_MARKER: &str = "END-OF-ROOT-HELP";
+
+fn notice_app(notice: &str) -> App {
+    let mut root = CommandNode::new("apt-ftparchive", Provenance::single(Source::HelpText));
+    let mut release = CommandNode::new("release", Provenance::single(Source::HelpText));
+    release.invocation_attested = true;
+    root.subcommands.push(release);
+    root.children_filled = true;
+
+    let mut app = App::new("apt-ftparchive".to_string(), root);
+    app.ensure_rows_fresh();
+    app.move_down();
+    assert_eq!(
+        app.selected_path(),
+        Some(vec!["apt-ftparchive".to_string(), "release".to_string()])
+    );
+    app.toggle_raw_mode();
+    app.set_raw_help(
+        vec!["apt-ftparchive".to_string(), "release".to_string()],
+        RawHelp::Ready(
+            vec![
+                Text::sanitize_preserving_layout(notice),
+                Text::sanitize_preserving_layout(""),
+                Text::sanitize_preserving_layout(
+                    "Showing the tool's own root --help instead, labelled below:",
+                ),
+                Text::sanitize_preserving_layout(""),
+                Text::sanitize_preserving_layout(CONTROL_USAGE),
+                Text::sanitize_preserving_layout(END_MARKER),
+            ],
+            "apt-ftparchive (name not heading-attested — showing root --help as a fallback)"
+                .to_string(),
+        ),
+    );
+    app
+}
+
+fn render(width: u16, height: u16, app: &App) -> (Buffer, Rect) {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| mandible_tui::render::render(frame, app))
+        .unwrap();
+    let detail = mandible_tui::layout::compute(Rect::new(0, 0, width, height), app.focus)
+        .detail
+        .expect("the tested widths must render the detail pane");
+    (terminal.backend().buffer().clone(), detail)
+}
+
+fn detail_lines(buffer: &Buffer, detail: Rect) -> Vec<String> {
+    let start_x = detail.x + 2;
+    let end_x = detail.x + detail.width - 2;
+    ((detail.y + 1)..(detail.y + detail.height - 1))
+        .map(|y| {
+            let mut line = String::new();
+            let mut x = start_x;
+            while x < end_x {
+                let symbol = buffer[(x, y)].symbol();
+                line.push_str(symbol);
+                // Ratatui stores a double-width glyph in its leading cell
+                // and reserves the following cell as a blank continuation.
+                // Skipping that placeholder reconstructs the visual text
+                // instead of inventing spaces between adjacent CJK glyphs.
+                x += UnicodeWidthStr::width(symbol).max(1) as u16;
+            }
+            line.trim_end().to_string()
+        })
+        .collect()
+}
+
+fn normalize(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn assert_detail_border_intact(buffer: &Buffer, detail: Rect) {
+    let right = detail.x + detail.width - 1;
+    let bottom = detail.y + detail.height - 1;
+    assert_eq!(buffer[(detail.x, detail.y)].symbol(), "╭");
+    assert_eq!(buffer[(right, detail.y)].symbol(), "╮");
+    assert_eq!(buffer[(detail.x, bottom)].symbol(), "╰");
+    assert_eq!(buffer[(right, bottom)].symbol(), "╯");
+    for y in (detail.y + 1)..bottom {
+        assert_eq!(buffer[(detail.x, y)].symbol(), "│");
+        assert_eq!(buffer[(right, y)].symbol(), "│");
+    }
+}
+
+fn assert_visual_lines_fit(lines: &[String], detail: Rect) {
+    let inner_width = detail.width.saturating_sub(4) as usize;
+    for line in lines {
+        assert!(
+            UnicodeWidthStr::width(line.as_str()) <= inner_width,
+            "visual line exceeds {inner_width} cells: {line:?}"
+        );
+    }
+}
+
+#[test]
+fn unverified_subcommand_notice_wraps_and_survives_resizing() {
+    let app = notice_app(NOTICE);
+
+    for (width, height) in [(90, 48), (60, 48)] {
+        let (buffer, detail) = render(width, height, &app);
+        let lines = detail_lines(&buffer, detail);
+        let joined = normalize(&lines.join("\n"));
+
+        assert_detail_border_intact(&buffer, detail);
+        assert_visual_lines_fit(&lines, detail);
+        assert!(
+            joined.contains(&normalize(NOTICE)),
+            "the complete notice was not recoverable at {width}x{height}: {joined:?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == CONTROL_USAGE),
+            "ordinary preformatted usage changed at {width}x{height}: {lines:?}"
+        );
+    }
+}
+
+#[test]
+fn wrapped_notice_contributes_to_scroll_extent() {
+    let mut app = notice_app(NOTICE);
+    let (mut buffer, mut detail) = render(60, 24, &app);
+    let mut saw_end = detail_lines(&buffer, detail)
+        .iter()
+        .any(|line| line == END_MARKER);
+
+    loop {
+        let before = app.detail_scroll;
+        app.detail_scroll_down();
+        if app.detail_scroll == before {
+            break;
+        }
+        (buffer, detail) = render(60, 24, &app);
+        saw_end |= detail_lines(&buffer, detail)
+            .iter()
+            .any(|line| line == END_MARKER);
+    }
+
+    assert!(
+        app.detail_scroll > 0,
+        "wrapped notice lines were not counted in the scroll extent"
+    );
+    assert!(saw_end, "scrolling never reached the root-help tail");
+    assert_detail_border_intact(&buffer, detail);
+}
+
+#[test]
+fn overlong_unicode_notice_token_is_split_by_display_width() {
+    let token = format!("release{}", "界".repeat(40));
+    let notice = NOTICE.replacen("release", &token, 1);
+    let app = notice_app(&notice);
+    let (buffer, detail) = render(60, 80, &app);
+    let lines = detail_lines(&buffer, detail);
+
+    assert_detail_border_intact(&buffer, detail);
+    assert_visual_lines_fit(&lines, detail);
+    let compact: String = lines
+        .join("\n")
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect();
+    assert!(
+        compact.contains(&token),
+        "the double-width token did not survive wrapping: {compact:?}"
+    );
+}


### PR DESCRIPTION
## Mechanism

`mandible-extract::help_text::not_attested_fallback` creates the refusal as a
Mandible-authored first line, optionally followed by a blank line, a
Mandible-authored root-help fallback label, another blank line, and the tool's
own root `--help` lines. That existing document reaches the TUI as
`RawHelp::Ready` and enters `detail_pane::render_verbatim`.

That renderer deliberately treated every body line as tool-authored
preformatted output: it bypassed `wrap_words`, and its `Paragraph` had no
`Wrap`. Ratatui therefore clipped the long notice at the pane's right inner
edge. At 60 columns, only `mandible could not verify` remained visible.

The renderer now recognizes only the existing, structurally distinct
unverified-subcommand prefix. It wraps that Mandible-authored prose at the
current detail pane inner width using the existing display-width-aware
`wrap_words` path and a consistent two-cell continuation indent. The raw-view
heading is contained the same way. Tool-authored root-help lines after the
prefix remain preformatted and unchanged. Rebuilding the visual lines on every
frame naturally rewraps on resize, and the expanded line count is passed to
`set_detail_extent`, so scrolling reaches the true end.

## Safety boundary

- `heading_attested` behavior is unchanged.
- No node became probe-eligible; `invocation_attested` still does not satisfy
  the gate.
- No new argv shape is sent.
- Parser, extraction, merge, and serialized tree output are unchanged.
- No IR or public schema changed.
- No tool- or command-specific logic was added.
- The tool-authored preformatted part of raw help is not reflowed.

## Before/after

Reproduced from unmodified current `main` at
`36a70c5e809dc78bc578bc80491c1c462df41621` and repeated with the patched
release binary.

Command:

```console
python3 scripts/pty_screenshot.py --keys 'jjjj,t' 90 30 ./target/release/mandible apt-ftparchive
```

Exact key groups: `jjjj` selects `release`; `t` opens raw help.

### 90×30 before

```text
╭ search [names]  (/ switches) ──────────────────────────────────────────────────────────╮
│›                                                                                       │
╰────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (7) ─────────────────────────────╮╭ apt-ftparchive › release ─────────────────╮
│▾ apt-ftparchive                           ││ verbatim — output of `apt-ftparchive rele │
│    packages                               ││                                           │
│    sources                                ││ mandible could not verify "release" as a  │
│    contents                               ││                                           │
│    release                                ││ Showing the tool's own root --help instea │
│    generate                               ││                                           │
│    clean                                  ││ apt 2.8.3 (amd64)                         │
│                                           ││ Usage: apt-ftparchive [options] command   │
│                                           ││ Commands: packages binarypath [overridefi │
│                                           ││           sources srcpath [overridefile [ │
│                                           ││           contents path                   │
│                                           ││           release path                    │
│                                           ││           generate config [groups]        │
│                                           ││           clean config                    │
│                                           ││                                           │
│                                           ││ apt-ftparchive generates index files for  │
│                                           ││ many styles of generation from fully auto │
│                                           ││ for dpkg-scanpackages and dpkg-scansource │
│                                           ││                                           │
│                                           ││ apt-ftparchive generates Package files fr │
│                                           ││ Package file contains the contents of all │
│                                           ││ each package as well as the MD5 hash and  │
│                                           ││ is supported to force the value of Priori │
│                                           ││                                           │
╰───────────────────────────────────────────╯╰───────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    ? help    ^C quit   help-text
```

### 90×30 after

```text
╭ search [names]  (/ switches) ──────────────────────────────────────────────────────────╮
│›                                                                                       │
╰────────────────────────────────────────────────────────────────────────────────────────╯
╭ commands (7) ─────────────────────────────╮╭ apt-ftparchive › release ─────────────────╮
│▾ apt-ftparchive                           ││ verbatim — output of `apt-ftparchive      │
│    packages                               ││ release (name not heading-attested —      │
│    sources                                ││ showing root --help as a fallback)`       │
│    contents                               ││                                           │
│    release                                ││   mandible could not verify "release" as  │
│    generate                               ││   a real subcommand name: it came from a  │
│    clean                                  ││   source the probe-safety gate does not   │
│                                           ││   accept as evidence a word is safe to    │
│                                           ││   run (a native/cobra artifact scan, or a │
│                                           ││   headingless invocation table's layout   │
│                                           ││   evidence — neither is a recognized      │
│                                           ││   --help heading), so it was never sent   │
│                                           ││   as an argument. This is a known         │
│                                           ││   limitation of the gate, not something   │
│                                           ││   already worked around.                  │
│                                           ││                                           │
│                                           ││   Showing the tool's own root --help      │
│                                           ││   instead, labelled below:                │
│                                           ││                                           │
│                                           ││ apt 2.8.3 (amd64)                         │
│                                           ││ Usage: apt-ftparchive [options] command   │
│                                           ││ Commands: packages binarypath [overridefi │
│                                           ││           sources srcpath [overridefile [ │
│                                           ││           contents path                   │
╰───────────────────────────────────────────╯╰───────────────────────────────────────────╯
  ↑↓ move    ←→ expand    / search    Tab pane    t raw    ? help    ^C quit   help-text
```

Narrow command:

```console
python3 scripts/pty_screenshot.py --keys 'jjjj,t' 60 24 ./target/release/mandible apt-ftparchive
```

### 60×24 before

```text
╭ search [names]  (/ switches) ────────────────────────────╮
│›                                                         │
╰──────────────────────────────────────────────────────────╯
╭ commands (7) ──────────────╮╭ apt-ftparchive › release ──╮
│▾ apt-ftparchive            ││ verbatim — output of `apt- │
│    packages                ││                            │
│    sources                 ││ mandible could not verify  │
│    contents                ││                            │
│    release                 ││ Showing the tool's own roo │
│    generate                ││                            │
│    clean                   ││ apt 2.8.3 (amd64)          │
│                            ││ Usage: apt-ftparchive [opt │
│                            ││ Commands: packages binaryp │
│                            ││           sources srcpath  │
│                            ││           contents path    │
│                            ││           release path     │
│                            ││           generate config  │
│                            ││           clean config     │
│                            ││                            │
│                            ││ apt-ftparchive generates i │
│                            ││ many styles of generation  │
│                            ││ for dpkg-scanpackages and  │
╰────────────────────────────╯╰────────────────────────────╯
  ↑↓ move    ←→ expand    ? help    ^C quit      help-text
```

### 60×24 after

```text
╭ search [names]  (/ switches) ────────────────────────────╮
│›                                                         │
╰──────────────────────────────────────────────────────────╯
╭ commands (7) ──────────────╮╭ apt-ftparchive › release ──╮
│▾ apt-ftparchive            ││ verbatim — output of       │
│    packages                ││ `apt-ftparchive release    │
│    sources                 ││ (name not heading-attested │
│    contents                ││ — showing root --help as a │
│    release                 ││ fallback)`                 │
│    generate                ││                            │
│    clean                   ││   mandible could not       │
│                            ││   verify "release" as a    │
│                            ││   real subcommand name: it │
│                            ││   came from a source the   │
│                            ││   probe-safety gate does   │
│                            ││   not accept as evidence a │
│                            ││   word is safe to run (a   │
│                            ││   native/cobra artifact    │
│                            ││   scan, or a headingless   │
│                            ││   invocation table's       │
│                            ││   layout evidence —        │
│                            ││   neither is a recognized  │
╰────────────────────────────╯╰────────────────────────────╯
  ↑↓ move    ←→ expand    ? help    ^C quit      help-text
```

Scrolling verification used exact key groups
`jjjj,t,<tab>,jjjjjjjjjjjj`. The final screen reaches the notice tail, the
fallback label, and then the first root-help line in the correct order:

```text
╭ commands (7) ──────────────╮╭ apt-ftparchive › release ──╮
│▾ apt-ftparchive            ││   word is safe to run (a   │
│    packages                ││   native/cobra artifact    │
│    sources                 ││   scan, or a headingless   │
│    contents                ││   invocation table's       │
│    release                 ││   layout evidence —        │
│    generate                ││   neither is a recognized  │
│    clean                   ││   --help heading), so it   │
│                            ││   was never sent as an     │
│                            ││   argument. This is a      │
│                            ││   known limitation of the  │
│                            ││   gate, not something      │
│                            ││   already worked around.   │
│                            ││                            │
│                            ││   Showing the tool's own   │
│                            ││   root --help instead,     │
│                            ││   labelled below:          │
│                            ││                            │
│                            ││ apt 2.8.3 (amd64)          │
╰────────────────────────────╯╰────────────────────────────╯
```

The same 60×24 capture with `NO_COLOR=1 MANDIBLE_ASCII=1` retained intact
ASCII borders and contained wrapping.

## Tests

The new `ratatui::backend::TestBackend` regression renders the actual
`RawHelp::Ready` path. It checks 90- and 60-column frames, every rendered
line's Unicode display width, rounded-border cells, whitespace-normalized
recovery of the complete notice, an unchanged ordinary usage line, scroll
extent, and a single overlong token containing 40 double-width CJK glyphs.

Pre-fix result on the parent commit:

```text
3 tests run: 0 passed, 3 failed
- the complete notice was not recoverable at 90x48
- wrapped notice lines were not counted in the scroll extent
- the double-width token did not survive wrapping
```

Post-fix focused result:

```text
3 tests run: 3 passed, 0 skipped
```

Workspace verification:

- `cargo fmt --all -- --check` — pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — blocked by an
  unchanged current-`main` lint at `mandible-core/src/text.rs:305`
  (`clippy::nonminimal_bool`). Rust 1.90 and the declared Rust 1.88 both report
  the same baseline failure.
- `cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D warnings`
  — blocked by the same unchanged baseline lint.
- Supplementary TUI-only Clippy after allowing only that baseline lint reaches
  another unchanged current-`main` lint at
  `mandible-tui/src/render/status_bar.rs:218` (`clippy::const_is_empty`).
- `cargo nextest run --workspace` — host prerequisites fail in the three
  containment tests documented by `AGENTS.md`: WSL1 has no user/PID/mount
  namespace support and no passwordless `sudo`. A no-fail-fast run completed
  all 1,150 tests: 1,147 passed, those same 3 failed, 0 skipped.
- `cargo run -p xtask -- corpus` — pass: 107 fixtures, 97 ok, 10 expected
  xfails, 0 failed.
- `cargo build --release` — pass.
- `bash scripts/changelog_guard.sh` — after normalizing this Windows checkout's
  CRLF script bytes, the guard executes but current `main` is already red:
  released `[0.2.2]` differs from tag `v0.2.2`. This patch does not alter that
  released section.
- `git diff --check` — pass.
- Real PTY checks at 90×30, 60×24, scrolled 60×24, and 60×24
  ASCII/`NO_COLOR` — pass.

## Scope

Addresses the TUI overflow follow-up recorded in #11.
