### PR TITLE
fix(help-text): drop a leading option-error line from DESCRIPTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A tool's own getopt-family "unrecognized option" complaint about the
+  `--help` probe could become the DESCRIPTION mandible shows in the TUI.**
+  A program with no `--help` of its own (`ssh-keygen`, whose parser has
+  none) answers the probe by printing its own one-line complaint —
+  `unknown option -- -` — sometimes followed by a real usage block,
+  sometimes (`c_rehash --help`: `Usage error; try -h.`) not followed by
+  anything at all. `mandible-extract/src/help_text/sections.rs`'s
+  leading-prose-becomes-the-description rule had no way to tell that
+  complaint apart from real descriptive prose. Two new predicates,
+  `is_option_error_line`/`is_option_error_paragraph`, recognize the
+  narrow, well-known shape (an optional `<progname>: ` prefix, then
+  `unknown`/`invalid`/`illegal`/`unrecognized option(s)` or busybox's
+  `Usage error; try -h.`, with at most a short flag-shaped trailer) and
+  drop it — including when it is the tool's *only* leading paragraph, in
+  which case the node now has no description at all rather than the
+  probe's own error text. Measured over the 2,301 frozen captures in
+  `audit/queue-captures/`: 116 tools have their DESCRIPTION changed by
+  this fix (`ssh`, `ssh-keygen`, `ssh-agent`, `sftp`, `c_rehash`, `nginx`,
+  `ping`, all fifteen probed `xfs_*` tools, and more — full list in the
+  fix's PR description); a broader, same-keyword-anywhere shape
+  additionally matches 52 tools this fix deliberately leaves untouched,
+  each for a specific, checked reason (a log-framed or otherwise
+  multi-token prefix, a real banner ahead of the complaint, or a later
+  line in the same paragraph carrying real content this fix will not risk
+  discarding). Full-`PATH` sweep confirms zero flag/subcommand/status
+  regressions — this fix touches only the `description` field.
+
 ## [0.4.2] - 2026-08-24
 
 ### Fixed

--- a/corpus/c_rehash/3.0.13/expected.snap
+++ b/corpus/c_rehash/3.0.13/expected.snap
@@ -1,0 +1,8 @@
+name: c_rehash
+provenance:
+  sources:
+  - help-text
+  confidence: 0.0
+children_filled: true
+unparsed:
+- Usage error; try -h.

--- a/corpus/c_rehash/3.0.13/help.stderr.txt
+++ b/corpus/c_rehash/3.0.13/help.stderr.txt
@@ -1,0 +1,1 @@
+Usage error; try -h.

--- a/corpus/c_rehash/3.0.13/meta.toml
+++ b/corpus/c_rehash/3.0.13/meta.toml
@@ -1,0 +1,47 @@
+# Regression fixture for `is_option_error_paragraph`/`is_option_error_line`
+# (`mandible-extract/src/help_text/sections.rs`), the fix for a leading
+# stderr option-error line becoming the DESCRIPTION.
+#
+# `c_rehash` is a perl script bundled with OpenSSL; it has no `--version`
+# of its own, hence the OpenSSL release that ships it as this fixture's
+# version. It has no `--help` either — only `-h`/`-help` — so probing it
+# with `--help` hits its own option parser's complaint before anything
+# else, and its *entire* captured output is one line: `Usage error; try
+# -h.`. Before this fix, `sections::parse_with_profile` set
+# `ParsedHelp::description` to exactly that line — the tool's complaint
+# about the probe's argument, not a description of what `c_rehash` does.
+#
+# Honest residual, deliberately not claimed by this fixture: because
+# `c_rehash --help` recovers no flags, no subcommands and no usage block,
+# `mandible-extract::help_text::build_node`'s `structurally_plausible`
+# check was already false either way, so the root node already degraded
+# to the verbatim/raw-text tier (`node.unparsed`, confidence 0.0)
+# regardless of this fix — the TUI's DESCRIPTION pane was never reachable
+# here to begin with (verified: `pty_screenshot.py` output is
+# byte-identical before and after this fix for this exact tool). This
+# fixture pins the fix at the level it actually operates on —
+# `ParsedHelp::description` — via the frozen `expected.snap`, which
+# freezes the whole `CommandNode` and therefore proves `description` is
+# absent (`null`) rather than merely unobserved. `ssh-keygen`
+# (`corpus/ssh-keygen/9.6p1`) is the fixture that demonstrates this fix's
+# *visible* effect, because its usage block keeps it out of the verbatim
+# tier.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "c_rehash"
+version = "3.0.13"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.4.2"
+
+[[capture]]
+argv = ["c_rehash", "--help"]
+stdout = "help.txt"
+stderr = "help.stderr.txt"
+exit_code = 1
+
+[contract]
+expected_framework = "generic"
+min_status = "verbatim"

--- a/corpus/filefrag/audit-seed2/expected.snap
+++ b/corpus/filefrag/audit-seed2/expected.snap
@@ -1,5 +1,4 @@
 name: filefrag
-description: '/usr/sbin/filefrag: invalid option -- ''-'''
 usage:
 - 'Usage: /usr/sbin/filefrag [-b{blocksize}[KMG]] [-BeEksvxX] file ...'
 flags:

--- a/corpus/nfsidmap/audit-seed/expected.snap
+++ b/corpus/nfsidmap/audit-seed/expected.snap
@@ -1,5 +1,4 @@
 name: nfsidmap
-description: 'nfsidmap: invalid option -- ''-'''
 usage:
 - 'nfsidmap: Usage: nfsidmap [-vh] [-c || [-u|-g|-r key] || -d || -l || [-t timeout] key desc]'
 flags:

--- a/corpus/nfsidmap/audit-seed2/expected.snap
+++ b/corpus/nfsidmap/audit-seed2/expected.snap
@@ -1,5 +1,4 @@
 name: nfsidmap
-description: '/usr/sbin/nfsidmap: invalid option -- ''-'''
 usage:
 - 'nfsidmap: Usage: nfsidmap [-vh] [-c || [-u|-g|-r key] || -d || -l || [-t timeout] key desc]'
 flags:

--- a/corpus/ping4/audit-seed4/expected.snap
+++ b/corpus/ping4/audit-seed4/expected.snap
@@ -1,5 +1,4 @@
 name: ping4
-description: '/usr/bin/ping4: invalid option -- ''-'''
 flags:
 - short: 'a'
   description: use audible ping

--- a/corpus/ssh-keygen/9.6p1/expected.snap
+++ b/corpus/ssh-keygen/9.6p1/expected.snap
@@ -1,5 +1,4 @@
 name: ssh-keygen
-description: unknown option -- -
 usage:
 - 'usage: ssh-keygen [-q] [-a rounds] [-b bits] [-C comment] [-f output_keyfile] [-m format] [-N new_passphrase] [-O option] [-t dsa | ecdsa | ecdsa-sk | ed25519 | ed25519-sk | rsa] [-w provider] [-Z cipher]'
 - ssh-keygen -p [-a rounds] [-f keyfile] [-m format] [-N new_passphrase] [-P old_passphrase] [-Z cipher]

--- a/corpus/ssh-keygen/9.6p1/meta.toml
+++ b/corpus/ssh-keygen/9.6p1/meta.toml
@@ -15,6 +15,17 @@
 # separate, narrower, already-documented gap in the bundle detector, not
 # the bare-token-value defect this fixture locks in; see
 # `corpus/ssh-keygen/audit-seed2` (`[xfail]`, "missing -U") for it.
+#
+# Re-blessed for a second, independent fix: `sections::is_option_error_line`
+# / `is_option_error_paragraph` now recognize this capture's leading
+# stderr line, `unknown option -- -` (ssh-keygen's own getopt complaint
+# about the `--help` probe, not a description of the tool), and drop it
+# rather than surface it as `description`. It was the tool's *only*
+# leading paragraph, so the tree's `description` field is now absent
+# entirely rather than replaced with something else — the honest outcome
+# per that predicate's own doc comment. Confirmed by
+# `pty_screenshot.py`: the DESCRIPTION pane this line used to populate is
+# gone from the detail pane, which now opens directly on USAGE.
 
 [bless]
 provenance = "agent"

--- a/corpus/xfs_io/audit-seed2/expected.snap
+++ b/corpus/xfs_io/audit-seed2/expected.snap
@@ -1,5 +1,4 @@
 name: xfs_io
-description: '/usr/sbin/xfs_io: invalid option -- ''-'''
 usage:
 - 'Usage: xfs_io [-adfinrRstVx] [-m mode] [-p prog] [[-c|-C] cmd]... file'
 flags:

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -655,12 +655,23 @@ fn parse_body(
     // when a later paragraph exists to fall back to, so a tool whose entire
     // leading prose happens to open with something version-shaped never
     // loses its only description.
-    let description_lines: Vec<&str> =
-        if paragraphs.len() > 1 && is_banner_paragraph(&paragraphs[0]) {
-            paragraphs[1..].iter().flatten().copied().collect()
-        } else {
-            paragraphs.into_iter().flatten().collect()
-        };
+    // The tool's own option-error complaint (`is_option_error_paragraph`,
+    // e.g. `ssh-keygen`'s `unknown option -- -`) is checked first and
+    // independently of the banner check above it: unlike a banner, it is
+    // allowed to drop the *only* leading paragraph (see that function's
+    // doc comment for why losing the description there is the honest
+    // outcome), so it cannot be folded into the `paragraphs.len() > 1`
+    // guard the banner check needs.
+    let drop_first_paragraph = match paragraphs.first() {
+        Some(first) if is_option_error_paragraph(first) => true,
+        Some(first) if paragraphs.len() > 1 && is_banner_paragraph(first) => true,
+        _ => false,
+    };
+    let description_lines: Vec<&str> = if drop_first_paragraph {
+        paragraphs[1..].iter().flatten().copied().collect()
+    } else {
+        paragraphs.into_iter().flatten().collect()
+    };
     if !description_lines.is_empty() {
         result.description = Some(description_lines.join(" "));
     }
@@ -1964,6 +1975,220 @@ fn looks_like_email(word: &str) -> bool {
         && domain
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-'))
+}
+
+/// True if `paragraph` (the same leading, blank-line-delimited unit
+/// [`is_banner_paragraph`] is consulted on — see the description-collection
+/// block in [`parse_with_profile`]) is the tool's own complaint about the
+/// probe's argument, not descriptive prose, and should be dropped rather
+/// than shown as the DESCRIPTION.
+///
+/// # The defect
+///
+/// A program built on a getopt-family option parser that has no `--help`
+/// flag answers the probe by treating `--help` as an unrecognized option:
+/// it prints its own one-line complaint, then (often, not always) still
+/// manages to print a usage line. `ssh-keygen --help` writes exactly two
+/// lines to stderr — `unknown option -- -` then its usage block — and
+/// `c_rehash --help` writes *one* line and stops there: `Usage error; try
+/// -h.`. Neither line describes what the tool does; both describe what the
+/// probe did wrong. But step 2 above (leading prose becomes the
+/// description) has no way to tell that apart from real descriptive
+/// prose — `wpa_cli`'s root description was exactly this kind of banner
+/// before that fix landed (see step 2's own comment) — and this shape
+/// slipped through the same gap: it is the tool's *own* self-referential
+/// complaint, not a version/author banner, so [`is_banner_paragraph`]'s
+/// two signals (name-version line, contact info) never fire on it either.
+///
+/// # The rule
+///
+/// Every line in the paragraph must match [`is_option_error_line`] below.
+/// Requiring *all* lines (not just the first) is what lets this fire on
+/// `myisamlog`, whose probe apparently retried against several rejected
+/// characters and printed four consecutive complaints
+/// (`illegal option: "--"` / `"-h"` / `"-e"` / `"-l"`) with no blank line
+/// between them — one paragraph, four lines, every one of them this exact
+/// shape — while refusing a paragraph the moment any line in it is
+/// something else, e.g. `crontab`'s second line (`crontab: usage error:
+/// unrecognized option`, a *different* self-referential message this
+/// predicate does not recognize as its own shape) or `vite`'s second line
+/// (an unrelated Qt platform-plugin error). Both are still probably junk,
+/// but this fix does not claim to know that; it only removes the lines it
+/// can name with confidence, per this file's standing rule of narrow
+/// predicates over broad ones.
+///
+/// # Why this can drop the *only* paragraph
+///
+/// [`is_banner_paragraph`] is only ever consulted when a later paragraph
+/// exists to fall back to (see the call site's comment) — dropping a
+/// tool's only leading paragraph there would trade a merely-unusual
+/// description for no description at all, a worse outcome when the
+/// paragraph might still be real prose that happens to look bannerish.
+/// This predicate is not exposed to that risk: it recognizes a *complaint*,
+/// which is never a description regardless of what else is or isn't
+/// available, so it is checked before, and independently of, the
+/// banner check — see the call site. `c_rehash`'s entire captured output
+/// is its one-line complaint; dropping it leaves the node with no
+/// description at all, which is the honest outcome — mandible does not
+/// know what `c_rehash` does, and showing the probe's own error about
+/// `--help` in the description pane is a worse answer than showing none.
+fn is_option_error_paragraph(paragraph: &[&str]) -> bool {
+    !paragraph.is_empty() && paragraph.iter().all(|line| is_option_error_line(line))
+}
+
+/// True if `line` (trimmed) is, on its own, one of the handful of
+/// conventional getopt-family "you gave me a bad option" complaints —
+/// see [`is_option_error_paragraph`] for why this exists and how it's used.
+///
+/// # The shape
+///
+/// An optional single-token `<name>: ` prefix (the invoking program's own
+/// name or full path — `nginx: ...`, `/usr/sbin/rpcbind: ...`), then one of
+/// four conventional complaints — `unknown`/`invalid`/`illegal`/
+/// `unrecognized` `option`(s) — as the very first thing on the (post-prefix)
+/// line, with at most a short, flag-shaped trailer (`-- '-'`, `: --help`,
+/// `"--help"`); or, verbatim, busybox's `Usage error; try -h.`.
+///
+/// The prefix is stripped only when the text before the first `": "` has no
+/// whitespace of its own — a bare name or path never contains a space, so
+/// this is what tells a real `<progname>: ` prefix (`ping`'s
+/// `/usr/bin/ping: invalid option -- '-'`) apart from a message that merely
+/// *contains* a colon (`debconf-copydb`'s `Unknown option: help`, whose
+/// pre-colon text, `"Unknown option"`, has a space and is therefore never
+/// mistaken for a program name). Both shapes are handled by the same code
+/// path: when the candidate prefix fails the no-whitespace test, stripping
+/// is simply skipped and the *whole* line is checked against the four
+/// complaints instead, which is exactly what `"Unknown option: help"`
+/// needs (the message itself contains the `": "` that a real prefix would
+/// have used).
+///
+/// The trailer bound (at most 24 characters, at most 3 whitespace-separated
+/// words, and drawn only from ASCII letters/digits plus a small punctuation
+/// set: space, `-`, `_`, `:`, `'`, `"`, `.`, `;`) is the safety argument
+/// against the sentence reading: a real description that merely *mentions*
+/// one of these phrases mid-clause (GNU tar's `--occurrence[=NUMBER]`
+/// entry — hypothetical prose like "an invalid option combination here
+/// raises an error" — never has the phrase open the line to begin with, so
+/// it never reaches the trailer check at all; a line that *does* open with
+/// the phrase but keeps going past a terse flag-shaped trailer (`socat`'s
+/// `unknown option "--help"; use option "-h" for help`, whose trailer runs
+/// well past both the length and word-count bound) is rejected there
+/// instead.
+///
+/// # Measured
+///
+/// Over the 2,301 frozen captures in `audit/queue-captures/` (spec
+/// §13.1d's frozen queue), measured the honest way — not by re-deriving
+/// paragraph collection by hand (which drifts from the real usage-block
+/// detection: an early attempt at this measurement undercounted because it
+/// didn't recognize `nfsidmap: Usage: ...`'s name-prefixed usage line the
+/// way the real scanner does), but by diffing [`parse_with_profile`]'s
+/// actual `description` output with and without this predicate wired in,
+/// over the same real call path: **116
+/// tools** have their DESCRIPTION changed by this fix, among them `ssh`,
+/// `ssh-keygen`, `ssh-keyscan`, `ssh-agent`, `sftp`, `slogin`,
+/// `ssh-copy-id`, `c_rehash`, `nginx`, `myisamlog`, `ping`, `ping4`,
+/// `ping6`, `reset`, `tput`, `tic`, `infocmp`, all fifteen probed `xfs_*`
+/// tools, all four `fsck.ext{2,3,4}`/`mke2fs` variants, and the four
+/// `debconf-*` tools (full list in this fix's PR description).
+///
+/// A **broader** shape — the same four keywords or "usage error" occurring
+/// anywhere in the tool's raw leading text — additionally matches **52
+/// tools** whose description this fix deliberately leaves untouched, each
+/// excluded for one of three checked reasons rather than rounded into the
+/// total:
+///
+/// 1. **The line never opens with a recognized phrase, even after
+///    prefix-stripping** (9 tools): a multi-token prefix — a timestamp
+///    and/or pid, not a bare name — on `filan`'s `2026/08/14 19:31:25
+///    filan[18942] E unknown option --help`, `procan`, `socat`, `socat1`
+///    (whose `; use option "-h" for help` continuation would also fail the
+///    trailer bound on its own); an extra field between the prefix and the
+///    message on `dash`/`sh`'s `/bin/dash: 0: Illegal option --` (the
+///    shell's own `argv[0]: lineno: message` convention) and `ftp`/`tnftp`'s
+///    `ftp: --: unknown option`; and a leading `*** ` marker on
+///    `nslookup`'s `*** Invalid option: -help`.
+/// 2. **A real banner or unrelated error precedes the complaint as the
+///    paragraph's own first line** (7 tools): `debugfs`, `dumpe2fs`,
+///    `e2image`, `resize2fs` (`e2image 1.47.0 (5-Feb-2023)`, a
+///    three-token version line that also isn't quite
+///    [`is_banner_paragraph`]'s two-token shape — a pre-existing,
+///    separate gap, not one this fix claims to close), `ntfstruncate`
+///    (version plus copyright), and `byobu-quiet`/`byobu-silent` (a `sed:
+///    couldn't readlink ...` line ahead of the real `tmux: unknown option
+///    -- X` complaint).
+/// 3. **The first line matches but a later line in the same paragraph
+///    carries real, distinct content** (36 tools) — `is_option_error_paragraph`'s
+///    all-lines requirement (above) correctly refuses the whole paragraph
+///    rather than guess which lines to drop: `crontab`'s second line
+///    (`crontab: usage error: unrecognized option`, a different
+///    self-referential message this predicate does not claim to
+///    recognize), `sshd`'s second line (its own version banner), `lsof`'s
+///    second/third lines (a different diagnostic, then its version
+///    banner), `mkfs.xfs`'s second line (`unknown option -\0 `, a literal
+///    embedded NUL that correctly fails the trailer's character-class
+///    check), and 32 more of the same shape: `Xvfb`, `arptables-nft-save`,
+///    `arptables-save`, `cgi-fcgi`, `cpgr`, `cppw`, `delv`, `devlink`,
+///    `ebtables-nft-save`, `ebtables-save`, `fuser`, `ip6tables-legacy-save`,
+///    `ip6tables-nft-save`, `ip6tables-save`, `iptables-legacy-save`,
+///    `iptables-nft-save`, `iptables-save`, `lvmdump`, `mytop`, `nfsconf`,
+///    `nfsidmap`, `nsupdate`, `pppoe-discovery`, `pptp`, `prtstat`,
+///    `rsyslogd`, `socat-broker.sh`, `socat-chain.sh`, `socat-mux.sh`,
+///    `vite`, `xfs_rtcp`, `zipdetails`.
+fn is_option_error_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let core = strip_option_error_progname_prefix(trimmed).unwrap_or(trimmed);
+    let lower = core.to_ascii_lowercase();
+    if lower == "usage error; try -h." || lower == "usage error; try -h" {
+        return true;
+    }
+    const KEYWORDS: [&str; 4] = [
+        "unknown option",
+        "invalid option",
+        "illegal option",
+        "unrecognized option",
+    ];
+    for kw in KEYWORDS {
+        let Some(mut tail) = lower.strip_prefix(kw) else {
+            continue;
+        };
+        // Accept the plural ("options") too, without a separate keyword list.
+        tail = tail.strip_prefix('s').unwrap_or(tail);
+        return option_error_tail_is_shapely(tail);
+    }
+    false
+}
+
+/// Strips a leading `<token>: ` prefix from `line` when, and only when,
+/// `<token>` itself contains no whitespace — see [`is_option_error_line`]
+/// for why that single condition is what tells a genuine `<progname>: `
+/// prefix apart from a message that merely contains a colon.
+fn strip_option_error_progname_prefix(line: &str) -> Option<&str> {
+    let (prefix, rest) = line.split_once(": ")?;
+    if prefix.is_empty() || prefix.chars().count() > 64 || prefix.contains(char::is_whitespace) {
+        return None;
+    }
+    Some(rest)
+}
+
+/// True if `tail` (everything after one of [`is_option_error_line`]'s four
+/// keyword phrases) is short and flag-shaped rather than the start of a
+/// longer sentence — see that function's doc comment for the false
+/// positive (`socat`'s continuation clause) this bound exists to refuse.
+fn option_error_tail_is_shapely(tail: &str) -> bool {
+    let tail = tail.trim();
+    if tail.is_empty() {
+        return true;
+    }
+    if tail.chars().count() > 24 || tail.split_whitespace().count() > 3 {
+        return false;
+    }
+    tail.chars().all(|c| {
+        c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '_' | ':' | '\'' | '"' | '.' | ';')
+    })
 }
 
 /// The column a tab in leading whitespace advances to, from whatever
