### PR TITLE
release: 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-08-26
+
 ### Fixed
 
 - **The TUI footer's confidence badge read `low confidence: 0% parsed` for `ssh-keygen` while `--doctor` reported `100.0% flags with text` for the same document**, because `sections::compute_confidence` divided a one-row option-table sample (a wrapped usage-synopsis fragment misread as a lone flag row) instead of treating it as too small to rate; fixed by giving a one-row sample its own `0.5` fallback, independent of whether a usage line was found — a fleet scan of `audit/queue-captures/` shows this removes 23 fabricated badges (including `ssh-keygen`'s) and fabricates none, and confirms an earlier version of this fix (folding the one-row case into the zero-row fallback) would have fabricated 7 new badges on cleanly-parsed single-flag tools (`byobu-disable`, `byobu-enable`, `bzless`, `bzmore`, `debconf-apt-progress`, `validlocale`, `xdg-user-dir`); `find`/`ip`'s genuine low-confidence badges (real, larger samples) are untouched.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "insta",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arboard",
  "base64",
@@ -2362,7 +2362,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.4.2" }
-mandible-extract = { path = "mandible-extract", version = "0.4.2" }
-mandible-search = { path = "mandible-search", version = "0.4.2" }
-mandible-tui = { path = "mandible-tui", version = "0.4.2" }
+mandible-core = { path = "mandible-core", version = "0.4.3" }
+mandible-extract = { path = "mandible-extract", version = "0.4.3" }
+mandible-search = { path = "mandible-search", version = "0.4.3" }
+mandible-tui = { path = "mandible-tui", version = "0.4.3" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Cuts 0.4.3: round A (#41-#44), the #38 external contribution + #39 follow-up, docs rules (#45). Non-breaking patch release; every change visually verified by the maintainer. Local gate: 1170 tests, fmt/clippy clean, corpus 110 fixtures / 0 failed, changelog guard green, no stray snapshots.