### PR TITLE
feat(packaging): nix flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,35 @@
+# Builds the nix flake so a broken derivation is caught by the PR that
+# breaks it, not by the first nix user after a release. Runs only when the
+# flake or the things it consumes change.
+name: nix
+
+on:
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "**/Cargo.toml"
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: nix build (x86_64-linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - name: nix flake check
+        run: nix flake check --print-build-logs
+      - name: nix build
+        run: nix build .#mandible --print-build-logs
+      - name: smoke-run the packaged binary
+        run: ./result/bin/mandible --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2096,6 +2096,10 @@ Known gaps are tracked as issues; busybox's applet list is
 
 ## [Unreleased]
 
+### Added
+
+- **`flake.nix`** (issue #7): mandible is installable and runnable via nix (`nix run github:AS-FOSS/mandible`, or as a flake input), packaging the workspace binary with shell completions; a `nix.yml` workflow builds the flake on every PR that touches it so a broken derivation fails the PR that broke it.
+
 ### Added (batch 6 part 6, framework-support workflow)
 
 - **`.github/workflows/frameworks.yml`** (spec §13.1a): a framework matrix

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "mandible: a universal, interactive TUI reference for CLI tools";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = eachSystem (pkgs: rec {
+        mandible = pkgs.rustPlatform.buildRustPackage {
+          pname = "mandible";
+          # Single source of truth: the workspace version (spec: crates are
+          # bumped together with workspace.package.version).
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+          src = self;
+          cargoLock.lockFile = ./Cargo.lock;
+          cargoBuildFlags = [
+            "--package"
+            "mandible"
+          ];
+          nativeBuildInputs = [ pkgs.installShellFiles ];
+          # The workspace's own suite runs in the repository's CI. The nix
+          # sandbox cannot provide what parts of it require (a pty, and the
+          # unprivileged user namespaces exec::containment builds on), so
+          # this derivation packages the binary rather than re-running
+          # verification that already gates every merge.
+          doCheck = false;
+          postInstall = pkgs.lib.optionalString (pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform) ''
+            installShellCompletion --cmd mandible \
+              --bash <($out/bin/mandible --completions bash) \
+              --zsh <($out/bin/mandible --completions zsh) \
+              --fish <($out/bin/mandible --completions fish)
+          '';
+          meta = {
+            description = "Universal, interactive TUI reference for CLI tools";
+            homepage = "https://github.com/AS-FOSS/mandible";
+            changelog = "https://github.com/AS-FOSS/mandible/blob/main/CHANGELOG.md";
+            license = with pkgs.lib.licenses; [
+              asl20
+              mit
+            ];
+            mainProgram = "mandible";
+          };
+        };
+        default = mandible;
+      });
+    };
+}


### PR DESCRIPTION
## What this changes

Adds `flake.nix` (the ask in #7): `nix run github:AS-FOSS/mandible` and flake-input usage, packaging the workspace binary via `rustPlatform.buildRustPackage` with `Cargo.lock` as the dependency source, shell completions installed from the binary's own `--completions`, and the workspace version read from the root `Cargo.toml` so releases need no flake edits. A `nix.yml` workflow builds the flake and smoke-runs the binary on any PR touching it.

The derivation packages rather than re-verifies (`doCheck = false`): the workspace suite needs a pty and unprivileged user namespaces the nix sandbox does not provide, and it already gates every merge in the repo's own CI.

## Notes

- `flake.lock` is not committed yet — this machine has no nix; the CI run resolves nixpkgs fresh. Committing a lock from any nix-equipped machine (`nix flake lock`) is a sensible follow-up.
- nixpkgs upstreaming is deliberately deferred.

Closes #7.