@@ -9824,6 +10049,105 @@ Options:
             parsed.description.as_deref(),
             Some("Build v2 is faster than v1. See the changelog for details.")
         );
+    }
+
+    // --- leading option-error line is not a description -------------------
+
+    /// `ssh-keygen --help`'s exact defect, byte-for-byte: its own getopt
+    /// complaint about the unrecognized `--help` probe, then its usage
+    /// block, and nothing else. The complaint is the *only* leading
+    /// paragraph — unlike the banner check above, this must still drop it,
+    /// leaving no description at all rather than showing the tool's own
+    /// error about the probe.
+    #[test]
+    fn a_leading_option_error_line_is_dropped_even_as_the_only_paragraph() {
+        let raw = "unknown option -- -\nusage: ssh-keygen [-q] [-a rounds]\n";
+        let parsed = parse_named(raw, "ssh-keygen");
+        assert_eq!(parsed.description, None);
+        assert!(!parsed.usage.is_empty(), "usage block must survive");
+    }
+
+    /// `c_rehash --help`'s degenerate case: the entire captured output is
+    /// one line, busybox-style `Usage error; try -h.`, with no usage block
+    /// to recover at all. Still dropped, for the same reason.
+    #[test]
+    fn a_lone_usage_error_line_is_dropped_with_nothing_left() {
+        let parsed = parse_named("Usage error; try -h.\n", "c_rehash");
+        assert_eq!(parsed.description, None);
+    }
+
+    /// A `<progname>: ` prefix (bare name or full path) is recognized and
+    /// stripped before matching the four conventional complaints —
+    /// `ping`'s real shape.
+    #[test]
+    fn a_progname_prefixed_option_error_line_is_dropped() {
+        let raw = "/usr/bin/ping: invalid option -- '-'\n\nUsage: ping [options] <destination>\n";
+        let parsed = parse_named(raw, "ping");
+        assert_eq!(parsed.description, None);
+    }
+
+    /// `myisamlog`'s shape: several consecutive complaints, one per
+    /// rejected character, with no blank line between them — one
+    /// paragraph, several lines, every one of them this exact shape. All
+    /// must match for the paragraph to be dropped.
+    #[test]
+    fn a_paragraph_of_several_option_error_lines_is_dropped() {
+        let raw = "illegal option: \"--\"\nillegal option: \"-h\"\nillegal option: \"-e\"\n\nUsage: myisamlog\n";
+        let parsed = parse_named(raw, "myisamlog");
+        assert_eq!(parsed.description, None);
+    }
+
+    /// A real description that merely *contains* one of the four keyword
+    /// phrases mid-sentence must never be dropped — the phrase has to open
+    /// the (post-prefix) line, not merely occur in it. This is the
+    /// `--occurrence`-style false positive the hard constraint on this fix
+    /// calls out by name.
+    #[test]
+    fn a_sentence_mentioning_invalid_option_mid_clause_survives() {
+        let raw = "An invalid option combination here raises an error, so check twice.\n\n\
+                    Usage: mytool [OPTIONS]\n";
+        let parsed = parse(raw);
+        assert_eq!(
+            parsed.description.as_deref(),
+            Some("An invalid option combination here raises an error, so check twice.")
+        );
+    }
+
+    /// A leading complaint followed by a *second, unrelated* line in the
+    /// same paragraph (no blank line between them) must not be dropped —
+    /// `is_option_error_paragraph` requires every line in the paragraph to
+    /// match, and refuses to guess which lines to keep. `sshd`'s real
+    /// shape: its own version banner sits directly under the complaint.
+    #[test]
+    fn a_mixed_paragraph_with_real_content_is_kept_whole() {
+        let raw = "unknown option -- -\nOpenSSH_9.6p1 Ubuntu, OpenSSL 3.0.13\n\n\
+                    usage: sshd [-46DdeGiqTtV]\n";
+        let parsed = parse_named(raw, "sshd");
+        assert_eq!(
+            parsed.description.as_deref(),
+            Some("unknown option -- - OpenSSH_9.6p1 Ubuntu, OpenSSL 3.0.13")
+        );
+    }
+
+    /// A trailing continuation clause past the terse-flag bound must not
+    /// qualify — `socat`'s real shape (minus its log-format prefix, which
+    /// independently also disqualifies it; this isolates the trailer
+    /// bound specifically).
+    #[test]
+    fn a_trailing_continuation_clause_is_not_a_shapely_trailer() {
+        assert!(!is_option_error_line(
+            "unknown option \"--help\"; use option \"-h\" for help"
+        ));
+    }
+
+    /// The busybox `Usage error; try -h.` shape matches verbatim, but nothing
+    /// that merely resembles it with extra words does.
+    #[test]
+    fn only_the_exact_usage_error_shape_matches() {
+        assert!(is_option_error_line("Usage error; try -h."));
+        assert!(!is_option_error_line(
+            "Usage error occurred while parsing; try -h."
+        ));
     }
 
     // --- headingless invocation table (spec §7 Tier B) -------------------


