### PR TITLE
Scroll preformatted detail-pane content instead of wrapping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Added
+
+- The detail pane's raw `--help` view (`t`) and USAGE-section synopsis lines now scroll horizontally with `h`/`l`/`←`/`→` instead of wrapping, with a `←`/`→` marker drawn in the pane's border when there is more content off that edge; the rest of the detail pane (description, flags) is unaffected and still wraps as before. Controlled by a new `[ui] horizontal_scroll` key in `~/.config/mandible/config.toml` (default `true`); setting it to `false` restores the previous wrapping behavior exactly.
+
 ### Fixed
 
 - Pressing `t` to flip between the parsed view and the tool's own `--help` reset the detail pane to the top on every toggle, which broke the exact comparison the verbatim view exists for; the pane now carries the reader's place as a proportion of the view's extent and resolves it against the other view's height, surviving any number of consecutive toggles, while a selection change still starts at the top.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ name = "mandible-core"
 version = "0.4.4"
 dependencies = [
  "anyhow",
+ "directories",
  "insta",
  "proptest",
  "serde",
@@ -938,6 +939,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ contains what you typed. `everything` searches flags, summaries and descriptions
 fuzzily, so `gco` finds `checkout`. `/` opens the first, and pressing it again
 switches to the second.
 
+### Settings
+
+`~/.config/mandible/config.toml` holds general settings, separate from the
+per-tool overrides below:
+
+```toml
+[ui]
+horizontal_scroll = true  # default; false restores the old wrap-everything behavior
+```
+
+`horizontal_scroll` controls whether preformatted detail-pane content — the
+raw `--help` view (`t`) and USAGE synopsis lines — scrolls with `h`/`l`
+instead of wrapping. A missing file, table, or key all mean the default.
+
 ### Overrides
 
 Anything mandible gets wrong about a tool, you can correct locally. Drop a TOML file

--- a/mandible-core/Cargo.toml
+++ b/mandible-core/Cargo.toml
@@ -17,10 +17,12 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow.workspace = true
+directories.workspace = true
 serde.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/mandible-core/src/config.rs
+++ b/mandible-core/src/config.rs
@@ -1,0 +1,227 @@
+//! The user's general settings file, `~/.config/mandible/config.toml`.
+//!
+//! This is deliberately the *only* general config file mandible reads.
+//! `mandible-extract/src/overrides/mod.rs` defines a different mechanism —
+//! per-tool structure/prose replacement, keyed by tool name, one file per
+//! tool under `overrides/<tool>.toml` — living beside this one in the same
+//! config directory but serving a different job (spec §7 Tier F). This
+//! module is for settings that apply to mandible itself, independent of
+//! which tool is open.
+//!
+//! Resolution reuses exactly the escape hatch `overrides` already
+//! establishes: [`CONFIG_DIR_ENV`] beats the per-OS default
+//! (`directories::ProjectDirs`), because macOS ignores `XDG_CONFIG_HOME`
+//! entirely and a second, independently-invented resolution path would be
+//! one more place for that difference to go unnoticed.
+//!
+//! **Failure shape.** No config directory resolvable, no file present, no
+//! `[ui]` table, or a key missing from it: all four are the ordinary
+//! "this tier doesn't apply" case (`overrides::detect`'s shape) and fall
+//! back to the default silently. Only a file that exists but fails to
+//! *parse* is a user mistake worth surfacing — that is the one case where
+//! the user's own intent is being discarded rather than simply absent — so
+//! it gets one `tracing::warn!` (routed through `MANDIBLE_LOG` like
+//! everything else in this project) and then the same default. Never a
+//! panic: this runs on the startup path, before anything the user typed on
+//! the command line has had a chance to be wrong.
+
+use std::path::PathBuf;
+
+/// Environment variable that overrides the config directory outright.
+///
+/// The same variable `mandible-extract`'s override tier uses — see that
+/// module's doc comment for why one explicit variable beats a per-OS
+/// mental model. Two independent config readers resolving the same
+/// directory two different ways is exactly the kind of drift this project
+/// has already been bitten by once; this module intentionally does not
+/// redefine its own copy.
+pub const CONFIG_DIR_ENV: &str = "MANDIBLE_CONFIG_DIR";
+
+/// UI settings — currently just the detail pane's horizontal-scroll
+/// behavior, but the natural home for any future terminal-rendering
+/// preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UiConfig {
+    /// Whether preformatted detail-pane content (the raw `--help` view and
+    /// USAGE-section synopsis lines) scrolls horizontally instead of
+    /// wrapping. Default on; `false` restores exactly the pre-existing
+    /// wrapping behavior, byte for byte.
+    pub horizontal_scroll: bool,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        UiConfig {
+            horizontal_scroll: true,
+        }
+    }
+}
+
+/// mandible's general settings, as read from `config.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Config {
+    /// Terminal-UI settings.
+    pub ui: UiConfig,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct RawConfig {
+    #[serde(default)]
+    ui: RawUiConfig,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct RawUiConfig {
+    horizontal_scroll: Option<bool>,
+}
+
+/// The config directory: `$MANDIBLE_CONFIG_DIR` if set and non-empty, else
+/// the per-OS directory `directories::ProjectDirs` resolves
+/// (`$XDG_CONFIG_HOME/mandible` on Linux), if a home directory could be
+/// determined at all.
+fn config_dir() -> Option<PathBuf> {
+    match std::env::var_os(CONFIG_DIR_ENV) {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => directories::ProjectDirs::from("", "", "mandible")
+            .map(|dirs| dirs.config_dir().to_path_buf()),
+    }
+}
+
+/// `config.toml`'s path, if a config directory could be resolved at all.
+pub fn config_path() -> Option<PathBuf> {
+    config_dir().map(|dir| dir.join("config.toml"))
+}
+
+/// Load the user's config, falling back to [`Config::default`] whenever the
+/// file doesn't (yet) express an opinion — see the module doc comment for
+/// exactly which cases that covers. Never panics and never returns an
+/// error: a config file is optional by nature, and the caller (startup)
+/// has no user input yet to blame a failure on.
+pub fn load() -> Config {
+    let Some(path) = config_path() else {
+        return Config::default();
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return Config::default();
+    };
+    match toml::from_str::<RawConfig>(&raw) {
+        Ok(parsed) => Config {
+            ui: UiConfig {
+                horizontal_scroll: parsed.ui.horizontal_scroll.unwrap_or(true),
+            },
+        },
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "malformed mandible config.toml; using defaults"
+            );
+            Config::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Isolate one test's env mutation from the others — `std::env::set_var`
+    /// is process-global and Rust's test runner is multi-threaded by
+    /// default, so two tests touching `MANDIBLE_CONFIG_DIR` concurrently
+    /// would race. A single mutex serializes just the tests in this module.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_config_dir<R>(dir: &std::path::Path, f: impl FnOnce() -> R) -> R {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY-equivalent: serialized by `ENV_LOCK` above, restored
+        // before the guard drops.
+        std::env::set_var(CONFIG_DIR_ENV, dir);
+        let result = f();
+        std::env::remove_var(CONFIG_DIR_ENV);
+        result
+    }
+
+    #[test]
+    fn missing_directory_falls_back_to_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(CONFIG_DIR_ENV);
+        // Can't assert much about the real per-OS directory (it may or may
+        // not exist on the machine running this test), but `load` must
+        // never panic either way.
+        let _ = load();
+    }
+
+    #[test]
+    fn missing_file_is_the_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = with_config_dir(dir.path(), load);
+        assert_eq!(cfg, Config::default());
+        assert!(cfg.ui.horizontal_scroll, "default is on");
+    }
+
+    #[test]
+    fn empty_ui_table_is_the_default() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.toml"), "[ui]\n").unwrap();
+        let cfg = with_config_dir(dir.path(), load);
+        assert!(cfg.ui.horizontal_scroll);
+    }
+
+    #[test]
+    fn explicit_false_is_honored() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "[ui]\nhorizontal_scroll = false\n",
+        )
+        .unwrap();
+        let cfg = with_config_dir(dir.path(), load);
+        assert!(!cfg.ui.horizontal_scroll);
+    }
+
+    #[test]
+    fn explicit_true_is_honored() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "[ui]\nhorizontal_scroll = true\n",
+        )
+        .unwrap();
+        let cfg = with_config_dir(dir.path(), load);
+        assert!(cfg.ui.horizontal_scroll);
+    }
+
+    /// Unknown keys, and unknown top-level tables, must not hard-fail —
+    /// only a value that fails to *parse* is a user mistake.
+    #[test]
+    fn unknown_keys_do_not_break_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "[ui]\nhorizontal_scroll = true\nsome_future_key = 42\n\n[some_future_table]\nx = 1\n",
+        )
+        .unwrap();
+        let cfg = with_config_dir(dir.path(), load);
+        assert!(cfg.ui.horizontal_scroll);
+    }
+
+    /// A file that exists but fails to *parse* degrades to defaults rather
+    /// than panicking or propagating an error up through startup.
+    #[test]
+    fn malformed_toml_falls_back_to_defaults_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("config.toml")).unwrap();
+        write!(f, "this is not valid toml [[[").unwrap();
+        drop(f);
+        let cfg = with_config_dir(dir.path(), load);
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn config_dir_env_is_honored_for_the_path_too() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = with_config_dir(dir.path(), || config_path().unwrap());
+        assert_eq!(path, dir.path().join("config.toml"));
+    }
+}

--- a/mandible-core/src/lib.rs
+++ b/mandible-core/src/lib.rs
@@ -10,6 +10,7 @@
 #![warn(missing_docs)]
 
 pub mod audit;
+pub mod config;
 mod merge;
 mod node;
 mod noderef;

