### PR TITLE
feat: open a subcommand path, and discover undocumented subcommands on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Added
+
+- `mandible cargo clippy` now opens cargo's tree at `clippy` instead of failing with "unexpected argument 'clippy' found" (issue #70): a trailing subcommand path is valid and lands exactly where browsing to that node lands, and a subcommand the parent's own help never documents — the `cargo-clippy`/`git-lfs` convention — is discovered as an executable named `<tool>-<sub>` on `PATH`, shown as a child marked `unverified` (a filename is evidence about the filesystem and a guess about the tool) and probed against its own binary, so a word read off a filename never becomes an argument to the parent; a path the finished tree turns out not to have is reported in the status line beside the real names rather than refused before the tool opens, and `--doctor`/`--report` still take a tool name alone.
+
 ### Fixed
 
 - `jar --help` no longer turns wrapped `-C foo/ ...` rows from its indented `Examples:` blocks into duplicate flags or loses the `Main operation mode:` group: when indentation would otherwise promote the preceding prose sentence to a fake heading and hide the ignorable marker, the parser now contains that whole region until a physical dedent or a positively worded, structurally attested multi-row flag section; generic `Input:`/`Output:` labels, command-shaped example data, and single flag-shaped samples remain contained, with no tool-name-keyed logic.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ produced a tool's output, then applies that framework's grammar. For example:
 > [!TIP]
 > You can also try to probe executable files: `mandible scripts/custom.py`
 
+> [!TIP]
+> Open straight at a subcommand: `mandible cargo clippy`. Commands the parent's
+> own help never lists — `cargo-clippy`, `git-lfs` and the like — are found on
+> `PATH` and shown marked `unverified`, since the naming convention is evidence
+> about the filesystem and a guess about the tool.
+
 ## Is it actually universal?
 
 That claim is measured, not asserted. `cargo xtask coverage` runs the pipeline against

--- a/mandible-core/src/merge.rs
+++ b/mandible-core/src/merge.rs
@@ -129,13 +129,16 @@ pub fn merge_nodes(mut candidates: Vec<CommandNode>) -> Result<CommandNode, Merg
         Axis::Structural,
     );
 
-    // The first contributor that carries one wins, not the highest
-    // structural authority: only tree assembly sets this (spec §5.4), and
-    // it is never in competition with a tier's account of the same node —
-    // a fill merges the discovered node with what the tool's binary said
-    // about itself, and the tier's candidate always carries `None`. Picking
-    // by authority would therefore let the tier's `None` erase the
-    // redirect, which is the one field a probe of this node depends on.
+    // Any contributor that carries one wins — the same "a merge can only
+    // add evidence, never take it away" reasoning `heading_attested` uses
+    // below, and for a field a probe of this node depends on. Only tree
+    // assembly sets it (spec §5.4), so at most one candidate ever has it:
+    // the discovered stub, merged on every fill against a tier's account of
+    // the binary itself, which is silent about it rather than in
+    // competition with it. `pick_option` would land on the same value (it
+    // skips `None`), by way of an authority comparison with nothing to
+    // compare — the stub carries no source at all, so it scores 0 on both
+    // axes — which reads as a contest this field never has.
     let discovered_binary = candidates.iter().find_map(|c| c.discovered_binary.clone());
 
     let structural_winner_idx =
@@ -711,6 +714,36 @@ mod tests {
         b.children_filled = true;
         let merged = merge_nodes(vec![a, b]).unwrap();
         assert!(merged.children_filled);
+    }
+
+    /// Spec §5.4: the discovered stub is merged against the tier's account
+    /// of the binary on every fill, and the redirect has to survive that —
+    /// it is what the *next* probe of this node is aimed at, so losing it
+    /// would send the following fill to the parent with a guessed word.
+    #[test]
+    fn a_discovered_binary_survives_a_merge_with_a_tier_that_has_none() {
+        let mut stub = CommandNode::new("clippy", Provenance::default());
+        stub.discovered_binary = Some("cargo-clippy".to_string());
+        let mut from_tier = node_from(Source::HelpText, "clippy");
+        from_tier.summary = Some(Text::sanitize("Checks a package"));
+
+        let merged = merge_nodes(vec![stub, from_tier]).unwrap();
+
+        assert_eq!(merged.discovered_binary.as_deref(), Some("cargo-clippy"));
+        assert_eq!(merged.summary.unwrap().as_str(), "Checks a package");
+    }
+
+    /// And an ordinary node never acquires one.
+    #[test]
+    fn merging_two_tier_nodes_leaves_no_discovered_binary() {
+        let a = node_from(Source::HelpText, "rebase");
+        let b = node_from(
+            Source::KnownSpec {
+                provider: "carapace".to_string(),
+            },
+            "rebase",
+        );
+        assert!(merge_nodes(vec![a, b]).unwrap().discovered_binary.is_none());
     }
 
     #[test]

--- a/mandible-core/src/merge.rs
+++ b/mandible-core/src/merge.rs
@@ -129,6 +129,15 @@ pub fn merge_nodes(mut candidates: Vec<CommandNode>) -> Result<CommandNode, Merg
         Axis::Structural,
     );
 
+    // The first contributor that carries one wins, not the highest
+    // structural authority: only tree assembly sets this (spec §5.4), and
+    // it is never in competition with a tier's account of the same node —
+    // a fill merges the discovered node with what the tool's binary said
+    // about itself, and the tier's candidate always carries `None`. Picking
+    // by authority would therefore let the tier's `None` erase the
+    // redirect, which is the one field a probe of this node depends on.
+    let discovered_binary = candidates.iter().find_map(|c| c.discovered_binary.clone());
+
     let structural_winner_idx =
         best_index(candidates.iter().map(|c| &c.provenance), Axis::Structural);
     let hidden = candidates[structural_winner_idx].hidden;
@@ -175,6 +184,7 @@ pub fn merge_nodes(mut candidates: Vec<CommandNode>) -> Result<CommandNode, Merg
         provenance,
         heading_attested,
         invocation_attested,
+        discovered_binary,
         confession,
     })
 }

--- a/mandible-core/src/node.rs
+++ b/mandible-core/src/node.rs
@@ -122,6 +122,21 @@ pub struct CommandNode {
     /// never flagged as a fabricated phantom subcommand merely for not
     /// being probe-eligible.
     pub invocation_attested: bool,
+    /// The binary this node was discovered as, when it was found by the
+    /// `<parent>-<sub>` PATH convention rather than documented by its
+    /// parent's own help text (spec §5.4) — e.g. `Some("cargo-clippy")` on
+    /// the `clippy` child of `cargo`. `None` for every node any extraction
+    /// tier produced, which is all of them: only the tree assembly above
+    /// this crate (`mandible/src/discovery.rs`) ever sets it.
+    ///
+    /// `Some` is the *unverified* state, and the TUI says so (spec §9.2): a
+    /// file on `PATH` whose name starts with the parent's own name plus a
+    /// dash is a convention, not a claim the parent made, so the node is
+    /// real evidence about the filesystem and a guess about the tool. It is
+    /// also the redirect this node's own probing follows — everything at or
+    /// below it is probed against *that* binary, so the guessed word never
+    /// becomes argv for the parent (spec §6).
+    pub discovered_binary: Option<String>,
     /// What this node's own `--help` text said about being an incomplete
     /// document, if anything (spec §6 rule 2b: the "truncation confession"
     /// convention — curl's `--help` ending "For all options use the manual
@@ -225,6 +240,7 @@ impl CommandNode {
             provenance,
             heading_attested: false,
             invocation_attested: false,
+            discovered_binary: None,
             confession: None,
         }
     }

