### PR TITLE
release: 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project intends to adhere to [Semantic Versioning](https://semver.org/)
 once it reaches a published 0.1.0 release.
 
-## [Unreleased]
+## [0.4.4] - 2026-08-27
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "insta",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arboard",
  "base64",
@@ -2362,7 +2362,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.4.3" }
-mandible-extract = { path = "mandible-extract", version = "0.4.3" }
-mandible-search = { path = "mandible-search", version = "0.4.3" }
-mandible-tui = { path = "mandible-tui", version = "0.4.3" }
+mandible-core = { path = "mandible-core", version = "0.4.4" }
+mandible-extract = { path = "mandible-extract", version = "0.4.4" }
+mandible-search = { path = "mandible-search", version = "0.4.4" }
+mandible-tui = { path = "mandible-tui", version = "0.4.4" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Cuts the 0.4.4 section: find 22→75 flags, iproute2 BNF alternation groups (ip/dcb/bridge/vdpa), LVM parenthesized alternation stanza (lvchange/pvchange/vgchange), cyan banner. All version strings bumped.