### PR TITLE
release: 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project intends to adhere to [Semantic Versioning](https://semver.org/)
 once it reaches a published 0.1.0 release.
 
-## [Unreleased]
+## [0.4.5] - 2026-08-28
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "directories",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arboard",
  "base64",
@@ -2364,7 +2364,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.4.4" }
-mandible-extract = { path = "mandible-extract", version = "0.4.4" }
-mandible-search = { path = "mandible-search", version = "0.4.4" }
-mandible-tui = { path = "mandible-tui", version = "0.4.4" }
+mandible-core = { path = "mandible-core", version = "0.4.5" }
+mandible-extract = { path = "mandible-extract", version = "0.4.5" }
+mandible-search = { path = "mandible-search", version = "0.4.5" }
+mandible-tui = { path = "mandible-tui", version = "0.4.5" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Cuts the 0.4.5 section: LVM stanza-head flags (+39 across 10 tools), horizontal scroll for preformatted content with per-line gutter clip markers and a config toggle, proportional scroll carry (vertical and horizontal) across the raw toggle, rule-8 scratch all-or-nothing refusal, mouse-teardown fix. All version strings bumped.