--- a/mandible-core/src/snapshot.rs
+++ b/mandible-core/src/snapshot.rs
@@ -351,6 +351,13 @@ pub struct NodeSnapshot {
     /// See [`crate::CommandNode::invocation_attested`].
     #[serde(skip_serializing_if = "is_false")]
     pub invocation_attested: bool,
+    /// The binary this node was discovered as under the `<parent>-<sub>`
+    /// PATH convention (spec §5.4), when it was. Omitted for every node an
+    /// extraction tier produced — which is every node a fixture replays,
+    /// since discovery reads the running machine's `PATH` and therefore
+    /// never happens under the corpus runner.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovered_binary: Option<String>,
     /// The tool's raw `--help` output, one line per entry, set only when no
     /// parse produced anything structurally plausible.
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -423,6 +430,7 @@ impl From<&CommandNode> for NodeSnapshot {
             children_filled: n.children_filled,
             heading_attested: n.heading_attested,
             invocation_attested: n.invocation_attested,
+            discovered_binary: n.discovered_binary.clone(),
             unparsed: n.unparsed.iter().map(|t| t.as_str().to_string()).collect(),
             // The order-preservation this whole module exists to protect:
             // straight `iter().map().collect()` over `n.subcommands`, no

--- a/mandible-extract/src/lib.rs
+++ b/mandible-extract/src/lib.rs
@@ -49,7 +49,9 @@ pub mod overrides;
 
 pub use errors::ExtractError;
 pub use exec::is_help_only_probe;
-pub use resolve::{resolve_tool, ResolvedTool};
+pub use resolve::{
+    discover_path_siblings, discover_path_siblings_in, resolve_tool, PathSibling, ResolvedTool,
+};
 pub use runner::{ExtractionResult, FillResult, Runner, TierStatus};
 pub use tier::{ExtractionTier, NodeHints};
 

--- a/mandible-extract/src/resolve.rs
+++ b/mandible-extract/src/resolve.rs
@@ -69,9 +69,13 @@ pub fn discover_path_siblings(parent: &str) -> Vec<PathSibling> {
 /// tests use, so they never have to mutate the process-global `PATH` (which
 /// the test harness runs in parallel threads and cannot serialize).
 pub fn discover_path_siblings_in(dirs: &[PathBuf], parent: &str) -> Vec<PathSibling> {
-    // A tool the user spelled as a path (`mandible ./scripts/tool.py`) has
-    // no `PATH` neighbourhood to look in, and joining a prefix containing a
-    // separator would search a directory nobody named.
+    // Neither of these has a `PATH` neighbourhood to look in. The empty
+    // check is the one that changes an answer: the prefix would collapse to
+    // a bare `-`, and every `-foo` on `PATH` would read as a subcommand of
+    // nothing. A tool the user spelled as a path (`mandible
+    // ./scripts/tool.py`) can never match — a directory entry's file name
+    // holds no separator — so that half only skips a scan whose result is
+    // already known.
     if parent.is_empty() || parent.contains(std::path::MAIN_SEPARATOR) {
         return Vec::new();
     }
@@ -321,11 +325,18 @@ mod tests {
         assert_eq!(names, vec!["aaa", "mmm", "zzz"]);
     }
 
-    /// A tool spelled as a path has no `PATH` neighbourhood, and the prefix
-    /// join would search a directory nobody named.
+    /// A parent with no `PATH` neighbourhood finds nothing in it.
+    ///
+    /// The empty spelling is the half that can go wrong: its prefix
+    /// collapses to a bare `-`, and every `-foo` on `PATH` would read as a
+    /// subcommand of nothing. A path-spelled tool is asserted alongside it
+    /// because that is the case the early return is *written* for, even
+    /// though a directory entry's file name can never contain a separator.
+    #[cfg(unix)]
     #[test]
-    fn a_path_spelled_tool_has_no_siblings() {
-        let dir = tempfile::TempDir::new().unwrap();
+    fn a_parent_with_no_neighbourhood_matches_nothing() {
+        let dir = sibling_dir(&["-foo", "tool-real"], &[]);
+        assert!(discover_path_siblings_in(&[dir.path().to_path_buf()], "").is_empty());
         assert!(discover_path_siblings_in(
             &[dir.path().to_path_buf()],
             &format!(
@@ -335,7 +346,6 @@ mod tests {
             )
         )
         .is_empty());
-        assert!(discover_path_siblings_in(&[dir.path().to_path_buf()], "").is_empty());
     }
 
     /// A `libexec`-shaped directory on `PATH` must not hand the background

--- a/mandible-extract/src/resolve.rs
+++ b/mandible-extract/src/resolve.rs
@@ -28,6 +28,99 @@ pub fn resolve_tool(name: &str) -> ResolvedTool {
     }
 }
 
+/// One child command discovered by the `<parent>-<sub>` convention: a file
+/// on `PATH` named after the parent tool plus a dash (spec §5.4). `cargo`'s
+/// `cargo-clippy` and `git`'s `git-lfs` are the two specimens; the rule is
+/// keyed on the naming convention alone and knows nothing about either tool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathSibling {
+    /// The subcommand name — the part after the dash, e.g. `"clippy"`.
+    pub name: String,
+    /// The binary's own name, e.g. `"cargo-clippy"` — what a probe of this
+    /// node is actually sent to (spec §6), and what the UI names as the
+    /// evidence behind an unverified node (spec §9.2).
+    pub binary: String,
+}
+
+/// Upper bound on how many convention-discovered children one parent gets.
+///
+/// A backstop against a directory full of `<parent>-*` helpers (git's own
+/// `libexec` layout is ~150 of them, and a machine that puts such a
+/// directory on `PATH` would otherwise hand the background warmer that many
+/// extra probes for names the parent never documented), not a tuning knob.
+const MAX_PATH_SIBLINGS: usize = 64;
+
+/// Every `<parent>-<sub>` executable on `PATH`, as [`PathSibling`]s, in
+/// alphabetical order by subcommand name.
+///
+/// Filesystem-only, like everything else in this module: no process is
+/// spawned to discover a sibling, and nothing here decides whether one may
+/// be *probed* — that stays with `exec::run_inert` and spec §6, reached the
+/// same way any root `--help` probe is.
+pub fn discover_path_siblings(parent: &str) -> Vec<PathSibling> {
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return Vec::new();
+    };
+    let dirs: Vec<PathBuf> = std::env::split_paths(&path_var).collect();
+    discover_path_siblings_in(&dirs, parent)
+}
+
+/// [`discover_path_siblings`] against an explicit directory list — the seam
+/// tests use, so they never have to mutate the process-global `PATH` (which
+/// the test harness runs in parallel threads and cannot serialize).
+pub fn discover_path_siblings_in(dirs: &[PathBuf], parent: &str) -> Vec<PathSibling> {
+    // A tool the user spelled as a path (`mandible ./scripts/tool.py`) has
+    // no `PATH` neighbourhood to look in, and joining a prefix containing a
+    // separator would search a directory nobody named.
+    if parent.is_empty() || parent.contains(std::path::MAIN_SEPARATOR) {
+        return Vec::new();
+    }
+    let prefix = format!("{parent}-");
+    let mut found: Vec<PathSibling> = Vec::new();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            let Some(binary) = file_name.to_str() else {
+                continue;
+            };
+            let Some(sub) = binary.strip_prefix(&prefix) else {
+                continue;
+            };
+            // The same name-shape rule every tier applies before believing a
+            // bare word is a command (spec §7 Tier B rule 3), so a build
+            // artifact (`cargo-clippy.exe.bak`, `git-2.43`) or a
+            // capitalized helper never becomes a tree row.
+            if !mandible_core::is_command_name_shaped(sub) {
+                continue;
+            }
+            // First `PATH` entry wins, exactly as `find_on_path` resolves a
+            // tool name, so a shadowed sibling is reported once and by the
+            // binary that would actually run.
+            if found.iter().any(|s| s.name == sub) {
+                continue;
+            }
+            if !is_executable(&entry.path()) {
+                continue;
+            }
+            found.push(PathSibling {
+                name: sub.to_string(),
+                binary: binary.to_string(),
+            });
+        }
+    }
+    // Alphabetical, not `readdir` order: there is no document order to
+    // preserve here (spec §4.4's ordering argument is about what a tool's
+    // own text listed), and directory order differs between filesystems, so
+    // sorting is what makes the tree the same on two machines with the same
+    // binaries installed.
+    found.sort_by(|a, b| a.name.cmp(&b.name));
+    found.truncate(MAX_PATH_SIBLINGS);
+    found
+}
+
 fn find_on_path(name: &str) -> Option<PathBuf> {
     // A path separator in `name` means the caller already gave us a path;
     // don't search PATH for it, just check it directly.
@@ -152,6 +245,111 @@ mod tests {
             .expect("relative path should resolve");
         assert!(path.is_absolute(), "still relative: {}", path.display());
         assert!(path.ends_with("toolish"), "{}", path.display());
+    }
+
+    /// A directory of fixtures for the sibling-discovery tests: every entry
+    /// is created executable unless `plain` names it.
+    #[cfg(unix)]
+    fn sibling_dir(names: &[&str], plain: &[&str]) -> tempfile::TempDir {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        for name in names {
+            let file = dir.path().join(name);
+            std::fs::write(&file, "#!/bin/sh\nexit 0\n").unwrap();
+            let mode = if plain.contains(name) { 0o644 } else { 0o755 };
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode)).unwrap();
+        }
+        dir
+    }
+
+    /// The specimen from issue #70: `cargo --help` never lists `clippy`, but
+    /// `cargo-clippy` is right there on `PATH` (spec §5.4).
+    #[cfg(unix)]
+    #[test]
+    fn discovers_dash_prefixed_executables_as_subcommands() {
+        let dir = sibling_dir(&["cargo-clippy", "cargo-nextest", "cargo", "rustc"], &[]);
+        let found = discover_path_siblings_in(&[dir.path().to_path_buf()], "cargo");
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["clippy", "nextest"]);
+        assert_eq!(found[0].binary, "cargo-clippy");
+    }
+
+    /// A file nobody can run is not a command, however it is named.
+    #[cfg(unix)]
+    #[test]
+    fn a_non_executable_file_is_not_a_sibling() {
+        let dir = sibling_dir(&["cargo-clippy", "cargo-notes"], &["cargo-notes"]);
+        let found = discover_path_siblings_in(&[dir.path().to_path_buf()], "cargo");
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["clippy"]);
+    }
+
+    /// The same name-shape rule every tier applies to a bare word (spec §7
+    /// Tier B rule 3): a versioned or capitalized helper beside the tool is
+    /// not a subcommand name.
+    #[cfg(unix)]
+    #[test]
+    fn a_name_that_is_not_command_shaped_is_not_a_sibling() {
+        let dir = sibling_dir(&["git-lfs", "git-2.43", "git-README", "git-"], &[]);
+        let found = discover_path_siblings_in(&[dir.path().to_path_buf()], "git");
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["lfs"]);
+    }
+
+    /// First `PATH` entry wins, exactly as [`find_on_path`] resolves a tool
+    /// name — a shadowed sibling must be reported once, under the binary
+    /// that would actually run.
+    #[cfg(unix)]
+    #[test]
+    fn a_shadowed_sibling_is_reported_once_from_the_first_path_entry() {
+        let first = sibling_dir(&["cargo-clippy"], &[]);
+        let second = sibling_dir(&["cargo-clippy"], &[]);
+        let found = discover_path_siblings_in(
+            &[first.path().to_path_buf(), second.path().to_path_buf()],
+            "cargo",
+        );
+        assert_eq!(found.len(), 1);
+    }
+
+    /// Directory order differs between filesystems; the tree must not.
+    #[cfg(unix)]
+    #[test]
+    fn siblings_come_back_in_alphabetical_order() {
+        let dir = sibling_dir(&["cargo-zzz", "cargo-aaa", "cargo-mmm"], &[]);
+        let found = discover_path_siblings_in(&[dir.path().to_path_buf()], "cargo");
+        let names: Vec<&str> = found.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["aaa", "mmm", "zzz"]);
+    }
+
+    /// A tool spelled as a path has no `PATH` neighbourhood, and the prefix
+    /// join would search a directory nobody named.
+    #[test]
+    fn a_path_spelled_tool_has_no_siblings() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(discover_path_siblings_in(
+            &[dir.path().to_path_buf()],
+            &format!(
+                ".{}scripts{}tool",
+                std::path::MAIN_SEPARATOR,
+                std::path::MAIN_SEPARATOR
+            )
+        )
+        .is_empty());
+        assert!(discover_path_siblings_in(&[dir.path().to_path_buf()], "").is_empty());
+    }
+
+    /// A `libexec`-shaped directory on `PATH` must not hand the background
+    /// warmer hundreds of extra probes.
+    #[cfg(unix)]
+    #[test]
+    fn discovery_is_capped() {
+        let names: Vec<String> = (0..MAX_PATH_SIBLINGS + 10)
+            .map(|i| format!("git-c{i:03}"))
+            .collect();
+        let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        let dir = sibling_dir(&refs, &[]);
+        let found = discover_path_siblings_in(&[dir.path().to_path_buf()], "git");
+        assert_eq!(found.len(), MAX_PATH_SIBLINGS);
     }
 
     /// Making the path absolute must not follow symlinks, because the

