### PR TITLE
fix(help-text): recover LVM's stanza-head mode-selecting flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ once it reaches a published 0.1.0 release.
 ### Fixed
 
 - Pressing `t` to flip between the parsed view and the tool's own `--help` reset the detail pane to the top on every toggle, which broke the exact comparison the verbatim view exists for; the pane now carries the reader's place as a proportion of the view's extent and resolves it against the other view's height, surviving any number of consecutive toggles, while a selection change still starts at the top.
+- LVM's per-mode synopsis stanzas (`vgchange`, and the whole `lv*`/`vg*`/`pv*` family) repeat the tool's own name plus that mode's mode-selecting flag on the stanza's head line (`vgchange -a|--activate y|n|ay`, `vgchange --systemid String VG`), which the engine kept only as the stanza's `group` label and never itself parsed for a flag — `sections::recover_stanza_head_flag` now also reads that flag out (via the existing alias/value grammar, so `-a|--activate y|n|ay` still reads as one flag) while leaving the head line as `group` exactly as before; recovers `vgchange`'s `--activate`, `--refresh`, `--systemid`, `--lockstart`, `--lockstop` and `--locktype`, all previously absent from the tree.
 
 ## [0.4.4] - 2026-08-27
 

--- a/corpus/vgchange/2.03.16/expected.snap
+++ b/corpus/vgchange/2.03.16/expected.snap
@@ -10,6 +10,14 @@ positionals:
     sources:
     - help-text
 flags:
+- short: 'a'
+  long: activate
+  value_name: y|n|ay
+  value_kind: Required
+  group: vgchange -a|--activate y|n|ay
+  provenance:
+    sources:
+    - help-text
 - short: 'K'
   long: ignoreactivationskip
   group: vgchange -a|--activate y|n|ay
@@ -104,6 +112,11 @@ flags:
   provenance:
     sources:
     - help-text
+- long: refresh
+  group: vgchange --refresh
+  provenance:
+    sources:
+    - help-text
 - short: 'A'
   long: autobackup
   value_name: y|n
@@ -160,10 +173,14 @@ flags:
   provenance:
     sources:
     - help-text
-- short: 'S'
-  long: select
+- long: systemid
   value_name: String
   value_kind: Required
+  group: vgchange --systemid String VG
+  provenance:
+    sources:
+    - help-text
+- long: lockstart
   group: vgchange --lockstart
   provenance:
     sources:
@@ -172,7 +189,27 @@ flags:
   long: select
   value_name: String
   value_kind: Required
+  group: vgchange --lockstart
+  provenance:
+    sources:
+    - help-text
+- long: lockstop
   group: vgchange --lockstop
+  provenance:
+    sources:
+    - help-text
+- short: 'S'
+  long: select
+  value_name: String
+  value_kind: Required
+  group: vgchange --lockstop
+  provenance:
+    sources:
+    - help-text
+- long: locktype
+  value_name: sanlock|dlm|none
+  value_kind: Required
+  group: vgchange --locktype sanlock|dlm|none VG
   provenance:
     sources:
     - help-text

--- a/mandible-extract/src/help_text/grammar.rs
+++ b/mandible-extract/src/help_text/grammar.rs
@@ -700,6 +700,53 @@ pub fn paren_alternation_member_content(input: &str) -> Option<&str> {
     }
 }
 
+// --- the stanza head's own mode-selecting flag --------------------------
+//
+// LVM's emitter documents each mode as a stanza: a prose description line,
+// then a synopsis head line that repeats the tool's own name followed by
+// that mode's mode-selecting flag, then the mode's `[...]`/`(...)` rows:
+//
+// ```text
+//   Activate or deactivate LVs.
+//   vgchange -a|--activate y|n|ay
+//     [ -K|--ignoreactivationskip ]
+//     ...
+// ```
+//
+// `sections::parse_body`'s generic heading scanner already recognizes a
+// line like `vgchange -a|--activate y|n|ay` as a *heading* whenever
+// more-indented content follows it (`heading_can_name_a_group`), and keeps
+// its full text as the block's `group` — but the heading is only ever
+// copied into `group`, never itself parsed for the flag it names, so
+// `--activate` never became a flag row. This module adds only the
+// predicate for recognizing the shape; `sections::recover_stanza_head_flag`
+// hands the recognized remainder to [`parse_flag_spec`] unchanged, exactly
+// as every other row shape in this file already does — `-a|--activate
+// y|n|ay` reads as one flag (short `a`, long `activate`, value `y|n|ay`)
+// for the same reason `bracket_flag_row_content`'s identical shape does:
+// [`take_rest_value_token`]'s `alias_follows` guard already keeps a
+// value's own `|` from being misread as a second alias.
+
+/// True if `rest` — the text immediately following a stanza head line's own
+/// tool-name prefix, already trimmed of leading whitespace — opens with a
+/// bare flag spelling.
+///
+/// This is the whole test: a bare invocation naming no flag at all
+/// (`vgchange` alone, `rest` empty) fails it, and so does an ordinary
+/// heading whose text merely happens to start with the tool's own name
+/// (`rest` starts with a word, not a dash). It does not attempt to decide
+/// where the flag's own value ends and a trailing positional begins —
+/// `--systemid String VG`'s `VG` and `--locktype sanlock|dlm|none VG`'s
+/// `VG` are left in `rest` for [`parse_flag_spec`] to leave unconsumed on
+/// its own (its value grammar already stops at the first whitespace gap
+/// that isn't a qualifying alias separator), rather than trimmed here by a
+/// second, narrower value-vs-positional guess.
+pub fn looks_like_stanza_head_flag(rest: &str) -> bool {
+    rest.split_whitespace()
+        .next()
+        .is_some_and(is_bare_flag_token)
+}
+
 // --- the flag-alternation group ----------------------------------------
 //
 // A *delimited alternation of flag spellings* is one notation with three
