### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-30
+
 ### Added
 
 - Every release body now opens with the install channels that actually work for that release — Homebrew, `cargo binstall`, `cargo install`, `nix run`, and the apt repository — instead of `cargo install` alone, rendered by `scripts/install_block.sh` so the list can be read and changed without pushing a tag to find out.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "directories",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "base64",
@@ -2364,7 +2364,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.4.5"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.4.5" }
-mandible-extract = { path = "mandible-extract", version = "0.4.5" }
-mandible-search = { path = "mandible-search", version = "0.4.5" }
-mandible-tui = { path = "mandible-tui", version = "0.4.5" }
+mandible-core = { path = "mandible-core", version = "0.5.0" }
+mandible-extract = { path = "mandible-extract", version = "0.5.0" }
+mandible-search = { path = "mandible-search", version = "0.5.0" }
+mandible-tui = { path = "mandible-tui", version = "0.5.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Version bump to 0.5.0 across the workspace and CHANGELOG sectioning for the release. The release body will carry the sectioned entries plus the install-channels block.

Breaking (per spec §4.5): the IR's `Flag`/`Positional` types are replaced by the kind-tagged `Entity`, and the public IR structs are `#[non_exhaustive]` — modifier and environment-variable stages follow in 0.5.x without another breaking release.