--- a/mandible-tui/src/app.rs
+++ b/mandible-tui/src/app.rs
@@ -192,14 +192,25 @@ pub struct App {
     detail_max_hscroll: std::cell::Cell<usize>,
     /// Whether `h`/`l`/`←`/`→` scroll the detail pane horizontally instead
     /// of doing nothing there, and whether preformatted content (raw view,
-    /// USAGE lines) is left unwrapped in the first place. Read once at
-    /// construction from `~/.config/mandible/config.toml`'s `[ui]` table
-    /// (`mandible_core::config`) — same "read once, plain field" shape as
-    /// [`Self::color_enabled`] and [`Self::glyphs`], and for the same
-    /// reason: it cannot change mid-run, and tests need to set it directly
-    /// without mutating process-wide environment state. `false` must
-    /// reproduce today's wrapping behavior byte for byte — this is an
-    /// opinionated default, so it ships with an off switch.
+    /// USAGE lines) is left unwrapped in the first place.
+    ///
+    /// Defaults to `true` here — [`App::new`] is a pure constructor with no
+    /// filesystem I/O, so it never itself reads
+    /// `~/.config/mandible/config.toml`. Reading that file is the
+    /// composition root's job: `mandible/src/app_runner.rs`'s `new_app`
+    /// calls `mandible_core::config::load` once and overwrites this field
+    /// on the freshly-built `App`, the same way every other startup concern
+    /// already lives there rather than in `App::new`. A constructor that
+    /// touches the real filesystem made every test (and every other
+    /// embedder of this crate) hostage to whichever `config.toml` happened
+    /// to exist on the machine running them — a `horizontal_scroll = false`
+    /// left over from someone's own use of mandible silently flipped this
+    /// field's default in the test suite and made "off reproduces today's
+    /// behavior" pass for the wrong reason.
+    ///
+    /// A plain `pub` field, like [`Self::color_enabled`] and
+    /// [`Self::glyphs`], so tests can set it directly without any global
+    /// state to isolate.
     pub horizontal_scroll_enabled: bool,
     /// Whether the `?` keybinding overlay is showing.
     pub show_help: bool,
@@ -341,7 +352,7 @@ impl App {
             pending_detail_fraction: std::cell::Cell::new(None),
             detail_hscroll: 0,
             detail_max_hscroll: std::cell::Cell::new(0),
-            horizontal_scroll_enabled: mandible_core::config::load().ui.horizontal_scroll,
+            horizontal_scroll_enabled: true,
             show_help: false,
             show_hidden: false,
             status_message: None,
@@ -994,8 +1005,8 @@ impl App {
         self.detail_hscroll = 0;
     }
 
-    /// `h`/`←`: scroll the detail pane left, when it has focus (spec §9's
-    /// "give preformatted content horizontal scrolling instead" of
+    /// `h`/`←`: scroll the detail pane left, when it has focus (spec §9:
+    /// preformatted detail-pane content scrolls horizontally rather than
     /// wrapping). A no-op when the config toggle is off, or already at the
     /// left edge — `saturating_sub` alone would still be correct here, but
     /// the early return also means a disabled toggle never touches

--- a/mandible-tui/src/app.rs
+++ b/mandible-tui/src/app.rs
@@ -176,6 +176,31 @@ pub struct App {
     /// extent; key handlers (`&mut App`) materialize it into
     /// [`Self::detail_scroll`] before applying their own movement.
     pending_detail_fraction: std::cell::Cell<Option<f64>>,
+    /// Detail pane horizontal scroll offset, in display columns. Only ever
+    /// nonzero for preformatted content (the raw `--help` view and
+    /// USAGE-section synopsis lines, spec §9) — prose is always wrapped to
+    /// the pane width and has nothing to scroll to.
+    detail_hscroll: usize,
+    /// How far the detail pane's widest *preformatted* line extends past
+    /// the current viewport width, written by the renderer each frame —
+    /// same `Cell`-for-interior-mutability reasoning as
+    /// [`Self::detail_max_scroll`]: rendering takes `&App`, and the content
+    /// width at the current pane width is a fact only the renderer knows.
+    /// Zero when nothing on screen is preformatted (plain prose has no
+    /// horizontal extent worth scrolling to), which both clamps `h`/`l` to
+    /// no-ops and tells the renderer not to draw the overflow affordance.
+    detail_max_hscroll: std::cell::Cell<usize>,
+    /// Whether `h`/`l`/`←`/`→` scroll the detail pane horizontally instead
+    /// of doing nothing there, and whether preformatted content (raw view,
+    /// USAGE lines) is left unwrapped in the first place. Read once at
+    /// construction from `~/.config/mandible/config.toml`'s `[ui]` table
+    /// (`mandible_core::config`) — same "read once, plain field" shape as
+    /// [`Self::color_enabled`] and [`Self::glyphs`], and for the same
+    /// reason: it cannot change mid-run, and tests need to set it directly
+    /// without mutating process-wide environment state. `false` must
+    /// reproduce today's wrapping behavior byte for byte — this is an
+    /// opinionated default, so it ships with an off switch.
+    pub horizontal_scroll_enabled: bool,
     /// Whether the `?` keybinding overlay is showing.
     pub show_help: bool,
     /// Whether hidden/deprecated items are shown (toggled with `.`).
@@ -258,6 +283,13 @@ const STATUS_MESSAGE_TTL: Duration = Duration::from_secs(4);
 /// flag stays set, so no change is ever dropped.
 const REBUILD_MIN_INTERVAL: Duration = Duration::from_millis(250);
 
+/// Columns moved per `h`/`l`/`←`/`→` press in the detail pane. Larger than
+/// the vertical scroll's one-line-per-press step deliberately: preformatted
+/// content this feature targets (long USAGE synopses, wide `--help` tables)
+/// tends to overflow by tens of columns at once, and a one-column step would
+/// take many presses to reveal anything.
+const DETAIL_HSCROLL_STEP: usize = 8;
+
 /// Case-insensitive **substring** match of `query` against `name`.
 ///
 /// Deliberately literal, not a subsequence, because that is the whole
@@ -307,6 +339,9 @@ impl App {
             detail_scroll: 0,
             detail_max_scroll: std::cell::Cell::new(0),
             pending_detail_fraction: std::cell::Cell::new(None),
+            detail_hscroll: 0,
+            detail_max_hscroll: std::cell::Cell::new(0),
+            horizontal_scroll_enabled: mandible_core::config::load().ui.horizontal_scroll,
             show_help: false,
             show_hidden: false,
             status_message: None,
@@ -535,6 +570,7 @@ impl App {
             self.selected += 1;
         }
         self.selected_flag = None;
+        self.detail_hscroll = 0;
         self.follow_selection();
     }
 
@@ -542,6 +578,7 @@ impl App {
     pub fn move_up(&mut self) {
         self.selected = self.selected.saturating_sub(1);
         self.selected_flag = None;
+        self.detail_hscroll = 0;
         self.follow_selection();
     }
 
@@ -665,6 +702,7 @@ impl App {
             }
         }
         self.selected_flag = None;
+        self.detail_hscroll = 0;
         self.follow_selection();
     }
 
@@ -697,6 +735,7 @@ impl App {
             self.selected = idx;
         }
         self.selected_flag = None;
+        self.detail_hscroll = 0;
         self.follow_selection();
     }
 
@@ -833,6 +872,11 @@ impl App {
         });
         self.pending_detail_fraction.set(fraction);
         self.detail_scroll = 0;
+        // A horizontal offset doesn't carry across the toggle either, for
+        // the same reason the vertical one doesn't get a fraction beyond
+        // it: raw text and a parsed USAGE block are unrelated documents,
+        // so "26 columns in" means nothing between them.
+        self.detail_hscroll = 0;
         self.raw_fetch_needed()
     }
 
@@ -947,6 +991,65 @@ impl App {
         // A new node's content has no relation to the old node's place;
         // a fraction carried across a view toggle must not survive into it.
         self.pending_detail_fraction.set(None);
+        self.detail_hscroll = 0;
+    }
+
+    /// `h`/`←`: scroll the detail pane left, when it has focus (spec §9's
+    /// "give preformatted content horizontal scrolling instead" of
+    /// wrapping). A no-op when the config toggle is off, or already at the
+    /// left edge — `saturating_sub` alone would still be correct here, but
+    /// the early return also means a disabled toggle never touches
+    /// [`Self::detail_hscroll`] at all, which is one less thing for the
+    /// "config off reproduces today's output exactly" property to depend
+    /// on holding elsewhere.
+    pub fn detail_hscroll_left(&mut self) {
+        if !self.horizontal_scroll_enabled {
+            return;
+        }
+        self.detail_hscroll = self.detail_hscroll.saturating_sub(DETAIL_HSCROLL_STEP);
+    }
+
+    /// `l`/`→`: scroll the detail pane right, clamped to
+    /// [`Self::detail_max_hscroll`] — the widest preformatted line on
+    /// screen minus the viewport width, written by the renderer each frame
+    /// exactly like [`Self::detail_max_scroll`] is for vertical scroll.
+    pub fn detail_hscroll_right(&mut self) {
+        if !self.horizontal_scroll_enabled {
+            return;
+        }
+        let max = self.detail_max_hscroll.get();
+        self.detail_hscroll = self
+            .detail_hscroll
+            .saturating_add(DETAIL_HSCROLL_STEP)
+            .min(max);
+    }
+
+    /// Record how far the detail pane's preformatted content can usefully
+    /// scroll horizontally, from the renderer. Called every frame the
+    /// detail pane draws preformatted content, with `0` when there is
+    /// none on screen — that both clamps `h`/`l` to a no-op and prevents a
+    /// stale nonzero extent from a previous node leaking into this frame's
+    /// overflow affordance (see [`Self::detail_hscroll_can_go_right`]).
+    pub fn set_detail_hextent(&self, max_line_width: usize, viewport_width: usize) {
+        self.detail_max_hscroll
+            .set(max_line_width.saturating_sub(viewport_width));
+    }
+
+    /// The current horizontal offset, clamped to what the last frame could
+    /// actually show — same shape as [`Self::clamped_detail_scroll`].
+    pub fn clamped_detail_hscroll(&self) -> usize {
+        self.detail_hscroll.min(self.detail_max_hscroll.get())
+    }
+
+    /// Whether there is preformatted content hidden off the left edge —
+    /// i.e. whether the overflow affordance belongs on that side.
+    pub fn detail_hscroll_can_go_left(&self) -> bool {
+        self.clamped_detail_hscroll() > 0
+    }
+
+    /// Whether there is preformatted content hidden off the right edge.
+    pub fn detail_hscroll_can_go_right(&self) -> bool {
+        self.clamped_detail_hscroll() < self.detail_max_hscroll.get()
     }
 
     /// Set a status bar message (e.g. after a copy).