@@ -1733,5 +1780,18 @@ mod tests {
     fn paren_alternation_member_content_refuses_a_non_flag_row() {
         assert_eq!(paren_alternation_member_content("( COMMON_OPTIONS,"), None);
         assert_eq!(paren_alternation_member_content("VG|Tag )"), None);
+    }
+
+    /// `looks_like_stanza_head_flag`'s whole test: a bare flag token as the
+    /// remainder's first word, real for every LVM shape it exists for, and
+    /// refused for a bare invocation with nothing after the name.
+    #[test]
+    fn looks_like_stanza_head_flag_requires_a_leading_flag_token() {
+        assert!(looks_like_stanza_head_flag("-a|--activate y|n|ay"));
+        assert!(looks_like_stanza_head_flag("--refresh"));
+        assert!(looks_like_stanza_head_flag("--systemid String VG"));
+        assert!(!looks_like_stanza_head_flag(""));
+        assert!(!looks_like_stanza_head_flag("VG"));
+        assert!(!looks_like_stanza_head_flag("is a general-purpose tool"));
     }
 }

--- a/mandible-extract/src/help_text/grammar.rs
+++ b/mandible-extract/src/help_text/grammar.rs
@@ -729,22 +729,66 @@ pub fn paren_alternation_member_content(input: &str) -> Option<&str> {
 
 /// True if `rest` — the text immediately following a stanza head line's own
 /// tool-name prefix, already trimmed of leading whitespace — opens with a
-/// bare flag spelling.
+/// bare flag spelling and names no *second* flag anywhere in what follows.
 ///
-/// This is the whole test: a bare invocation naming no flag at all
-/// (`vgchange` alone, `rest` empty) fails it, and so does an ordinary
-/// heading whose text merely happens to start with the tool's own name
-/// (`rest` starts with a word, not a dash). It does not attempt to decide
-/// where the flag's own value ends and a trailing positional begins —
-/// `--systemid String VG`'s `VG` and `--locktype sanlock|dlm|none VG`'s
-/// `VG` are left in `rest` for [`parse_flag_spec`] to leave unconsumed on
-/// its own (its value grammar already stops at the first whitespace gap
-/// that isn't a qualifying alias separator), rather than trimmed here by a
-/// second, narrower value-vs-positional guess.
+/// Two conditions:
+///
+/// 1. The first word is a bare flag spelling ([`is_bare_flag_token`]). A
+///    bare invocation naming no flag at all (`vgchange` alone, `rest`
+///    empty) fails it, and so does an ordinary heading whose text merely
+///    happens to start with the tool's own name (`rest` starts with a
+///    word, not a dash).
+/// 2. **No later word in `rest` is itself a bare flag spelling**, whether
+///    bracketed or bare. Every real LVM specimen this predicate was
+///    measured against — `-a|--activate y|n|ay`, `--systemid String VG`,
+///    `--locktype sanlock|dlm|none VG` — carries its value as a bare token
+///    or a `|`-separated list and nothing else; LVM's own convention never
+///    puts a second flag on the head line at all, docopt-bracketed or not.
+///    Two real, otherwise indistinguishable specimens showed why this has
+///    to be checked structurally rather than assumed:
+///    - `blkid --help`'s labelled `Usage:` block writes `blkid -p
+///      [--match-tag <tag>] [--offset <offset>] [--size <size>] [--output
+///      <format>] <dev> ...` — `blkid`'s own name, a bare `-p`, then a
+///      *second* flag, `--match-tag`, sitting inside a bracket group.
+///      Without this clause, [`parse_flag_spec`]'s value grammar read that
+///      bracket group as `-p`'s own optional value, fabricating `-p
+///      [--match-tag <tag>]` while `--match-tag` itself was silently
+///      dropped.
+///    - `jar --help`'s own `Examples:` block (an illustrative, filled-in
+///      invocation, not a synopsis at all) writes `jar --update --file
+///      foo.jar --main-class com.foo.Main --module-version 1.0` — four
+///      real flags chained with no brackets anywhere. Without this clause,
+///      [`parse_flag_spec`]'s alias loop tried `--file` as a *second
+///      spelling* of the same flag (discarding the name, since `--update`
+///      already won, but still advancing past it), then read `--file`'s
+///      own value `foo.jar` as `--update`'s.
+///
+///    Refusing the whole line in both cases is the same choice
+///    [`bracket_flag_row_content`]'s own `|`-reappearance guard already
+///    makes for the identical hazard shape: missing beats invented. This
+///    does not cost real recall — a line shaped either way is an ordinary
+///    alternate invocation form or a worked example, both already handled
+///    (or correctly left alone) by the existing labelled-usage-block engine
+///    (`extract_usage_flags`) and the `is_ignorable_heading`/
+///    `in_ignorable_section` machinery respectively, never a stanza head
+///    this reader is the only path to.
+///
+/// Beyond that, it does not attempt to decide where the flag's own value
+/// ends and a trailing positional begins — `--systemid String VG`'s `VG`
+/// and `--locktype sanlock|dlm|none VG`'s `VG` are left in `rest` for
+/// [`parse_flag_spec`] to leave unconsumed on its own (its value grammar
+/// already stops at the first whitespace gap that isn't a qualifying alias
+/// separator), rather than trimmed here by a second, narrower
+/// value-vs-positional guess.
 pub fn looks_like_stanza_head_flag(rest: &str) -> bool {
-    rest.split_whitespace()
-        .next()
-        .is_some_and(is_bare_flag_token)
+    let mut words = rest.split_whitespace();
+    let Some(first) = words.next() else {
+        return false;
+    };
+    if !is_bare_flag_token(first) {
+        return false;
+    }
+    !words.any(|w| is_bare_flag_token(w.trim_start_matches(['[', '(', '{'])))
 }
 
 // --- the flag-alternation group ----------------------------------------
@@ -1793,5 +1837,24 @@ mod tests {
         assert!(!looks_like_stanza_head_flag(""));
         assert!(!looks_like_stanza_head_flag("VG"));
         assert!(!looks_like_stanza_head_flag("is a general-purpose tool"));
+    }
+
+    /// A *second* flag anywhere in the remainder refuses the whole line,
+    /// bracketed or bare — `blkid`'s `-p [--match-tag <tag>] ...` and
+    /// `jar`'s `--update --file foo.jar --main-class ...` are both real
+    /// tools this predicate must not fire on (see its own doc comment for
+    /// why each one fabricated a wrong flag before this guard existed).
+    #[test]
+    fn looks_like_stanza_head_flag_refuses_a_second_flag_anywhere_in_rest() {
+        assert!(!looks_like_stanza_head_flag(
+            "-p [--match-tag <tag>] [--offset <offset>] <dev> ..."
+        ));
+        assert!(!looks_like_stanza_head_flag(
+            "--update --file foo.jar --main-class com.foo.Main --module-version 1.0"
+        ));
+        // The bare, no-second-flag shape is unaffected.
+        assert!(looks_like_stanza_head_flag(
+            "--locktype sanlock|dlm|none VG"
+        ));
     }
 }

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -44,8 +44,8 @@
 use super::grammar::{
     bracket_flag_row_content, is_bare_flag_spelling, is_bare_flag_token,
     looks_like_bracket_flag_row, looks_like_flag_start, looks_like_paren_alternation_open,
-    paren_alternation_member_content, paren_depth_delta, parse_bundled_shorts,
-    parse_flag_alternation, parse_flag_spec, split_alternatives, FlagSpec,
+    looks_like_stanza_head_flag, paren_alternation_member_content, paren_depth_delta,
+    parse_bundled_shorts, parse_flag_alternation, parse_flag_spec, split_alternatives, FlagSpec,
 };
 use super::profile::{heading_matches_markers, FrameworkProfile};
 use mandible_core::{
@@ -1117,6 +1117,23 @@ fn parse_body(
             // it as its own candidate.
             i = heading_idx + 1;
             continue;
+        }
+
+        // Reaching here means genuinely more-indented content follows this
+        // heading (the branch above always `continue`s otherwise) — LVM's
+        // own stanza shape, a head line naming a mode-selecting flag
+        // followed by that mode's `[...]`/`(...)` rows. Recovering the
+        // flag is independent of whatever the content turns out to be
+        // (a recognized flags block below, a word grid, or — `vgchange
+        // --systemid String VG`'s `[ COMMON_OPTIONS ]` — a single
+        // placeholder row `flags_block_start` never recognizes as a flags
+        // block at all): the head line names its flag either way, so this
+        // runs once per heading rather than being folded into any one of
+        // the branches that follow.
+        if let Some(flag) = recover_stanza_head_flag(&heading, tool_name) {
+            if result.flags.len() < MAX_RECOVERED_ENTRIES {
+                result.flags.push(flag);
+            }
         }
 
         // A headed command table whose first row sits on the heading's own
@@ -3472,6 +3489,67 @@ fn meaningful_flag_group(heading: String) -> Option<String> {
     } else {
         Some(heading)
     }
+}
+
+/// Recover the mode-selecting flag a stanza head line itself names —
+/// `grammar::looks_like_stanza_head_flag`'s shape — in addition to the
+/// heading text still becoming the stanza's `group` label exactly as
+/// before this change (`meaningful_flag_group`, called here with the same
+/// heading text the flags-block scan beside this call site already passes
+/// it, so a stanza's own head flag and its bracket-row flags always agree
+/// on `group`).
+///
+/// `None` for a bare invocation naming no flag at all (`vgchange` alone),
+/// for a heading that is not the tool's own name at a word boundary
+/// (`starts_with_tool_name`), and for an ignorable heading
+/// (`is_ignorable_heading` — an `Examples:`-shaped block's own rows must
+/// never be mined for a flag merely because one of them happens to repeat
+/// the tool's name). `tool_name` absent (framework or generic parse with no
+/// resolved name) also yields `None`; this recovery has no other way to
+/// know the head line's own name is the *tool's* name rather than
+/// coincidence.
+///
+/// Never fabricates required-ness: the flag is emitted exactly like any
+/// other recovered flag (`required: false`), even though LVM's own prose
+/// ("any one is required") makes it semantically mandatory — the IR has no
+/// per-group "choose exactly one of N" relation to spend on that.
+fn recover_stanza_head_flag(heading: &str, tool_name: Option<&str>) -> Option<Flag> {
+    let name = tool_name?;
+    if is_ignorable_heading(heading) || !starts_with_tool_name(heading, name) {
+        return None;
+    }
+    // `starts_with_tool_name` already confirmed `heading` opens with `name`
+    // at a word boundary, so `strip_prefix` here cannot fail — used instead
+    // of a raw byte-offset slice (AGENTS.md's UTF-8 boundary rule) even
+    // though `name` is always ASCII in practice.
+    let rest = heading.strip_prefix(name)?;
+    let rest = rest.trim_start();
+    if !looks_like_stanza_head_flag(rest) {
+        return None;
+    }
+    let spec = parse_flag_spec(rest);
+    if spec.short.is_none() && spec.long.is_none() {
+        return None;
+    }
+    Some(Flag {
+        short: spec.short,
+        long: spec.long,
+        value_name: spec.value_name,
+        value_kind: spec.value_kind,
+        choices: Vec::new(),
+        repeatable: false,
+        required: false,
+        negatable: spec.negatable,
+        single_dash: false,
+        hidden: false,
+        deprecated: None,
+        inherited: false,
+        group: meaningful_flag_group(heading.to_string()),
+        description: None,
+        default: None,
+        env_var: None,
+        provenance: Provenance::single(Source::HelpText),
+    })
 }
 
 fn emit_flags(
@@ -7937,13 +8015,23 @@ mod tests {
     }
 
     /// A stanza whose own description wraps across more than one physical
-    /// line (`pydoc3`'s `-p`/`-b`/`-w` forms) must not be admitted at all —
-    /// the shared continuation loop only recognizes a *single* physical
-    /// line as prose to drop, so an interior wrapped line would otherwise
-    /// be silently read as more usage notation and mined for fabricated
-    /// positionals (`HTTP`, `HTML` were invented from exactly this before
-    /// the guard existed). A single-line description (`-k`, `-n`) is
-    /// unaffected.
+    /// line (`pydoc3`'s `-p`/`-b`/`-w` forms) must not be *admitted into the
+    /// usage block* at all — the shared continuation loop only recognizes a
+    /// *single* physical line as prose to drop, so an interior wrapped line
+    /// would otherwise be silently read as more usage notation and mined
+    /// for fabricated positionals (`HTTP`, `HTML` were invented from
+    /// exactly this before the guard existed). A single-line description
+    /// (`-k`, `-n`) is unaffected.
+    ///
+    /// `-p`'s own flag is recovered anyway, by a *different, independent*
+    /// path this fix adds (`recover_stanza_head_flag`, via the generic
+    /// heading scanner `pydoc3 -p <port>` falls to once the usage block
+    /// refuses it) — one that only ever reads the head line's own text,
+    /// never the wrapped description beneath it, so it carries none of the
+    /// fabrication risk this guard exists for. This is a real, correct
+    /// flag (`pydoc3 -p <port>` genuinely starts an HTTP server), not a
+    /// regression of the guard: the assertion this test pins is "no
+    /// fabricated positional", not "no `-p` flag ever, by any means".
     #[test]
     fn stanza_with_wrapped_multi_line_description_is_refused() {
         let help = "pydoc - the Python documentation tool\n\npydoc3 <name> ...\n    Show text documentation on something.\n\npydoc3 -k <keyword>\n    Search for a keyword in the synopsis lines of all available modules.\n\npydoc3 -p <port>\n    Start an HTTP server on the given port on the local machine.  Port\n    number 0 can be used to get an arbitrary unused port.\n";
@@ -7953,11 +8041,12 @@ mod tests {
             "flags: {:?}",
             parsed.flags
         );
-        assert!(
-            !parsed.flags.iter().any(|f| f.short == Some('p')),
-            "flags: {:?}",
-            parsed.flags
-        );
+        let p = parsed
+            .flags
+            .iter()
+            .find(|f| f.short == Some('p'))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(p.value_name.as_deref(), Some("<port>"));
         assert!(
             !parsed
                 .positionals
@@ -8098,6 +8187,124 @@ mod tests {
             .find(|f| f.long.as_deref() == Some("bbb"))
             .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
         assert_eq!(bbb.value_name.as_deref(), Some("y|n"));
+    }
+
+    // --- the stanza head's own mode-selecting flag ----------------------
+    //
+    // LVM's real `vgchange --help` (`corpus/vgchange/2.03.16`) documents six
+    // stanzas whose head line names a flag never recovered before this fix:
+    // `-a|--activate y|n|ay`, `--refresh`, `--systemid String VG`,
+    // `--lockstart`, `--lockstop`, `--locktype sanlock|dlm|none VG`. These
+    // synthetic fixtures pin the same shapes with a made-up tool name, one
+    // hazard per test, independent of that real fixture's own upkeep.
+
+    /// The multi-alias head: `-a|--activate y|n|ay` must read as *one* flag
+    /// (short `a`, long `activate`, value `y|n|ay`), not three — the same
+    /// `alias_follows`/`take_rest_value_token` guard `bracket_flag_row_content`
+    /// already relies on for the identical ambiguity.
+    #[test]
+    fn stanza_head_multi_alias_flag_reads_as_one_flag_with_its_value() {
+        // Mirrors `vgchange`'s own shape exactly: a first stanza whose bare
+        // head *does* anchor the usage block (its own bracket row follows
+        // immediately), then a second stanza behind a too-short
+        // (`MIN_PROSE_SENTENCE_WORDS`-failing, spec §7's own recorded gap)
+        // description, which breaks the usage-block's multi-stanza
+        // continuation and leaves the second stanza's own head line for
+        // the generic heading scanner to find — the exact path that read
+        // `vgchange -a|--activate y|n|ay` as a heading and nothing else,
+        // before this fix.
+        let help = "tool\n\
+                     \t[ -x|--xflag ]\n\
+                     \n\
+                     Do a thing.\n\
+                     tool -a|--activate y|n|ay\n\
+                     \t[ -f|--force ]\n";
+        let parsed = parse_with_profile(help, None, Some("tool"));
+        let activate = parsed
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("activate"))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(activate.short, Some('a'));
+        assert_eq!(activate.value_name.as_deref(), Some("y|n|ay"));
+        assert_eq!(activate.value_kind, ValueKind::Required);
+        assert_eq!(activate.group.as_deref(), Some("tool -a|--activate y|n|ay"));
+        assert!(
+            !activate.required,
+            "not attempted: no fabricated required-ness"
+        );
+        assert_eq!(
+            parsed.flags.iter().filter(|f| f.short == Some('a')).count(),
+            1,
+            "flags: {:?}",
+            parsed.flags
+        );
+    }
+
+    /// The value-plus-positional head: `--systemid String VG` names one
+    /// flag whose value is `String`; the trailing `VG` is a positional, not
+    /// a second flag and not swallowed into the value.
+    #[test]
+    fn stanza_head_value_plus_positional_leaves_the_positional_alone() {
+        // `vgchange`'s own `--systemid` stanza, faithfully: `[ COMMON_OPTIONS ]`
+        // is a placeholder row, not a flag row (its content does not start
+        // with `-`), so `flags_block_start` never recognizes a flags block
+        // here at all — this stanza gets no `group`-bearing block from
+        // anything else in the engine, and the head line is the *only*
+        // place its flag is ever named.
+        let help = "tool\n\
+                     \n\
+                     Change the system ID.\n\
+                     tool --systemid String VG\n\
+                     \t[ COMMON_OPTIONS ]\n";
+        let parsed = parse_with_profile(help, None, Some("tool"));
+        let systemid = parsed
+            .flags
+            .iter()
+            .find(|f| f.long.as_deref() == Some("systemid"))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(systemid.value_name.as_deref(), Some("String"));
+        assert!(
+            !parsed.flags.iter().any(|f| f.long.as_deref() == Some("VG")),
+            "flags: {:?}",
+            parsed.flags
+        );
+    }
+
+    /// The bare head (`tool` alone, no flag) must yield no flag and change
+    /// nothing — the first stanza of every LVM tool's own synopsis.
+    #[test]
+    fn bare_stanza_head_with_no_flag_yields_no_flag() {
+        let help = "tool\n\t[ -f|--force ]\n";
+        let parsed = parse_with_profile(help, None, Some("tool"));
+        assert_eq!(parsed.flags.len(), 1, "flags: {:?}", parsed.flags);
+        assert_eq!(parsed.flags[0].long.as_deref(), Some("force"));
+    }
+
+    /// A negative case that must **not** be read as a stanza head: a
+    /// two-word section heading that is not the tool's own name at all
+    /// (`starts_with_tool_name` fails outright), even though it is followed
+    /// by indented `[...]` flag rows exactly like a real LVM stanza.
+    #[test]
+    fn a_heading_not_named_after_the_tool_is_never_read_as_a_stanza_head_flag() {
+        let help = "tool\n\t[ -f|--force ]\n\nCommon options:\n\t[ -d|--debug ]\n";
+        let parsed = parse_with_profile(help, None, Some("tool"));
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("options")),
+            "flags: {:?}",
+            parsed.flags
+        );
+        assert!(
+            parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("debug")),
+            "flags: {:?}",
+            parsed.flags
+        );
     }
 
     // --- compute_confidence's one-row-sample fallback -------------------

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -956,7 +956,6 @@ fn parse_body(
             i += 1;
             continue;
         }
