### PR TITLE
fix(mandible): recolor the about-screen banner from orange to teal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- The `mandible mandible` easter-egg banner was painted with xterm-256 index 173 (an orange), an odd, unexplained choice given the rest of the UI's single-cyan-accent contract; it now uses index 30, a dark cyan/teal chosen for balanced WCAG contrast against both a plain black and a plain white terminal background (~4.4:1 and ~4.8:1 respectively), and the SGR code is now a named `BANNER_COLOR` constant next to the banner's other constants (`LETTERS`, `TRAJECTORY`, `LETTER_DELAY`, `FPS`) instead of a string literal at the call site.
+
 ## [0.4.3] - 2026-08-26
 
 ### Fixed

--- a/mandible/src/about.rs
+++ b/mandible/src/about.rs
@@ -120,6 +120,21 @@ const LETTER_DELAY: usize = 2;
 const LETTER_HEIGHT: usize = 8;
 const LETTER_SPACING: &str = "  ";
 const FPS: u64 = 20;
+/// SGR code for the wordmark's colour, xterm-256 index 30 (`#008787`, a
+/// dark cyan/teal). This isn't a named ANSI colour (spec §9.2 prefers those,
+/// since they resolve through the user's own terminal theme) because the
+/// banner is written with raw escape codes straight to stdout, outside
+/// `mandible-tui`'s `ratatui`/`crossterm` styling — there is no `Color`
+/// enum here to hand a theme-relative value to. Absent that, the fixed
+/// index has to work against both a plain black and a plain white
+/// background, which rules out a bright/pale cyan: WCAG relative-luminance
+/// contrast for xterm 30 (RGB 0,135,135) is ~4.4:1 on white and ~4.8:1 on
+/// black, close to the mathematically best a single colour can do against
+/// both extremes at once (the balance point is ~4.6:1 each way; brighter
+/// cyans such as index 80 push past 12:1 on black but drop under 2:1 on
+/// white, i.e. they wash out on a light terminal — the failure mode §9.2
+/// warns about).
+const BANNER_COLOR: &str = "38;5;30";
 
 fn max_shift() -> usize {
     TRAJECTORY.iter().copied().max().unwrap_or(0)
@@ -175,7 +190,7 @@ fn animate(color: bool) {
             let _ = write!(out, "\x1b[{canvas_height}A");
         }
         for line in frame(&offsets) {
-            let _ = writeln!(out, "\x1b[2K{}", paint(&line, "38;5;173", color));
+            let _ = writeln!(out, "\x1b[2K{}", paint(&line, BANNER_COLOR, color));
         }
         let _ = out.flush();
         std::thread::sleep(std::time::Duration::from_millis(1000 / FPS));


### PR DESCRIPTION
Recolors the `mandible mandible` easter-egg banner from xterm-256 index 173 (orange) to index 30 (a dark cyan/teal), and lifts the SGR code out of a call-site string literal into a named `BANNER_COLOR` constant beside the banner's other constants.

The orange was an unexplained outlier next to the rest of the UI's single-cyan-accent styling contract (spec §9.2).

## Why index 30 and not a brighter cyan

The banner is written with raw ANSI escapes straight to stdout, outside `mandible-tui`'s `ratatui`/`crossterm` styling — there is no `Color` enum here to hand a theme-relative value to, the way spec §9.2's accent does with `Color::Cyan`. So the fixed index has to work unaided against both a plain black and a plain white terminal background.

WCAG relative-luminance contrast, computed for the xterm 6×6×6 cube's cyan family and re-derived independently during review:

| index | RGB | on black | on white |
|---|---|---|---|
| 173 (outgoing orange) | 215,135,95 | 7.52:1 | 2.79:1 |
| 80 (bright cyan) | 95,215,215 | 12.19:1 | **1.72:1** |
| 37 | 0,175,175 | 7.75:1 | 2.71:1 |
| **30 (chosen)** | **0,135,135** | **4.82:1** | **4.36:1** |

A bright cyan such as index 80 pushes past 12:1 on black but drops under 2:1 on white — it washes out entirely on a light terminal, the failure mode §9.2 warns about. Index 30 is the closest the 216-colour cube gets to the balance point (~4.6:1 each way), clearing the 3:1 non-text minimum in both directions.

**The tradeoff, stated plainly:** index 30 is dimmer on a dark terminal than the orange it replaces (4.82 vs 7.52), bought in exchange for being legible on light (4.36 vs 2.79). If the maintainer prefers the outgoing colour's visual weight, index 73 (95,175,175) gives 8.24:1 on black / 2.55:1 on white — same weight as the orange, but cyan. It is a one-constant change.

## Verification

`pyte` strips colour attributes when it replays a pty, so `scripts/pty_screenshot.py` **cannot** show this change and no screenshot is offered as proof of it. Instead, raw pty bytes were captured from `mandible mandible` for both binaries:

- before (main @ fc0206d): 312 × `\x1b[38;5;173m`, 0 × `\x1b[38;5;30m`
- after (this branch): 0 × `\x1b[38;5;173m`, 312 × `\x1b[38;5;30m`

The matching count confirms only the colour code moved, nothing structural. It does **not** prove subjective legibility on a physical terminal — that rests on the contrast table above and on the maintainer's own visual pass.

## See it yourself

```console
$ git switch fix/tui-flag-columns
$ cargo build --release
$ ./target/release/mandible mandible
```

The animated block-letter `mandible` wordmark wipes in left-to-right and settles. **Look for:** the wordmark is a dark cyan/teal, not orange. Everything else on the about screen — version, tagline, "The rule:", repository and licence lines — is unchanged. Worth running once in a dark-background terminal and once in a light-background one; the point of index 30 is that it stays readable in both.

## Gates

Re-run independently on this branch by the orchestrator, not taken on the worker's report:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1170 tests run, 1170 passed, 0 skipped
- `cargo xtask corpus` — 110 fixtures: 100 ok, 10 xfail (as expected), 0 failed
- `cargo build --release` — ok

`git diff --numstat main..HEAD -- mandible-extract/` is empty: this branch touches no extraction code, so it is independent of the three parser lanes in flight.