--- a/mandible-extract/src/resolve.rs
+++ b/mandible-extract/src/resolve.rs
@@ -253,10 +253,19 @@ mod tests {
 
     /// A directory of fixtures for the sibling-discovery tests: every entry
     /// is created executable unless `plain` names it.
+    ///
+    /// `new_in(".")` rather than `TempDir::new()`, for the same reason the
+    /// two tests above build their fixtures that way: this crate's tests
+    /// share one process under `cargo test`, some of them redirect `TMPDIR`
+    /// at a scratch directory they then delete (spec §6 rule 8), and a
+    /// concurrent `TempDir::new()` fails with `NotFound` on a `$TMPDIR` that
+    /// no longer exists. `cargo nextest` gives each test its own process and
+    /// never sees it, which is exactly the kind of runner-dependent failure
+    /// not worth leaving in place.
     #[cfg(unix)]
     fn sibling_dir(names: &[&str], plain: &[&str]) -> tempfile::TempDir {
         use std::os::unix::fs::PermissionsExt;
-        let dir = tempfile::TempDir::new().unwrap();
+        let dir = tempfile::TempDir::new_in(".").unwrap();
         for name in names {
             let file = dir.path().join(name);
             std::fs::write(&file, "#!/bin/sh\nexit 0\n").unwrap();

--- a/mandible-tui/src/app.rs
+++ b/mandible-tui/src/app.rs
@@ -284,6 +284,16 @@ pub struct App {
     /// (`mandible/src/app_runner.rs`'s `run_review`) attaches it right
     /// after building the app for each sampled tool.
     pub review: Option<crate::app_review::ReviewOverlay>,
+    /// A subcommand path the command line asked to open — `mandible cargo
+    /// clippy` sets `["cargo", "clippy"]` (spec §5.4). Cleared by
+    /// [`App::settle_requested_path`] as soon as it lands on the node, or
+    /// as soon as the tree is complete enough to say the node does not
+    /// exist. `None` for a plain `mandible <tool>`.
+    ///
+    /// It cannot simply be selected at startup: the tree is empty until the
+    /// background root fill arrives (spec §5.2 step 1), so this is an intent
+    /// held across frames rather than an action taken on one.
+    pub requested_path: Option<Vec<String>>,
 }
 
 /// One view's scroll position in the detail pane: a line offset and a
@@ -397,6 +407,7 @@ impl App {
             glyphs: crate::glyphs::from_env(),
             selected_flag: None,
             review: None,
+            requested_path: None,
         };
         app.ensure_rows_fresh();
         app
@@ -752,6 +763,64 @@ impl App {
         // collapses a whole arrival batch into one rebuild.
         self.search_index_stale = true;
         self.mark_dirty();
+    }
+
+    /// Try to land on [`Self::requested_path`] — the subcommand path the
+    /// command line named (`mandible cargo clippy`, spec §5.4).
+    ///
+    /// Called after every batch of background fills, because the tree the
+    /// path addresses does not exist yet when the app is built: the node
+    /// arrives some frames later, and until it does there is nothing to
+    /// select and nothing to complain about either.
+    ///
+    /// Landing means exactly what browsing there by hand means — the
+    /// ancestors are opened and the node is selected, nothing is expanded
+    /// beyond that, because expansion is user intent (spec §5.2).
+    ///
+    /// The give-up condition is deliberately narrow: the parent that would
+    /// hold the missing segment must be **known-complete and not still being
+    /// filled**, so a path that simply has not arrived yet is never reported
+    /// as absent. Reporting it in the status line rather than refusing at
+    /// the command line is what keeps `mandible <tool> <typo>` a tool that
+    /// opened with a message instead of a shell error — the tree beside it
+    /// is exactly where the real name is.
+    pub fn settle_requested_path(&mut self) {
+        let Some(target) = self.requested_path.clone() else {
+            return;
+        };
+        if resolve(&self.root, &target).is_some() {
+            for depth in 1..target.len() {
+                self.expanded.insert(target[..depth].to_vec());
+            }
+            self.mark_dirty();
+            self.ensure_rows_fresh();
+            if let Some(idx) = self.rows.iter().position(|row| row.path == target) {
+                self.selected = idx;
+                self.selected_flag = None;
+                self.reset_detail_scroll();
+                self.follow_selection();
+            }
+            self.requested_path = None;
+            return;
+        }
+
+        // The first segment that isn't in the tree; everything before it is.
+        let Some(depth) = (1..target.len()).find(|&d| resolve(&self.root, &target[..=d]).is_none())
+        else {
+            return;
+        };
+        let parent_path = target[..depth].to_vec();
+        let parent_complete =
+            resolve(&self.root, &parent_path).is_some_and(|node| node.children_filled);
+        if parent_complete && !self.pending.contains(&parent_path) {
+            let message = format!(
+                "{} has no subcommand {:?}",
+                parent_path.join(" "),
+                target[depth]
+            );
+            self.set_status(message);
+            self.requested_path = None;
+        }
     }
 
     /// `←`/`h`: collapse the selected row if it's expanded, else jump
@@ -1412,6 +1481,72 @@ mod tests {
         ));
         root.subcommands.push(rebase);
         root
+    }
+
+    fn path(segments: &[&str]) -> Vec<String> {
+        segments.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// `mandible git rebase` lands exactly where browsing there lands: the
+    /// ancestors opened, the node selected (spec §5.4).
+    #[test]
+    fn a_requested_path_selects_its_node_once_the_tree_has_it() {
+        let mut app = App::new("git".to_string(), sample_tree_known_complete());
+        app.requested_path = Some(path(&["git", "rebase", "--onto-helper"]));
+
+        app.settle_requested_path();
+
+        assert_eq!(app.selected_node().unwrap().name, "--onto-helper");
+        assert!(
+            app.requested_path.is_none(),
+            "a landed path must not be re-applied on every later fill"
+        );
+    }
+
+    /// The tree is empty until the background root fill arrives (spec §5.2
+    /// step 1), and a path that has not arrived yet is not a path that is
+    /// missing — nothing may be reported until the parent that would hold it
+    /// is known-complete.
+    #[test]
+    fn a_requested_path_waits_instead_of_reporting_a_node_that_has_not_arrived() {
+        let stub = CommandNode::new("git", Provenance::default());
+        let mut app = App::new("git".to_string(), stub);
+        app.requested_path = Some(path(&["git", "rebase"]));
+
+        app.settle_requested_path();
+
+        assert!(app.status_message.is_none(), "{:?}", app.status_message);
+        assert!(
+            app.requested_path.is_some(),
+            "the intent must survive until the tree can answer"
+        );
+    }
+
+    /// And once it can answer, it says so rather than sitting on a
+    /// selection the user never asked for.
+    #[test]
+    fn a_requested_path_that_the_finished_tree_lacks_is_reported() {
+        let mut app = App::new("git".to_string(), sample_tree_known_complete());
+        app.requested_path = Some(path(&["git", "nosuchthing"]));
+
+        app.settle_requested_path();
+
+        let message = app.status_message.clone().expect("should have reported");
+        assert!(message.contains("nosuchthing"), "{message}");
+        assert!(app.requested_path.is_none());
+    }
+
+    /// A fill still in flight for the parent is not an answer either.
+    #[test]
+    fn a_requested_path_waits_while_its_parent_is_still_filling() {
+        let mut app = App::new("git".to_string(), sample_tree_known_complete());
+        app.requested_path = Some(path(&["git", "nosuchthing"]));
+        app.mark_pending(path(&["git"]));
+
+        app.settle_requested_path();
+
+        assert!(app.status_message.is_none(), "{:?}", app.status_message);
+        assert!(app.requested_path.is_some());
     }
 
     #[test]

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -1916,6 +1916,19 @@ const LOW_CONFIDENCE: f32 = 0.5;
 /// present, and it is the same reasoning that moved the framework out of
 /// here: repeated identical metadata is noise, not provenance.
 pub fn provenance_caveat(node: &CommandNode, glyphs: Glyphs) -> Option<String> {
+    // Spec §5.4: this node's name came off a filename on `PATH`, not out of
+    // the parent's own help text, so the strongest caveat available about
+    // it is that the command may not exist at all. Checked before
+    // everything below, including the verbatim exemption: how well the
+    // binary's own help parsed says nothing about whether the parent
+    // dispatches to it, and naming the binary is what lets the reader
+    // settle that themselves.
+    if let Some(binary) = &node.discovered_binary {
+        return Some(format!(
+            "unverified: not in the parent's help; found on PATH as `{binary}`"
+        ));
+    }
+
     // A node rendered verbatim is not a bad parse — it is the designed
     // honest fallback (spec §7 Tier B step 3), it carries confidence 0.0
     // by construction, and the pane already says so in its own words. Every
@@ -2532,6 +2545,34 @@ mod tests {
             true,
         ));
         assert_eq!(provenance_caveat(&node, crate::glyphs::UNICODE), None);
+    }
+
+    /// Spec §5.4: a node discovered by the `<parent>-<sub>` PATH convention
+    /// names the binary it was found as, so the reader can settle for
+    /// themselves whether the parent really dispatches to it.
+    #[test]
+    fn a_convention_discovered_node_says_it_is_unverified() {
+        let mut node = node_with_flags();
+        node.provenance = Provenance::with_confidence(Source::HelpText, 0.97);
+        node.discovered_binary = Some("cargo-clippy".to_string());
+        let caveat = provenance_caveat(&node, crate::glyphs::UNICODE)
+            .expect("a convention-discovered node must say so");
+        assert!(caveat.contains("unverified"), "{caveat:?}");
+        assert!(caveat.contains("cargo-clippy"), "{caveat:?}");
+    }
+
+    /// How well the *binary's own* help parsed says nothing about whether
+    /// the parent dispatches to it, so the two caveats are not alternatives
+    /// and the unverified one is the load-bearing half.
+    #[test]
+    fn an_unverified_node_says_so_even_when_it_degraded_to_verbatim() {
+        let mut node = node_with_flags();
+        node.provenance = Provenance::with_confidence(Source::HelpText, 0.0);
+        node.unparsed = vec![Text::sanitize("CARGO-CLIPPY(1)")];
+        node.discovered_binary = Some("cargo-clippy".to_string());
+        let caveat = provenance_caveat(&node, crate::glyphs::UNICODE)
+            .expect("verbatim must not swallow the unverified caveat");
+        assert!(caveat.contains("unverified"), "{caveat:?}");
     }
 
     /// A barely-parsed node says so. `find` scores 0.11 and `ip` 0.09 in

--- a/mandible-tui/src/render/tree_pane.rs
+++ b/mandible-tui/src/render/tree_pane.rs
@@ -249,7 +249,7 @@ fn build_row_line(
             spans.push(Span::raw(" ".repeat(pad_to - name_part_width)));
             if row.unverified {
                 let badge = truncate_to_width_marker(UNVERIFIED_BADGE, remaining, glyphs.ellipsis);
-                remaining -= display_width(&badge);
+                remaining = remaining.saturating_sub(display_width(&badge));
                 spans.push(Span::styled(badge, style::warning(color_enabled)));
             }
             if let Some(summary) = summary {
@@ -261,7 +261,7 @@ fn build_row_line(
                 // The separator only earns its cells when something legible
                 // follows it.
                 if remaining > display_width(&separator) {
-                    remaining -= display_width(&separator);
+                    remaining = remaining.saturating_sub(display_width(&separator));
                     let truncated = truncate_to_width_marker(&summary, remaining, glyphs.ellipsis);
                     spans.push(Span::styled(separator, style::muted(color_enabled)));
                     spans.push(Span::styled(truncated, style::muted(color_enabled)));

--- a/mandible-tui/src/render/tree_pane.rs
+++ b/mandible-tui/src/render/tree_pane.rs
@@ -43,6 +43,14 @@ use ratatui::Frame;
 /// every summary in the pane off past the edge.
 const SUMMARY_COLUMN_CAP_PERCENT: usize = 40;
 
+/// What a convention-discovered row says about itself (spec §5.4, §9.2).
+///
+/// A word rather than a glyph, and an ASCII one: a symbol here would have
+/// to be learned, and this is the row's own claim about whether the command
+/// exists — the one thing on the row that must survive a terminal with no
+/// colour, no Unicode and no legend (spec §9.2's "what may be drawn").
+const UNVERIFIED_BADGE: &str = "unverified";
+
 /// Render the tree pane into `area`.
 pub fn render(frame: &mut Frame, area: Rect, app: &App, hide_summaries: bool) {
     let focused = app.focus == Focus::Tree;
@@ -209,34 +217,54 @@ fn build_row_line(
         return Line::from(spans);
     }
 
-    if !hide_summary && name_part_width < width {
-        // A row's summary never changes because of a search. Swapping it
-        // for a "why this matched" hint made the pane's content shift under
-        // the user mid-keystroke, which is a worse problem than the one it
-        // solved — the filter itself is now precise enough not to need
-        // explaining.
-        if let Some(summary) = &row.summary {
-            let clean_summary = defensive_single_line(summary);
-            if !clean_summary.is_empty() {
-                // Align to the shared column when the name is short
-                // enough to leave room for it; otherwise the summary
-                // simply starts right after the name (still never
-                // truncating the name to force alignment).
-                // At least one space, always. When a name is longer than
-                // the shared column, `pad_to` used to collapse to exactly
-                // the name's width and the summary began in the very next
-                // cell: `dselect-upgradeFollow dselect…` in `apt-get`,
-                // which reads as one mangled word rather than a name and
-                // its description.
-                let pad_to = summary_column.max(name_part_width + 1);
-                let remaining = width.saturating_sub(pad_to);
-                if remaining > 0 {
-                    let padding = " ".repeat(pad_to - name_part_width);
-                    let truncated_summary =
-                        truncate_to_width_marker(&clean_summary, remaining, glyphs.ellipsis);
-                    spans.push(Span::raw(padding));
-                    spans.push(Span::styled(truncated_summary, style::muted(color_enabled)));
-                    return Line::from(spans);
+    // A row's summary never changes because of a search. Swapping it for a
+    // "why this matched" hint made the pane's content shift under the user
+    // mid-keystroke, which is a worse problem than the one it solved — the
+    // filter itself is now precise enough not to need explaining.
+    let summary = if hide_summary {
+        None
+    } else {
+        row.summary
+            .as_ref()
+            .map(|s| defensive_single_line(s))
+            .filter(|s| !s.is_empty())
+    };
+    // The unverified marker is *not* dropped with the summaries at narrow
+    // widths (spec §9.1's width ladder): a summary is a convenience, and
+    // this says whether the command on the row is one the tool documents at
+    // all (spec §5.4, §9.2). It takes the column first, and the summary
+    // gets what is left.
+    if (row.unverified || summary.is_some()) && name_part_width < width {
+        // Align to the shared column when the name is short enough to leave
+        // room for it; otherwise the summary simply starts right after the
+        // name (still never truncating the name to force alignment). At
+        // least one space, always. When a name is longer than the shared
+        // column, `pad_to` used to collapse to exactly the name's width and
+        // the summary began in the very next cell:
+        // `dselect-upgradeFollow dselect…` in `apt-get`, which reads as one
+        // mangled word rather than a name and its description.
+        let pad_to = summary_column.max(name_part_width + 1);
+        let mut remaining = width.saturating_sub(pad_to);
+        if remaining > 0 {
+            spans.push(Span::raw(" ".repeat(pad_to - name_part_width)));
+            if row.unverified {
+                let badge = truncate_to_width_marker(UNVERIFIED_BADGE, remaining, glyphs.ellipsis);
+                remaining -= display_width(&badge);
+                spans.push(Span::styled(badge, style::warning(color_enabled)));
+            }
+            if let Some(summary) = summary {
+                let separator = if row.unverified {
+                    format!(" {} ", glyphs.dot)
+                } else {
+                    String::new()
+                };
+                // The separator only earns its cells when something legible
+                // follows it.
+                if remaining > display_width(&separator) {
+                    remaining -= display_width(&separator);
+                    let truncated = truncate_to_width_marker(&summary, remaining, glyphs.ellipsis);
+                    spans.push(Span::styled(separator, style::muted(color_enabled)));
+                    spans.push(Span::styled(truncated, style::muted(color_enabled)));
                 }
             }
         }
@@ -298,6 +326,7 @@ mod tests {
             children_filled: true,
             hidden: false,
             pending: false,
+            unverified: false,
         }
     }
 
@@ -329,6 +358,83 @@ mod tests {
         let line = build_row_line(&r, 40, false, false, 10, true, None, crate::glyphs::UNICODE);
         let text = rendered(&line);
         assert!(display_width(&text) <= 40);
+    }
+
+    /// Spec §5.4/§9.2: a node the parent's own help never listed says so on
+    /// its row, in the warning shade — the one sanctioned non-accent colour.
+    #[test]
+    fn an_unverified_row_carries_the_badge() {
+        let mut r = row(1, "clippy", None, false);
+        r.unverified = true;
+        let line = build_row_line(&r, 80, false, false, 20, true, None, crate::glyphs::UNICODE);
+        assert!(rendered(&line).contains("unverified"), "{line:?}");
+        let badge = line
+            .spans
+            .iter()
+            .find(|s| s.content.contains("unverified"))
+            .expect("badge span");
+        assert_eq!(badge.style, style::warning(true));
+    }
+
+    #[test]
+    fn an_ordinary_row_carries_no_badge() {
+        let r = row(1, "clean", Some("Remove the target directory"), false);
+        let line = build_row_line(&r, 80, false, false, 20, true, None, crate::glyphs::UNICODE);
+        assert!(!rendered(&line).contains("unverified"), "{line:?}");
+    }
+
+    /// The badge takes the column first and the summary follows it, so a
+    /// discovered node that *does* have a summary shows both.
+    #[test]
+    fn a_badged_row_still_shows_its_summary_behind_a_separator() {
+        let mut r = row(1, "clippy", Some("Checks a package"), false);
+        r.unverified = true;
+        let line = build_row_line(&r, 80, false, false, 20, true, None, crate::glyphs::UNICODE);
+        let text = rendered(&line);
+        assert!(text.contains("unverified · Checks a package"), "{text:?}");
+    }
+
+    /// Spec §9.1's width ladder drops summaries on a narrow pane. The badge
+    /// is not a summary: it says whether the command exists at all.
+    #[test]
+    fn the_badge_survives_the_narrow_width_ladder() {
+        let mut r = row(1, "clippy", Some("Checks a package"), false);
+        r.unverified = true;
+        let line = build_row_line(&r, 40, true, false, 12, true, None, crate::glyphs::UNICODE);
+        let text = rendered(&line);
+        assert!(text.contains("unverified"), "{text:?}");
+        assert!(!text.contains("Checks a package"), "{text:?}");
+    }
+
+    #[test]
+    fn a_badged_row_still_respects_the_width_budget() {
+        // From the width at which the row's fixed prefix (indent, chevron,
+        // space) fits at all — narrower than that, no row of any kind fits,
+        // badge or no badge.
+        for width in prefix_width(2)..40 {
+            let mut r = row(
+                2,
+                "generate-rpm",
+                Some("a summary long enough to spill"),
+                false,
+            );
+            r.unverified = true;
+            let line = build_row_line(
+                &r,
+                width,
+                false,
+                false,
+                10,
+                true,
+                None,
+                crate::glyphs::UNICODE,
+            );
+            assert!(
+                display_width(&rendered(&line)) <= width,
+                "overflowed at width {width}: {:?}",
+                rendered(&line)
+            );
+        }
     }
 
     #[test]

--- a/mandible-tui/src/tree.rs
+++ b/mandible-tui/src/tree.rs
@@ -40,6 +40,12 @@ pub struct TreeRow {
     /// row instead of a static chevron (spec §9 "designed degraded
     /// states").
     pub pending: bool,
+    /// True when this node was found by the `<parent>-<sub>` PATH
+    /// convention rather than documented by its parent's own help text
+    /// (spec §5.4) — [`mandible_core::CommandNode::discovered_binary`]. The
+    /// row says so (spec §9.2): the command is a guess made from a
+    /// filename, and every other row on screen is not.
+    pub unverified: bool,
 }
 
 /// Flatten `root` into visible rows.
@@ -98,6 +104,7 @@ fn make_row(
         children_filled: node.children_filled,
         hidden: node.hidden,
         pending,
+        unverified: node.discovered_binary.is_some(),
     }
 }
 

--- a/mandible-tui/tests/path_discovered_node.rs
+++ b/mandible-tui/tests/path_discovered_node.rs
@@ -1,0 +1,114 @@
+//! The convention-discovered node, rendered through a real frame
+//! (`ratatui::backend::TestBackend` — AGENTS.md §3.2: there is no tty in
+//! this sandbox).
+//!
+//! `mandible cargo` shows `clippy` because `cargo-clippy` sits on `PATH`,
+//! not because `cargo --help` ever mentions it (spec §5.4). That is a guess
+//! made from a filename, and the whole point of showing it is that the
+//! screen says so: the tree row carries the `unverified` badge and the
+//! footer names the binary the guess came from. Exercised here through the
+//! real `render` path rather than only through `tree_pane`'s and
+//! `detail_pane`'s own unit tests, for the reason `confidence_footer.rs`
+//! gives — those call the builders directly, never the frame the user sees.
+
+use mandible_core::{CommandNode, Provenance, Source, Text};
+use mandible_tui::app::App;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+const WIDTH: u16 = 100;
+const HEIGHT: u16 = 30;
+
+/// `cargo` with one documented child and one discovered by the convention.
+fn cargo_with_a_discovered_child() -> App {
+    let mut root = CommandNode::new("cargo", Provenance::single(Source::HelpText));
+    root.children_filled = true;
+
+    let mut clean = CommandNode::new("clean", Provenance::single(Source::HelpText));
+    clean.summary = Some(Text::sanitize("Remove the target directory"));
+    clean.heading_attested = true;
+    clean.children_filled = true;
+    root.subcommands.push(clean);
+
+    let mut clippy = CommandNode::new("clippy", Provenance::single(Source::HelpText));
+    clippy.summary = Some(Text::sanitize("Checks a package to catch common mistakes"));
+    clippy.discovered_binary = Some("cargo-clippy".to_string());
+    clippy.children_filled = true;
+    root.subcommands.push(clippy);
+
+    App::new("cargo".to_string(), root)
+}
+
+fn screen(app: &App) -> Vec<String> {
+    let backend = TestBackend::new(WIDTH, HEIGHT);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| mandible_tui::render::render(frame, app))
+        .unwrap();
+    let buffer = terminal.backend().buffer().clone();
+    (0..HEIGHT)
+        .map(|y| {
+            (0..WIDTH)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+fn row_containing<'a>(screen: &'a [String], needle: &str) -> &'a str {
+    screen
+        .iter()
+        .find(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("no row contains {needle:?}: {screen:#?}"))
+}
+
+#[test]
+fn the_discovered_row_is_badged_and_the_documented_one_is_not() {
+    let app = cargo_with_a_discovered_child();
+    let screen = screen(&app);
+
+    let clippy = row_containing(&screen, "clippy");
+    assert!(
+        clippy.contains("unverified"),
+        "the discovered row must say so: {clippy:?}"
+    );
+    // The summary is not sacrificed to the badge.
+    assert!(clippy.contains("Checks a package"), "{clippy:?}");
+
+    let clean = row_containing(&screen, "clean");
+    assert!(
+        !clean.contains("unverified"),
+        "a documented row must not be badged: {clean:?}"
+    );
+}
+
+#[test]
+fn selecting_the_discovered_node_names_its_binary_in_the_footer() {
+    let mut app = cargo_with_a_discovered_child();
+    app.ensure_rows_fresh();
+    app.move_down();
+    app.move_down();
+    assert_eq!(
+        app.selected_path(),
+        Some(vec!["cargo".to_string(), "clippy".to_string()])
+    );
+
+    let screen = screen(&app);
+    let footer = &screen[(HEIGHT - 1) as usize];
+    assert!(footer.contains("unverified"), "{footer:?}");
+    assert!(
+        footer.contains("cargo-clippy"),
+        "the footer must name the evidence: {footer:?}"
+    );
+}
+
+/// The badge is the row's claim about whether the command exists, so it has
+/// to survive a terminal with no colour at all (spec §9.2's "what may be
+/// drawn": colour may never be the sole carrier of meaning).
+#[test]
+fn the_badge_is_legible_without_color() {
+    let mut app = cargo_with_a_discovered_child();
+    app.color_enabled = false;
+    let screen = screen(&app);
+    assert!(row_containing(&screen, "clippy").contains("unverified"));
+}

--- a/mandible/src/app_runner.rs
+++ b/mandible/src/app_runner.rs
@@ -227,6 +227,12 @@ fn run_loop(term: &mut terminal::Term, app: &mut App) -> anyhow::Result<LoopExit
     let runner = Arc::new(Runner::new(default_tiers()));
     let resolved = resolve_tool(&app.tool);
     let warmer = Warmer::new();
+    // One `PATH` scan for the session (spec §5.4). Done here rather than
+    // inside the extraction pipeline because it reads the running machine's
+    // filesystem: a tier that did it would make every corpus fixture depend
+    // on what happens to be installed beside the tool — see
+    // `crate::discovery`'s module doc.
+    let siblings = mandible_extract::discover_path_siblings(&resolved.name);
 
     // Queue the root itself before the first frame. `main` hands us a stub
     // root carrying only the tool's name, so this is the fill that
@@ -239,17 +245,32 @@ fn run_loop(term: &mut terminal::Term, app: &mut App) -> anyhow::Result<LoopExit
         // Splice in any background fills that completed since the last
         // iteration before rendering, so the tree reflects them promptly.
         for warmed in warmer.drain() {
-            let node = warmed.result.node.clone();
+            let mut node = warmed.result.node;
+            // The root's children are the tool's own documented commands
+            // plus whatever the `<tool>-<sub>` convention finds on PATH
+            // (spec §5.4). Attached at the root only, because that is where
+            // the convention lives: cargo dispatches `cargo clippy` to
+            // `cargo-clippy`, and nothing dispatches `cargo clippy fix` to
+            // `cargo-clippy-fix`.
+            if warmed.path.len() == 1 {
+                crate::discovery::attach_path_siblings(&mut node, &siblings);
+            }
+            // Spliced before the cascade, not after: `warm_children` resolves
+            // each child's probe target against the tree, so the node it is
+            // about has to be in the tree first.
+            app.splice_filled_node(&warmed.path, node);
             // Cascade unconditionally: every fill queues the children it
             // just discovered, so the background walk reaches the whole
             // tree instead of stopping one level past whatever the user
             // expanded. Marking them pending is what makes them render as
             // loading rows rather than as silently empty ones.
-            let queued = warmer.warm_children(&runner, &resolved, &node, &warmed.path);
-            app.splice_filled_node(&warmed.path, node);
+            let queued = warmer.warm_children(&runner, &resolved, &app.root, &warmed.path);
             for path in queued {
                 app.mark_pending(path);
             }
+            // The node `mandible <tool> <sub>` asked for may have just
+            // arrived — or may now be known not to exist (spec §5.4).
+            app.settle_requested_path();
         }
 
         // Let a transient status message ("copied: …") time out. This loop
@@ -402,8 +423,12 @@ fn apply_effect(
         }
         Effect::Fill(path) => {
             if let Some(existing) = mandible_core::resolve(&app.root, &path).cloned() {
+                // Same redirect the background cascade applies (spec §5.4):
+                // an expand on a convention-discovered node probes that
+                // node's own binary, never the parent with a guessed word.
+                let (tool, probe_path) = crate::discovery::probe_target(&app.root, resolved, &path);
                 app.mark_pending(path.clone());
-                warmer.submit(Arc::clone(runner), resolved.clone(), path, existing);
+                warmer.submit(Arc::clone(runner), tool, probe_path, path, existing);
             }
         }
         // Run on the UI thread rather than through the warm pool. This is
@@ -426,10 +451,23 @@ fn apply_effect(
                 heading_attested: mandible_core::resolve(&app.root, &path)
                     .is_some_and(|n| n.heading_attested),
             };
-            let result = match mandible_extract::help_text::raw_help(resolved, &path, hints) {
+            // Through the same redirect the parse itself went through
+            // (spec §5.4), for exactly the reason above: under a
+            // convention-discovered node the tree was built from
+            // `cargo-clippy --help`, so that is the document `t` has to
+            // show — and the argv line it prints names the binary that was
+            // really run, not an invocation nobody made.
+            let (raw_tool, raw_path) = crate::discovery::probe_target(&app.root, resolved, &path);
+            let result = match mandible_extract::help_text::raw_help(&raw_tool, &raw_path, hints) {
                 // Render the argv exactly as a human would type it, so
                 // the pane can name its own source rather than assume one.
-                Ok((lines, flag)) => RawHelp::Ready(lines, format!("{} {flag}", path.join(" "))),
+                Ok((lines, flag)) => {
+                    let argv = std::iter::once(raw_tool.name.clone())
+                        .chain(raw_path.iter().skip(1).cloned())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    RawHelp::Ready(lines, format!("{argv} {flag}"))
+                }
                 // Shown in the pane, not swallowed: "refused: kill is
                 // never probed" is a useful answer to `t`, and a blank
                 // pane is not.
@@ -458,6 +496,7 @@ fn submit_root_fill(
     warmer.submit(
         Arc::clone(runner),
         resolved.clone(),
+        root_path.clone(),
         root_path,
         app.root.clone(),
     );

--- a/mandible/src/background.rs
+++ b/mandible/src/background.rs
@@ -110,10 +110,16 @@ impl Warmer {
     /// the submission was refused — the app is quitting, or the
     /// [`MAX_WARMED_NODES`] budget is spent — so a cascading caller knows
     /// to stop walking.
+    /// `tool` and `probe_path` say *what gets probed* — ordinarily the
+    /// session's tool at this node's own path, but a convention-discovered
+    /// node is probed against its own binary at a rebased path (spec §5.4,
+    /// `crate::discovery::probe_target`). `path` stays the node's place in
+    /// the tree, which is where the result is spliced.
     pub fn submit(
         &self,
         runner: Arc<Runner>,
         tool: ResolvedTool,
+        probe_path: Vec<String>,
         path: Vec<String>,
         existing: mandible_core::CommandNode,
     ) -> bool {
@@ -132,7 +138,7 @@ impl Warmer {
             if cancelled.load(Ordering::Relaxed) || stale(&generation) {
                 return;
             }
-            let result = runner.fill_node(&tool, &path, existing);
+            let result = runner.fill_node(&tool, &probe_path, existing);
             // Checked again after the probe, not only before it: a
             // re-extract that lands mid-probe is exactly the case this
             // exists for, and splicing this result would put a node from
@@ -162,23 +168,34 @@ impl Warmer {
     ///
     /// [`MAX_WARMED_NODES`] keeps the walk from becoming unbounded on a
     /// very large tree.
+    /// `root` is the whole tree, not just the node being walked: each
+    /// child's probe target is resolved against it
+    /// (`crate::discovery::probe_target`), because whether a node is probed
+    /// through the session's tool or through a `<parent>-<sub>` binary of
+    /// its own is a fact about its ancestors (spec §5.4). The node at `path`
+    /// must already be spliced into `root` when this is called.
     pub fn warm_children(
         &self,
         runner: &Arc<Runner>,
         tool: &ResolvedTool,
-        node: &mandible_core::CommandNode,
+        root: &mandible_core::CommandNode,
         path: &[String],
     ) -> Vec<Vec<String>> {
         let mut queued = Vec::new();
+        let Some(node) = mandible_core::resolve(root, path) else {
+            return queued;
+        };
         for child in &node.subcommands {
             if child.children_filled {
                 continue;
             }
             let mut child_path = path.to_vec();
             child_path.push(child.name.clone());
+            let (child_tool, probe_path) = crate::discovery::probe_target(root, tool, &child_path);
             if !self.submit(
                 Arc::clone(runner),
-                tool.clone(),
+                child_tool,
+                probe_path,
                 child_path.clone(),
                 child.clone(),
             ) {

--- a/mandible/src/cli.rs
+++ b/mandible/src/cli.rs
@@ -85,6 +85,41 @@ impl Cli {
         path.extend(self.subcommand.iter().cloned());
         Some(path)
     }
+
+    /// The refusal for the one combination no mode can honour: extra words
+    /// alongside a whole-tool diagnostic.
+    ///
+    /// A subcommand path addresses one node of one tool's tree, which is a
+    /// thing only the TUI has. `--doctor`/`--report` take their tool as the
+    /// flag's own value, so **every** positional beside them is extra — with
+    /// `--doctor cargo clippy`, clap binds `clippy` to the tool positional
+    /// and the diagnostic still describes `cargo`.
+    ///
+    /// Said plainly rather than dropped. Before a path was accepted at all
+    /// this combination was a parse error, and silently ignoring it now
+    /// would print a report about `cargo` to a reader who believes they
+    /// asked about `cargo clippy` — trading a clear refusal for a confidently
+    /// mislabelled answer.
+    pub fn subcommand_path_conflict(&self) -> Option<String> {
+        if self.doctor.is_none() && self.report.is_none() {
+            return None;
+        }
+        let stray: Vec<&str> = self
+            .tool
+            .as_deref()
+            .into_iter()
+            .chain(self.subcommand.iter().map(String::as_str))
+            .collect();
+        if stray.is_empty() {
+            return None;
+        }
+        let words = stray.join(" ");
+        let tool = self.target_tool().unwrap_or_default();
+        Some(format!(
+            "--doctor and --report take a tool name only; drop {words:?} or run \
+             `mandible {tool} {words}` for the interactive tree"
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -126,5 +161,35 @@ mod tests {
     #[test]
     fn a_bare_tool_requests_no_path() {
         assert!(parse(&["git"]).requested_path().is_none());
+    }
+
+    /// A path alongside a whole-tool diagnostic is refused, never dropped:
+    /// silently ignoring it reports on `cargo` while the reader believes
+    /// they asked about `cargo clippy`. This was a parse error before a path
+    /// was accepted at all, and must not become a mislabelled answer.
+    #[test]
+    fn a_path_alongside_a_whole_tool_diagnostic_is_refused() {
+        let refusal = parse(&["--doctor", "cargo", "clippy"])
+            .subcommand_path_conflict()
+            .expect("must refuse rather than drop the words");
+        assert!(refusal.contains("clippy"), "{refusal}");
+        assert!(parse(&["--report", "cargo", "clippy"])
+            .subcommand_path_conflict()
+            .is_some());
+        // One stray word is as wrong as two: `--doctor cargo clippy` binds
+        // `clippy` to the tool positional, and the report is still `cargo`'s.
+        assert!(parse(&["--doctor", "cargo", "clippy"])
+            .subcommand
+            .is_empty());
+    }
+
+    #[test]
+    fn the_ordinary_forms_conflict_with_nothing() {
+        assert!(parse(&["cargo", "clippy"])
+            .subcommand_path_conflict()
+            .is_none());
+        assert!(parse(&["--doctor", "cargo"])
+            .subcommand_path_conflict()
+            .is_none());
     }
 }

--- a/mandible/src/cli.rs
+++ b/mandible/src/cli.rs
@@ -11,6 +11,15 @@ pub struct Cli {
     /// or `--review` is given.
     pub tool: Option<String>,
 
+    /// A subcommand path within TOOL to open at, e.g. `mandible cargo
+    /// clippy` or `mandible git remote add` (spec §5.4). Opens exactly
+    /// where browsing to that node would land; a name the tool's own help
+    /// never documents still lands when a `<tool>-<sub>` binary is on PATH,
+    /// marked unverified. TUI only — `--doctor` and `--report` describe a
+    /// whole tool, and take a tool name alone.
+    #[arg(value_name = "SUBCOMMAND")]
+    pub subcommand: Vec<String>,
+
     /// Print extraction diagnostics for TOOL (tier statuses, node/flag
     /// counts, %described, catalog vendoring date, timing) instead of
     /// opening the TUI. See spec §5.3.
@@ -62,5 +71,60 @@ impl Cli {
             .as_deref()
             .or(self.doctor.as_deref())
             .or(self.tool.as_deref())
+    }
+
+    /// The full node path this invocation asks to open — the tool name
+    /// followed by [`Self::subcommand`] — or `None` when no subcommand was
+    /// given (`mandible git`, which opens at the root like it always has).
+    pub fn requested_path(&self) -> Option<Vec<String>> {
+        if self.subcommand.is_empty() {
+            return None;
+        }
+        let tool = self.tool.as_deref()?;
+        let mut path = vec![tool.to_string()];
+        path.extend(self.subcommand.iter().cloned());
+        Some(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(std::iter::once("mandible").chain(args.iter().copied()))
+            .expect("should parse")
+    }
+
+    /// Issue #70: `cargo clippy` is a real command that `cargo --help` never
+    /// lists, and mandible used to refuse the words outright with
+    /// "unexpected argument 'clippy' found".
+    #[test]
+    fn a_subcommand_path_parses_into_tool_and_words() {
+        let cli = parse(&["cargo", "clippy"]);
+        assert_eq!(cli.tool.as_deref(), Some("cargo"));
+        assert_eq!(cli.subcommand, vec!["clippy".to_string()]);
+        assert_eq!(
+            cli.requested_path(),
+            Some(vec!["cargo".to_string(), "clippy".to_string()])
+        );
+    }
+
+    #[test]
+    fn several_words_nest_in_order() {
+        let cli = parse(&["git", "remote", "add"]);
+        assert_eq!(
+            cli.requested_path(),
+            Some(vec![
+                "git".to_string(),
+                "remote".to_string(),
+                "add".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn a_bare_tool_requests_no_path() {
+        assert!(parse(&["git"]).requested_path().is_none());
     }
 }

--- a/mandible/src/discovery.rs
+++ b/mandible/src/discovery.rs
@@ -1,0 +1,283 @@
+//! Children discovered by the `<parent>-<sub>` PATH convention (spec §5.4).
+//!
+//! `cargo --help` never mentions `clippy`; `cargo-clippy` sits on `PATH`,
+//! and `cargo clippy` works because cargo dispatches to it. git does the
+//! same for `git-lfs`. The convention is the tool's, not this program's, so
+//! the rule here is keyed on the *name shape* alone and knows nothing about
+//! cargo or git (AGENTS.md §1) — `mandible-extract`'s
+//! [`discover_path_siblings`] is the filesystem half, and this module is
+//! what attaches the result to a tree and decides what a probe of such a
+//! node is aimed at.
+//!
+//! **Why here and not in an extraction tier.** Discovery reads the running
+//! machine's `PATH`, so a tier that did it would make every corpus fixture
+//! (spec §13.2 — frozen bytes, zero subprocesses, a synthetic
+//! `/corpus-replay/<tool>` path) depend on which binaries happen to be
+//! installed beside the machine running the suite. It is tree *assembly*,
+//! which is already this crate's job rather than the extractor's — the same
+//! division the background warmer's cascade lives on (spec §5.2).
+//!
+//! **Nothing here decides what may be executed.** A discovered node's own
+//! probe is the ordinary root `--help` of the sibling binary — exactly what
+//! `mandible cargo-clippy` already runs — so it passes through
+//! `exec::run_inert` and spec §6 untouched, and the guessed word never
+//! becomes an argument to the parent. See [`probe_target`].
+
+use mandible_core::{CommandNode, Provenance};
+use mandible_extract::{resolve_tool, PathSibling, ResolvedTool};
+
+/// Add a child node for every sibling the parent's own help text did not
+/// already document, marked with the binary it was discovered as.
+///
+/// Appended after the documented children, never merged into them: a name
+/// the tool itself listed is attested, and a convention guess must not be
+/// able to overwrite what the tool said about it — a sibling whose name is
+/// already a child (or an alias of one) is simply dropped, since the
+/// documented node already reaches the same command.
+pub fn attach_path_siblings(root: &mut CommandNode, siblings: &[PathSibling]) {
+    for sibling in siblings {
+        let documented = root
+            .subcommands
+            .iter()
+            .any(|c| c.name == sibling.name || c.aliases.contains(&sibling.name));
+        if documented {
+            continue;
+        }
+        let mut node = CommandNode::new(sibling.name.clone(), Provenance::default());
+        node.discovered_binary = Some(sibling.binary.clone());
+        root.subcommands.push(node);
+    }
+}
+
+/// Which binary a node's probe is aimed at, and the path to probe it under.
+///
+/// Ordinarily the tool the session opened, at the node's own tree path. Under
+/// a convention-discovered node it is that node's binary instead, with the
+/// path rebased onto it: `["cargo", "clippy"]` becomes `cargo-clippy` at
+/// `["clippy"]` (a root probe — `cargo-clippy --help`), and a child of it,
+/// `["cargo", "clippy", "fix"]`, becomes `cargo-clippy` at `["clippy",
+/// "fix"]` (`cargo-clippy fix --help`).
+///
+/// This is what keeps spec §6 whole. `clippy` is a word read off a filename,
+/// not one the parent's help attested, so it is exactly the kind of word the
+/// attestation gate exists to keep out of argv — and it never enters one:
+/// the probe is a *root* `--help` of a real binary, which needs no
+/// attestation because it is not a subcommand word at all, and every deeper
+/// word under it is attested by that binary's own help in the ordinary way.
+pub fn probe_target(
+    root: &CommandNode,
+    tool: &ResolvedTool,
+    path: &[String],
+) -> (ResolvedTool, Vec<String>) {
+    // Deepest first: a discovered node nested under another one is probed
+    // against the nearer of the two, which is the binary that actually
+    // documents the remaining words.
+    for depth in (1..path.len()).rev() {
+        let Some(node) = mandible_core::resolve(root, &path[..=depth]) else {
+            continue;
+        };
+        let Some(binary) = node.discovered_binary.as_deref() else {
+            continue;
+        };
+        let mut rebased = vec![node.name.clone()];
+        rebased.extend_from_slice(&path[depth + 1..]);
+        return (resolve_tool(binary), rebased);
+    }
+    (tool.clone(), path.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mandible_core::Source;
+
+    fn node(name: &str) -> CommandNode {
+        CommandNode::new(name, Provenance::single(Source::HelpText))
+    }
+
+    fn sibling(name: &str, binary: &str) -> PathSibling {
+        PathSibling {
+            name: name.to_string(),
+            binary: binary.to_string(),
+        }
+    }
+
+    fn path(segments: &[&str]) -> Vec<String> {
+        segments.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn an_undocumented_sibling_becomes_a_child_carrying_its_binary() {
+        let mut root = node("cargo");
+        root.subcommands.push(node("build"));
+        attach_path_siblings(&mut root, &[sibling("clippy", "cargo-clippy")]);
+
+        let clippy = root
+            .subcommands
+            .iter()
+            .find(|c| c.name == "clippy")
+            .expect("the sibling should have been attached");
+        assert_eq!(clippy.discovered_binary.as_deref(), Some("cargo-clippy"));
+        // Never probe-eligible as a word of the parent: the whole point is
+        // that its own binary is probed instead (spec §6).
+        assert!(!clippy.heading_attested);
+    }
+
+    /// A name the tool's own help already documents is attested; the
+    /// convention must not add a second row for it, nor overwrite it with an
+    /// empty stub.
+    #[test]
+    fn a_documented_name_is_not_duplicated_by_the_convention() {
+        let mut root = node("git");
+        let mut push = node("push");
+        push.summary = Some(mandible_core::Text::sanitize("Update remote refs"));
+        root.subcommands.push(push);
+        attach_path_siblings(&mut root, &[sibling("push", "git-push")]);
+
+        assert_eq!(root.subcommands.len(), 1);
+        assert!(root.subcommands[0].discovered_binary.is_none());
+        assert!(root.subcommands[0].summary.is_some());
+    }
+
+    #[test]
+    fn an_alias_of_a_documented_command_is_not_duplicated_either() {
+        let mut root = node("cargo");
+        let mut build = node("build");
+        build.aliases.push("b".to_string());
+        root.subcommands.push(build);
+        attach_path_siblings(&mut root, &[sibling("b", "cargo-b")]);
+
+        assert_eq!(root.subcommands.len(), 1);
+    }
+
+    #[test]
+    fn an_ordinary_node_is_probed_against_the_tool_at_its_own_path() {
+        let root = node("git");
+        let tool = resolve_tool("git");
+        let (target, probe_path) = probe_target(&root, &tool, &path(&["git", "rebase"]));
+        assert_eq!(target.name, "git");
+        assert_eq!(probe_path, path(&["git", "rebase"]));
+    }
+
+    /// The regression this whole feature turns on: a discovered node is a
+    /// *root* probe of its own binary, so the guessed word never reaches the
+    /// parent's argv (spec §6).
+    #[test]
+    fn a_discovered_node_is_probed_as_its_own_binarys_root() {
+        let mut root = node("cargo");
+        attach_path_siblings(&mut root, &[sibling("clippy", "cargo-clippy")]);
+        let tool = resolve_tool("cargo");
+
+        let (target, probe_path) = probe_target(&root, &tool, &path(&["cargo", "clippy"]));
+        assert_eq!(target.name, "cargo-clippy");
+        assert_eq!(
+            probe_path.len(),
+            1,
+            "words must be empty, i.e. a root probe: {probe_path:?}"
+        );
+        assert_eq!(probe_path[0], "clippy", "the node keeps its own name");
+    }
+
+    /// Serializes the one test that has to touch `PATH`; `set_var` is
+    /// process-global and `cargo test` runs this binary's tests on threads.
+    #[cfg(unix)]
+    static PATH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[cfg(unix)]
+    fn shim(dir: &std::path::Path, name: &str, body: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let file = dir.join(name);
+        std::fs::write(&file, format!("#!/bin/sh\ncat <<'EOF'\n{body}\nEOF\n")).unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    /// The end-to-end half, against **real argv** through the real runner
+    /// and a real spawn (AGENTS.md §3.1: a tier test that never builds argv
+    /// proves nothing about the pipeline).
+    ///
+    /// Both halves matter. The discovered node fills from its own binary —
+    /// which is the whole feature — *and* the same node filled the obvious
+    /// way, as a word of the parent, recovers nothing at all, because the
+    /// word came off a filename and the attestation gate refuses to send it
+    /// (spec §6 rule 0's closing paragraph). The redirect is what makes the
+    /// feature work; without it there is no probe to make.
+    #[cfg(unix)]
+    #[test]
+    fn a_discovered_node_fills_from_its_own_binary_and_never_through_the_parent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        shim(
+            dir.path(),
+            "mytool",
+            "Usage: mytool [OPTIONS]\n\nOptions:\n  --parent-only  Only the parent documents this",
+        );
+        shim(
+            dir.path(),
+            "mytool-extra",
+            "Usage: mytool extra [OPTIONS]\n\nOptions:\n  --only-in-extra  Only this binary documents this",
+        );
+
+        let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original = std::env::var_os("PATH");
+        let mut dirs = vec![dir.path().to_path_buf()];
+        if let Some(existing) = &original {
+            dirs.extend(std::env::split_paths(existing));
+        }
+        // Prepended, never replaced: other tests in this binary resolve real
+        // tools off `PATH` while this one runs.
+        std::env::set_var("PATH", std::env::join_paths(dirs).unwrap());
+
+        let mut root = node("mytool");
+        attach_path_siblings(
+            &mut root,
+            &mandible_extract::discover_path_siblings("mytool"),
+        );
+        let tool = resolve_tool("mytool");
+        let extra = root
+            .subcommands
+            .iter()
+            .find(|c| c.name == "extra")
+            .expect("mytool-extra should have been discovered")
+            .clone();
+        let tree_path = path(&["mytool", "extra"]);
+
+        let runner = mandible_extract::Runner::new(mandible_extract::default_tiers());
+        let (target, probe_path) = probe_target(&root, &tool, &tree_path);
+        let filled = runner.fill_node(&target, &probe_path, extra.clone());
+        let through_parent = runner.fill_node(&tool, &tree_path, extra);
+
+        if let Some(original) = original {
+            std::env::set_var("PATH", original);
+        }
+
+        assert!(
+            filled
+                .node
+                .flags()
+                .any(|f| f.long() == Some("only-in-extra")),
+            "the discovered node must be filled from its own binary: {:?}",
+            filled.node.flags().map(|f| f.long()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            through_parent.node.flags().count(),
+            0,
+            "a word read off a filename must never be probed as the parent's argv"
+        );
+    }
+
+    #[test]
+    fn a_child_of_a_discovered_node_is_probed_against_the_same_binary() {
+        let mut root = node("git");
+        attach_path_siblings(&mut root, &[sibling("lfs", "git-lfs")]);
+        let lfs = root
+            .subcommands
+            .iter_mut()
+            .find(|c| c.name == "lfs")
+            .expect("attached");
+        lfs.subcommands.push(node("push"));
+        let tool = resolve_tool("git");
+
+        let (target, probe_path) = probe_target(&root, &tool, &path(&["git", "lfs", "push"]));
+        assert_eq!(target.name, "git-lfs");
+        assert_eq!(probe_path, path(&["lfs", "push"]));
+    }
+}

--- a/mandible/src/discovery.rs
+++ b/mandible/src/discovery.rs
@@ -34,7 +34,23 @@ use mandible_extract::{resolve_tool, PathSibling, ResolvedTool};
 /// able to overwrite what the tool said about it — a sibling whose name is
 /// already a child (or an alias of one) is simply dropped, since the
 /// documented node already reaches the same command.
+///
+/// **A parent that documents no subcommand at all gets none of these.** The
+/// convention is a tool *dispatching* on its first argument, and a tool that
+/// dispatches says so by documenting at least one command of its own; where
+/// there is no such list, a `<parent>-<sub>` file is far more likely a
+/// sibling tool sharing a name prefix. Measured on this rule's own worst
+/// case: `dpkg --help` lists no commands (its operations are flags), and the
+/// 27 `dpkg-*` programs beside it — `dpkg-deb`, `dpkg-architecture`,
+/// `dpkg-buildpackage` — are separate tools that `dpkg deb` does not reach.
+/// Without this, `mandible dpkg` opened on 27 rows of guesses and nothing
+/// else. Keyed on what the parent's own text said, never on its name (§1),
+/// and it cannot suppress issue #70's case: `cargo --help` and `git --help`
+/// both document plenty.
 pub fn attach_path_siblings(root: &mut CommandNode, siblings: &[PathSibling]) {
+    if root.subcommands.is_empty() {
+        return;
+    }
     for sibling in siblings {
         let documented = root
             .subcommands
@@ -139,6 +155,17 @@ mod tests {
         assert!(root.subcommands[0].summary.is_some());
     }
 
+    /// `dpkg --help` lists no commands at all, and the 27 `dpkg-*` programs
+    /// beside it are separate tools — `dpkg deb` reaches nothing. A tool
+    /// that dispatches documents at least one command of its own, so a
+    /// parent with no command list gets no convention children.
+    #[test]
+    fn a_parent_that_documents_no_subcommands_gets_no_convention_children() {
+        let mut root = node("dpkg");
+        attach_path_siblings(&mut root, &[sibling("deb", "dpkg-deb")]);
+        assert!(root.subcommands.is_empty());
+    }
+
     #[test]
     fn an_alias_of_a_documented_command_is_not_duplicated_either() {
         let mut root = node("cargo");
@@ -165,6 +192,7 @@ mod tests {
     #[test]
     fn a_discovered_node_is_probed_as_its_own_binarys_root() {
         let mut root = node("cargo");
+        root.subcommands.push(node("build"));
         attach_path_siblings(&mut root, &[sibling("clippy", "cargo-clippy")]);
         let tool = resolve_tool("cargo");
 
@@ -204,11 +232,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn a_discovered_node_fills_from_its_own_binary_and_never_through_the_parent() {
-        let dir = tempfile::TempDir::new().unwrap();
+        let dir = tempfile::TempDir::new_in(".").unwrap();
+        // The parent documents one command of its own, which is what says
+        // it dispatches at all (`attach_path_siblings`).
         shim(
             dir.path(),
             "mytool",
-            "Usage: mytool [OPTIONS]\n\nOptions:\n  --parent-only  Only the parent documents this",
+            "Usage: mytool [OPTIONS] <COMMAND>\n\nCommands:\n  local  A command the parent documents\n\nOptions:\n  --parent-only  Only the parent documents this",
         );
         shim(
             dir.path(),
@@ -226,12 +256,23 @@ mod tests {
         // tools off `PATH` while this one runs.
         std::env::set_var("PATH", std::env::join_paths(dirs).unwrap());
 
-        let mut root = node("mytool");
+        let tool = resolve_tool("mytool");
+        let runner = mandible_extract::Runner::new(mandible_extract::default_tiers());
+        // The real root, from the real binary, so the documented/discovered
+        // split is the one the running product would see.
+        let mut root = runner
+            .extract_full_for(&tool)
+            .root
+            .expect("the shim's own --help should extract");
+        assert!(
+            root.subcommands.iter().any(|c| c.name == "local"),
+            "the parent's own command list must be recovered first: {:?}",
+            root.subcommands.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
         attach_path_siblings(
             &mut root,
             &mandible_extract::discover_path_siblings("mytool"),
         );
-        let tool = resolve_tool("mytool");
         let extra = root
             .subcommands
             .iter()
@@ -240,7 +281,6 @@ mod tests {
             .clone();
         let tree_path = path(&["mytool", "extra"]);
 
-        let runner = mandible_extract::Runner::new(mandible_extract::default_tiers());
         let (target, probe_path) = probe_target(&root, &tool, &tree_path);
         let filled = runner.fill_node(&target, &probe_path, extra.clone());
         let through_parent = runner.fill_node(&tool, &tree_path, extra);
@@ -267,6 +307,7 @@ mod tests {
     #[test]
     fn a_child_of_a_discovered_node_is_probed_against_the_same_binary() {
         let mut root = node("git");
+        root.subcommands.push(node("commit"));
         attach_path_siblings(&mut root, &[sibling("lfs", "git-lfs")]);
         let lfs = root
             .subcommands

--- a/mandible/src/main.rs
+++ b/mandible/src/main.rs
@@ -48,18 +48,8 @@ fn main() -> anyhow::Result<()> {
     };
     let tool = tool.to_string();
 
-    // A subcommand path addresses one node of one tool's tree, which is a
-    // thing only the TUI has. `--doctor`/`--report` describe a whole tool,
-    // so extra words there are a request nothing can honour — said plainly
-    // rather than ignored, since a silently dropped argument reads as a
-    // report about `cargo clippy` that is really about `cargo`.
-    if !cli.subcommand.is_empty() && (cli.doctor.is_some() || cli.report.is_some()) {
-        anyhow::bail!(
-            "--doctor and --report take a tool name only; drop {:?} or run \
-             `mandible {tool} {}` for the interactive tree",
-            cli.subcommand.join(" "),
-            cli.subcommand.join(" "),
-        );
+    if let Some(refusal) = cli.subcommand_path_conflict() {
+        anyhow::bail!(refusal);
     }
 
     // `mandible mandible` shows the about screen rather than extracting

--- a/mandible/src/main.rs
+++ b/mandible/src/main.rs
@@ -7,6 +7,7 @@ mod about;
 mod app_runner;
 mod background;
 mod cli;
+mod discovery;
 mod doctor;
 mod pipeline;
 mod report;
@@ -46,6 +47,20 @@ fn main() -> anyhow::Result<()> {
         );
     };
     let tool = tool.to_string();
+
+    // A subcommand path addresses one node of one tool's tree, which is a
+    // thing only the TUI has. `--doctor`/`--report` describe a whole tool,
+    // so extra words there are a request nothing can honour — said plainly
+    // rather than ignored, since a silently dropped argument reads as a
+    // report about `cargo clippy` that is really about `cargo`.
+    if !cli.subcommand.is_empty() && (cli.doctor.is_some() || cli.report.is_some()) {
+        anyhow::bail!(
+            "--doctor and --report take a tool name only; drop {:?} or run \
+             `mandible {tool} {}` for the interactive tree",
+            cli.subcommand.join(" "),
+            cli.subcommand.join(" "),
+        );
+    }
 
     // `mandible mandible` shows the about screen rather than extracting
     // the binary's own `--help`. Self-introspection is still available
@@ -119,7 +134,11 @@ fn main() -> anyhow::Result<()> {
         );
     }
     let stub = mandible_core::CommandNode::new(tool.clone(), mandible_core::Provenance::default());
-    let app = app_runner::new_app(tool, stub);
+    let mut app = app_runner::new_app(tool, stub);
+    // Held as an intent rather than acted on: the tree is a bare stub until
+    // the background root fill lands, so there is nothing to select yet
+    // (spec §5.2 step 1, §5.4).
+    app.requested_path = cli.requested_path();
 
     app_runner::run(app)
 }

--- a/spec.md
+++ b/spec.md
@@ -700,9 +700,10 @@ as `cargo-clippy` at `["clippy", "fix"]`. The expand path and the raw view
 (`t`) use the same redirect, so the pane shows the document the tree was
 built from and names the argv that produced it. `CommandNode::
 discovered_binary` carries this on the node (`None` for everything a tier
-produces); merge keeps the first contributor that has one, since the tier
-candidate a fill merges against always has `None` and would otherwise erase
-the redirect, and the snapshot format omits it when absent.
+produces); merge keeps any contributor that has one — a merge can only add
+evidence, and the tier candidate a fill merges against is silent about this
+rather than in competition with it — and the snapshot format omits it when
+absent, so no fixture moves.
 
 **The node is marked unverified, and stays marked.** A filename is evidence
 about the filesystem and a guess about the tool: cargo really does dispatch

--- a/spec.md
+++ b/spec.md
@@ -651,6 +651,69 @@ pane), and saves a verdict to the manifest immediately after every
 confirmation, never batched, so a killed session resumes at the next pending
 entry with everything answered so far intact.
 
+### 5.4 Subcommand paths, and children the parent never documented
+
+**`mandible <tool> <sub> [<sub>...]`** opens the tool at that node — the same
+place browsing there lands: the ancestors are expanded, the node is selected,
+and nothing else is expanded, because expansion is user intent (§5.2). The
+path is an *intent held across frames*, not an action taken at startup: the
+tree is a bare stub until the background root fill arrives, so the node is
+selected in whichever frame it first exists. A path the tree turns out not to
+have is reported in the status line — once the parent that would hold it is
+known-complete and not still filling, never before — rather than refused at
+the command line, because the tree beside the message is where the real name
+is. `--doctor` and `--report` describe a whole tool and take a tool name
+alone; extra words there are refused rather than dropped.
+
+**A `<parent>-<sub>` executable on `PATH` is a child discovered by
+convention.** `cargo --help` never lists `clippy`; `cargo-clippy` sits on
+`PATH`, and `cargo clippy` works because cargo dispatches to it. git does the
+same for `git-lfs`, and the rule is keyed on the naming convention alone —
+never on a tool's name (§1).
+
+- **The parent's own documentation wins.** A sibling whose name the tool
+  already documents (as a command or an alias) is dropped: the attested node
+  already reaches the same command, and a guess must not overwrite what the
+  tool said. The rest are appended after the documented children.
+- **Root level only.** The convention is a tool dispatching on its *first*
+  argument. Nothing dispatches `cargo clippy fix` to `cargo-clippy-fix`, so
+  nothing looks for one; a discovered node's own children come from its
+  binary's help in the ordinary way.
+- **Name-shape checked, first `PATH` entry wins, alphabetical, capped.** The
+  same "is this a command name" rule every tier applies to a bare word (§7
+  Tier B rule 3) keeps a versioned or capitalized helper out; a shadowed
+  sibling is reported once, under the binary that would actually run;
+  alphabetical because there is no document order to preserve and `readdir`
+  order differs between filesystems; capped at 64 per parent, so a `libexec`
+  directory on `PATH` cannot hand the warmer hundreds of extra probes.
+- **It is tree assembly, not an extraction tier.** Discovery reads the
+  running machine's `PATH`. A tier that did it would make every corpus
+  fixture (§13.2 — frozen bytes, zero subprocesses, a synthetic replay path)
+  depend on what happens to be installed beside the tool, and would put a
+  machine-local fact into `--doctor`'s account of what the *tool* said.
+
+**Probing follows the binary, not the guess.** A discovered node's probe
+target is its own binary with the path rebased onto it: `["cargo", "clippy"]`
+is probed as `cargo-clippy` at `["clippy"]` — a root `--help`, byte for byte
+what `mandible cargo-clippy` already runs — and `["cargo", "clippy", "fix"]`
+as `cargo-clippy` at `["clippy", "fix"]`. The expand path and the raw view
+(`t`) use the same redirect, so the pane shows the document the tree was
+built from and names the argv that produced it. `CommandNode::
+discovered_binary` carries this on the node (`None` for everything a tier
+produces); merge keeps the first contributor that has one, since the tier
+candidate a fill merges against always has `None` and would otherwise erase
+the redirect, and the snapshot format omits it when absent.
+
+**The node is marked unverified, and stays marked.** A filename is evidence
+about the filesystem and a guess about the tool: cargo really does dispatch
+`cargo clippy`, and nothing dispatches `dpkg query` to `dpkg-query`. So the
+tree row carries an `unverified` marker and the detail pane names the binary
+the guess came from, ahead of every other caveat — how well that binary's own
+help parsed says nothing about whether the parent dispatches to it (§9.2).
+Showing the row is right, because the command is usually real and is
+otherwise unreachable from the tool the user opened; showing it unmarked
+would be the same move as inventing structure.
+
 ---
 
 ## 6. Execution safety policy
@@ -1176,6 +1239,20 @@ damage a user's machine, and it gets its own section and its own tests.
    **Residual:** a tool wraps its own help text at the `COLUMNS` we set, so a
    path split across two lines cannot be matched. The scratch prefix is kept
    short to make that rarer; it does not eliminate it.
+
+**A convention-discovered node adds no argv shape, and no exemption.** §5.4's
+`<parent>-<sub>` children are named by a file on `PATH`, not by anything the
+parent's help attested — exactly the kind of word rule 0's closing paragraph
+keeps out of argv — and no such word ever enters one. The node is probed as
+its *own binary's root* `--help`, which is not a subcommand word at all and
+so needs no attestation, precisely as the root the user typed does not. Every
+gate then applies to that binary on its own terms: rule 0 matches the file
+name it was discovered under (a `pkill`-named sibling is refused every shape
+but `--help`, like any other `pkill`), rule 8's scratch redirect and rule 4's
+reap are the same probe machinery, and a *deeper* word under such a node is
+attested by that binary's own help in the ordinary way. Discovery itself
+spawns nothing: it is a `readdir`, in the same filesystem-only module that
+already resolves a tool name.
 
 A test asserts rules 1, 2, and 3 by running the full pipeline against a shim
 binary that logs its argv and environment, and failing on any invocation outside
@@ -2107,6 +2184,11 @@ full text on selection; a tree summary only has to disambiguate `push` from
   summaries, never without names.
 - Width ladder: full layout above 60 columns; **names only** below it (drop
   summaries rather than showing eight useless characters); stacked panes below 50.
+- **An `unverified` marker (§5.4) takes the summary's column ahead of the
+  summary**, and the width ladder does not drop it: a summary is a
+  convenience, and this is the row's claim about whether the command exists
+  at all. A plain word rather than a glyph, so it survives a terminal with no
+  colour and no Unicode (§9.2).
 
 ### 9.1a Flag rows: one table, one column
 
@@ -2163,7 +2245,7 @@ One accent, spent only on information. Everything else is neutral.
 | Deprecated | Muted + a `(deprecated)` tag |
 | Search match characters | Underline, within the name only |
 | Provenance footer | Muted |
-| Low confidence | Warning color — the **one** sanctioned exception to single-accent |
+| Low confidence, and an `unverified` node (§5.4) | Warning color — the **one** sanctioned exception to single-accent |
 
 Four implementation rules that matter more than the palette:
 

--- a/spec.md
+++ b/spec.md
@@ -675,6 +675,20 @@ never on a tool's name (§1).
   already documents (as a command or an alias) is dropped: the attested node
   already reaches the same command, and a guess must not overwrite what the
   tool said. The rest are appended after the documented children.
+- **A parent that documents no command at all gets none of these.**
+  Dispatching on a first argument is a thing a tool says it does by listing
+  at least one command of its own; where there is no such list, a
+  `<parent>-<sub>` file is far more likely a sibling *tool* sharing a name
+  prefix. `dpkg --help` lists no commands — its operations are flags — and
+  the 27 `dpkg-*` programs beside it (`dpkg-deb`, `dpkg-architecture`,
+  `dpkg-buildpackage`) are separate tools that `dpkg deb` does not reach;
+  without this rule `mandible dpkg` opened on 27 rows of guesses and nothing
+  else. It is keyed on what the parent's own text said, never on its name
+  (§1), and cannot suppress the case this section exists for: `cargo --help`
+  and `git --help` both document plenty. It does not make the convention
+  reliable where a list exists — `apt --help` lists commands, so `apt-get`
+  and `apt-cache` are shown, marked, and are not `apt get` — which is what
+  the marker below is for.
 - **Root level only.** The convention is a tool dispatching on its *first*
   argument. Nothing dispatches `cargo clippy fix` to `cargo-clippy-fix`, so
   nothing looks for one; a discovered node's own children come from its


### PR DESCRIPTION
Closes #70.

`mandible cargo clippy` now opens the tree at `cargo › clippy`. Two halves:

- **CLI subcommand path**: `mandible <tool> <sub> [<sub>...]` navigates to that node once the tree fills, reporting a genuinely missing name in the status line only after its parent is filled — never confusing "not arrived yet" with "does not exist".
- **Generic `<parent>-<sub>` PATH discovery**: a subcommand the parent's help never documents, but which exists on PATH by the dash convention (`cargo-clippy`, `git-lfs`), joins the tree as an **unverified** node — badged in the row, explained in the caveat line, parsed from its own binary's `--help`. No tool-name-keyed logic; root level only; a parent that documents no commands at all gets no convention children (keeps `dpkg` from sprouting 27 fake subcommands). Probing rebases onto the discovered binary's own root, so spec §6's attestation gate gains no new argv shape.

Spec: new §5.4, §6 closing paragraph, §9.1/§9.2 marker rows. Left out deliberately: `ip`'s `OBJECT := { … }` family — that's a Tier B grammar recognizer with its own attestation ruling and fleet measurement, tracked separately.

Gates: nextest 1345/1345, corpus 113 byte-identical, fmt/clippy clean, 15 §3.4 plants each with a named red test. All commits GPG-signed.