### PR TITLE
chore(lint): widen the machine-local-path lint and write the rule down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,20 @@ update Appendix A in the same commit, with the method.
   exists is not evidence that it does. If something is meant to be tracked,
   `git add` it and confirm with `git ls-files`; if a doc claims a file is
   tracked, that claim is checkable and belongs in a test.
+- **A location that only resolves on the machine you are sitting at never goes
+  into a committed file.** Working against local, untracked data is normal here
+  — the frozen `--help` captures under `audit/queue-captures/` are exactly that
+  — and a task brief will often hand you where they live. That is permission to
+  *read* them. It is not licence to write where they live into a source file, a
+  test, a fixture, or a doc comment: such a line passes every gate on the
+  machine that wrote it and is a lie on every other one. Anything a committed
+  file must be able to open is reached repo-relative
+  (`include_str!("../../corpus/…")`) or committed beside it as a corpus fixture.
+  `mandible-extract/tests/no_machine_local_paths.rs` enforces this over the
+  workspace's Rust sources and records the incident that produced it; it cannot
+  see `.toml`, markdown, commit messages or PR bodies, so those are on you.
+  Three agents in a single round had to be stopped mid-task for this one line,
+  which is why it is written down as well as linted.
 - **`NOTICE` is not optional.** Vendored third-party *data* carries attribution
   obligations, and it is the most likely genuine legal exposure in this project.
 - Gates before reporting done: `cargo fmt --all -- --check`,

--- a/mandible-extract/tests/no_machine_local_paths.rs
+++ b/mandible-extract/tests/no_machine_local_paths.rs
@@ -42,58 +42,81 @@ use std::path::{Path, PathBuf};
 /// test, and the `/tmp/ptyvenv` that `AGENTS.md` documents for the pty
 /// screenshot tool. `/home` and `/Users` catch a developer's own checkout
 /// path, which is the same mistake wearing different clothes.