### PR DESCRIPTION
## Summary

`ssh-keygen` has no `--help`. Probing it prints the tool's own getopt
complaint to stderr *before* its usage block:

```
unknown option -- -
usage: ssh-keygen [-q] [-a rounds] [-b bits] ...
```

That first line was becoming the DESCRIPTION mandible shows in the TUI.
`c_rehash --help` is the degenerate case — its entire output is
`Usage error; try -h.`, which likewise became the description.

`mandible-extract/src/help_text/sections.rs` gains two new predicates,
consumed at the paragraph-selection site in `parse_with_profile` (step 2,
"leading prose becomes the description"):

```rust
fn is_option_error_paragraph(paragraph: &[&str]) -> bool {
    !paragraph.is_empty() && paragraph.iter().all(|line| is_option_error_line(line))
}

fn is_option_error_line(line: &str) -> bool {
    let trimmed = line.trim();
    if trimmed.is_empty() {
        return false;
    }
    let core = strip_option_error_progname_prefix(trimmed).unwrap_or(trimmed);
    let lower = core.to_ascii_lowercase();
    if lower == "usage error; try -h." || lower == "usage error; try -h" {
        return true;
    }
    const KEYWORDS: [&str; 4] = [
        "unknown option",
        "invalid option",
        "illegal option",
        "unrecognized option",
    ];
    for kw in KEYWORDS {
        let Some(mut tail) = lower.strip_prefix(kw) else {
            continue;
        };
        tail = tail.strip_prefix('s').unwrap_or(tail);
        return option_error_tail_is_shapely(tail);
    }
    false
}
```