@@ -1660,6 +1763,106 @@ mod tests {
             app.search_populate_count(),
             after_reload + 1,
             "the first arrival after a reload must not be throttled"
+        );
+    }
+
+    // --- detail pane horizontal scroll ---
+
+    #[test]
+    fn detail_hscroll_clamps_at_both_ends() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.horizontal_scroll_enabled = true;
+        app.set_detail_hextent(50, 20); // max 30
+
+        for _ in 0..10 {
+            app.detail_hscroll_right();
+        }
+        assert_eq!(
+            app.clamped_detail_hscroll(),
+            30,
+            "must never exceed max_line_width - viewport_width"
+        );
+
+        for _ in 0..10 {
+            app.detail_hscroll_left();
+        }
+        assert_eq!(app.clamped_detail_hscroll(), 0, "must never go negative");
+    }
+
+    #[test]
+    fn detail_hscroll_is_a_noop_with_the_config_toggle_off() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.horizontal_scroll_enabled = false;
+        app.set_detail_hextent(50, 20);
+        app.detail_hscroll_right();
+        app.detail_hscroll_right();
+        assert_eq!(
+            app.clamped_detail_hscroll(),
+            0,
+            "off must not scroll at all"
+        );
+    }
+
+    #[test]
+    fn detail_hscroll_resets_on_selection_change() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.set_detail_hextent(50, 20);
+        app.detail_hscroll_right();
+        assert!(app.clamped_detail_hscroll() > 0, "precondition");
+
+        app.move_down();
+        assert_eq!(
+            app.clamped_detail_hscroll(),
+            0,
+            "a new selection has unrelated content to scroll through"
+        );
+    }
+
+    #[test]
+    fn detail_hscroll_resets_on_collapse_or_jump_to_parent() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.selected = 2; // rebase
+        app.expand_selected();
+        app.ensure_rows_fresh();
+        app.selected = 3; // --onto-helper
+        app.set_detail_hextent(50, 20);
+        app.detail_hscroll_right();
+        assert!(app.clamped_detail_hscroll() > 0, "precondition");
+
+        app.collapse_or_jump_to_parent();
+        assert_eq!(app.clamped_detail_hscroll(), 0);
+    }
+
+    #[test]
+    fn detail_hscroll_resets_on_raw_mode_toggle() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.set_detail_hextent(50, 20);
+        app.detail_hscroll_right();
+        assert!(app.clamped_detail_hscroll() > 0, "precondition");
+
+        app.toggle_raw_mode();
+        assert_eq!(app.clamped_detail_hscroll(), 0);
+    }
+
+    #[test]
+    fn detail_hscroll_overflow_flags_track_the_current_offset() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.set_detail_hextent(50, 20); // max 30
+        assert!(!app.detail_hscroll_can_go_left());
+        assert!(app.detail_hscroll_can_go_right());
+
+        app.detail_hscroll_right(); // step 8: offset 8
+        assert!(app.detail_hscroll_can_go_left());
+        assert!(app.detail_hscroll_can_go_right());
+
+        for _ in 0..10 {
+            app.detail_hscroll_right();
+        }
+        assert_eq!(app.clamped_detail_hscroll(), 30);
+        assert!(app.detail_hscroll_can_go_left());
+        assert!(
+            !app.detail_hscroll_can_go_right(),
+            "fully scrolled right: nothing more to reveal"
         );
     }
 }

--- a/mandible-tui/src/event.rs
+++ b/mandible-tui/src/event.rs
@@ -89,6 +89,13 @@ fn handle_detail_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
     match key.code {
         KeyCode::Down | KeyCode::Char('j') => app.detail_scroll_down(),
         KeyCode::Up | KeyCode::Char('k') => app.detail_scroll_up(),
+        // `h`/`l` and the arrow keys mean something different per pane
+        // (spec §2): in the tree they collapse/expand, here they scroll
+        // preformatted content horizontally. Scoped to this function, which
+        // only runs while `Focus::Detail` — `handle_tree_key` keeps its own
+        // meaning for the same keys untouched.
+        KeyCode::Left | KeyCode::Char('h') => app.detail_hscroll_left(),
+        KeyCode::Right | KeyCode::Char('l') => app.detail_hscroll_right(),
         KeyCode::Char('y') => return copy_text_for_selection(app).map(Effect::Copy),
         _ => {}
     }
@@ -251,6 +258,39 @@ mod tests {
             handle_key(&mut a, key(KeyCode::Char('y'))),
             Some(Effect::Copy("git".to_string()))
         );
+    }
+
+    /// `h`/`l` mean something different per pane (spec §2): in the tree
+    /// they collapse/jump-to-parent and expand; in the detail pane they
+    /// scroll preformatted content horizontally. Neither meaning should
+    /// leak into the other pane's focus.
+    #[test]
+    fn h_and_l_are_scoped_to_the_focused_pane() {
+        let mut a = app();
+        a.expand_selected();
+        a.ensure_rows_fresh();
+        a.selected = 1; // "add", a leaf
+
+        // Tree focus: `h` jumps to parent, unaffected by horizontal scroll.
+        assert_eq!(a.focus, Focus::Tree);
+        handle_key(&mut a, key(KeyCode::Char('h')));
+        assert_eq!(a.selected_row().unwrap().name, "git");
+        assert_eq!(a.clamped_detail_hscroll(), 0);
+
+        // Detail focus: `l` scrolls horizontally rather than expanding a
+        // tree row, and does not move the tree selection at all.
+        a.toggle_focus();
+        assert_eq!(a.focus, Focus::Detail);
+        a.set_detail_hextent(50, 10); // give it something to scroll to
+        let selected_before = a.selected;
+        handle_key(&mut a, key(KeyCode::Char('l')));
+        assert_eq!(a.selected, selected_before, "l must not move the tree");
+        assert!(
+            a.clamped_detail_hscroll() > 0,
+            "l should have scrolled the detail pane right"
+        );
+        handle_key(&mut a, key(KeyCode::Char('h')));
+        assert_eq!(a.clamped_detail_hscroll(), 0, "h should scroll back left");
     }
 
     #[test]

--- a/mandible-tui/src/glyphs.rs
+++ b/mandible-tui/src/glyphs.rs
@@ -49,6 +49,13 @@ pub struct Glyphs {
     pub absent: &'static str,
     /// Horizontal rule drawn after a section heading.
     pub rule: &'static str,
+    /// Overflow affordance drawn in the detail pane's top border when
+    /// horizontally-scrollable content extends further left than the
+    /// current view (spec §9: preformatted content scrolls rather than
+    /// wraps, and needs a visible sign there is more to see).
+    pub more_left: char,
+    /// Same, for content extending further right.
+    pub more_right: char,
 }
 
 /// The full set, for terminals in a UTF-8 locale.
@@ -66,6 +73,8 @@ pub const UNICODE: Glyphs = Glyphs {
     arrows_horizontal: "←→",
     absent: "—",
     rule: "─",
+    more_left: '←',
+    more_right: '→',
 };
 
 /// The fallback. Every entry is one column wide or plainly readable, so
@@ -84,6 +93,8 @@ pub const ASCII: Glyphs = Glyphs {
     arrows_horizontal: "left/right",
     absent: "-",
     rule: "-",
+    more_left: '<',
+    more_right: '>',
 };
 
 /// Pick a glyph set from the environment.
@@ -122,6 +133,8 @@ mod tests {
         // The whole point: nothing here can render as tofu.
         assert!(ASCII.chevron_open.is_ascii());
         assert!(ASCII.chevron_closed.is_ascii());
+        assert!(ASCII.more_left.is_ascii());
+        assert!(ASCII.more_right.is_ascii());
         for s in [
             ASCII.ellipsis,
             ASCII.prompt,

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -90,6 +90,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // mandible decided.
     if let Some(raw) = app.raw_help_for_selected() {
         render_raw_mode(frame, inner, app, raw);
+        draw_hscroll_affordance(frame, area, app);
         return;
     }
 
@@ -106,6 +107,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             &format!("unparsed {} showing raw --help output", app.glyphs.absent),
             node.unparsed.iter().map(|t| t.as_str().to_string()),
         );
+        draw_hscroll_affordance(frame, area, app);
         return;
     }
 
@@ -117,6 +119,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         app.color_enabled,
         app.selected_flag.as_ref(),
         app.glyphs,
+        app,
     );
     // Search selecting a flag scrolls straight to it (spec §10): the line
     // index is exact because every line above was pre-wrapped by us, not
@@ -132,6 +135,39 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         .wrap(Wrap { trim: false })
         .scroll((scroll, 0));
     frame.render_widget(paragraph, inner);
+    draw_hscroll_affordance(frame, area, app);
+}
+
+/// Draw the horizontal-scroll overflow affordance in the detail pane's
+/// border — a single glyph on the top edge, the one row spec §9's border
+/// rules let a pane draw anything other than the plain rule character or a
+/// title into (`border_integrity.rs` checks every *other* border cell
+/// strictly). Placed a couple of cells inside the top-right corner, never
+/// on it, so a very long breadcrumb can never push this into corner
+/// territory and `border_integrity.rs`'s exact-corner-glyph assertion never
+/// sees anything but the rounded/ASCII corner it expects.
+///
+/// A no-op with the config toggle off — `app.horizontal_scroll_enabled` is
+/// exactly the same guard the scroll keys use (`App::detail_hscroll_left`
+/// /`_right`), so "off" never draws a marker for an offset the user has no
+/// way to have created.
+fn draw_hscroll_affordance(frame: &mut Frame, area: Rect, app: &App) {
+    if !app.horizontal_scroll_enabled || area.width < 6 || area.height == 0 {
+        return;
+    }
+    let can_left = app.detail_hscroll_can_go_left();
+    let can_right = app.detail_hscroll_can_go_right();
+    if !can_left && !can_right {
+        return;
+    }
+    let buf = frame.buffer_mut();
+    let y = area.y;
+    if can_right {
+        buf[(area.x + area.width - 2, y)].set_char(app.glyphs.more_right);
+    }
+    if can_left {
+        buf[(area.x + area.width - 3, y)].set_char(app.glyphs.more_left);
+    }
 }
 
 /// Render the verbatim view (`t`): the tool's own `--help` output for the