-const MACHINE_LOCAL_PREFIXES: [&str; 4] = ["\"/tmp/", "\"/home/", "\"/Users/", "\"/var/folders/"];
+/// Deliberately matched *without* requiring a preceding `"`. The first
+/// version of this lint anchored on the quote, which only ever matched a
+/// prefix sitting at the very *start* of a string literal — so a
+/// machine-local path embedded further into one, `"file:///home/…"`, went
+/// unseen. (Measured, because the obvious guesses are wrong: `r"/home/…"`
+/// and `concat!("/home/", user)` were both already caught by the anchored
+/// form, since each puts a quote immediately before the prefix. Only the
+/// mid-literal case is new.) Comment lines are skipped below, which is
+/// what the quote was really buying.
+///
+/// One hole neither form closes, stated so nobody assumes otherwise:
+/// a path assembled piecewise, `PathBuf::from("/home").join(user)`, has no
+/// `/home/` substring anywhere and is invisible to a line-wise text lint.
+/// Catching that needs a real AST pass, which is not worth it for a
+/// mistake that has never once arrived in that shape.
+///
+/// `/root/` is deliberately **not** on this list, and the reason is worth
+/// keeping: adding it fires on `framework::artifact`'s clap fingerprint,
+/// `b"/root/.cargo/registry/src/index.crates.io/clap_builder-…/src/lib.rs"`,
+/// which is not a path this code ever opens — it is a byte pattern *other*
+/// binaries carry, baked in by whichever machine compiled them, and the
+/// test that uses it writes it into a `tempfile::tempdir()`. That is the
+/// "inline literal" the assertion below recommends, so flagging it would
+/// be the detector degrading working code to catch a case nobody has ever
+/// hit. Same tension applies to the four prefixes that *are* listed: if a
+/// future fingerprint has to embed one of them, the fingerprint is right
+/// and this list is what changes.
+const MACHINE_LOCAL_PREFIXES: [&str; 4] = ["/tmp/", "/home/", "/Users/", "/var/folders/"];
+
+/// Directories with no first-party Rust source to lint. `target` and `tmp`
+/// are build and scratch output, `.git` and `.claude` are tooling state
+/// (the latter holds agent worktrees, whose own checkouts are linted on
+/// their own branches, not through this one).
+const SKIPPED_DIRS: [&str; 4] = ["target", ".git", ".claude", "tmp"];
 
 #[test]
 fn no_source_file_references_a_machine_local_absolute_path() {
     let workspace_root = workspace_root();
-    let crate_src_dirs = [
-        "mandible-core/src",
-        "mandible-extract/src",
-        "mandible-search/src",
-        "mandible-tui/src",
-        "mandible/src",
-        "xtask/src",
-        "mandible-extract/tests",
-        "mandible-tui/tests",
-    ];
 
+    // Walked from the workspace root rather than from a hand-listed set of
+    // crate directories. The list version silently stopped covering
+    // anything it was not updated for: `mandible-core/tests` existed and
+    // was never on it, so a test added there was unlinted, and every new
+    // crate would have arrived the same way — a lint that needs a human to
+    // remember it is the thing it was written to replace.
     let mut violations = Vec::new();
-    for dir in crate_src_dirs {
-        let dir = workspace_root.join(dir);
-        if !dir.exists() {
+    for file in rust_files(&workspace_root) {
+        // The lint's own pattern table necessarily contains the
+        // literals it searches for. Exempting the implementing file is
+        // the standard shape for a self-referential lint.
+        if file
+            .file_name()
+            .is_some_and(|n| n == "no_machine_local_paths.rs")
+        {
             continue;
         }
-        for file in rust_files(&dir) {
-            // The lint's own pattern table necessarily contains the
-            // literals it searches for. Exempting the implementing file is
-            // the standard shape for a self-referential lint.
-            if file
-                .file_name()
-                .is_some_and(|n| n == "no_machine_local_paths.rs")
-            {
+        let text = std::fs::read_to_string(&file).unwrap_or_default();
+        for (lineno, line) in text.lines().enumerate() {
+            // This file quotes the offending shape in its own doc
+            // comment to explain the rule; exempt doc/line comments
+            // so the explanation doesn't trip the check it documents.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
                 continue;
             }
-            let text = std::fs::read_to_string(&file).unwrap_or_default();
-            for (lineno, line) in text.lines().enumerate() {
-                // This file quotes the offending shape in its own doc
-                // comment to explain the rule; exempt doc/line comments
-                // so the explanation doesn't trip the check it documents.
-                let trimmed = line.trim_start();
-                if trimmed.starts_with("//") {
-                    continue;
-                }
-                for prefix in MACHINE_LOCAL_PREFIXES {
-                    if line.contains(prefix) {
-                        violations.push(format!(
-                            "{}:{}: {}",
-                            file.strip_prefix(&workspace_root)
-                                .unwrap_or(&file)
-                                .display(),
-                            lineno + 1,
-                            line.trim()
-                        ));
-                    }
+            for prefix in MACHINE_LOCAL_PREFIXES {
+                if line.contains(prefix) {
+                    violations.push(format!(
+                        "{}:{}: {}",
+                        file.strip_prefix(&workspace_root)
+                            .unwrap_or(&file)
+                            .display(),
+                        lineno + 1,
+                        line.trim()
+                    ));
                 }
             }
         }
@@ -117,6 +140,12 @@ fn rust_files(dir: &Path) -> Vec<PathBuf> {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
+            if path
+                .file_name()
+                .is_some_and(|n| SKIPPED_DIRS.iter().any(|s| n == *s))
+            {
+                continue;
+            }
             out.extend(rust_files(&path));
         } else if path.extension().is_some_and(|e| e == "rs") {
             out.push(path);


### PR DESCRIPTION
`mandible-extract/tests/no_machine_local_paths.rs` exists because an agent was handed a scratch directory to work in and wrote the path into two tests, which then passed every gate on that machine and would have panicked for every other reader of the repository. Its own doc comment tells that story.

It happened again this round: three separate parser lanes had a machine-absolute path to `audit/queue-captures/` in their working trees, from the same cause — a task brief handed each worker where the frozen captures live so they could *read* them, and "where to read from" was heard as "a path you may write into source." None of it reached a commit, but the lint is what should have made that certain, and it had two holes.

## Hole 1: a hand-listed set of directories

The lint walked eight named `src`/`tests` directories. That list had already fallen behind the tree it claims to cover — `mandible-core/tests` exists and was never added — so a test placed there was unlinted, and every new crate would have arrived the same way. A lint that needs a human to remember it is the thing the lint was written to replace.

Now walks the workspace root, skipping only build output and tooling state (`target`, `tmp`, `.git`, `.claude`).

## Hole 2: the quote anchor

Every pattern was anchored as `"\"/home/`, i.e. it only matched a prefix at the very *start* of a string literal.

**Measured rather than assumed, because the obvious guesses are wrong.** The first version of this PR's commit message claimed `r"/home/…"` and `concat!("/home/", user)` slipped through. They did not — each puts a quote immediately before the prefix, so the anchored form already caught both. The one case the anchor genuinely missed is a machine-local path embedded further into a literal:

```rust
let c = "file:///home/ubuntu/x";   // anchored form: no match. now caught.
```

The claim in the code and the commit message was corrected to that before this PR went up.

**A hole neither form closes,** recorded next to the list so nobody assumes otherwise: `PathBuf::from("/home").join(user)` has no `/home/` substring anywhere and is invisible to any line-wise text lint. Catching it needs a real AST pass, which is not worth it for a shape the mistake has never once arrived in.

## Deliberately *not* done: adding `/root/`

It looks like an obvious omission. Adding it fires on `framework::artifact`'s clap fingerprint:

```rust
b"/root/.cargo/registry/src/index.crates.io/clap_builder-4.5.0/src/lib.rs",
```

That is not a path this code opens — it is a byte pattern *other* binaries carry, baked in by whichever machine compiled them, and the test using it writes it into a `tempfile::tempdir()`. That is precisely the "inline literal" the lint's own assertion recommends. Flagging it would be the detector degrading working code to catch a case nobody has ever hit, which this project has a standing rule against. The reasoning is recorded beside the prefix list so the next reader does not "fix" the omission.

## Verified by attack, not by assertion

Per AGENTS.md §3.1 — committed first, then attacked, then restored:

| attack | result |
|---|---|
| violating test dropped into `mandible-core/tests` (the directory-list hole) | lint **FAILS**, naming `mandible-core/tests/attack_probe.rs:3` |
| `"file:///home/ubuntu/x"` in a test (the anchor hole) | lint **FAILS**, naming `mandible-core/tests/attack2.rs:3` |
| both removed | lint **passes**, tree clean |

## AGENTS.md

Gains the rule in prose as well, in §5 beside "A result that exists only on one machine is not a result." The lint cannot see `.toml`, markdown, commit messages or PR bodies, and the failure mode is an instruction-following one — an agent told where to read writing that location into source — which a lint catches only after the fact. Worded around the read-vs-write distinction so it never has to quote a machine-absolute path itself.

No CHANGELOG entry: this is internal tooling and a working agreement, with no user-visible behaviour change.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1170 tests run, 1170 passed, 0 skipped
- `cargo xtask corpus` — 0 failed