-
         // Headingless flags block: the current line already looks like a
         // flag entry, so there is no heading to consume — scan it in
         // place.
@@ -8024,6 +8023,87 @@ mod tests {
     use super::*;
 
     // --- multi-stanza unlabelled synopsis (fix/multi-stanza-synopsis) ---
+
+    /// `jar --help`'s own `Examples:` block writes a worked, filled-in
+    /// invocation with several real flags chained on one line and no
+    /// brackets anywhere — `jar --update --file foo.jar --main-class
+    /// com.foo.Main --module-version 1.0` — structurally indistinguishable
+    /// from a bare stanza head by the flag-count-one shape alone. A plain
+    /// English sentence at column 0 earlier in the document (`"restore
+    /// individual classes or resources from an archive."`) is read as a
+    /// heading whose "content" is the entire indented `Examples:` block
+    /// beneath it (an unrelated, pre-existing engine quirk: any
+    /// more-indented content promotes the line above it to a heading), so
+    /// `is_ignorable_heading`/`in_ignorable_section` never independently
+    /// sees the `Examples:` marker text at all here — the second-flag
+    /// guard in [`grammar::looks_like_stanza_head_flag`] is what actually
+    /// stops this one. The real, described `--update`/`-u` and
+    /// `--file`/`-f` rows survive untouched.
+    #[test]
+    fn jars_chained_example_invocation_is_never_read_as_a_stanza_head() {
+        let help = "jar creates an archive for classes and resources, and can manipulate or\n\
+                     restore individual classes or resources from an archive.\n\
+                     \n\
+                     \x20Examples:\n\
+                     \x20jar --update --file foo.jar --main-class com.foo.Main --module-version 1.0\n\
+                     \x20\x20\x20\x20-C foo/ module-info.class\n\
+                     \n\
+                     Main operation mode:\n\
+                     \n\
+                     \x20-u, --update               Update an existing jar archive\n\
+                     \x20-f, --file=FILE             The archive file name\n";
+        let parsed = parse_with_profile(help, None, Some("jar"));
+        let update_flags: Vec<_> = parsed
+            .flags
+            .iter()
+            .filter(|f| f.long.as_deref() == Some("update"))
+            .collect();
+        assert_eq!(update_flags.len(), 1, "flags: {:?}", parsed.flags);
+        assert_eq!(update_flags[0].short, Some('u'));
+        assert!(
+            update_flags[0].value_name.is_none(),
+            "flags: {:?}",
+            parsed.flags
+        );
+        assert!(
+            parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("file")),
+            "flags: {:?}",
+            parsed.flags
+        );
+    }
+
+    #[test]
+    fn blkids_alternate_usage_form_is_never_read_as_a_stanza_head() {
+        let help = "Usage:\n\
+                     blkid --label <label> | --uuid <uuid>\n\
+                     \n\
+                     blkid -p [--match-tag <tag>] [--offset <offset>] [--size <size>]\n\
+                     \x20\x20\x20\x20\x20\x20[--output <format>] <dev> ...\n\
+                     \n\
+                     Low-level probing options:\n\
+                     \x20-p, --probe            low-level superblocks probing (bypass cache)\n\
+                     \x20-i, --info             gather information about I/O limits\n";
+        let parsed = parse_with_profile(help, None, Some("blkid"));
+        let p_flags: Vec<_> = parsed
+            .flags
+            .iter()
+            .filter(|f| f.short == Some('p'))
+            .collect();
+        assert_eq!(p_flags.len(), 1, "flags: {:?}", parsed.flags);
+        assert_eq!(p_flags[0].long.as_deref(), Some("probe"));
+        assert!(
+            !parsed
+                .flags
+                .iter()
+                .any(|f| f.long.as_deref() == Some("match-tag")
+                    || f.value_name.as_deref() == Some("--match-tag <tag>")),
+            "flags: {:?}",
+            parsed.flags
+        );
+    }
 
     /// `vgck --updatemetadata` — a *second* stanza, past the blank line
     /// this fix teaches the usage-block loop to look beyond — is now