@@ -229,9 +265,32 @@ fn render_verbatim(
     lines.push(Line::default());
     let body: Vec<String> = body.collect();
     let wrapped_prefix_lines = unverified_notice_prefix_len(&body);
+
+    // Everything past the mandible-authored notice prefix is the tool's
+    // own preformatted bytes (see this function's doc comment above) —
+    // exactly the content spec §9 wants scrolled rather than wrapped. The
+    // notice prefix itself stays prose: it's mandible's own text, already
+    // wrapped by `push_wrapped_notice`, and immune to the horizontal
+    // offset the same way DESCRIPTION/FLAGS stay immune in the structured
+    // view below.
+    let hoffset = if app.horizontal_scroll_enabled {
+        let max_width = body
+            .iter()
+            .skip(wrapped_prefix_lines)
+            .map(|line| display_width(line))
+            .max()
+            .unwrap_or(0);
+        app.set_detail_hextent(max_width, width);
+        app.clamped_detail_hscroll()
+    } else {
+        0
+    };
+
     for (index, text) in body.into_iter().enumerate() {
         if index < wrapped_prefix_lines {
             push_wrapped_notice(&mut lines, &text, width);
+        } else if app.horizontal_scroll_enabled {
+            lines.push(Line::from(hscroll_trim(&text, hoffset).into_owned()));
         } else {
             lines.push(Line::from(text));
         }
@@ -240,6 +299,35 @@ fn render_verbatim(
     let scroll = app.clamped_detail_scroll() as u16;
     let paragraph = Paragraph::new(lines).scroll((scroll, 0));
     frame.render_widget(paragraph, inner);
+}
+
+/// Trim `offset` display-width columns off the left of `s`, for horizontal
+/// scrolling of preformatted content. Character-by-character, never a raw
+/// byte slice (AGENTS.md: never slice tool-derived text at a byte offset —
+/// this project has shipped a UTF-8-boundary panic from exactly that
+/// shortcut once already). A double-width character that straddles the
+/// offset boundary is dropped whole rather than split — splitting it would
+/// emit half a cell and misalign every column after it, which is worse
+/// than losing one character's width of the scroll.
+fn hscroll_trim(s: &str, offset: usize) -> std::borrow::Cow<'_, str> {
+    if offset == 0 {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut remaining = offset;
+    let mut result = String::new();
+    let mut trimming = true;
+    for ch in s.chars() {
+        if trimming {
+            let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if w <= remaining {
+                remaining -= w;
+                continue;
+            }
+            trimming = false;
+        }
+        result.push(ch);
+    }
+    std::borrow::Cow::Owned(result)
 }
 
 /// Recognize only the display-only prose prepended by `not_attested_fallback`.
@@ -310,9 +398,17 @@ fn build_lines(
     color_enabled: bool,
     target_flag: Option<&FlagKey>,
     glyphs: Glyphs,
+    app: &App,
 ) -> BuiltLines {
     let mut lines = Vec::new();
     let mut target_flag_line = None;
+    // Reset every frame, not just when a USAGE section is present below —
+    // otherwise a node with no USAGE at all would leave the previous
+    // node's extent sitting in the `Cell`, and the overflow affordance
+    // would draw for content that isn't even on screen anymore.
+    if app.horizontal_scroll_enabled {
+        app.set_detail_hextent(0, width);
+    }
 
     if let Some(summary) = &node.summary {
         for chunk in wrap_words(summary.as_str(), width) {
@@ -341,14 +437,36 @@ fn build_lines(
 
     if !node.usage.is_empty() {
         lines.push(heading_line_ruled("USAGE", width, color_enabled, glyphs));
-        for u in &node.usage {
-            let full = usage_signature(&node.name, u.as_str());
-            // Indented as a block, the way API documentation sets a
-            // signature apart from its prose.
-            let indent = "  ";
-            let avail = width.saturating_sub(display_width(indent)).max(1);
-            for chunk in wrap_words(&full, avail) {
-                lines.push(Line::from(format!("{indent}{chunk}")));
+        // Indented as a block, the way API documentation sets a signature
+        // apart from its prose.
+        let indent = "  ";
+        if app.horizontal_scroll_enabled {
+            // A synopsis is preformatted — spacing inside it is part of
+            // its meaning (spec §9: "wrapping makes soup"). One `Line` per
+            // usage form, never re-flowed; `h`/`l` reveal the rest instead
+            // of the old greedy word-wrap eating it into a ragged block.
+            let usage_lines: Vec<String> = node
+                .usage
+                .iter()
+                .map(|u| format!("{indent}{}", usage_signature(&node.name, u.as_str())))
+                .collect();
+            let max_width = usage_lines
+                .iter()
+                .map(|line| display_width(line))
+                .max()
+                .unwrap_or(0);
+            app.set_detail_hextent(max_width, width);
+            let hoffset = app.clamped_detail_hscroll();
+            for line in usage_lines {
+                lines.push(Line::from(hscroll_trim(&line, hoffset).into_owned()));
+            }
+        } else {
+            for u in &node.usage {
+                let full = usage_signature(&node.name, u.as_str());
+                let avail = width.saturating_sub(display_width(indent)).max(1);
+                for chunk in wrap_words(&full, avail) {
+                    lines.push(Line::from(format!("{indent}{chunk}")));
+                }
             }
         }
         lines.push(Line::default());
@@ -1078,6 +1196,16 @@ mod tests {
         n
     }
 
+    /// A minimal `App` for tests that only need `build_lines`'s `app`
+    /// parameter for its horizontal-scroll bookkeeping — the config
+    /// defaults to on, matching a real run with no `config.toml`.
+    fn test_app() -> App {
+        App::new(
+            "test".to_string(),
+            CommandNode::new("test", Provenance::single(Source::HelpText)),
+        )
+    }
+
     fn text_of(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
     }
@@ -1097,7 +1225,15 @@ mod tests {
     fn hidden_flags_suppressed_by_default() {
         let mut node = node_with_flags();
         node.flags[0].hidden = true;
-        let built = build_lines(&node, false, 80, true, None, crate::glyphs::UNICODE);
+        let built = build_lines(
+            &node,
+            false,
+            80,
+            true,
+            None,
+            crate::glyphs::UNICODE,
+            &test_app(),
+        );
         let joined: String = built.lines.iter().map(text_of).collect();
         assert!(!joined.contains("--interactive"));
     }
@@ -1106,7 +1242,15 @@ mod tests {
     fn hidden_flags_shown_when_toggled() {
         let mut node = node_with_flags();
         node.flags[0].hidden = true;
-        let built = build_lines(&node, true, 80, true, None, crate::glyphs::UNICODE);
+        let built = build_lines(
+            &node,
+            true,
+            80,
+            true,
+            None,
+            crate::glyphs::UNICODE,
+            &test_app(),
+        );
         let joined: String = built.lines.iter().map(text_of).collect();
         assert!(joined.contains("--interactive"));
     }
@@ -1524,6 +1668,7 @@ mod tests {
             true,
             Some(&FlagKey::Long("interactive".to_string())),
             crate::glyphs::UNICODE,
+            &test_app(),
         );
         let idx = built.target_flag_line.expect("flag should be found");
         let line_text = text_of(&built.lines[idx]);
@@ -1533,7 +1678,15 @@ mod tests {
     #[test]
     fn no_target_flag_means_no_scroll_override() {
         let node = node_with_flags();
-        let built = build_lines(&node, false, 80, true, None, crate::glyphs::UNICODE);
+        let built = build_lines(
+            &node,
+            false,
+            80,
+            true,
+            None,
+            crate::glyphs::UNICODE,
+            &test_app(),
+        );
         assert_eq!(built.target_flag_line, None);
     }
 
@@ -1758,13 +1911,21 @@ mod tests {
     /// carries an over-long token must still show the whole token
     /// somewhere in the rendered lines, and never emit an ellipsis in its
     /// place.
+    ///
+    /// Pinned with the horizontal-scroll toggle explicitly **off**: this is
+    /// the pre-existing wrapping behavior, and `horizontal_scroll = false`
+    /// (spec: the config toggle for this feature) must reproduce it
+    /// exactly. The toggle **on** has its own test below, where the same
+    /// token stays on one unwrapped line instead.
     #[test]
-    fn build_lines_wraps_rather_than_truncates_a_long_usage_token() {
+    fn build_lines_wraps_rather_than_truncates_a_long_usage_token_with_scroll_disabled() {
         let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
         let long_url = "https://registry.example.com/v2/org/repo/blobs/uploads/deadbeefcafefeed0123456789abcdef0123456789abcdef0123456789abcd";
         node.usage = vec![Text::sanitize(long_url)];
 
-        let built = build_lines(&node, false, 46, true, None, crate::glyphs::UNICODE);
+        let mut app = test_app();
+        app.horizontal_scroll_enabled = false;
+        let built = build_lines(&node, false, 46, true, None, crate::glyphs::UNICODE, &app);
         // Every usage line carries its own 2-space block indent (see the
         // USAGE section of `build_lines`) — strip it per line before
         // rejoining so adjacent chunks of the broken token reassemble
@@ -1785,6 +1946,67 @@ mod tests {
         assert!(
             !joined.contains('…'),
             "an over-long token must never be ellipsis-truncated: {joined:?}"
+        );
+        assert!(
+            built.lines.len() > 1,
+            "with scrolling disabled the long token should still wrap across lines: {:?}",
+            built.lines.iter().map(text_of).collect::<Vec<_>>()
+        );
+    }
+
+    /// The toggle **on** (the default): a USAGE synopsis is preformatted
+    /// and must stay on one line rather than being greedily word-wrapped,
+    /// with `h`/`l` revealing the rest instead (spec §9: "wrapping makes
+    /// soup" for this content).
+    #[test]
+    fn usage_synopsis_stays_on_one_line_when_horizontal_scroll_is_enabled() {
+        let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
+        let long_url = "https://registry.example.com/v2/org/repo/blobs/uploads/deadbeefcafefeed0123456789abcdef0123456789abcdef0123456789abcd";
+        node.usage = vec![Text::sanitize(long_url)];
+
+        let app = test_app();
+        assert!(app.horizontal_scroll_enabled, "default is on");
+        let built = build_lines(&node, false, 46, true, None, crate::glyphs::UNICODE, &app);
+        let usage_lines: Vec<String> = built
+            .lines
+            .iter()
+            .map(text_of)
+            .filter(|t| t.contains(long_url))
+            .collect();
+        assert_eq!(
+            usage_lines.len(),
+            1,
+            "a preformatted synopsis must not be split across lines: {:?}",
+            built.lines.iter().map(text_of).collect::<Vec<_>>()
+        );
+    }
+
+    /// Scrolling right trims preformatted USAGE content from the left —
+    /// the same offset the affordance in the border reflects — while
+    /// leaving everything else (here, nothing else on this node) alone.
+    /// Two-pass, matching how a real frame works: the first pass tells
+    /// `App` how wide the content is (`set_detail_hextent`), only after
+    /// which a scroll key has something to clamp against.
+    #[test]
+    fn usage_synopsis_scrolls_horizontally_when_enabled() {
+        let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
+        let long_url = "x".repeat(200);
+        node.usage = vec![Text::sanitize(&long_url)];
+
+        let mut app = test_app();
+        let _ = build_lines(&node, false, 46, true, None, crate::glyphs::UNICODE, &app);
+        app.detail_hscroll_right();
+        app.detail_hscroll_right();
+        let built = build_lines(&node, false, 46, true, None, crate::glyphs::UNICODE, &app);
+        let usage_line = built
+            .lines
+            .iter()
+            .map(text_of)
+            .find(|t| t.contains('x'))
+            .expect("usage line should still be present");
+        assert!(
+            !usage_line.trim_start().starts_with("url xxxx"),
+            "the line should have scrolled past its own start: {usage_line:?}"
         );
     }
 }

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -290,7 +290,9 @@ fn render_verbatim(
         if index < wrapped_prefix_lines {
             push_wrapped_notice(&mut lines, &text, width);
         } else if app.horizontal_scroll_enabled {
-            lines.push(Line::from(hscroll_trim(&text, hoffset).into_owned()));
+            lines.push(Line::from(
+                hscroll_window(&text, hoffset, width).into_owned(),
+            ));
         } else {
             lines.push(Line::from(text));
         }
@@ -301,30 +303,51 @@ fn render_verbatim(
     frame.render_widget(paragraph, inner);
 }
 
-/// Trim `offset` display-width columns off the left of `s`, for horizontal
-/// scrolling of preformatted content. Character-by-character, never a raw
-/// byte slice (AGENTS.md: never slice tool-derived text at a byte offset —
-/// this project has shipped a UTF-8-boundary panic from exactly that
-/// shortcut once already). A double-width character that straddles the
-/// offset boundary is dropped whole rather than split — splitting it would
-/// emit half a cell and misalign every column after it, which is worse
-/// than losing one character's width of the scroll.
-fn hscroll_trim(s: &str, offset: usize) -> std::borrow::Cow<'_, str> {
-    if offset == 0 {
+/// The visible window of `s` for horizontal scrolling of preformatted
+/// content: `offset` display-width columns trimmed off the left, then
+/// capped to at most `width` columns of what remains.
+///
+/// The cap matters as much as the trim. The structured detail pane's
+/// `Paragraph` keeps `Wrap` enabled as a defensive fallback (this module's
+/// top doc comment) for content this function's caller does *not* produce —
+/// every other line here is already pre-wrapped to fit. A preformatted
+/// line handed over wider than `width` is exactly the shape `Wrap` exists
+/// to catch, so without the cap it silently re-wraps a synopsis this
+/// feature deliberately stopped wrapping, restarting the continuation flush
+/// left with no memory of the line's own indent — precisely the
+/// "wrapping makes soup" failure this feature exists to remove, just
+/// reintroduced one layer up. Found by rendering `ip` through a real pty
+/// rather than trusting `TestBackend` (AGENTS.md §3.2): a synthetic fixture
+/// narrow enough to need the cap was never in the corpus.
+///
+/// Character-by-character, never a raw byte slice (AGENTS.md: never slice
+/// tool-derived text at a byte offset — this project has shipped a
+/// UTF-8-boundary panic from exactly that shortcut once already). A
+/// double-width character that straddles either boundary is dropped whole
+/// rather than split — splitting it would emit half a cell and misalign
+/// every column after it, which is worse than losing one character's width
+/// of the scroll.
+fn hscroll_window(s: &str, offset: usize, width: usize) -> std::borrow::Cow<'_, str> {
+    if offset == 0 && display_width(s) <= width {
         return std::borrow::Cow::Borrowed(s);
     }
     let mut remaining = offset;
+    let mut budget = width;
     let mut result = String::new();
-    let mut trimming = true;
+    let mut trimming = offset > 0;
     for ch in s.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
         if trimming {
-            let w = UnicodeWidthChar::width(ch).unwrap_or(0);
             if w <= remaining {
                 remaining -= w;
                 continue;
             }
             trimming = false;
         }
+        if w > budget {
+            break;
+        }
+        budget -= w;
         result.push(ch);
     }
     std::borrow::Cow::Owned(result)
@@ -458,7 +481,9 @@ fn build_lines(
             app.set_detail_hextent(max_width, width);
             let hoffset = app.clamped_detail_hscroll();
             for line in usage_lines {
-                lines.push(Line::from(hscroll_trim(&line, hoffset).into_owned()));
+                lines.push(Line::from(
+                    hscroll_window(&line, hoffset, width).into_owned(),
+                ));
             }
         } else {
             for u in &node.usage {
@@ -1966,18 +1991,38 @@ mod tests {
 
         let app = test_app();
         assert!(app.horizontal_scroll_enabled, "default is on");
-        let built = build_lines(&node, false, 46, true, None, crate::glyphs::UNICODE, &app);
-        let usage_lines: Vec<String> = built
+        let width = 46;
+        let built = build_lines(
+            &node,
+            false,
+            width,
+            true,
+            None,
+            crate::glyphs::UNICODE,
+            &app,
+        );
+        // Unscrolled, the line shows a `width`-column prefix of the
+        // synopsis — the rest reachable with `l`, never reflowed onto a
+        // second line the way the disabled path wraps it.
+        let usage_lines: Vec<&Line> = built
             .lines
             .iter()
-            .map(text_of)
-            .filter(|t| t.contains(long_url))
+            .filter(|l| text_of(l).trim_start().starts_with("url https"))
             .collect();
         assert_eq!(
             usage_lines.len(),
             1,
             "a preformatted synopsis must not be split across lines: {:?}",
             built.lines.iter().map(text_of).collect::<Vec<_>>()
+        );
+        let shown = text_of(usage_lines[0]);
+        assert!(
+            long_url.starts_with(shown.trim_start().trim_start_matches("url ")),
+            "the visible portion must be an unbroken prefix of the real synopsis: {shown:?}"
+        );
+        assert!(
+            display_width(&shown) <= width,
+            "must not overflow the pane and rely on Paragraph::Wrap to save it: {shown:?}"
         );
     }
 

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -139,10 +139,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 /// Draw the horizontal-scroll overflow affordance in the detail pane's
-/// border — a single glyph on the top edge, the one row spec §9's border
-/// rules let a pane draw anything other than the plain rule character or a
-/// title into (`border_integrity.rs` checks every *other* border cell
-/// strictly). Placed a couple of cells inside the top-right corner, never
+/// border — a single glyph on the top edge, the one row that already
+/// legitimately carries something other than the plain rule character (the
+/// breadcrumb title, spec §2) and so the one row `border_integrity.rs`
+/// checks less strictly than the other three. Placed a couple of cells
+/// inside the top-right corner, never
 /// on it, so a very long breadcrumb can never push this into corner
 /// territory and `border_integrity.rs`'s exact-corner-glyph assertion never
 /// sees anything but the rounded/ASCII corner it expects.
@@ -151,6 +152,22 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 /// exactly the same guard the scroll keys use (`App::detail_hscroll_left`
 /// /`_right`), so "off" never draws a marker for an offset the user has no
 /// way to have created.
+///
+/// **Deliberately drawn regardless of which pane has focus**, even though
+/// `h`/`l`/`←`/`→` only reach [`App::detail_hscroll_left`]/`_right` while
+/// `Focus::Detail` (`event::handle_detail_key`) — with the tree focused,
+/// this can promise more content on a side no keypress currently reaches.
+/// That was a conscious choice, not an oversight: the alternative is a pane
+/// that silently clips a USAGE line or raw `--help` text with no sign
+/// anything is missing until the reader happens to `Tab` over and press
+/// `l`, and a wrong-but-honest "there's more, go focus this pane to see it"
+/// is a smaller failure than that silent clipping — the same asymmetry
+/// spec §9's border-corruption lesson already treats as the more dangerous
+/// direction (content quietly doing something the reader can't see beats
+/// content quietly *not* telling them there's more of it). Revisit this if
+/// user feedback says the marker reads as broken rather than as "Tab over
+/// for more" — the fix then is gating on `app.focus == Focus::Detail` here,
+/// not changing what the marker itself draws.
 fn draw_hscroll_affordance(frame: &mut Frame, area: Rect, app: &App) {
     if !app.horizontal_scroll_enabled || area.width < 6 || area.height == 0 {
         return;
@@ -229,14 +246,12 @@ fn render_raw_mode(frame: &mut Frame, inner: Rect, app: &App, raw: &crate::app::
 /// block in this pane is (see this
 /// module's top doc comment on why the rest of the pane pre-wraps
 /// everything itself) — this is preformatted output, and re-wrapping it
-/// would silently edit the tool author's own text. Without `Wrap`,
-/// `ratatui::widgets::Paragraph` clips an over-width line at the pane's
-/// edge rather than reflowing it, which is the "horizontal scroll rather
-/// than reflow" spec §7 Tier B step 3 calls for; a horizontal scroll
-/// *offset* is not yet wired to a key in this batch (it always starts at
-/// column 0), but the important safety property — content never reflows,
-/// and can therefore never smear into the pane border the way an
-/// unsanitized newline once did (spec §9) — holds regardless. Safe to hand
+/// would silently edit the tool author's own text. `h`/`l`/`←`/`→` scroll
+/// it horizontally instead (spec §9: preformatted detail-pane content
+/// scrolls rather than wraps); the important safety property — content
+/// never reflows, and can therefore never smear into the pane border the
+/// way an unsanitized newline once did (spec §9) — holds regardless of
+/// which offset is showing. Safe to hand
 /// straight to a `Span` because every `Text` reaching here already went
 /// through one of `mandible_core::Text`'s sanitizing constructors —
 /// `Text::sanitize` for `node.unparsed` (level-3 degradation), or
@@ -314,9 +329,9 @@ fn render_verbatim(
 /// line handed over wider than `width` is exactly the shape `Wrap` exists
 /// to catch, so without the cap it silently re-wraps a synopsis this
 /// feature deliberately stopped wrapping, restarting the continuation flush
-/// left with no memory of the line's own indent — precisely the
-/// "wrapping makes soup" failure this feature exists to remove, just
-/// reintroduced one layer up. Found by rendering `ip` through a real pty
+/// left with no memory of the line's own indent — precisely the reflowed,
+/// meaning-scrambling failure spec §9 introduced this feature to remove,
+/// just reintroduced one layer up. Found by rendering `ip` through a real pty
 /// rather than trusting `TestBackend` (AGENTS.md §3.2): a synthetic fixture
 /// narrow enough to need the cap was never in the corpus.
 ///
@@ -465,8 +480,8 @@ fn build_lines(
         let indent = "  ";
         if app.horizontal_scroll_enabled {
             // A synopsis is preformatted — spacing inside it is part of
-            // its meaning (spec §9: "wrapping makes soup"). One `Line` per
-            // usage form, never re-flowed; `h`/`l` reveal the rest instead
+            // its meaning, so spec §9 has it scroll rather than wrap. One
+            // `Line` per usage form, never re-flowed; `h`/`l` reveal the rest instead
             // of the old greedy word-wrap eating it into a ragged block.
             let usage_lines: Vec<String> = node
                 .usage
@@ -1981,8 +1996,8 @@ mod tests {
 
     /// The toggle **on** (the default): a USAGE synopsis is preformatted
     /// and must stay on one line rather than being greedily word-wrapped,
-    /// with `h`/`l` revealing the rest instead (spec §9: "wrapping makes
-    /// soup" for this content).
+    /// with `h`/`l` revealing the rest instead (spec §9: preformatted
+    /// detail-pane content scrolls rather than wraps).
     #[test]
     fn usage_synopsis_stays_on_one_line_when_horizontal_scroll_is_enabled() {
         let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));

--- a/mandible-tui/src/render/help_overlay.rs
+++ b/mandible-tui/src/render/help_overlay.rs
@@ -25,6 +25,10 @@ const BINDINGS: &[(Option<&str>, &str)] = &[
         Some("t"),
         "Verbatim: the tool\u{2019}s own --help, unparsed",
     ),
+    (
+        Some("h l  ← →"),
+        "Scroll preformatted text sideways (detail pane focused)",
+    ),
     (Some("."), "Show hidden and deprecated items"),
     (None, "ACTIONS"),
     (Some("y"), "Copy selected flag or command path"),

--- a/mandible-tui/src/render/status_bar.rs
+++ b/mandible-tui/src/render/status_bar.rs
@@ -1,6 +1,7 @@
 //! The status bar: keybinding hints, or a transient status message (spec
 //! §2's footer row: `↑↓ move   → expand   / search   y copy   ? help   q
-//! quit`).
+//! quit`; `→`'s label has since grown a second meaning, spec §9, see
+//! [`hints`]).
 
 use crate::app::App;
 use crate::sanitize::{defensive_single_line, display_width, truncate_to_width};
@@ -25,10 +26,18 @@ use ratatui::Frame;
 /// together reads as one long string rather than a list of keys.
 /// Built per-frame because the arrow glyphs depend on what the terminal
 /// can draw (see [`crate::glyphs`]).
+///
+/// `←→` already meant two things before the detail pane's horizontal
+/// scroll existed — `↑↓ move` names one hint for "move the tree selection"
+/// *and* "scroll the detail pane" depending on focus, and that ambiguity
+/// was accepted deliberately rather than switching the row. `←→` now covers
+/// a third meaning (collapse/expand vs. horizontal scroll) the same way:
+/// the label names both rather than picking one focus's meaning and
+/// leaving it wrong in the other, which a focus-conditional label would.
 fn hints(glyphs: crate::glyphs::Glyphs) -> Vec<String> {
     vec![
         format!("{} move", glyphs.arrows_vertical),
-        format!("{} expand", glyphs.arrows_horizontal),
+        format!("{} expand/scroll", glyphs.arrows_horizontal),
         "/ search".to_string(),
         "Tab pane".to_string(),
         "t raw".to_string(),

--- a/mandible-tui/src/render/status_bar.rs
+++ b/mandible-tui/src/render/status_bar.rs
@@ -34,10 +34,25 @@ use ratatui::Frame;
 /// a third meaning (collapse/expand vs. horizontal scroll) the same way:
 /// the label names both rather than picking one focus's meaning and
 /// leaving it wrong in the other, which a focus-conditional label would.
-fn hints(glyphs: crate::glyphs::Glyphs) -> Vec<String> {
+///
+/// That label does still depend on one thing: `horizontal_scroll_enabled`.
+/// This is the config's state, not the focus state — `[ui]
+/// horizontal_scroll = false` promises the pre-existing rendering exactly,
+/// and the footer is part of what a user sees, so `expand/scroll` would be
+/// advertising a behavior they explicitly turned off. `expand` alone is
+/// also shorter, which matters independently: at 80 columns the wider
+/// label pushed `Tab pane` off the row — the one hint that gets a user
+/// *to* the pane where the scroll half of the label would apply — so
+/// leaving the short label as the default-off case fixes both at once.
+fn hints(glyphs: crate::glyphs::Glyphs, horizontal_scroll_enabled: bool) -> Vec<String> {
+    let horizontal_hint = if horizontal_scroll_enabled {
+        format!("{} expand/scroll", glyphs.arrows_horizontal)
+    } else {
+        format!("{} expand", glyphs.arrows_horizontal)
+    };
     vec![
         format!("{} move", glyphs.arrows_vertical),
-        format!("{} expand/scroll", glyphs.arrows_horizontal),
+        horizontal_hint,
         "/ search".to_string(),
         "Tab pane".to_string(),
         "t raw".to_string(),
@@ -73,8 +88,12 @@ const LEFT_MARGIN: &str = "  ";
 /// reader most needs to be told the full list exists. Pinning it also
 /// means adding a hint can no longer silently push it off the row, which
 /// is how `r` stayed invisible for five releases.
-fn hints_for_width(width: usize, glyphs: crate::glyphs::Glyphs) -> String {
-    let all = hints(glyphs);
+fn hints_for_width(
+    width: usize,
+    glyphs: crate::glyphs::Glyphs,
+    horizontal_scroll_enabled: bool,
+) -> String {
+    let all = hints(glyphs, horizontal_scroll_enabled);
     let split = all.len().saturating_sub(PINNED_HINTS);
     let (rest, pinned) = all.split_at(split);
     let pinned_len: usize = pinned.iter().map(|h| h.chars().count()).sum::<usize>()
@@ -128,7 +147,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let margin_width = display_width(LEFT_MARGIN) * 2;
     let hints_budget = width.saturating_sub(right_width + margin_width + 2);
-    let hints = hints_for_width(hints_budget, app.glyphs);
+    let hints = hints_for_width(hints_budget, app.glyphs, app.horizontal_scroll_enabled);
 
     let mut spans = vec![
         Span::raw(LEFT_MARGIN),
@@ -169,8 +188,8 @@ mod tests {
 
     #[test]
     fn wide_terminal_shows_every_hint() {
-        let rendered = hints_for_width(120, crate::glyphs::UNICODE);
-        for h in hints(crate::glyphs::UNICODE) {
+        let rendered = hints_for_width(120, crate::glyphs::UNICODE, true);
+        for h in hints(crate::glyphs::UNICODE, true) {
             assert!(rendered.contains(&h), "{h} missing from {rendered:?}");
         }
     }
@@ -184,7 +203,7 @@ mod tests {
     /// rather than quietly shrinking the footer.
     #[test]
     fn every_action_key_is_named_at_full_width() {
-        let rendered = hints_for_width(140, crate::glyphs::UNICODE);
+        let rendered = hints_for_width(140, crate::glyphs::UNICODE, true);
         for key in [
             "/ search", "Tab pane", "t raw", "y copy", "r reload", "? help",
         ] {
@@ -196,7 +215,7 @@ mod tests {
     /// thing that should turn into boxes for someone who cannot get out.
     #[test]
     fn ascii_fallback_hints_are_pure_ascii() {
-        let rendered = hints_for_width(120, crate::glyphs::ASCII);
+        let rendered = hints_for_width(120, crate::glyphs::ASCII, true);
         assert!(rendered.is_ascii(), "{rendered:?}");
         assert!(rendered.contains("^C quit"));
     }
@@ -207,7 +226,7 @@ mod tests {
     #[test]
     fn quit_hint_survives_a_narrow_terminal() {
         for width in [20, 30, 40, 60, 88] {
-            let hints = hints_for_width(width, crate::glyphs::UNICODE);
+            let hints = hints_for_width(width, crate::glyphs::UNICODE, true);
             assert!(hints.contains("^C quit"), "width {width}: {hints:?}");
             // A narrow row hides most of the footer, which is exactly
             // where the reader needs to know the full list exists.
@@ -217,6 +236,66 @@ mod tests {
                 "width {width} overflowed: {hints:?}"
             );
         }
+    }
+
+    /// The whole point of the review round that added this: `[ui]
+    /// horizontal_scroll = false` must restore the footer exactly, not
+    /// just the pane content. `expand/scroll` is also long enough to push
+    /// `Tab pane` off an 80-column row, so the off state fixes both at
+    /// once — proven by comparing directly against the pre-feature label.
+    #[test]
+    fn horizontal_hint_matches_the_config_toggle() {
+        for width in [40, 60, 80, 100, 120, 140] {
+            let on = hints_for_width(width, crate::glyphs::UNICODE, true);
+            let off = hints_for_width(width, crate::glyphs::UNICODE, false);
+
+            assert!(
+                !off.contains("expand/scroll"),
+                "off must not advertise the disabled behavior at width {width}: {off:?}"
+            );
+
+            // `off`'s label is strictly shorter, so at any width it can
+            // only fit as many or more of the non-pinned hints than `on`
+            // does — never fewer. This is the structural version of the
+            // review-round finding: the wider `on` label pushed `Tab
+            // pane` off an 80-column row, and `off` restoring the short
+            // label must never lose a hint `on` still had room for.
+            for hint in ["t raw", "Esc back", "y copy", "r reload", "Tab pane"] {
+                if on.contains(hint) {
+                    assert!(
+                        off.contains(hint),
+                        "off dropped {hint:?} at width {width} while on kept it: on={on:?} off={off:?}"
+                    );
+                }
+            }
+        }
+
+        // At a comfortable width, off still names collapse/expand — it
+        // only drops the "/scroll" half, not the whole hint.
+        let off_wide = hints_for_width(120, crate::glyphs::UNICODE, false);
+        assert!(off_wide.contains("expand"), "{off_wide:?}");
+
+        // The specific bug this test pins: `render()` subtracts the
+        // right-hand provenance text's width from an 80-column terminal
+        // before budgeting hints (see `render`'s `hints_budget`), which is
+        // what actually pushed `Tab pane` off the row in a real 80-column
+        // frame — the review round's finding used a full pty capture, not
+        // `hints_for_width` in isolation. Reproduced at the raw-width
+        // crossover: the enabled label is long enough to cost `Tab pane`
+        // — the one hint that reaches the pane the feature applies to —
+        // while the disabled label, exactly as wide as before this
+        // feature existed, keeps it.
+        let crossover = 68;
+        let on = hints_for_width(crossover, crate::glyphs::UNICODE, true);
+        let off = hints_for_width(crossover, crate::glyphs::UNICODE, false);
+        assert!(
+            !on.contains("Tab pane"),
+            "expected width {crossover} to be the known trade-off point: {on:?}"
+        );
+        assert!(
+            off.contains("Tab pane"),
+            "off must restore Tab pane at the width where on drops it: {off:?}"
+        );
     }
 
     /// The controls keep a left margin rather than starting hard against
@@ -231,8 +310,8 @@ mod tests {
     /// budgeted for it — otherwise the two overlap at narrow widths.
     #[test]
     fn hints_shrink_to_leave_room_for_the_right_hand_text() {
-        let full = hints_for_width(120, crate::glyphs::UNICODE);
-        let squeezed = hints_for_width(40, crate::glyphs::UNICODE);
+        let full = hints_for_width(120, crate::glyphs::UNICODE, true);
+        let squeezed = hints_for_width(40, crate::glyphs::UNICODE, true);
         assert!(
             squeezed.chars().count() < full.chars().count(),
             "hints should give way: {squeezed:?} vs {full:?}"

--- a/mandible-tui/tests/border_integrity.rs
+++ b/mandible-tui/tests/border_integrity.rs
@@ -428,8 +428,8 @@ fn ascii_glyph_set_renders_a_pure_ascii_frame() {
 }
 
 /// A node whose USAGE synopsis is wider than the pane: the horizontal-scroll
-/// overflow affordance (spec §9's "give preformatted content horizontal
-/// scrolling instead" of wrapping) must show a right-pointing marker while
+/// overflow affordance (spec §9: preformatted detail-pane content scrolls
+/// rather than wraps) must show a right-pointing marker while
 /// unscrolled, switch to a left-pointing one once fully scrolled right, and
 /// — the point of testing it here rather than only in `detail_pane`'s own
 /// unit tests — never disturb any of the border cells `assert_border_intact`
@@ -491,6 +491,43 @@ fn detail_pane_hscroll_affordance_marks_overflow_without_corrupting_the_border()
         buffer[(right_marker, detail_rect.y)].symbol(),
         "→",
         "fully scrolled right: nothing more to reveal"
+    );
+}
+
+/// The affordance is drawn regardless of which pane has focus — a
+/// deliberate choice documented on `draw_hscroll_affordance` itself: even
+/// though `h`/`l`/`←`/`→` only reach the detail pane's scroll while it is
+/// focused, a marker that disappeared with the tree focused would let a
+/// USAGE line clip silently until the reader happened to `Tab` over, which
+/// is the worse failure. Pinned here so a future change to that decision is
+/// a deliberate edit to this test, not a silent regression.
+#[test]
+fn detail_pane_hscroll_affordance_shows_even_with_the_tree_focused() {
+    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
+    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+
+    let mut app = App::new("wide".to_string(), root);
+    app.focus = mandible_tui::Focus::Tree;
+    assert!(app.horizontal_scroll_enabled, "default is on");
+
+    let width = 60u16;
+    let height = 20u16;
+    let regions =
+        mandible_tui::layout::compute(ratatui::layout::Rect::new(0, 0, width, height), app.focus);
+    let detail_rect = regions.detail.expect("detail pane visible at this width");
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| mandible_tui::render::render(frame, &app))
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    assert_border_intact(&buffer, detail_rect);
+    let right_marker = detail_rect.x + detail_rect.width - 2;
+    assert_eq!(
+        buffer[(right_marker, detail_rect.y)].symbol(),
+        "→",
+        "the affordance is not gated on detail-pane focus"
     );
 }
 

--- a/mandible-tui/tests/border_integrity.rs
+++ b/mandible-tui/tests/border_integrity.rs
@@ -427,6 +427,145 @@ fn ascii_glyph_set_renders_a_pure_ascii_frame() {
     }
 }
 
+/// A node whose USAGE synopsis is wider than the pane: the horizontal-scroll
+/// overflow affordance (spec §9's "give preformatted content horizontal
+/// scrolling instead" of wrapping) must show a right-pointing marker while
+/// unscrolled, switch to a left-pointing one once fully scrolled right, and
+/// — the point of testing it here rather than only in `detail_pane`'s own
+/// unit tests — never disturb any of the border cells `assert_border_intact`
+/// checks strictly (left/right/bottom edges, all four corners).
+#[test]
+fn detail_pane_hscroll_affordance_marks_overflow_without_corrupting_the_border() {
+    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
+    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+
+    let mut app = App::new("wide".to_string(), root);
+    app.focus = mandible_tui::Focus::Detail;
+    assert!(app.horizontal_scroll_enabled, "default is on");
+
+    let width = 60u16;
+    let height = 20u16;
+    let regions =
+        mandible_tui::layout::compute(ratatui::layout::Rect::new(0, 0, width, height), app.focus);
+    let detail_rect = regions.detail.expect("detail pane visible at this width");
+
+    let render_once = |app: &App| -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| mandible_tui::render::render(frame, app))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    };
+
+    // Unscrolled: more content to the right, none to the left.
+    let buffer = render_once(&app);
+    assert_border_intact(&buffer, regions.search);
+    assert_border_intact(&buffer, detail_rect);
+    let right_marker = detail_rect.x + detail_rect.width - 2;
+    let left_marker = detail_rect.x + detail_rect.width - 3;
+    assert_eq!(
+        buffer[(right_marker, detail_rect.y)].symbol(),
+        "→",
+        "should signal more content to the right"
+    );
+    assert_ne!(
+        buffer[(left_marker, detail_rect.y)].symbol(),
+        "←",
+        "nothing scrolled off the left yet"
+    );
+
+    // Scroll all the way right: the affordance should flip.
+    for _ in 0..64 {
+        app.detail_hscroll_right();
+    }
+    let buffer = render_once(&app);
+    assert_border_intact(&buffer, regions.search);
+    assert_border_intact(&buffer, detail_rect);
+    assert_eq!(
+        buffer[(left_marker, detail_rect.y)].symbol(),
+        "←",
+        "should signal more content to the left once scrolled"
+    );
+    assert_ne!(
+        buffer[(right_marker, detail_rect.y)].symbol(),
+        "→",
+        "fully scrolled right: nothing more to reveal"
+    );
+}
+
+/// The ASCII glyph set's affordance markers (`<`/`>`) are what actually
+/// reach the screen under `MANDIBLE_ASCII=1` — the Unicode arrows above are
+/// exactly the kind of glyph this project refuses to rely on everywhere.
+#[test]
+fn detail_pane_hscroll_affordance_uses_the_ascii_glyphs() {
+    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
+    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+
+    let mut app = App::new("wide".to_string(), root);
+    app.focus = mandible_tui::Focus::Detail;
+    app.glyphs = mandible_tui::glyphs::ASCII;
+
+    let width = 60u16;
+    let height = 20u16;
+    let regions =
+        mandible_tui::layout::compute(ratatui::layout::Rect::new(0, 0, width, height), app.focus);
+    let detail_rect = regions.detail.expect("detail pane visible at this width");
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| mandible_tui::render::render(frame, &app))
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    // ASCII borders use `+` corners, not the rounded glyphs
+    // `assert_border_intact` checks for — this asserts the ASCII-specific
+    // property directly instead.
+    let right_marker = detail_rect.x + detail_rect.width - 2;
+    assert_eq!(buffer[(right_marker, detail_rect.y)].symbol(), ">");
+    for y in 0..height {
+        for x in 0..width {
+            assert!(
+                buffer[(x, y)].symbol().is_ascii(),
+                "non-ASCII symbol {:?} at ({x},{y}) with the ASCII glyph set",
+                buffer[(x, y)].symbol()
+            );
+        }
+    }
+}
+
+/// The config toggle off must reproduce today's rendering exactly: no
+/// affordance marker anywhere on the detail pane's border, even for a node
+/// whose USAGE is far wider than the pane — because with the toggle off
+/// that content wraps instead of overflowing, so there is nothing to mark.
+#[test]
+fn detail_pane_hscroll_affordance_absent_when_the_config_toggle_is_off() {
+    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
+    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+
+    let mut app = App::new("wide".to_string(), root);
+    app.focus = mandible_tui::Focus::Detail;
+    app.horizontal_scroll_enabled = false;
+
+    let width = 60u16;
+    let height = 20u16;
+    let regions =
+        mandible_tui::layout::compute(ratatui::layout::Rect::new(0, 0, width, height), app.focus);
+    let detail_rect = regions.detail.expect("detail pane visible at this width");
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| mandible_tui::render::render(frame, &app))
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    assert_border_intact(&buffer, detail_rect);
+    let top_row: String = (detail_rect.x..detail_rect.x + detail_rect.width)
+        .map(|x| buffer[(x, detail_rect.y)].symbol().to_string())
+        .collect();
+    assert!(!top_row.contains('→') && !top_row.contains('←'));
+}
+
 /// The Unicode set is still what a UTF-8 terminal gets — the fallback must
 /// not quietly become the default for everyone.
 #[test]

--- a/mandible/src/app_runner.rs
+++ b/mandible/src/app_runner.rs
@@ -53,6 +53,31 @@ enum LoopExit {
     ReviewSubmit(ReviewSubmission),
 }
 
+/// Build an `App` for `tool`, with settings resolved from the user's
+/// `config.toml` applied on top of `App::new`'s pure defaults.
+///
+/// `App::new` itself does no filesystem I/O — it is a plain constructor, so
+/// every embedder (including this crate's own tests, and `mandible-tui`'s)
+/// gets deterministic defaults regardless of what happens to exist on the
+/// machine running them. Reading `~/.config/mandible/config.toml` is a
+/// startup concern, so it belongs here at the composition root beside
+/// everything else `main.rs`/`app_runner.rs` already resolves before the
+/// first frame — never inside `App::new`, which broke exactly this: a
+/// `horizontal_scroll = false` left over from someone's own use of
+/// mandible on the machine running the test suite silently changed what
+/// "off reproduces today's behavior" was testing against.
+///
+/// The one real call site for a fresh tool session, whether that's `mandible
+/// <tool>` ([`main`][crate::main] via the caller of this function) or one
+/// tool inside `mandible --review` ([`run_review_loop`]) — both go through
+/// this instead of `App::new` directly, so the config is never forgotten on
+/// either path.
+pub fn new_app(tool: String, stub: mandible_core::CommandNode) -> App {
+    let mut app = App::new(tool, stub);
+    app.horizontal_scroll_enabled = mandible_core::config::load().ui.horizontal_scroll;
+    app
+}
+
 /// Run the interactive TUI for `app` until the user quits. Always restores
 /// the terminal on the way out, even if the loop returns an error.
 pub fn run(mut app: App) -> anyhow::Result<()> {
@@ -124,7 +149,7 @@ fn run_review_loop(term: &mut terminal::Term, dir: &Path, seed: u64) -> anyhow::
             entry.tool.clone(),
             mandible_core::Provenance::default(),
         );
-        let mut app = App::new(entry.tool.clone(), stub);
+        let mut app = new_app(entry.tool.clone(), stub);
         app.review = Some(review_overlay_for(&entry, remaining, total));
 
         match run_loop(term, &mut app)? {
@@ -459,5 +484,68 @@ fn discard_input_typed_during_the_block() {
             }
             _ => return,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mandible_core::config::CONFIG_DIR_ENV;
+
+    /// Serializes this module's tests against `MANDIBLE_CONFIG_DIR` —
+    /// `std::env::set_var` is process-global and nextest runs tests from
+    /// one binary on multiple threads, so two tests setting it concurrently
+    /// would race.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn stub() -> mandible_core::CommandNode {
+        mandible_core::CommandNode::new("git", mandible_core::Provenance::default())
+    }
+
+    /// The regression this whole fix exists for: `new_app` — not `App::new`
+    /// — is where a real `config.toml` takes effect. Reproduces the report
+    /// exactly: a `config.toml` with `horizontal_scroll = false` on disk
+    /// must actually turn the feature off on an `App` built through the
+    /// real composition root, and `App::new` itself must stay pure (always
+    /// `true`, regardless of what's on disk) so nothing but this one
+    /// function ever reads the file.
+    #[test]
+    fn new_app_honors_config_toml_while_app_new_stays_pure() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "[ui]\nhorizontal_scroll = false\n",
+        )
+        .unwrap();
+        std::env::set_var(CONFIG_DIR_ENV, dir.path());
+
+        let pure = App::new("git".to_string(), stub());
+        assert!(
+            pure.horizontal_scroll_enabled,
+            "App::new must never read config.toml itself"
+        );
+
+        let wired = new_app("git".to_string(), stub());
+        assert!(
+            !wired.horizontal_scroll_enabled,
+            "new_app must apply the real config.toml"
+        );
+
+        std::env::remove_var(CONFIG_DIR_ENV);
+    }
+
+    /// The default: no `config.toml` on disk still leaves the feature on
+    /// through the real composition root, not just through `App::new`.
+    #[test]
+    fn new_app_defaults_to_horizontal_scroll_on_with_no_config_file() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var(CONFIG_DIR_ENV, dir.path());
+
+        let app = new_app("git".to_string(), stub());
+        assert!(app.horizontal_scroll_enabled);
+
+        std::env::remove_var(CONFIG_DIR_ENV);
     }
 }

--- a/mandible/src/main.rs
+++ b/mandible/src/main.rs
@@ -119,7 +119,7 @@ fn main() -> anyhow::Result<()> {
         );
     }
     let stub = mandible_core::CommandNode::new(tool.clone(), mandible_core::Provenance::default());
-    let app = mandible_tui::App::new(tool, stub);
+    let app = app_runner::new_app(tool, stub);
 
     app_runner::run(app)
 }

--- a/spec.md
+++ b/spec.md
@@ -1899,6 +1899,20 @@ overflows the border by one cell per wide character.
   a final dimmed "Inherited" group, and hidden/deprecated flags suppressed unless
   toggled with `.`.
 - Scroll state is per-pane; the wheel scrolls the pane under the cursor.
+- **Detail-pane content that is preformatted scrolls horizontally instead of
+  wrapping; prose does not.** The raw `--help` view (`t`) and a node's
+  USAGE-section synopsis lines are the tool author's own layout — wrapping
+  them at pane width reflows spacing that was part of their meaning, into
+  something no more readable than the original. `h`/`l`/`←`/`→` scroll that
+  content when the detail pane has focus, clamped to the widest line on
+  screen, with a `←`/`→` marker in the pane's border when there is more off
+  that edge. The summary, description, and flag list are unaffected either
+  way — they are mandible's own prose and keep wrapping to the pane width as
+  everywhere else in this section. Opinionated enough to need an escape
+  hatch: `[ui] horizontal_scroll` in `~/.config/mandible/config.toml`
+  (`mandible-core`'s `config` module — a sibling of Tier F's per-tool
+  `overrides/<tool>.toml`, spec §7) defaults to `true`, and `false` restores
+  plain wrapping for this content too.
 
 **Empty and degraded states are designed, not incidental:** a node whose children
 are still being extracted shows a subtle spinner row; a tool where only Tier B


### PR DESCRIPTION
## Summary

The detail pane wraps every line at the pane width. That's correct for prose, but the raw `--help` view (`t`) and USAGE-section synopsis lines are preformatted — wrapping them makes soup out of ragged real-world output (see spec §9, which now documents this rule).

- `h`/`l`/`←`/`→` now scroll the detail pane horizontally when it has focus, affecting only preformatted content (raw view, USAGE lines). Prose (summary, description, flags) is unaffected and still wraps.
- A `←`/`→` marker appears in the pane's top border when there is more content off that edge; it respects the ASCII glyph set (`<`/`>`) and never touches a border corner. Drawn regardless of which pane has focus — a deliberate choice (see `draw_hscroll_affordance`'s doc comment and its pinned test): a marker that disappeared with the tree focused would let content clip silently until the reader happened to `Tab` over.
- The footer's `←→` hint reads `expand/scroll` when the feature is on and `expand` when `[ui] horizontal_scroll = false` — tracking the *config* state, not focus (focus-conditional footers are explicitly rejected elsewhere in this file's history, and `↑↓ move` already carries the same two-meanings-one-label ambiguity across panes without switching).
- Horizontal offset clamps to `max_line_width - viewport_width`, never goes negative, and resets on selection change and on the raw/parsed toggle.
- New config key: `[ui] horizontal_scroll` in `~/.config/mandible/config.toml` (default `true`). Setting it to `false` reproduces the pre-existing rendering exactly, footer included — verified with a byte-for-byte diff against a pre-feature binary (see Tests below). Missing file/table/key all mean the default, same shape as the existing per-tool override tier. `App::new` stays a pure constructor (no filesystem I/O); the config file is read once at the composition root (`app_runner::new_app`), so nothing about this crate's behavior — including its own test suite — depends on what happens to be sitting in a developer's `~/.config/mandible/config.toml`.

This is `mandible-tui`/`mandible` only — no `mandible-extract` changes.

## See it yourself

```console
$ cargo build --release
$ ./target/release/mandible find      # press t for the raw view, then h/l to scroll
$ ./target/release/mandible ip        # press Tab to focus the detail pane, then h/l on USAGE
```

Look for the `←`/`→` marker in the pane's top border when content extends past an edge. To turn it off, add to `~/.config/mandible/config.toml`:

```toml
[ui]
horizontal_scroll = false
```

## Before / after

`find --help`'s raw view (`t`), at 90 columns — before wraps by clipping at the edge with no way to see the rest; after scrolls with `h`/`l`, `←`/`→` in the border showing which directions have more:

```
Before:
╭ find ─────────────────────────────────────╮
│ verbatim — output of `find --help`        │
│                                           │
│ Usage: /usr/bin/find [-H] [-L] [-P] [-Ole │
│                                           │
│ Default path is the current directory; de │
│ Expression may consist of: operators, opt │

After (scrolled right with l x4):
╭ find ───────────────────────────────────←→╮
│ verbatim — output of `find --help`        │
│                                           │
│ -P] [-Olevel] [-D debugopts] [path...] [e │
│                                           │
│ ctory; default expression is -print.      │
│ tors, options, tests, and actions.        │
```

`ip`'s USAGE section at 60 columns — before greedily word-wraps each synopsis, restarting flush-left; after keeps each synopsis on one line and reveals the rest with `l`:

```
Before:
╭ ip ────────────────────────╮
│ USAGE ──────────────────── │
│   ip [ OPTIONS ] OBJECT {  │
│   COMMAND | help }         │
│   ip [ -force ] -batch     │
│   filename                 │

After (scrolled right once):
╭ ip ──────────────────────←→╮
│ USAGE ──────────────────── │
│ PTIONS ] OBJECT { COMMAND  │
│ force ] -batch filename    │
```

Both captured with `scripts/pty_screenshot.py`, in a venv with `pyte` installed, against release binaries built before and after this branch (confirmed by differing checksums).

## Tests

- `mandible-core`: `config::tests` — missing file/table/key fall back to defaults; explicit `true`/`false` honored; unknown keys/tables don't break parsing; malformed TOML falls back without panicking; `MANDIBLE_CONFIG_DIR` honored for the path.
- `mandible` `app_runner::tests`: `new_app` applies a real `config.toml` while `App::new` itself stays pure regardless of what's on disk.
- `mandible-tui` `app::tests`: horizontal clamping at both ends, no-op with the config toggle off, reset on selection change / collapse-to-parent / raw-mode toggle, and the left/right overflow-flag pair tracking the current offset.
- `mandible-tui` `event::tests`: `h`/`l` scoped correctly per focused pane, never leaking into the other pane's meaning.
- `mandible-tui` `render::detail_pane::tests`: USAGE stays on one unwrapped line when the toggle is on vs. wraps across lines when off (the "byte-identical when off" pin), and scrolling right actually shifts a long synopsis.
- `mandible-tui` `render::status_bar::tests::horizontal_hint_matches_the_config_toggle`: the arrow hint never advertises `expand/scroll` with the toggle off, and the disabled label — being shorter — never fits *fewer* of the other hints than the enabled one at any width.
- `mandible-tui/tests/border_integrity.rs`: the affordance marks overflow on the correct side without corrupting any border cell, renders correctly in the ASCII glyph set, is entirely absent with the config toggle off, and stays visible with the tree pane focused (the deliberate focus-independence choice).
- **Manual byte-for-byte parity check** (not part of the automated suite, done for this PR): with `MANDIBLE_CONFIG_DIR` pointing at a `horizontal_scroll = false` config, `find` and `ip` in both structured and raw views at 80×24 produced output identical to a pre-feature binary — footer included.

## Gates

```
cargo fmt --all -- --check                                                    OK
cargo clippy --workspace --all-targets -- -D warnings                         OK, 0 warnings
cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D warnings   OK, 0 warnings
cargo nextest run --workspace                                                  1216 tests run, 1216 passed
cargo nextest run --workspace (MANDIBLE_CONFIG_DIR forcing horizontal_scroll=false)   1216 tests run, 1216 passed
cargo run -p xtask -- corpus                                                   113 fixtures: 104 ok, 9 xfail (as expected), 0 failed
cargo build --release                                                         OK
```

Based on current `main` (d663e65 / PR #62), no rebase needed for the latest commit.