`is_option_error_line` strips an optional single-token `<progname>: `
prefix (a bare name or full path — `nginx: ...`, `/usr/sbin/rpcbind: ...`
— never a prefix containing its own space, which is what tells a real
progname prefix apart from a message that merely contains a colon, e.g.
`debconf-copydb`'s `Unknown option: help`), then requires one of the four
conventional getopt complaints to open the (post-prefix) line, with at
most a short (<=24 char, <=3-word, small-punctuation-only) trailer. No
tool names anywhere in the predicate — it keys entirely on shape.

**Unlike `is_banner_paragraph`, this predicate can fire when it is the
tool's *only* leading paragraph** — dropping it leaves the node with no
description at all, which is honest: mandible does not know what
`c_rehash` does, and showing the probe's own error is worse than showing
nothing.

## Fleet-wide measurement (mandatory per task)

Measured over the 2,301 frozen captures in `audit/queue-captures/`, by
diffing `parse_with_profile`'s actual `description` output with and
without this predicate wired in (not by hand-reproducing the paragraph
loop, which drifts from the real usage-block detector — an early attempt
undercounted because it didn't recognize `nfsidmap: Usage: ...`'s
name-prefixed usage line the way the real scanner does).

**116 tools** have their DESCRIPTION changed by this fix:

```
applydeltarpm, arpd, badblocks, bcache-super-show, bdftopcf, blkmapd,
btrfs-map-logical, btrfs-select-super, c_rehash, captoinfo, clear,
combinedeltarpm, cron, debconf-copydb, debconf-escape,
debconf-set-selections, debconf-show, demandoc, dig, e2freefrag, e2fsck,
e2mmpstatus, e2undo, ebtables-nft-restore, ebtables-restore, faillock,
filefrag, fsck.ext2, fsck.ext3, fsck.ext4, getcap, host, infocmp,
infotocap, install-sgmlcatalog, json_pp, key.dns_resolver, lsattr, lspci,
makedeltarpm, makewhatis, mandoc, mandocd, mapropos, mcatman, mdig,
mke2fs, mkfs.ext2, mkfs.ext3, mkfs.ext4, mman, msoelim, mwhatis,
myisamlog, nc, nc.openbsd, netcat, nfnl_osf, nginx, numactl,
pam_timestamp_check, paperconf, ping, ping4, ping6, poff, pppdump,
pppstats, pstree, pstree.x11, request-key, reset, reset-trace-bpfcc,
rpc.gssd, rpc.svcgssd, rpcbind, rpcinfo, rtacct, scandeps, scp, sftp,
slogin, sm-notify, ssh, ssh-agent, ssh-copy-id, ssh-keygen, ssh-keyscan,
tic, toe, tput, tracepath, tset, tune2fs, update-mime-database, xfs_admin,
xfs_bmap, xfs_copy, xfs_db, xfs_estimate, xfs_freeze, xfs_fsr, xfs_growfs,
xfs_info, xfs_io, xfs_logprint, xfs_mdrestore, xfs_metadump, xfs_mkfile,
xfs_ncheck, xfs_quota, xfs_repair, xfs_scrub, xfs_spaceman, xsubpp,
zerofree
```

A **broader** shape — the same four keywords or "usage error" occurring
anywhere in the leading text — additionally matches **52 tools** this fix
deliberately does not admit, for three checked reasons (full detail and
per-tool breakdown in `is_option_error_line`'s doc comment):

1. **Never opens with a recognized phrase even after prefix-stripping** (9):
   `filan`/`procan`/`socat`/`socat1` (timestamp+pid log prefix),
   `dash`/`sh` (`argv[0]: lineno: message` shell convention),
   `ftp`/`tnftp` (extra `--:` field), `nslookup` (leading `***` marker).
2. **A real banner/unrelated error precedes the complaint** (7):
   `debugfs`, `dumpe2fs`, `e2image`, `resize2fs`, `ntfstruncate` (version
   banners), `byobu-quiet`/`byobu-silent` (a `sed:` error ahead of the
   real complaint).
3. **First line matches but a later line in the same paragraph carries
   real content** (36) — the all-lines requirement correctly refuses the
   whole paragraph rather than guess which lines to drop: `Xvfb`,
   `arptables-nft-save`, `arptables-save`, `cgi-fcgi`, `cpgr`, `cppw`,
   `crontab`, `delv`, `devlink`, `ebtables-nft-save`, `ebtables-save`,
   `fuser`, `ip6tables-legacy-save`, `ip6tables-nft-save`,
   `ip6tables-save`, `iptables-legacy-save`, `iptables-nft-save`,
   `iptables-save`, `lsof`, `lvmdump`, `mkfs.xfs` (embedded NUL byte on
   its second line, correctly refused by the trailer charset), `mytop`,
   `nfsconf`, `nfsidmap`, `nsupdate`, `pppoe-discovery`, `pptp`,
   `prtstat`, `rsyslogd`, `sshd`, `socat-broker.sh`, `socat-chain.sh`,
   `socat-mux.sh`, `vite`, `xfs_rtcp`, `zipdetails`.

## Sweep-diff (before/after, full `PATH`)

Compared against the shared frozen baseline
(`/tmp/.../scratchpad/baseline.txt`, 2,254 tools) with this branch's own
`xtask coverage` run:

```
overall: IDENTICAL
sweep transition: 2254 -> 2254 tools, 2254 matched, 0 appeared, 0 disappeared, 21 excluded (near 10s cap)
# status transitions
(none)
# flag-count losses: 0 lost across 0 tool(s)
# flag-count gains: 0 gained across 0 tool(s)
# field-level changes: 0 tool(s)
```

Zero regressions — expected, since the coverage scoreboard doesn't track
`description` text and this fix touches nothing else (no flag, subcommand,
or status field changes). The 21 "excluded, near cap" tools show the same
before/after timing noise on both sides (no tool newly crossed the cap),
consistent with spec §13.1b rule 3 (wall-clock noise, not a regression).

## Corpus

- Re-blessed `filefrag/audit-seed2`, `nfsidmap/audit-seed`,
  `nfsidmap/audit-seed2`, `ping4/audit-seed4`, `ssh-keygen/9.6p1`,
  `xfs_io/audit-seed2` — in every case the *only* diff is the
  `description:` line disappearing from `expected.snap`; nothing else
  moved.
- Added `corpus/c_rehash/3.0.13` (new fixture, `[bless] provenance =
  "agent"`) for the degenerate one-line/no-usage shape. Honest note in
  its own `meta.toml`: because `c_rehash --help` recovers no flags/
  subcommands/usage, `build_node`'s `structurally_plausible` check was
  already false regardless of this fix, so the root node was already
  routed to the verbatim/raw-text tier before this fix landed too — this
  fixture pins the fix at the level it actually operates
  (`ParsedHelp::description`, via the frozen snapshot proving it's
  `null`), not a visible TUI change for this specific tool. `ssh-keygen`
  is the fixture that demonstrates the fix's *visible* effect, because its
  usage block keeps it out of the verbatim tier.
- Added unit tests directly exercising both shapes, the progname-prefixed
  shape, the multi-line `myisamlog` shape, the mixed-paragraph-not-dropped
  shape (`sshd`), the `--occurrence`-style false-positive guard, and the
  trailer-length/exact-usage-error-shape predicates.
- `cargo run -p xtask -- corpus`: **108 fixtures, 98 ok, 10 xfail (as
  expected), 0 failed.**

## See it yourself

```
mandible --doctor ssh-keygen
mandible ssh-keygen      # DESCRIPTION pane
mandible c_rehash
```

**Before** (`ssh-keygen`, DESCRIPTION pane shows the probe's own error):

```
╭ ssh-keygen ────────────────────────────────────╮
│ DESCRIPTION ────────────────────────────────── │
│ unknown option -- -                            │
│                                                 │
│ USAGE ──────────────────────────────────────── │
│   ssh-keygen [-q] [-a rounds] [-b bits] [-C    │
│   comment] [-f output_keyfile] [-m format] ... │
```

**After** (`ssh-keygen`, DESCRIPTION gone, opens straight on USAGE):

```
╭ ssh-keygen ────────────────────────────────────╮
│ USAGE ──────────────────────────────────────── │
│   ssh-keygen [-q] [-a rounds] [-b bits] [-C    │
│   comment] [-f output_keyfile] [-m format] ... │
```

`c_rehash` is byte-identical before and after (see the Corpus section
above for why: it was already on the verbatim/raw-text rendering path
regardless of this fix).

## Test plan

- [x] `cargo build --release`
- [x] Full-`PATH` sweep-diff vs. shared baseline: `overall: IDENTICAL`
- [x] `cargo run -p xtask -- corpus`: 98 ok, 10 xfail, 0 failed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`: 1155 passed, 0 failed
- [x] `pty_screenshot.py` before/after for `ssh-keygen` and `c_rehash`