--- a/mandible-extract/src/help_text/sections.rs
+++ b/mandible-extract/src/help_text/sections.rs
@@ -905,6 +905,39 @@ fn parse_body(
         .description
         .as_deref()
         .is_some_and(|d| command_mode_seed(d, profile));
+    // True from the moment an `is_ignorable_heading` heading (`EXAMPLES:`,
+    // a `Report bugs`-shaped line) is captured until a *structurally
+    // strong* block — a real flags block, word grid, or command table, not
+    // merely "content that fell through to the generic bare-block
+    // fallback" — is recognized under some later, non-ignorable heading.
+    // Exists solely to gate [`recover_stanza_head_flag`] below: an
+    // `EXAMPLES:` section's own invocation lines (`bpftrace -e
+    // 'tracepoint:raw_syscalls:sys_enter { ... }'`, `bpftrace -l
+    // '*sleep*'`) are, line for line, indistinguishable from a genuine
+    // LVM stanza head — the tool's own name, then a bare flag token, with
+    // more-indented content (the example's own one-line description)
+    // beneath it. `is_ignorable_heading` alone cannot see this: it is
+    // tested per candidate heading, and neither example line's own text
+    // starts with "example" or contains "report bugs" — only the
+    // `EXAMPLES:` heading that introduces them does, and every following
+    // heading candidate is re-examined independently of it (the "rewind"
+    // path below carries no memory of what came before). Measured: a full
+    // sweep before this guard existed fabricated `bpftrace -e`/`-l` flag
+    // rows whose value was a fragment of the example invocation, and it
+    // displaced the real, described `-e`/`-l` rows the tool's own
+    // `Options:`-shaped block already provides.
+    //
+    // Deliberately *not* reset by the generic `scan_bare_block` +
+    // `emit_choices`/`emit_subcommands` fallback (the path every one of
+    // `EXAMPLES:`'s own invocation lines actually takes, since their
+    // one-line description is not flag- or command-shaped): resetting
+    // there would clear the flag on the *first* example line and reopen
+    // the fabrication on the second. Only a positively-recognized
+    // structural block — the same set of branches that already gate their
+    // own emission on `!is_ignorable_heading(&heading)`, plus a few more
+    // whose shape cannot occur inside an examples section at all — clears
+    // it.
+    let mut in_ignorable_section = false;
 
     // 3. Section blocks: scan the rest of the output for a heading line
     // followed by more-indented content — or, if the very first content
@@ -991,6 +1024,9 @@ fn parse_body(
         let heading_indent = leading_whitespace(line);
         let heading = line.trim().to_string();
         let heading_idx = i;
+        if is_ignorable_heading(&heading) {
+            in_ignorable_section = true;
+        }
         i += 1;
         while i < lines.len() && lines[i].trim().is_empty() {
             i += 1;
@@ -1028,6 +1064,7 @@ fn parse_body(
                     i += 1;
                 }
                 if !is_ignorable_heading(&heading) {
+                    in_ignorable_section = false;
                     let recognized = is_recognized_command_heading(&heading, profile);
                     if recognized {
                         command_mode = true;
@@ -1096,6 +1133,7 @@ fn parse_body(
                 {
                     i = end;
                     command_mode = true;
+                    in_ignorable_section = false;
                     let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
                     total_entries += seen;
                     clean_entries += clean;
@@ -1130,9 +1168,22 @@ fn parse_body(
         // block at all): the head line names its flag either way, so this
         // runs once per heading rather than being folded into any one of
         // the branches that follow.
-        if let Some(flag) = recover_stanza_head_flag(&heading, tool_name) {
-            if result.flags.len() < MAX_RECOVERED_ENTRIES {
-                result.flags.push(flag);
+        //
+        // Gated on `!in_ignorable_section`: `bpftrace --help`'s own
+        // `EXAMPLES:` block writes each example as "the tool's own name,
+        // then a bare flag token, then a one-line description" —
+        // `bpftrace -e 'tracepoint:raw_syscalls:sys_enter { ... }'` — the
+        // identical shape to a real stanza head, and without this guard it
+        // fabricated `-e`/`-l` rows whose value was a fragment of the
+        // example invocation, displacing the real, described rows from
+        // `bpftrace`'s own `Options:` block. See `in_ignorable_section`'s
+        // own doc comment for why this has to be section context rather
+        // than a per-line check.
+        if !in_ignorable_section {
+            if let Some(flag) = recover_stanza_head_flag(&heading, tool_name) {
+                if result.flags.len() < MAX_RECOVERED_ENTRIES {
+                    result.flags.push(flag);
+                }
             }
         }
 
@@ -1169,6 +1220,7 @@ fn parse_body(
                         entries.insert(0, (first_name, None));
                         i = end;
                         command_mode = true;
+                        in_ignorable_section = false;
                         let raw_tokens = command_table_token_index(raw);
                         let (seen, clean) =
                             emit_headed_command_table(entries, &raw_tokens, &mut result);
@@ -1195,6 +1247,10 @@ fn parse_body(
                 command_mode = false;
                 continue;
             }
+            // A real, non-ignorable flags block — structurally strong
+            // evidence we are not (or no longer) inside an examples-shaped
+            // section. See `in_ignorable_section`'s own doc comment.
+            in_ignorable_section = false;
             if packed {
                 let seen = entries.len();
                 emit_packed_flags(meaningful_flag_group(heading), entries, &mut result);
@@ -1239,6 +1295,7 @@ fn parse_body(
             if let Some((end, entries)) = scan_argparse_subparsers(&lines, i, heading_indent) {
                 i = end;
                 command_mode = false;
+                in_ignorable_section = false;
                 let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
                 total_entries += seen;
                 clean_entries += clean;
@@ -1265,6 +1322,7 @@ fn parse_body(
             let (end, entries) = scan_bare_block(&lines, i, heading_indent, false);
             i = end;
             command_mode = false;
+            in_ignorable_section = false;
             let (block_seen, block_clean) =
                 emit_declared_positionals(entries, &usage_lines, &mut result);
             total_entries += block_seen;
@@ -1342,6 +1400,7 @@ fn parse_body(
             if let Some((end, entries)) = scan_bare_command_table(&lines, i) {
                 i = end;
                 command_mode = true;
+                in_ignorable_section = false;
                 let raw_tokens = command_table_token_index(raw);
                 let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, &mut result);
                 total_entries += seen;
@@ -1366,6 +1425,7 @@ fn parse_body(
             let (end, entries) = scan_comma_separated_commands(&lines, i);
             i = end;
             command_mode = true;
+            in_ignorable_section = false;
             let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
             total_entries += seen;
             clean_entries += clean;
@@ -1388,6 +1448,17 @@ fn parse_body(
 
         if recognized || command_mode {
             command_mode = true;
+            // Only `recognized` (this exact heading's own text says
+            // "commands") is strong enough to clear the flag here — the
+            // `command_mode` sticky-chain half of this condition is not:
+            // it can still be true from an *inherited* chain rather than
+            // this heading's own evidence, which is exactly the kind of
+            // indirect signal `in_ignorable_section` must not trust (see
+            // its own doc comment on why the generic bare-block fallback
+            // is deliberately excluded from clearing it).
+            if recognized {
+                in_ignorable_section = false;
+            }
             let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
             total_entries += seen;
             clean_entries += clean;
@@ -8302,6 +8373,64 @@ mod tests {
                 .flags
                 .iter()
                 .any(|f| f.long.as_deref() == Some("debug")),
+            "flags: {:?}",
+            parsed.flags
+        );
+    }
+
+    /// `bpftrace --help`'s real `EXAMPLES:` block writes each example as
+    /// "the tool's own name, then a bare flag token, then a one-line
+    /// description" — `tool -e 'tracepoint:raw_syscalls:sys_enter { ... }'`
+    /// — line for line the same shape as a genuine LVM stanza head. Without
+    /// `in_ignorable_section` gating `recover_stanza_head_flag`, this
+    /// fabricated `-e`/`-l` rows whose value was a fragment of the example
+    /// invocation, displacing the real, described `-e`/`-l` rows from the
+    /// `OPTIONS:` block above. This pins the fix: the real, described flags
+    /// survive untouched and nothing from `EXAMPLES:` is mined at all.
+    #[test]
+    fn examples_section_invocation_lines_are_never_read_as_stanza_heads() {
+        let help = "tool - a tool\n\
+                     \n\
+                     OPTIONS:\n\
+                     \x20\x20\x20\x20-e 'program'   execute this program\n\
+                     \x20\x20\x20\x20-l [search]    list probes\n\
+                     \n\
+                     EXAMPLES:\n\
+                     tool -l '*sleep*'\n\
+                     \x20\x20\x20\x20list probes containing \"sleep\"\n\
+                     tool -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'\n\
+                     \x20\x20\x20\x20count syscalls by process name\n";
+        let parsed = parse_with_profile(help, None, Some("tool"));
+        let e_flags: Vec<_> = parsed
+            .flags
+            .iter()
+            .filter(|f| f.short == Some('e'))
+            .collect();
+        assert_eq!(e_flags.len(), 1, "flags: {:?}", parsed.flags);
+        assert_eq!(e_flags[0].value_name.as_deref(), Some("'program'"));
+        assert!(
+            e_flags[0].description.is_some(),
+            "flags: {:?}",
+            parsed.flags
+        );
+
+        let l_flags: Vec<_> = parsed
+            .flags
+            .iter()
+            .filter(|f| f.short == Some('l'))
+            .collect();
+        assert_eq!(l_flags.len(), 1, "flags: {:?}", parsed.flags);
+        assert!(
+            l_flags[0].description.is_some(),
+            "flags: {:?}",
+            parsed.flags
+        );
+
+        assert!(
+            !parsed.flags.iter().any(|f| f
+                .value_name
+                .as_deref()
+                .is_some_and(|v| v.contains("sleep") || v.contains("tracepoint"))),
             "flags: {:?}",
             parsed.flags
         );


### PR DESCRIPTION
LVM's help emitter (`vgchange`, and the whole `lv*`/`vg*`/`pv*` family) documents each mode as a stanza: a prose description, then a synopsis head line repeating the tool's own name plus that mode's mode-selecting flag, then the mode's `[...]`/`(...)` rows. The head line was kept only as the stanza's `group` label; its own flag never became a flag row. `vgchange`'s own fixture shows the gap directly — fifteen rows carried `group: vgchange -a|--activate y|n|ay` but no `long: activate` row existed anywhere, and `--refresh`/`--systemid`/`--lockstart`/`--lockstop`/`--locktype` were absent the same way.

## The reader

- `grammar::looks_like_stanza_head_flag(rest)` — true when the text after a stanza head's own tool-name prefix opens with a bare flag token **and no later word — bracketed or bare — is itself a bare flag spelling**. The second half of that rule was added after two real false positives (below); every real LVM specimen this fix targets never puts a second flag on its own head line.
- `sections::recover_stanza_head_flag(heading, tool_name)` — called once, in the generic layout scanner, right after confirming more-indented content follows a heading candidate (the same gate that already lets a heading own a flags block). Guarded by `starts_with_tool_name` and `is_ignorable_heading`. Hands the remainder straight to the existing `parse_flag_spec` — no new alias/value parser — so `-a|--activate y|n|ay` reads as one flag via the same `alias_follows`/`take_rest_value_token` guard the bracket-row reader already relies on.
- `in_ignorable_section: bool` — sticky section-context flag, set when an `is_ignorable_heading` heading (`EXAMPLES:`, a `Report bugs`-shaped line) is captured, cleared only when a *structurally strong* block (a real flags block, word grid, or command table) is later recognized under a non-ignorable heading. Gates the reader above. `is_ignorable_heading` alone tests only the *candidate* heading, never the section it sits inside, and a tool's own example invocations are otherwise indistinguishable line-for-line from a real stanza head.
- `looks_like_bracket_flag_row` is untouched — still only fires on a whole `[...]` line, so `lsof`'s usage-continuation shape is unaffected.
- No per-tool logic anywhere: every predicate fires on shape (the tool's own name from parse context, a flag token, an absence of a second flag or of ignorable section context), never a tool-name list.

## Two false positives found and fixed during review

An independent full-sweep review (thank you) caught two real regressions the corpus suite and the first sweep both missed:

1. **`bpftrace`'s own `EXAMPLES:` block.** Each example line is "the tool's own name, then a bare flag token, then a one-line description" — `bpftrace -e 'tracepoint:raw_syscalls:sys_enter { ... }'` — indistinguishable from a stanza head by shape alone. Before the fix, this fabricated `-e`/`-l` rows whose value was a fragment of the example invocation, **displacing** the real, described `-e`/`-l` rows from `bpftrace`'s own `OPTIONS:` block (a described-field regression on a previously-`ok`-parsing tool, not just a missed gain). Fixed by `in_ignorable_section` (above). Verified directly against the real capture: `bpftrace` now shows **zero** field-level entries in the sweep-diff — not a smaller fabrication, none at all.
2. **`blkid`'s and `jar`'s own multi-flag lines.** `blkid`'s labelled `Usage:` block writes `blkid -p [--match-tag <tag>] [--offset <offset>] ...` — a *second* flag, `--match-tag`, inside a bracket group right after `-p`. `jar`'s own `Examples:` block (itself caught by rule 1, except the fake-heading engine quirk documented in the code means `is_ignorable_heading` never independently sees `Examples:` here — a *different*, pre-existing quirk this fix also had to account for) writes `jar --update --file foo.jar --main-class com.foo.Main --module-version 1.0` — four real flags chained with no brackets at all. Both fabricated a wrong value for the first flag from the second flag's own syntax, in both cases **displacing** an already-real, described flag (`blkid`'s `-p`/`--probe`, `jar`'s `--update`/`-u`). Fixed by widening `looks_like_stanza_head_flag`'s own guard to refuse *any* second flag-shaped word in the remainder, bracketed or not. `sg_ses --control [--byte1=B1] ...` turned out to be the identical `blkid` shape and is fixed by the same guard.

Real, synthetic regression tests now pin all three shapes (`examples_section_invocation_lines_are_never_read_as_stanza_heads`, `blkids_alternate_usage_form_is_never_read_as_a_stanza_head`, `jars_chained_example_invocation_is_never_read_as_a_stanza_head`), plus a grammar-level unit test for the second-flag guard itself.

## Measurement (re-run in full after both fixes above)

Full-`PATH` sweep, before/after this change in isolation, rebased onto current `main`:

```
overall: CHANGED
sweep transition: 2254 -> 2254 tools, 2254 matched, 0 appeared, 0 disappeared, 20 excluded (near 10s cap)

# status transitions
  pydoc3: ok -> low-confidence

# flag-count losses (the bar — never netted): 0 lost across 0 tool(s)

# flag-count gains: 39 gained across 10 tool(s)
  lvconvert: 117 -> 133 (+16)
  lvchange: 66 -> 73 (+7)
  vgchange: 57 -> 63 (+6)
  pydoc3: 2 -> 5 (+3)
  vgcfgrestore: 20 -> 22 (+2)
  lvcreate: 138 -> 139 (+1)
  pvck: 24 -> 25 (+1)
  vgexport: 20 -> 21 (+1)
  vgimport: 21 -> 22 (+1)
  vgsplit: 25 -> 26 (+1)

# field-level changes: 10 tool(s) (adds/removes/changes, never just a count)
  lvchange: flags added: --rebuild, --refresh, --resync, --syncaction
  lvconvert: flags added: --mergemirrors, --mergesnapshot, --mergethin, --raidintegrity, --repair, --replace, --splitcache, --startpoll; value_name changed: --type
  lvcreate: flags added: -s,--snapshot
  pvck: flags added: --repairtype
  pydoc3: flags added: -b, -p, -w
  vgcfgrestore: flags added: -f,--file, -l,--list
  vgchange: flags added: --lockstart, --lockstop, --locktype, --refresh, --systemid, -a,--activate
  vgexport: flags added: -a,--all
  vgimport: flags added: -a,--all
  vgsplit: flags added: -n,--name

# appeared (0), disappeared (0)
```

This is the field-level section reported **in full**, changes and adds both, per the request — not summarized down to "all additive". `blkid`, `deluser`, `jar`, `sg_ses` and `bpftrace` no longer appear anywhere in this report: all five were the false-positive gains from before the two fixes above, now correctly absent rather than merely smaller.

**`lvconvert`'s `--type` is a real value_name change, and it survives — here's why that's acceptable.** `lvconvert --help` legitimately reuses `--type` as its own mode-discriminator across 13 different stanzas (`--type linear`, `--type striped`, `--type mirror`, ... `--type snapshot`), each showing one illustrative enum member on its own head line — exactly LVM's convention this fix targets, applied to a flag that happens to recur. `--type` was **already** a duplicated, arbitrary-single-sample flag before this fix (the pre-existing unlabelled-synopsis usage-block continuation, from #57, already mined it from whichever stanza it reaches first, landing on `striped`); this fix reaches more of those same 13 stanzas via the generic heading scanner, and the sample that survives into the coverage tool's single-value fingerprint shifts to `snapshot` (the last stanza in the document). The IR has no representation for "this flag's value is one of N enum members depending on mode" — same gap the "Not attempted" note below names for required-ness — so this is a pre-existing representational limitation whose *arbitrary* answer moves, not a new fabrication or a real value lost. `lvchange -M,--persistent`'s value_name, which did flip between two samples in an earlier round of this fix, is now stable (`n`, unchanged before/after) — the stricter second-flag guard incidentally settled it.

`audit reclassify` (the 2,301 frozen captures) reproduces the same single `pydoc3` transition in isolation; the same pre-existing `queue.toml` drift noted before (unrelated to this change, present with this change fully reverted too) still accounts for the rest of that command's raw output.

## Duplicates

`vgchange`'s scoreboard already carries duplicate flag rows (the same spelling documented in more than one stanza) — 57 rows / 46 unique ids before this change, 63 rows / 52 unique ids after. The duplicate count itself (11) is unchanged; every one of the 6 new rows is a spelling that did not exist anywhere in the tree before. No dedup logic was added (issue #49's separate problem).

## Not attempted

LVM's own prose says "any one is required" for the stanza's own flag, but the IR has no "choose exactly one of N" relation — `Flag::required` is a per-flag bool. The recovered head flag is emitted as an ordinary flag with `required: false` rather than fabricating a constraint the IR cannot express. Relatedly, a flag reused across many stanzas as a mode discriminator (`lvconvert --type`) has no "one of these sample values" representation either — see the measurement section above.

`vgchange`'s stanza 4 ("Activate or deactivate LVs.", 4 words) still fails the usage-block continuation's own `is_prose_sentence` 5-word floor and breaks that block early, exactly as recorded previously — that finding is not stale. What's newly true: the stanza this breaks on, and every stanza after it, still gets its flag recovered anyway, because the generic heading scanner (this reader's own call site) picks them up independently of the usage-block continuation. Widening the 5-word floor itself is a separate change with its own measurement and is not attempted here.

## Fixtures

`corpus/vgchange/2.03.16/expected.snap` re-blessed and reviewed field by field: the six new flag rows (`-a,--activate`, `--refresh`, `--systemid`, `--lockstart`, `--lockstop`, `--locktype`) carry the correct short/long/value/group, `VG` is never fabricated as a flag, and no other row moved. `git status` after `--bless` showed several unrelated `[xfail]` fixtures gaining a snapshot on that run (a pre-existing `--bless` quirk, unrelated to this change); those were deleted rather than committed.

## Gates

`cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D warnings`; `cargo nextest run --workspace` — 1225 passed, 0 skipped; `cargo xtask corpus` — 113 fixtures, 104 ok, 9 xfail, 0 failed; `cargo build --release`.

## See it yourself

```console
$ cargo build --release
$ ./target/release/mandible vgchange
```

Look for the new flag rows named directly after each mode's own head line — `-a, --activate y|n|ay`, `--refresh`, `--systemid String`, `--lockstart`, `--lockstop`, `--locktype sanlock|dlm|none` — each carrying its own stanza's synopsis text as its group label.