### PR TITLE
feat: shell handoff — Enter hands the browsed command to the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Added
+
+- Browsing can now end on the shell prompt instead of in the clipboard (issue #40): `mandible --print-selection <tool>` browses exactly as usual but makes `Enter` print the selected command — plus the flag search landed on, in its long spelling where the tool documents one and always in the affirmative form (`--color`, never the un-runnable `--[no-]color`) — to stdout and exit, drawing the UI on stderr so stdout carries that one line and nothing else, and `mandible --shell-init bash` (or `zsh`) prints the binding that puts it on the command line ready to edit: `Ctrl-X m` opens mandible on the word already typed and replaces the line with what you select, leaving it untouched if you quit instead. Without the flag nothing moves — `Enter` is still one of the three keys that expand a row.
+
 ### Fixed
+
+- The `y` clipboard fallback and the "is anything a terminal at the other end" colour check now both address the stream the UI is actually drawn on rather than reaching for stdout on their own, so the OSC-52 escape sequence can no longer be written into output another program is reading and a session whose stdout is redirected is no longer rendered monochrome while its terminal sits on stderr; a source lint keeps every path to a terminal inside `mandible-tui`'s one terminal module.
 
 - `jar --help` no longer turns wrapped `-C foo/ ...` rows from its indented `Examples:` blocks into duplicate flags or loses the `Main operation mode:` group: when indentation would otherwise promote the preceding prose sentence to a fake heading and hide the ignorable marker, the parser now contains that whole region until a physical dedent or a positively worded, structurally attested multi-row flag section; generic `Input:`/`Output:` labels, command-shaped example data, and single flag-shaped samples remain contained, with no tool-name-keyed logic.
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,25 @@ Search has two modes: `names` matches command names literally; `everything`
 searches flags and descriptions fuzzily, so `gco` finds `checkout`. `/` opens
 the first, pressing it again switches to the second.
 
+### Onto the prompt
+
+`y` gets a spelling as far as the clipboard. To land it on the command line
+instead, add the shell integration:
+
+```console
+$ eval "$(mandible --shell-init bash)"   # or: zsh — in your ~/.bashrc, ~/.zshrc
+```
+
+Now type a tool name, press `Ctrl-X m`, browse, and press `Enter`: the command
+you selected — `git commit --amend`, say — replaces the line, ready to edit.
+Quit with `q` and the line is left exactly as it was.
+
+The binding is a few lines of shell around `mandible --print-selection <tool>`,
+which browses as usual but makes `Enter` print the selection instead of
+expanding the row (the UI draws on stderr, so stdout carries just that one
+line). Bind it to a different key, or wrap it in your own widget, by reading
+what `--shell-init` prints.
+
 ### Diagnostics
 
 ```console

--- a/mandible-core/src/entity.rs
+++ b/mandible-core/src/entity.rs
@@ -99,13 +99,29 @@ impl Spelling {
     /// The user-visible form: dashes, then `[no-]` if negatable, then the
     /// name — exactly the reconstruction the pre-0.5.0 `Flag::spelling` performed.
     pub fn render(&self) -> String {
-        let dashes = match self.dashes {
+        let no = if self.negatable { "[no-]" } else { "" };
+        format!("{}{no}{}", self.dash_prefix(), self.name)
+    }
+
+    /// The form a user types: dashes and the name, with no `[no-]`
+    /// notation.
+    ///
+    /// [`Spelling::render`] is documentation — `--[no-]color` is how the
+    /// tool *describes* two spellings on one row, and it is not one of
+    /// them. Anything handing a spelling to a shell (spec §2's
+    /// `--print-selection`) needs the affirmative form, which is what this
+    /// returns; a reader who wants the negation types the `no-` themselves,
+    /// exactly as they would have read it off the row.
+    pub fn typed(&self) -> String {
+        format!("{}{}", self.dash_prefix(), self.name)
+    }
+
+    fn dash_prefix(&self) -> &'static str {
+        match self.dashes {
             Dashes::None => "",
             Dashes::Single => "-",
             Dashes::Double => "--",
-        };
-        let no = if self.negatable { "[no-]" } else { "" };
-        format!("{dashes}{no}{}", self.name)
+        }
     }
 }
 
@@ -358,6 +374,30 @@ impl Entity {
             }
         }
         spelling
+    }
+
+    /// The single spelling to put on a command line for this entity: the
+    /// long-like one when the tool documents one, otherwise the short
+    /// letter. `None` for an entity that is not a flag, and for a flag with
+    /// no spellings at all.
+    ///
+    /// The preference is the same one [`Entity::key`] already applies for
+    /// identity, and for the same reason: the long spelling is the one that
+    /// still reads as itself in someone's shell history a week later.
+    /// Rendered through [`Spelling::typed`], so a negatable flag composes as
+    /// `--color`, never as the un-runnable `--[no-]color`.
+    ///
+    /// No value placeholder is appended. A flag that takes one composes as
+    /// the bare flag, and the value is the user's to type — spec §2's
+    /// `--print-selection` hands over a line to *edit*, and inventing
+    /// `--output FILE` on it would put a literal `FILE` in their history.
+    pub fn shell_spelling(&self) -> Option<String> {
+        if !matches!(self.kind, EntityKind::Flag) {
+            return None;
+        }
+        self.long_spelling()
+            .or_else(|| self.short_spelling())
+            .map(Spelling::typed)
     }
 
     /// The canonical identity key for cross-source matching, with the same
@@ -749,6 +789,74 @@ mod tests {
         assert_eq!(e.spelling(), "-h, -?, -help, --help");
         // The long-like spelling wins the identity key.
         assert_eq!(e.key(), Some(FlagKey::Long("help".into())));
+    }
+
+    /// `shell_spelling` prefers the long-like spelling, falls back to the
+    /// short letter, and never emits the `[no-]` notation — the three rules
+    /// spec §2's `--print-selection` composes a command line from.
+    #[test]
+    fn shell_spelling_prefers_long_and_drops_the_no_notation() {
+        let both = Entity::flag_spelled(
+            Some('i'),
+            Some("interactive".into()),
+            false,
+            false,
+            Provenance::default(),
+        );
+        assert_eq!(both.shell_spelling().as_deref(), Some("--interactive"));
+
+        let short_only = Entity::flag_short('x', Provenance::default());
+        assert_eq!(short_only.shell_spelling().as_deref(), Some("-x"));
+
+        // A single-dash long keeps its one dash: `-help`, not `--help`.
+        let single = Entity::flag_spelled(
+            None,
+            Some("help".into()),
+            true,
+            false,
+            Provenance::default(),
+        );
+        assert_eq!(single.shell_spelling().as_deref(), Some("-help"));
+
+        // `--[no-]color` documents two spellings; only the affirmative one
+        // can be typed, and `spelling()` keeps showing the documentation.
+        let negatable = Entity::flag_spelled(
+            None,
+            Some("color".into()),
+            false,
+            true,
+            Provenance::default(),
+        );
+        assert_eq!(negatable.spelling(), "--[no-]color");
+        assert_eq!(negatable.shell_spelling().as_deref(), Some("--color"));
+    }
+
+    /// A value placeholder stays out of the composed spelling: the line is
+    /// handed over to be edited, and a literal `FILE` in it is worse than
+    /// nothing.
+    #[test]
+    fn shell_spelling_omits_the_value_placeholder() {
+        let mut e = Entity::flag_long("output", Provenance::default());
+        e.value_name = Some("FILE".into());
+        e.value_kind = ValueKind::Required;
+        assert_eq!(e.spelling(), "--output FILE");
+        assert_eq!(e.shell_spelling().as_deref(), Some("--output"));
+    }
+
+    /// Only flags compose. A positional's spelling is a placeholder name
+    /// (`pathspec`), and appending it to a command line would put that
+    /// literal word on the user's prompt.
+    #[test]
+    fn shell_spelling_is_none_for_non_flags() {
+        let p = Entity::positional("pathspec", Provenance::default());
+        assert_eq!(p.shell_spelling(), None);
+
+        let mut m = Entity::new(EntityKind::Modifier, Provenance::default());
+        m.spellings = vec![Spelling::bare("d")];
+        assert_eq!(m.shell_spelling(), None);
+
+        let empty = Entity::new(EntityKind::Flag, Provenance::default());
+        assert_eq!(empty.shell_spelling(), None);
     }
 
     #[test]

--- a/mandible-tui/src/app.rs
+++ b/mandible-tui/src/app.rs
@@ -75,6 +75,11 @@ pub enum Effect {
     /// The caller should run the probe and hand the result back through
     /// [`App::set_raw_help`].
     FetchRaw(Vec<String>),
+    /// Print this composed command line on stdout and exit (spec §2's
+    /// `--print-selection`). Only ever produced while
+    /// [`App::print_selection`] is set, which no ordinary `mandible <tool>`
+    /// session does.
+    PrintSelection(String),
 }
 
 /// One node's raw `--help` text, as far as the verbatim view has got.
@@ -276,6 +281,18 @@ pub struct App {
     /// detail pane to that flag"). Cleared on any navigation that isn't a
     /// search-result selection.
     pub selected_flag: Option<mandible_core::FlagKey>,
+    /// Whether `Enter` composes the selection onto the calling shell's
+    /// prompt instead of expanding the selected row (spec §2's
+    /// `--print-selection`).
+    ///
+    /// `false` in every ordinary `mandible <tool>` session, and nothing in
+    /// this crate ever sets it: the composition root
+    /// (`mandible/src/app_runner.rs`'s `new_app`) turns it on for the one
+    /// invocation that asked, the same way it applies `config.toml`. With
+    /// it off, every key means exactly what it meant before this mode
+    /// existed — `→`/`Enter`/`l` all expand — which is the property
+    /// `mandible-tui`'s own tests pin.
+    pub print_selection: bool,
     /// `Some` for the duration of one tool's session inside `mandible
     /// --review`, `None` in the ordinary `mandible <tool>` path. Carries the
     /// tool's stratum, pre-tag suggestions, and sample progress for the
@@ -396,6 +413,7 @@ impl App {
             palette,
             glyphs: crate::glyphs::from_env(),
             selected_flag: None,
+            print_selection: false,
             review: None,
         };
         app.ensure_rows_fresh();
@@ -601,6 +619,43 @@ impl App {
     /// The selected row's path from the root, e.g. `["git", "rebase"]`.
     pub fn selected_path(&self) -> Option<Vec<String>> {
         Some(self.selected_row()?.path.clone())
+    }
+
+    /// The command line this selection composes to: the selected node's
+    /// full command path, plus the selected flag's typed spelling when
+    /// search landed on one (spec §2's `--print-selection`).
+    ///
+    /// `git commit` for a command row; `git commit --amend` when
+    /// [`Self::selected_flag`] holds a flag that command actually
+    /// documents. A flag target that no longer resolves — the tree was
+    /// re-extracted, the row moved — composes the path alone rather than
+    /// guessing: a command that is merely incomplete can be finished on the
+    /// prompt, and one carrying a flag its tool does not have cannot.
+    ///
+    /// Nothing is appended for a flag's value: see
+    /// `Entity::shell_spelling`.
+    pub fn selection_command(&self) -> Option<String> {
+        let path = &self.selected_row()?.path;
+        let mut line = path.join(" ");
+        if let Some(spelling) = self.selected_flag.as_ref().and_then(|key| {
+            mandible_core::resolve_flag(&self.root, path, key).and_then(|e| e.shell_spelling())
+        }) {
+            line.push(' ');
+            line.push_str(&spelling);
+        }
+        Some(line)
+    }
+
+    /// Set the palette, keeping [`Self::color_enabled`] in step.
+    ///
+    /// The two are one decision read at two kinds of call site (see
+    /// `color_enabled`'s note), so they are set together here rather than
+    /// assigned separately by whoever knows the terminal — the composition
+    /// root, which is the only place that knows which stream is being drawn
+    /// on.
+    pub fn set_palette(&mut self, palette: crate::style::Palette) {
+        self.color_enabled = palette.color;
+        self.palette = palette;
     }
 
     fn mark_dirty(&mut self) {
@@ -1586,6 +1641,61 @@ mod tests {
         app.move_up();
         assert_ne!(app.selected_path(), before, "the press must actually move");
         assert_eq!(app.selected_flag, None);
+    }
+
+    /// `--print-selection`'s whole output, composed the way the user got
+    /// there: search a flag spelling, and the line is that flag's command
+    /// plus the flag — `git rebase --autosquash`, ready to edit.
+    #[test]
+    fn selection_command_composes_a_searched_flag_onto_its_command() {
+        let mut root = sample_tree();
+        root.subcommands[1]
+            .entities
+            .push(mandible_core::Entity::flag_spelled(
+                Some('i'),
+                Some("autosquash".to_string()),
+                false,
+                false,
+                Provenance::single(Source::HelpText),
+            ));
+
+        let mut app = App::new("git".to_string(), root);
+        app.focus_search();
+        app.cycle_search_mode(); // Name -> Wide
+        for c in "autosquash".chars() {
+            app.search_input_char(c);
+        }
+        settle_search(&mut app);
+        app.ensure_rows_fresh();
+
+        assert_eq!(app.selected_row().unwrap().name, "rebase", "precondition");
+        // The long spelling, not the `-i` the tool printed first.
+        assert_eq!(
+            app.selection_command().as_deref(),
+            Some("git rebase --autosquash")
+        );
+    }
+
+    /// No flag target: a command row composes to its own full path, which
+    /// is the other half of what `Enter` accepts.
+    #[test]
+    fn selection_command_is_the_command_path_with_no_flag_target() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        assert_eq!(app.selection_command().as_deref(), Some("git"));
+        app.selected = 2; // rebase
+        assert_eq!(app.selection_command().as_deref(), Some("git rebase"));
+    }
+
+    /// A flag target the selected command does not document composes the
+    /// path alone. An incomplete line can be finished on the prompt; one
+    /// carrying a flag the tool does not have cannot, and printing it
+    /// would be the mode's one chance to hand over something wrong.
+    #[test]
+    fn selection_command_drops_a_flag_target_that_does_not_resolve() {
+        let mut app = App::new("git".to_string(), sample_tree());
+        app.selected = 2; // rebase, which documents no flags at all
+        app.selected_flag = Some(mandible_core::FlagKey::Long("autosquash".to_string()));
+        assert_eq!(app.selection_command().as_deref(), Some("git rebase"));
     }
 
     #[test]

--- a/mandible-tui/src/clipboard.rs
+++ b/mandible-tui/src/clipboard.rs
@@ -4,39 +4,46 @@
 //!
 //! Tries the OS clipboard via `arboard` first; if that's unavailable (no
 //! display server, headless box, sandboboxed terminal), degrades to an
-//! OSC-52 escape sequence written to stdout, which most modern terminal
-//! emulators (including over SSH) intercept and use to set their own
-//! clipboard.
+//! OSC-52 escape sequence written to the terminal, which most modern
+//! terminal emulators (including over SSH) intercept and use to set their
+//! own clipboard.
 
+use crate::terminal::Sink;
 use base64::Engine;
 use std::io::Write;
 
 /// Copy `text` to the clipboard, trying the OS clipboard first and falling
-/// back to an OSC-52 terminal escape sequence. Returns `Ok(())` if either
-/// mechanism plausibly succeeded (OSC-52 has no confirmation channel, so a
-/// successful *write* is treated as success).
-pub fn copy(text: &str) -> Result<(), CopyError> {
+/// back to an OSC-52 terminal escape sequence written to `sink`. Returns
+/// `Ok(())` if either mechanism plausibly succeeded (OSC-52 has no
+/// confirmation channel, so a successful *write* is treated as success).
+///
+/// `sink` is the stream the UI is drawn on, and the escape sequence has to
+/// go there rather than to stdout unconditionally: under `mandible
+/// --print-selection` stdout is a pipe the calling shell reads a command
+/// off, and an OSC-52 sequence written into it would be handed to the shell
+/// as part of that command.
+pub fn copy(text: &str, sink: Sink) -> Result<(), CopyError> {
     match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text.to_string())) {
         Ok(()) => Ok(()),
-        Err(_) => copy_via_osc52(text),
+        Err(_) => copy_via_osc52(text, sink),
     }
 }
 
 /// Errors copying to the clipboard by any mechanism.
 #[derive(Debug, thiserror::Error)]
 pub enum CopyError {
-    /// Writing the OSC-52 escape sequence to stdout failed.
+    /// Writing the OSC-52 escape sequence to the terminal failed.
     #[error("failed to write OSC-52 sequence: {0}")]
     Write(#[from] std::io::Error),
 }
 
-fn copy_via_osc52(text: &str) -> Result<(), CopyError> {
+fn copy_via_osc52(text: &str, sink: Sink) -> Result<(), CopyError> {
     let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
     // ESC ] 5 2 ; c ; <base64> BEL
     let sequence = format!("\x1b]52;c;{encoded}\x07");
-    let mut stdout = std::io::stdout();
-    stdout.write_all(sequence.as_bytes())?;
-    stdout.flush()?;
+    let mut writer = sink.writer();
+    writer.write_all(sequence.as_bytes())?;
+    writer.flush()?;
     Ok(())
 }
 

--- a/mandible-tui/src/event.rs
+++ b/mandible-tui/src/event.rs
@@ -50,6 +50,17 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
 fn handle_search_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
     match key.code {
         KeyCode::Esc => app.escape_search(),
+        // In `--print-selection` mode Enter accepts from the search box
+        // too, because that is where the flag journey ends: type part of a
+        // flag's name, the top hit selects its parent command and points
+        // the detail pane at the flag, and Enter hands the composed line
+        // back to the shell. Making it mean "move focus to the tree" there
+        // would put a second Enter between the user and the thing they came
+        // for. `Esc` still moves focus out while keeping the filter, which
+        // is what anyone who wanted the other meaning is reaching for.
+        KeyCode::Enter if app.print_selection => {
+            return app.selection_command().map(Effect::PrintSelection)
+        }
         KeyCode::Enter => app.focus = Focus::Tree,
         KeyCode::Backspace => app.search_backspace(),
         // Arrows move the (filtered) tree selection without leaving the
@@ -75,6 +86,15 @@ fn handle_tree_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
     match key.code {
         KeyCode::Down | KeyCode::Char('j') => app.move_down(),
         KeyCode::Up | KeyCode::Char('k') => app.move_up(),
+        // `--print-selection` only: Enter accepts the selection and quits.
+        // Guarded rather than folded into the arm below so that with the
+        // mode off this function is byte-for-byte the one that shipped —
+        // `→`, `Enter` and `l` all expand, exactly as spec §2's table says.
+        // Expansion keeps both its other keys in the mode, so nothing
+        // becomes unreachable.
+        KeyCode::Enter if app.print_selection => {
+            return app.selection_command().map(Effect::PrintSelection)
+        }
         KeyCode::Right | KeyCode::Enter | KeyCode::Char('l') => {
             return app.expand_selected().map(Effect::Fill)
         }
@@ -294,6 +314,80 @@ mod tests {
         );
         handle_key(&mut a, key(KeyCode::Char('h')));
         assert_eq!(a.clamped_detail_hscroll(), 0, "h should scroll back left");
+    }
+
+    /// The hard requirement on `--print-selection`: with the mode off,
+    /// `Enter` is still one of the three expand keys, indistinguishable
+    /// from `→` and `l` (spec §2's interaction table).
+    ///
+    /// Asserted as an equality between the three effects rather than as
+    /// "Enter returns Fill", because the mode was added by putting a
+    /// guarded arm *in front of* the shared one, and the way that goes
+    /// wrong is the guard admitting a default session.
+    #[test]
+    fn enter_still_expands_when_print_selection_is_off() {
+        let by_key = |code| {
+            let mut a = app();
+            handle_key(&mut a, key(code))
+        };
+        let expected = Some(Effect::Fill(vec!["git".to_string()]));
+        assert_eq!(by_key(KeyCode::Enter), expected);
+        assert_eq!(by_key(KeyCode::Right), expected);
+        assert_eq!(by_key(KeyCode::Char('l')), expected);
+    }
+
+    /// With the mode on, `Enter` composes the selection instead — and
+    /// `→`/`l` keep expanding, so nothing becomes unreachable.
+    #[test]
+    fn enter_prints_the_selection_when_the_mode_is_on() {
+        let mut a = app();
+        a.print_selection = true;
+        assert_eq!(
+            handle_key(&mut a, key(KeyCode::Enter)),
+            Some(Effect::PrintSelection("git".to_string()))
+        );
+        assert_eq!(
+            handle_key(&mut a, key(KeyCode::Right)),
+            Some(Effect::Fill(vec!["git".to_string()]))
+        );
+    }
+
+    /// The end of the flag journey: search puts the tree on the flag's
+    /// parent command and remembers the flag (`App`'s own tests cover that
+    /// half), and `Enter` accepts from inside the search box — without the
+    /// detour through the tree an ordinary session takes, since that would
+    /// put a second `Enter` between the user and the thing they came for.
+    #[test]
+    fn enter_accepts_from_the_search_box_and_composes_the_flag() {
+        let mut root = CommandNode::new("git", Provenance::single(Source::HelpText));
+        let mut commit = CommandNode::new("commit", Provenance::single(Source::HelpText));
+        commit.entities.push(mandible_core::Entity::flag_long(
+            "amend",
+            Provenance::single(Source::HelpText),
+        ));
+        root.subcommands.push(commit);
+        let mut a = App::new("git".to_string(), root);
+        a.print_selection = true;
+        a.ensure_rows_fresh();
+        a.select_index(1); // "commit"
+        a.selected_flag = Some(mandible_core::FlagKey::Long("amend".to_string()));
+
+        a.focus_search();
+        assert_eq!(a.focus, Focus::Search);
+        assert_eq!(
+            handle_key(&mut a, key(KeyCode::Enter)),
+            Some(Effect::PrintSelection("git commit --amend".to_string()))
+        );
+    }
+
+    /// …and with the mode off, that same `Enter` still just moves focus to
+    /// the tree, producing no effect at all.
+    #[test]
+    fn enter_in_the_search_box_still_moves_focus_by_default() {
+        let mut a = app();
+        a.focus_search();
+        assert_eq!(handle_key(&mut a, key(KeyCode::Enter)), None);
+        assert_eq!(a.focus, Focus::Tree);
     }
 
     #[test]

--- a/mandible-tui/src/render/help_overlay.rs
+++ b/mandible-tui/src/render/help_overlay.rs
@@ -11,7 +11,7 @@ use ratatui::Frame;
 const BINDINGS: &[(Option<&str>, &str)] = &[
     (None, "MOVE"),
     (Some("↑ ↓  k j"), "Move selection"),
-    (Some("→  Enter  l"), "Expand"),
+    (Some(EXPAND_KEYS), "Expand"),
     (Some("←  h"), "Collapse, or jump to parent"),
     (Some("Tab"), "Switch between tree and detail"),
     (None, "SEARCH"),
@@ -38,6 +38,28 @@ const BINDINGS: &[(Option<&str>, &str)] = &[
     (Some("q"), "Quit (from the tree)"),
 ];
 
+/// The key `--print-selection` rebinds, as it reads in [`BINDINGS`].
+const EXPAND_KEYS: &str = "→  Enter  l";
+
+/// [`BINDINGS`] as `--print-selection` leaves them: `Enter` is the accept
+/// key there, so the Expand row can no longer claim it and the overlay
+/// gains the row that says what it does instead.
+///
+/// The overlay is the one place a user goes when a key did something they
+/// did not expect. Leaving it describing the default bindings in a mode
+/// that changed one would make it wrong exactly there.
+fn bindings(print_selection: bool) -> Vec<(Option<&'static str>, &'static str)> {
+    let mut rows = BINDINGS.to_vec();
+    if !print_selection {
+        return rows;
+    }
+    if let Some(at) = rows.iter().position(|(key, _)| *key == Some(EXPAND_KEYS)) {
+        rows[at].0 = Some("→  l");
+        rows.insert(at + 1, (Some("Enter"), "Print this selection and exit"));
+    }
+    rows
+}
+
 /// Width of the key column. Wide enough for the longest chord, so the
 /// descriptions align into one column the way the detail pane's do.
 const KEY_COLUMN: usize = 15;
@@ -48,6 +70,7 @@ pub fn render(
     full_area: Rect,
     glyphs: crate::glyphs::Glyphs,
     color_enabled: bool,
+    print_selection: bool,
 ) {
     let popup = centered_popup(full_area, 62, 70);
     frame.render_widget(Clear, popup);
@@ -69,8 +92,9 @@ pub fn render(
     }
 
     let width = inner.width as usize;
-    let mut lines: Vec<Line> = Vec::with_capacity(BINDINGS.len());
-    for (key, desc) in BINDINGS {
+    let rows = bindings(print_selection);
+    let mut lines: Vec<Line> = Vec::with_capacity(rows.len());
+    for (key, desc) in &rows {
         match key {
             // A section heading: a blank line above it (except first), then
             // the label. Grouping eleven bindings into three named sets is
@@ -99,4 +123,37 @@ pub fn render(
     }
 
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The default overlay is the table spec §2 prints, untouched.
+    #[test]
+    fn the_default_overlay_is_unchanged() {
+        assert_eq!(bindings(false), BINDINGS.to_vec());
+    }
+
+    /// In `--print-selection`, `Enter` is documented once, as the accept
+    /// key — the Expand row must not also claim it, or the overlay
+    /// contradicts itself about the only key the mode moved.
+    #[test]
+    fn print_selection_moves_enter_off_the_expand_row() {
+        let rows = bindings(true);
+        assert!(
+            !rows.iter().any(|(key, _)| *key == Some(EXPAND_KEYS)),
+            "Expand must give Enter up: {rows:?}"
+        );
+        let enter: Vec<_> = rows
+            .iter()
+            .filter(|(key, _)| key.is_some_and(|k| k.contains("Enter")))
+            .collect();
+        assert_eq!(enter.len(), 1, "exactly one Enter row: {enter:?}");
+        assert_eq!(enter[0].1, "Print this selection and exit");
+        // Expansion keeps its other two keys, so nothing is unreachable.
+        assert!(rows
+            .iter()
+            .any(|(key, desc)| *key == Some("→  l") && *desc == "Expand"));
+    }
 }

--- a/mandible-tui/src/render/mod.rs
+++ b/mandible-tui/src/render/mod.rs
@@ -34,7 +34,13 @@ pub fn render(frame: &mut Frame, app: &App) {
     status_bar::render(frame, regions.status, app);
 
     if app.show_help {
-        help_overlay::render(frame, area, app.glyphs, app.color_enabled);
+        help_overlay::render(
+            frame,
+            area,
+            app.glyphs,
+            app.color_enabled,
+            app.print_selection,
+        );
     }
 
     if let Some(review) = &app.review {

--- a/mandible-tui/src/render/status_bar.rs
+++ b/mandible-tui/src/render/status_bar.rs
@@ -44,13 +44,25 @@ use ratatui::Frame;
 /// label pushed `Tab pane` off the row — the one hint that gets a user
 /// *to* the pane where the scroll half of the label would apply — so
 /// leaving the short label as the default-off case fixes both at once.
-fn hints(glyphs: crate::glyphs::Glyphs, horizontal_scroll_enabled: bool) -> Vec<String> {
+fn hints(
+    glyphs: crate::glyphs::Glyphs,
+    horizontal_scroll_enabled: bool,
+    print_selection: bool,
+) -> Vec<String> {
     let horizontal_hint = if horizontal_scroll_enabled {
         format!("{} expand/scroll", glyphs.arrows_horizontal)
     } else {
         format!("{} expand", glyphs.arrows_horizontal)
     };
-    vec![
+    let mut hints = Vec::new();
+    // First in the list, so it is the last hint a narrowing row drops:
+    // under `--print-selection` this is the key the whole invocation
+    // exists for, and it is the one key whose meaning differs from the
+    // one a reader already knows.
+    if print_selection {
+        hints.push("Enter select".to_string());
+    }
+    hints.extend([
         format!("{} move", glyphs.arrows_vertical),
         horizontal_hint,
         "/ search".to_string(),
@@ -61,7 +73,8 @@ fn hints(glyphs: crate::glyphs::Glyphs, horizontal_scroll_enabled: bool) -> Vec<
         "r reload".to_string(),
         "? help".to_string(),
         "^C quit".to_string(),
-    ]
+    ]);
+    hints
 }
 
 /// Gap between hints. Wide on purpose: at two spaces the row reads as one
@@ -92,8 +105,9 @@ fn hints_for_width(
     width: usize,
     glyphs: crate::glyphs::Glyphs,
     horizontal_scroll_enabled: bool,
+    print_selection: bool,
 ) -> String {
-    let all = hints(glyphs, horizontal_scroll_enabled);
+    let all = hints(glyphs, horizontal_scroll_enabled, print_selection);
     let split = all.len().saturating_sub(PINNED_HINTS);
     let (rest, pinned) = all.split_at(split);
     let pinned_len: usize = pinned.iter().map(|h| h.chars().count()).sum::<usize>()
@@ -147,7 +161,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let margin_width = display_width(LEFT_MARGIN) * 2;
     let hints_budget = width.saturating_sub(right_width + margin_width + 2);
-    let hints = hints_for_width(hints_budget, app.glyphs, app.horizontal_scroll_enabled);
+    let hints = hints_for_width(
+        hints_budget,
+        app.glyphs,
+        app.horizontal_scroll_enabled,
+        app.print_selection,
+    );
 
     let mut spans = vec![
         Span::raw(LEFT_MARGIN),
@@ -188,8 +207,8 @@ mod tests {
 
     #[test]
     fn wide_terminal_shows_every_hint() {
-        let rendered = hints_for_width(120, crate::glyphs::UNICODE, true);
-        for h in hints(crate::glyphs::UNICODE, true) {
+        let rendered = hints_for_width(120, crate::glyphs::UNICODE, true, false);
+        for h in hints(crate::glyphs::UNICODE, true, false) {
             assert!(rendered.contains(&h), "{h} missing from {rendered:?}");
         }
     }
@@ -203,7 +222,7 @@ mod tests {
     /// rather than quietly shrinking the footer.
     #[test]
     fn every_action_key_is_named_at_full_width() {
-        let rendered = hints_for_width(140, crate::glyphs::UNICODE, true);
+        let rendered = hints_for_width(140, crate::glyphs::UNICODE, true, false);
         for key in [
             "/ search", "Tab pane", "t raw", "y copy", "r reload", "? help",
         ] {
@@ -215,7 +234,7 @@ mod tests {
     /// thing that should turn into boxes for someone who cannot get out.
     #[test]
     fn ascii_fallback_hints_are_pure_ascii() {
-        let rendered = hints_for_width(120, crate::glyphs::ASCII, true);
+        let rendered = hints_for_width(120, crate::glyphs::ASCII, true, false);
         assert!(rendered.is_ascii(), "{rendered:?}");
         assert!(rendered.contains("^C quit"));
     }
@@ -226,7 +245,7 @@ mod tests {
     #[test]
     fn quit_hint_survives_a_narrow_terminal() {
         for width in [20, 30, 40, 60, 88] {
-            let hints = hints_for_width(width, crate::glyphs::UNICODE, true);
+            let hints = hints_for_width(width, crate::glyphs::UNICODE, true, false);
             assert!(hints.contains("^C quit"), "width {width}: {hints:?}");
             // A narrow row hides most of the footer, which is exactly
             // where the reader needs to know the full list exists.
@@ -246,8 +265,8 @@ mod tests {
     #[test]
     fn horizontal_hint_matches_the_config_toggle() {
         for width in [40, 60, 80, 100, 120, 140] {
-            let on = hints_for_width(width, crate::glyphs::UNICODE, true);
-            let off = hints_for_width(width, crate::glyphs::UNICODE, false);
+            let on = hints_for_width(width, crate::glyphs::UNICODE, true, false);
+            let off = hints_for_width(width, crate::glyphs::UNICODE, false, false);
 
             assert!(
                 !off.contains("expand/scroll"),
@@ -272,7 +291,7 @@ mod tests {
 
         // At a comfortable width, off still names collapse/expand — it
         // only drops the "/scroll" half, not the whole hint.
-        let off_wide = hints_for_width(120, crate::glyphs::UNICODE, false);
+        let off_wide = hints_for_width(120, crate::glyphs::UNICODE, false, false);
         assert!(off_wide.contains("expand"), "{off_wide:?}");
 
         // The specific bug this test pins: `render()` subtracts the
@@ -286,8 +305,8 @@ mod tests {
         // while the disabled label, exactly as wide as before this
         // feature existed, keeps it.
         let crossover = 68;
-        let on = hints_for_width(crossover, crate::glyphs::UNICODE, true);
-        let off = hints_for_width(crossover, crate::glyphs::UNICODE, false);
+        let on = hints_for_width(crossover, crate::glyphs::UNICODE, true, false);
+        let off = hints_for_width(crossover, crate::glyphs::UNICODE, false, false);
         assert!(
             !on.contains("Tab pane"),
             "expected width {crossover} to be the known trade-off point: {on:?}"
@@ -296,6 +315,38 @@ mod tests {
             off.contains("Tab pane"),
             "off must restore Tab pane at the width where on drops it: {off:?}"
         );
+    }
+
+    /// `--print-selection` changes what `Enter` does, so the footer says
+    /// so — and says nothing extra in every other session. The second half
+    /// is the load-bearing one: the default footer is the row that shipped,
+    /// hint for hint.
+    #[test]
+    fn the_select_hint_appears_only_in_print_selection_mode() {
+        let on = hints(crate::glyphs::UNICODE, true, true);
+        let off = hints(crate::glyphs::UNICODE, true, false);
+        assert_eq!(on.first().map(String::as_str), Some("Enter select"));
+        assert_eq!(&on[1..], &off[..], "the mode adds one hint and moves none");
+        assert!(
+            !off.iter().any(|h| h.contains("Enter")),
+            "the default footer must not mention Enter: {off:?}"
+        );
+    }
+
+    /// Being first in the list makes this the last hint dropped as the row
+    /// narrows, which is what it should be in a mode named after it. It is
+    /// not *pinned* — below roughly 34 columns only `? help` and `^C quit`
+    /// remain, and `?` is what makes everything dropped discoverable
+    /// again.
+    #[test]
+    fn the_select_hint_is_the_last_one_dropped() {
+        for width in [40, 60, 88, 120] {
+            let rendered = hints_for_width(width, crate::glyphs::UNICODE, true, true);
+            assert!(
+                rendered.contains("Enter select"),
+                "width {width}: {rendered:?}"
+            );
+        }
     }
 
     /// The controls keep a left margin rather than starting hard against
@@ -310,8 +361,8 @@ mod tests {
     /// budgeted for it — otherwise the two overlap at narrow widths.
     #[test]
     fn hints_shrink_to_leave_room_for_the_right_hand_text() {
-        let full = hints_for_width(120, crate::glyphs::UNICODE, true);
-        let squeezed = hints_for_width(40, crate::glyphs::UNICODE, true);
+        let full = hints_for_width(120, crate::glyphs::UNICODE, true, false);
+        let squeezed = hints_for_width(40, crate::glyphs::UNICODE, true, false);
         assert!(
             squeezed.chars().count() < full.chars().count(),
             "hints should give way: {squeezed:?} vs {full:?}"

--- a/mandible-tui/src/style.rs
+++ b/mandible-tui/src/style.rs
@@ -94,9 +94,21 @@ pub struct Palette {
 }
 
 impl Palette {
-    /// The palette this process's environment describes.
+    /// The palette this process's environment describes for output written
+    /// to stdout.
     pub fn from_env() -> Palette {
-        let color = color_enabled_from_env();
+        Palette::for_sink(crate::terminal::Sink::Stdout)
+    }
+
+    /// The palette for output written to `sink`.
+    ///
+    /// The sink is part of the question, not a detail: the "is anything a
+    /// terminal at the other end" half of [`color_enabled_for_sink`] is
+    /// about the stream being drawn on. `mandible --print-selection` draws
+    /// on stderr while stdout is a pipe, and asking stdout there would
+    /// answer about the pipe and render the whole UI monochrome.
+    pub fn for_sink(sink: crate::terminal::Sink) -> Palette {
+        let color = color_enabled_for_sink(sink);
         Palette {
             color,
             extended: color && extended_from_env(),
@@ -269,10 +281,17 @@ pub fn search_match() -> Style {
     Style::default().add_modifier(Modifier::UNDERLINED)
 }
 
+/// [`color_enabled_for_sink`] for output written to stdout — what a
+/// non-TUI command that prints there (the `mandible mandible` about
+/// screen) asks.
+pub fn color_enabled_from_env() -> bool {
+    color_enabled_for_sink(crate::terminal::Sink::Stdout)
+}
+
 /// True unless the user's environment asks for no color at all
 /// (`NO_COLOR`, <https://no-color.org> — any non-empty value disables
-/// color; unset or empty leaves color on).
-pub fn color_enabled_from_env() -> bool {
+/// color; unset or empty leaves color on), or `sink` is not a terminal.
+pub fn color_enabled_for_sink(sink: crate::terminal::Sink) -> bool {
     // `NO_COLOR` is an explicit request and wins outright
     // (<https://no-color.org>).
     if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
@@ -291,7 +310,7 @@ pub fn color_enabled_from_env() -> bool {
     // And nothing is a terminal at the other end of a pipe. Writing SGR
     // sequences into a file or a grep is the conventional mistake here —
     // `mandible mandible > notes.txt` should leave text, not escape codes.
-    crate::terminal::stdout_is_tty()
+    sink.is_tty()
 }
 
 /// A pure-ASCII border set.

--- a/mandible-tui/src/terminal.rs
+++ b/mandible-tui/src/terminal.rs
@@ -1,6 +1,22 @@
 //! Terminal setup/teardown. Kept separate from [`crate::render`] so
 //! rendering can always be exercised in tests via
 //! `ratatui::backend::TestBackend`, without a real tty.
+//!
+//! **Everything this crate writes to the terminal goes through a [`Sink`]**
+//! — the drawing, the alternate-screen and mouse-capture sequences, and the
+//! OSC-52 clipboard fallback — and the same [`Sink`] answers whether there
+//! is a terminal at the other end at all ([`Sink::is_tty`], which decides
+//! color). That is one choice, made once at startup, rather than three
+//! modules each reaching for `io::stdout()` on their own.
+//!
+//! It exists because `mandible --print-selection` (spec §2) draws its UI
+//! while stdout carries exactly one line — the composed command — for the
+//! calling shell to read. Under that mode stdout is a pipe: an escape
+//! sequence written there is corruption of the mode's only output, and a
+//! `stdout().is_terminal()` color check answers about the pipe rather than
+//! about the screen the user is looking at.
+//! `mandible-tui/tests/drawing_goes_through_the_sink.rs` is what keeps that
+//! true as the crate grows.
 
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::execute;
@@ -9,32 +25,97 @@ use crossterm::terminal::{
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
-use std::io::{self, IsTerminal, Stdout};
+use std::io::{self, IsTerminal, Stderr, Stdout};
 
 /// A live terminal handle, backed by `crossterm`.
-pub type Term = Terminal<CrosstermBackend<Stdout>>;
+pub type Term = Terminal<CrosstermBackend<SinkWriter>>;
 
-/// True if stdout is an interactive terminal. mandible must check this and
-/// fail with a clear message rather than let `enable_raw_mode` produce an
-/// opaque OS error ("No such device or address") when stdout is redirected
-/// or there is no controlling tty.
-pub fn stdout_is_tty() -> bool {
-    io::stdout().is_terminal()
+/// Which stream the TUI draws on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sink {
+    /// stdout: the ordinary `mandible <tool>` session, where stdout *is*
+    /// the screen.
+    Stdout,
+    /// stderr: `mandible --print-selection`, where stdout is reserved for
+    /// the one line the calling shell reads back.
+    Stderr,
 }
 
-/// Enter raw mode, the alternate screen, and mouse capture. Callers must
-/// pair this with [`restore`] (ideally via a panic hook / drop guard in the
-/// binary) so a crash doesn't leave the user's terminal in raw mode.
-pub fn init() -> io::Result<Term> {
+impl Sink {
+    /// True if this sink is an interactive terminal. mandible must check
+    /// this and fail with a clear message rather than let
+    /// `enable_raw_mode` produce an opaque OS error ("No such device or
+    /// address") when the stream is redirected or there is no controlling
+    /// tty.
+    pub fn is_tty(self) -> bool {
+        match self {
+            Sink::Stdout => io::stdout().is_terminal(),
+            Sink::Stderr => io::stderr().is_terminal(),
+        }
+    }
+
+    /// The name to put in an error message about this stream.
+    pub fn name(self) -> &'static str {
+        match self {
+            Sink::Stdout => "stdout",
+            Sink::Stderr => "stderr",
+        }
+    }
+
+    /// A fresh handle to this sink's stream. Handles are cheap and
+    /// independently buffered locks, so callers take one per write rather
+    /// than sharing.
+    pub fn writer(self) -> SinkWriter {
+        match self {
+            Sink::Stdout => SinkWriter::Stdout(io::stdout()),
+            Sink::Stderr => SinkWriter::Stderr(io::stderr()),
+        }
+    }
+}
+
+/// A writable handle to a [`Sink`]. An enum rather than a `Box<dyn Write>`
+/// so the backend type stays one concrete type and nothing has to be
+/// allocated to draw a frame.
+#[derive(Debug)]
+pub enum SinkWriter {
+    /// A handle to stdout.
+    Stdout(Stdout),
+    /// A handle to stderr.
+    Stderr(Stderr),
+}
+
+impl io::Write for SinkWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            SinkWriter::Stdout(w) => w.write(buf),
+            SinkWriter::Stderr(w) => w.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            SinkWriter::Stdout(w) => w.flush(),
+            SinkWriter::Stderr(w) => w.flush(),
+        }
+    }
+}
+
+/// Enter raw mode, the alternate screen, and mouse capture on `sink`.
+/// Callers must pair this with [`restore`] on the *same* sink (ideally via
+/// a panic hook / drop guard in the binary) so a crash doesn't leave the
+/// user's terminal in raw mode.
+pub fn init(sink: Sink) -> io::Result<Term> {
     enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+    let mut writer = sink.writer();
+    execute!(writer, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(writer);
     Terminal::new(backend)
 }
 
 /// Leave raw mode, the alternate screen, and mouse capture. Safe to call
-/// even if `init` partially failed.
+/// even if [`init`] partially failed, and must be given the same `sink`
+/// [`init`] was — the sequences that undo the alternate screen have to
+/// reach the stream that entered it.
 ///
 /// Order is load-bearing and the reverse of [`init`]: mouse capture is
 /// switched off and pending input drained *while the terminal is still
@@ -44,10 +125,10 @@ pub fn init() -> io::Result<Term> {
 /// shell's input buffer, echoed after exit as garbage. The drain eats
 /// reports already in flight when the capture-off sequence was written;
 /// `poll` with a zero timeout never blocks, so this is safe even when
-/// `init` never got as far as raw mode.
-pub fn restore() -> io::Result<()> {
-    let mut stdout = io::stdout();
-    execute!(stdout, DisableMouseCapture, LeaveAlternateScreen)?;
+/// [`init`] never got as far as raw mode.
+pub fn restore(sink: Sink) -> io::Result<()> {
+    let mut writer = sink.writer();
+    execute!(writer, DisableMouseCapture, LeaveAlternateScreen)?;
     while crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
         let _ = crossterm::event::read();
     }

--- a/mandible-tui/tests/drawing_goes_through_the_sink.rs
+++ b/mandible-tui/tests/drawing_goes_through_the_sink.rs
@@ -1,0 +1,97 @@
+//! `mandible-tui` may only reach a terminal stream through
+//! [`terminal::Sink`], never by naming `stdout`/`stderr` itself.
+//!
+//! The rule exists because `mandible --print-selection` (spec §2) draws its
+//! UI while stdout carries exactly one line — the composed command — for
+//! the calling shell to read back. Under that mode **any** byte this crate
+//! writes to stdout on its own initiative is corruption of the mode's only
+//! output, and it corrupts it silently: the shell puts whatever arrived on
+//! the user's prompt.
+//!
+//! It is a lint rather than a type because the offending call is always a
+//! plausible-looking one-liner. Both existing cases were: `clipboard`'s
+//! OSC-52 fallback wrote its escape sequence to `io::stdout()`, and
+//! `style`'s color check asked `io::stdout().is_terminal()` — which under
+//! this mode answers about the pipe rather than about the screen the user
+//! is looking at, rendering the whole UI monochrome. Neither is visible in
+//! a `TestBackend` render test, because neither goes through the backend.
+//!
+//! Modelled on `mandible-extract/tests/no_process_outside_exec.rs`, which
+//! polices spec §6/§8's `Command::new` boundary the same way.
+
+use std::path::{Path, PathBuf};
+
+/// Every way a Rust source line can reach a standard stream directly.
+/// `write!`/`writeln!` are not listed: they take an explicit writer, and
+/// the only writers this crate can obtain are the sink's.
+const FORBIDDEN: &[&str] = &[
+    "io::stdout(",
+    "io::stderr(",
+    "stdout()",
+    "stderr()",
+    "println!",
+    "print!",
+    "eprintln!",
+    "eprint!",
+];
+
+#[test]
+fn nothing_outside_terminal_rs_writes_to_a_standard_stream() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    assert!(src.is_dir(), "expected {} to exist", src.display());
+
+    // The one module allowed to name the streams: it is what defines the
+    // sink, and `Sink::writer`/`Sink::is_tty` are the two functions that
+    // hand every other module its answer.
+    let allowed = src.join("terminal.rs");
+
+    let mut violations = Vec::new();
+    walk_rs_files(&src, &mut |path, contents| {
+        if path == allowed {
+            return;
+        }
+        for (line_no, line) in contents.lines().enumerate() {
+            // Prose about a stream is fine; a call to one is not. Same
+            // comment heuristic the exec-boundary lint uses.
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            for needle in FORBIDDEN {
+                if line.contains(needle) {
+                    violations.push(format!(
+                        "{}:{}: {} — write to the terminal through \
+                         `crate::terminal::Sink`, not `{needle}`",
+                        path.display(),
+                        line_no + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    });
+
+    assert!(
+        violations.is_empty(),
+        "mandible-tui reaches a standard stream outside terminal.rs, so \
+         `mandible --print-selection` can no longer promise that stdout \
+         carries only the selection:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn walk_rs_files(dir: &Path, visit: &mut impl FnMut(&Path, &str)) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_rs_files(&path, visit);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            if let Ok(contents) = std::fs::read_to_string(&path) {
+                visit(&path, &contents);
+            }
+        }
+    }
+}

--- a/mandible/src/about.rs
+++ b/mandible/src/about.rs
@@ -201,7 +201,7 @@ fn animate(color: bool) {
 
 /// True when the banner can be drawn: a real terminal, in a UTF-8 locale.
 fn banner_possible() -> bool {
-    mandible_tui::terminal::stdout_is_tty()
+    mandible_tui::terminal::Sink::Stdout.is_tty()
         && mandible_tui::glyphs::from_env() == mandible_tui::glyphs::UNICODE
 }
 

--- a/mandible/src/app_runner.rs
+++ b/mandible/src/app_runner.rs
@@ -51,6 +51,25 @@ enum LoopExit {
     /// `app.review.is_some()`; [`run`]'s plain single-tool path never sees
     /// this variant since it never attaches a review overlay.
     ReviewSubmit(ReviewSubmission),
+    /// `Enter` accepted a selection under `--print-selection`. Carries the
+    /// composed command line, which [`run`] prints on stdout *after* the
+    /// terminal is restored. Only ever produced when
+    /// `app.print_selection` is set, which nothing but `main` sets.
+    PrintSelection(String),
+}
+
+/// What [`apply_effect`] decided the event loop should do next.
+///
+/// It replaced a bare `bool` when a second reason to leave the loop
+/// appeared: `false` could only ever mean "quit", so a new exit had to
+/// carry its payload some other way — and the other way is a field
+/// somewhere that the three call sites would each have to remember to
+/// read.
+enum Control {
+    /// Keep polling.
+    Continue,
+    /// Leave the loop for this reason.
+    Exit(LoopExit),
 }
 
 /// Build an `App` for `tool`, with settings resolved from the user's
@@ -72,19 +91,37 @@ enum LoopExit {
 /// tool inside `mandible --review` ([`run_review_loop`]) — both go through
 /// this instead of `App::new` directly, so the config is never forgotten on
 /// either path.
-pub fn new_app(tool: String, stub: mandible_core::CommandNode) -> App {
+///
+/// `sink` is the stream the UI will be drawn on, which is also what
+/// decides whether there is a terminal at the other end to color for — see
+/// [`mandible_tui::style::Palette::for_sink`]. It is the composition
+/// root's to know for the same reason `config.toml` is.
+pub fn new_app(tool: String, stub: mandible_core::CommandNode, sink: terminal::Sink) -> App {
     let mut app = App::new(tool, stub);
     app.horizontal_scroll_enabled = mandible_core::config::load().ui.horizontal_scroll;
+    app.set_palette(mandible_tui::style::Palette::for_sink(sink));
     app
 }
 
 /// Run the interactive TUI for `app` until the user quits. Always restores
 /// the terminal on the way out, even if the loop returns an error.
-pub fn run(mut app: App) -> anyhow::Result<()> {
-    let mut term = terminal::init().context("failed to initialize the terminal")?;
-    let result = run_loop(&mut term, &mut app).map(|_| ());
-    let restore_result = terminal::restore().context("failed to restore the terminal");
-    result.and(restore_result)
+pub fn run(mut app: App, sink: terminal::Sink) -> anyhow::Result<()> {
+    let mut term = terminal::init(sink).context("failed to initialize the terminal")?;
+    let result = run_loop(&mut term, &mut app, sink);
+    let restore_result = terminal::restore(sink).context("failed to restore the terminal");
+    // The loop's own error wins over the restore's, as it did when this
+    // was one `result.and(restore_result)` — but the restore has already
+    // run either way, which is the part that matters.
+    let exit = result?;
+    restore_result?;
+    // Printed after the terminal is restored, never before: under
+    // `--print-selection` this is the one line the calling shell reads,
+    // and writing it while the alternate screen is still up interleaves it
+    // with the teardown sequences on their way to the *other* stream.
+    if let LoopExit::PrintSelection(line) = exit {
+        println!("{line}");
+    }
+    Ok(())
 }
 
 /// `mandible --review <seed>`: walk `<dir>/<seed>.toml`'s pending entries in
@@ -110,9 +147,11 @@ pub fn run_review(dir: &Path, seed: u64) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let mut term = terminal::init().context("failed to initialize the terminal")?;
+    let mut term =
+        terminal::init(terminal::Sink::Stdout).context("failed to initialize the terminal")?;
     let result = run_review_loop(&mut term, dir, seed);
-    let restore_result = terminal::restore().context("failed to restore the terminal");
+    let restore_result =
+        terminal::restore(terminal::Sink::Stdout).context("failed to restore the terminal");
     result.and(restore_result)
 }
 
@@ -149,11 +188,17 @@ fn run_review_loop(term: &mut terminal::Term, dir: &Path, seed: u64) -> anyhow::
             entry.tool.clone(),
             mandible_core::Provenance::default(),
         );
-        let mut app = new_app(entry.tool.clone(), stub);
+        let mut app = new_app(entry.tool.clone(), stub, terminal::Sink::Stdout);
         app.review = Some(review_overlay_for(&entry, remaining, total));
 
-        match run_loop(term, &mut app)? {
+        match run_loop(term, &mut app, terminal::Sink::Stdout)? {
             LoopExit::Quit => break,
+            // `--review` never turns `print_selection` on, so `Enter` is
+            // the verdict key there and never the accept key. Ending the
+            // session is the honest response to a variant this path
+            // cannot produce, rather than an `unreachable!` on a state
+            // one field change away from being reachable.
+            LoopExit::PrintSelection(_) => break,
             LoopExit::ReviewSubmit(submission) => {
                 apply_submission(&path, &mut manifest, idx, submission)?;
             }
@@ -223,7 +268,11 @@ fn record_skip(
     audit::save(path, manifest)
 }
 
-fn run_loop(term: &mut terminal::Term, app: &mut App) -> anyhow::Result<LoopExit> {
+fn run_loop(
+    term: &mut terminal::Term,
+    app: &mut App,
+    sink: terminal::Sink,
+) -> anyhow::Result<LoopExit> {
     let runner = Arc::new(Runner::new(default_tiers()));
     let resolved = resolve_tool(&app.tool);
     let warmer = Warmer::new();
@@ -314,9 +363,11 @@ fn run_loop(term: &mut terminal::Term, app: &mut App) -> anyhow::Result<LoopExit
                 }
                 if !claimed {
                     if let Some(effect) = tui_event::handle_key(app, key) {
-                        if !apply_effect(app, effect, &runner, &resolved, &warmer) {
+                        if let Control::Exit(exit) =
+                            apply_effect(app, effect, &runner, &resolved, &warmer, sink)
+                        {
                             warmer.cancel();
-                            return Ok(LoopExit::Quit);
+                            return Ok(exit);
                         }
                     }
                 }
@@ -326,9 +377,11 @@ fn run_loop(term: &mut terminal::Term, app: &mut App) -> anyhow::Result<LoopExit
                 let area = ratatui::layout::Rect::new(0, 0, size.width, size.height);
                 let regions = layout::compute(area, app.focus);
                 if let Some(effect) = tui_event::handle_mouse(app, mouse, &regions) {
-                    if !apply_effect(app, effect, &runner, &resolved, &warmer) {
+                    if let Control::Exit(exit) =
+                        apply_effect(app, effect, &runner, &resolved, &warmer, sink)
+                    {
                         warmer.cancel();
-                        return Ok(LoopExit::Quit);
+                        return Ok(exit);
                     }
                 }
             }
@@ -349,27 +402,37 @@ fn run_loop(term: &mut terminal::Term, app: &mut App) -> anyhow::Result<LoopExit
         // map lookup that returns `None` unless the mode is on and this
         // node is genuinely unfetched.
         if let Some(effect) = app.raw_fetch_needed() {
-            if !apply_effect(app, effect, &runner, &resolved, &warmer) {
+            if let Control::Exit(exit) =
+                apply_effect(app, effect, &runner, &resolved, &warmer, sink)
+            {
                 warmer.cancel();
-                return Ok(LoopExit::Quit);
+                return Ok(exit);
             }
         }
     }
 }
 
-/// Apply an [`Effect`] produced by the event layer. Returns `false` if the
-/// app should quit.
+/// Apply an [`Effect`] produced by the event layer, saying whether the
+/// loop should keep going.
 fn apply_effect(
     app: &mut App,
     effect: Effect,
     runner: &Arc<Runner>,
     resolved: &mandible_extract::ResolvedTool,
     warmer: &Warmer,
-) -> bool {
+    sink: terminal::Sink,
+) -> Control {
     match effect {
-        Effect::Quit => return false,
+        Effect::Quit => return Control::Exit(LoopExit::Quit),
+        // The composed line is carried out of the loop rather than printed
+        // here: the terminal is still in raw mode and on the alternate
+        // screen at this point, and `run` prints it once both are undone.
+        Effect::PrintSelection(line) => return Control::Exit(LoopExit::PrintSelection(line)),
         Effect::Copy(text) => {
-            let status = match clipboard::copy(&text) {
+            // To `sink`, not to stdout: the OSC-52 fallback writes an
+            // escape sequence, and under `--print-selection` stdout is the
+            // line the calling shell will run.
+            let status = match clipboard::copy(&text, sink) {
                 Ok(()) => format!("copied: {text}"),
                 Err(_) => format!("copy failed (clipboard unavailable): {text}"),
             };
@@ -438,7 +501,7 @@ fn apply_effect(
             app.set_raw_help(path, result);
         }
     }
-    true
+    Control::Continue
 }
 
 /// Queue the root for a background fill, which is what starts the cascade
@@ -526,7 +589,7 @@ mod tests {
             "App::new must never read config.toml itself"
         );
 
-        let wired = new_app("git".to_string(), stub());
+        let wired = new_app("git".to_string(), stub(), terminal::Sink::Stdout);
         assert!(
             !wired.horizontal_scroll_enabled,
             "new_app must apply the real config.toml"
@@ -543,7 +606,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var(CONFIG_DIR_ENV, dir.path());
 
-        let app = new_app("git".to_string(), stub());
+        let app = new_app("git".to_string(), stub(), terminal::Sink::Stdout);
         assert!(app.horizontal_scroll_enabled);
 
         std::env::remove_var(CONFIG_DIR_ENV);

--- a/mandible/src/cli.rs
+++ b/mandible/src/cli.rs
@@ -1,5 +1,6 @@
 //! Command-line argument parsing.
 
+use crate::shell_init::ShellInit;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -35,6 +36,31 @@ pub struct Cli {
     /// ~/.zfunc/_mandible`).
     #[arg(long, value_name = "SHELL")]
     pub completions: Option<clap_complete::Shell>,
+
+    /// Browse as usual, but make `Enter` print the selected command (plus
+    /// the selected flag, if search landed on one) to stdout and exit,
+    /// instead of expanding the row. The TUI itself draws on stderr, so
+    /// stdout carries the composed line and nothing else — which is what
+    /// lets a shell binding put it on the prompt, ready to edit:
+    /// `mandible --shell-init bash` prints one.
+    ///
+    /// Nothing is printed if you quit instead (`q`, `Ctrl-C`), so the
+    /// binding leaves the line alone. `→`/`l` still expand.
+    #[arg(long, conflicts_with_all = ["doctor", "report", "review", "completions", "shell_init"])]
+    pub print_selection: bool,
+
+    /// Print the shell integration for SHELL (`bash` or `zsh`) to stdout
+    /// and exit: a widget that opens `mandible --print-selection` on the
+    /// word already on your command line and replaces the line with what
+    /// you select. Add `eval "$(mandible --shell-init bash)"` to your
+    /// shell's rc file.
+    ///
+    /// Emitted by the binary rather than installed as a file, for the same
+    /// reason `--completions` is (spec §15): one generator, so no packaging
+    /// channel can ship a snippet that disagrees with the flags this
+    /// version has.
+    #[arg(long, value_name = "SHELL")]
+    pub shell_init: Option<ShellInit>,
 
     /// Review `<dir>/<SEED>.toml`'s pending entries (`xtask audit sample`'s
     /// output) one at a time, inside the real TUI: each tool opens exactly

--- a/mandible/src/main.rs
+++ b/mandible/src/main.rs
@@ -10,9 +10,11 @@ mod cli;
 mod doctor;
 mod pipeline;
 mod report;
+mod shell_init;
 
 use clap::{CommandFactory, Parser};
 use cli::Cli;
+use mandible_tui::terminal::Sink;
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -30,8 +32,13 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if let Some(shell) = cli.shell_init {
+        print!("{}", shell.snippet());
+        return Ok(());
+    }
+
     if let Some(seed) = cli.review {
-        if !mandible_tui::terminal::stdout_is_tty() {
+        if !Sink::Stdout.is_tty() {
             anyhow::bail!(
                 "mandible --review requires an interactive terminal (stdout is not a tty)."
             );
@@ -51,7 +58,16 @@ fn main() -> anyhow::Result<()> {
     // the binary's own `--help`. Self-introspection is still available
     // through `mandible --doctor mandible`, which runs the real pipeline
     // against it — the form anyone actually wants for that purpose.
-    if cli.doctor.is_none() && cli.report.is_none() && tool == env!("CARGO_PKG_NAME") {
+    //
+    // Not under `--print-selection`, where stdout belongs to the calling
+    // shell: an easter egg printed there would be handed to the user as a
+    // command to run. In that mode mandible is a tool like any other, and
+    // browsing it composes `mandible` like browsing any other name does.
+    if cli.doctor.is_none()
+        && cli.report.is_none()
+        && !cli.print_selection
+        && tool == env!("CARGO_PKG_NAME")
+    {
         about::print();
         return Ok(());
     }
@@ -93,9 +109,29 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    if !mandible_tui::terminal::stdout_is_tty() {
+    // Which stream the UI is drawn on, decided once here and carried
+    // everywhere that touches the terminal (`mandible_tui::terminal::Sink`).
+    // Under `--print-selection` stdout is the calling shell's, so the UI
+    // moves to stderr and stdout carries the composed command and nothing
+    // else.
+    let sink = if cli.print_selection {
+        Sink::Stderr
+    } else {
+        Sink::Stdout
+    };
+
+    if !sink.is_tty() {
+        let stream = sink.name();
+        if cli.print_selection {
+            anyhow::bail!(
+                "mandible --print-selection draws on stderr, and {stream} is not a tty. \
+                 Run it with stderr attached to your terminal — \
+                 `sel=$(mandible --print-selection {tool})` does that, and \
+                 `mandible --shell-init bash` prints a binding that does it for you."
+            );
+        }
         anyhow::bail!(
-            "mandible requires an interactive terminal (stdout is not a tty). \
+            "mandible requires an interactive terminal ({stream} is not a tty). \
              Try running it directly in a terminal, or use `mandible --doctor {tool}` \
              for a non-interactive report."
         );
@@ -119,7 +155,8 @@ fn main() -> anyhow::Result<()> {
         );
     }
     let stub = mandible_core::CommandNode::new(tool.clone(), mandible_core::Provenance::default());
-    let app = app_runner::new_app(tool, stub);
+    let mut app = app_runner::new_app(tool, stub, sink);
+    app.print_selection = cli.print_selection;
 
-    app_runner::run(app)
+    app_runner::run(app, sink)
 }

--- a/mandible/src/shell_init.rs
+++ b/mandible/src/shell_init.rs
@@ -1,0 +1,73 @@
+//! `mandible --shell-init <shell>`: the snippet that turns
+//! `--print-selection` into a key on the user's prompt.
+//!
+//! A TUI cannot type into the shell that launched it, so the handoff is the
+//! one every picker uses: the shell runs mandible in a command
+//! substitution, mandible draws on stderr and prints the composed command
+//! on stdout, and the shell's own line editor puts that line where the
+//! cursor is. bash does it through `READLINE_LINE`/`READLINE_POINT` in a
+//! `bind -x` function; zsh through `BUFFER`/`CURSOR` in a zle widget.
+//!
+//! The snippets are files in `packaging/shell/`, compiled in with
+//! `include_str!` and printed by the binary rather than installed to a
+//! path. That is spec §15's completions rule applied to the same problem:
+//! one generator, so no packaging channel can ship a snippet that
+//! disagrees with the flags the installed binary actually has, and
+//! `cargo install` users get it without any packaging at all.
+
+use clap::ValueEnum;
+
+/// A shell `--shell-init` can emit an integration for.
+///
+/// Deliberately not `clap_complete::Shell`: that enum names every shell
+/// clap can complete for, and this flag can only honestly offer the ones
+/// with a snippet written and tested for them. Offering `fish` in the help
+/// text and printing nothing for it would be worse than not offering it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ShellInit {
+    /// bash 4.0 or newer (`READLINE_LINE` in a `bind -x` function).
+    Bash,
+    /// zsh (`BUFFER` in a zle widget).
+    Zsh,
+}
+
+impl ShellInit {
+    /// The snippet to print, verbatim.
+    pub fn snippet(self) -> &'static str {
+        match self {
+            ShellInit::Bash => include_str!("../../packaging/shell/mandible.bash"),
+            ShellInit::Zsh => include_str!("../../packaging/shell/mandible.zsh"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each snippet has to actually edit its shell's line buffer — the
+    /// whole point of the handoff — and each has to invoke the mode that
+    /// makes the composed line the only thing on stdout. A snippet that
+    /// called plain `mandible <tool>` would hang the shell on a UI whose
+    /// output it was capturing.
+    #[test]
+    fn each_snippet_edits_its_shells_line_buffer_through_print_selection() {
+        for (shell, buffer, cursor) in [
+            (ShellInit::Bash, "READLINE_LINE", "READLINE_POINT"),
+            (ShellInit::Zsh, "BUFFER", "CURSOR"),
+        ] {
+            let snippet = shell.snippet();
+            assert!(snippet.contains("mandible --print-selection"), "{shell:?}");
+            assert!(snippet.contains(buffer), "{shell:?} must set {buffer}");
+            assert!(snippet.contains(cursor), "{shell:?} must set {cursor}");
+        }
+    }
+
+    /// Both snippets bind the same key, so the two rc files a user might
+    /// have do not disagree about how to reach the same feature.
+    #[test]
+    fn both_snippets_bind_the_same_key() {
+        assert!(ShellInit::Bash.snippet().contains(r#""\C-xm""#));
+        assert!(ShellInit::Zsh.snippet().contains("'^Xm'"));
+    }
+}

--- a/mandible/tests/shell_handoff_cli.rs
+++ b/mandible/tests/shell_handoff_cli.rs
@@ -1,0 +1,164 @@
+//! `--print-selection` and `--shell-init` at the process boundary, which
+//! is the only place the promise they make can be checked: **stdout
+//! carries the composed selection and nothing else.**
+//!
+//! Everything here runs the real binary with stdout on a pipe — the shape
+//! the shell binding uses (`sel=$(mandible --print-selection git)`) — so a
+//! byte written to stdout by any path lands where the test can see it.
+//! What these cannot do is drive the UI: this sandbox has no tty
+//! (AGENTS.md §3.2), and `--print-selection` refuses without one. That
+//! half is verified through `scripts/pty_screenshot.py`, and the
+//! composition itself is unit-tested in `mandible-tui`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn mandible() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_mandible"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("the mandible crate has a parent workspace dir")
+        .to_path_buf()
+}
+
+/// Refusing is fine; refusing *onto stdout* is not. Whatever the mode has
+/// to say about a missing terminal goes to stderr, because a shell binding
+/// puts stdout on the user's prompt and running it.
+#[test]
+fn a_refusal_leaves_stdout_empty_and_explains_itself_on_stderr() {
+    let out = mandible()
+        .args(["--print-selection", "git"])
+        .output()
+        .expect("failed to run mandible");
+
+    assert!(!out.status.success(), "expected a non-zero exit");
+    assert_eq!(
+        out.stdout,
+        b"",
+        "stdout must stay empty: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("stderr is not a tty"),
+        "the message must name the stream it needs: {stderr:?}"
+    );
+}
+
+/// `mandible mandible` is an about screen printed to stdout. Under
+/// `--print-selection` stdout belongs to the calling shell, so the easter
+/// egg must not fire there — a binding invoked on the word `mandible`
+/// would otherwise hand the user an ASCII banner to run.
+#[test]
+fn the_about_screen_never_reaches_a_print_selection_stdout() {
+    let plain = mandible()
+        .arg("mandible")
+        .output()
+        .expect("failed to run mandible");
+    assert!(
+        !plain.stdout.is_empty(),
+        "precondition: `mandible mandible` prints the about screen"
+    );
+
+    let piped = mandible()
+        .args(["--print-selection", "mandible"])
+        .output()
+        .expect("failed to run mandible");
+    assert_eq!(
+        piped.stdout,
+        b"",
+        "stdout must stay empty: {:?}",
+        String::from_utf8_lossy(&piped.stdout)
+    );
+}
+
+/// The diagnostic flags all print to stdout, so combining one with
+/// `--print-selection` would put a diagnostic dump where a command line
+/// belongs. Refused by clap rather than left to surprise someone.
+#[test]
+fn print_selection_refuses_to_share_stdout_with_a_diagnostic() {
+    for other in [
+        vec!["--doctor", "git"],
+        vec!["--report", "git"],
+        vec!["--completions", "bash"],
+        vec!["--shell-init", "bash"],
+        vec!["--review", "1"],
+    ] {
+        let out = mandible()
+            .arg("--print-selection")
+            .args(&other)
+            .output()
+            .expect("failed to run mandible");
+        assert!(
+            !out.status.success(),
+            "{other:?} should conflict with --print-selection"
+        );
+        assert!(
+            out.stdout.is_empty(),
+            "{other:?}: stdout must stay empty, got {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+    }
+}
+
+/// Without the flag, a non-tty stdout still gets the message it always
+/// got. The mode is opt-in, including in how it fails.
+#[test]
+fn the_default_refusal_is_unchanged() {
+    let out = mandible().arg("git").output().expect("failed to run");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("mandible requires an interactive terminal (stdout is not a tty)"),
+        "{stderr:?}"
+    );
+}
+
+/// The snippets are shell code, and a snippet that does not parse is a
+/// broken rc file for everyone who evaluated it. `bash -n` is the check
+/// the shell itself would do.
+#[test]
+fn the_bash_snippet_parses_as_bash() {
+    let out = mandible()
+        .args(["--shell-init", "bash"])
+        .output()
+        .expect("failed to run mandible");
+    assert!(out.status.success());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("mandible.bash");
+    std::fs::write(&path, &out.stdout).expect("write snippet");
+
+    let check = Command::new("bash")
+        .arg("-n")
+        .arg(&path)
+        .output()
+        .expect("failed to run bash -n");
+    assert!(
+        check.status.success(),
+        "bash rejected the snippet: {}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+}
+
+/// One generator, spec §15's rule for completions applied to these: what
+/// the binary prints is the file in the repo, byte for byte, so no
+/// packaging channel can ship a snippet that disagrees with it.
+#[test]
+fn each_snippet_is_the_packaged_file_verbatim() {
+    for (shell, file) in [("bash", "mandible.bash"), ("zsh", "mandible.zsh")] {
+        let out = mandible()
+            .args(["--shell-init", shell])
+            .output()
+            .expect("failed to run mandible");
+        assert!(out.status.success(), "{shell}");
+        let packaged = std::fs::read(repo_root().join("packaging/shell").join(file))
+            .unwrap_or_else(|e| panic!("reading packaging/shell/{file}: {e}"));
+        assert_eq!(
+            out.stdout, packaged,
+            "`--shell-init {shell}` must print packaging/shell/{file} verbatim"
+        );
+    }
+}

--- a/mandible/tests/shell_handoff_cli.rs
+++ b/mandible/tests/shell_handoff_cli.rs
@@ -154,10 +154,13 @@ fn each_snippet_is_the_packaged_file_verbatim() {
             .output()
             .expect("failed to run mandible");
         assert!(out.status.success(), "{shell}");
-        let packaged = std::fs::read(repo_root().join("packaging/shell").join(file))
+        // Compared as text, not as bytes: a mismatch here is read by a
+        // human, and two 1 KB byte vectors in an assertion message are not.
+        let printed = String::from_utf8(out.stdout).expect("the snippet is UTF-8");
+        let packaged = std::fs::read_to_string(repo_root().join("packaging/shell").join(file))
             .unwrap_or_else(|e| panic!("reading packaging/shell/{file}: {e}"));
         assert_eq!(
-            out.stdout, packaged,
+            printed, packaged,
             "`--shell-init {shell}` must print packaging/shell/{file} verbatim"
         );
     }

--- a/packaging/mandible.1
+++ b/packaging/mandible.1
@@ -18,6 +18,14 @@ mandible \- a universal, interactive TUI reference for CLI tools
 .I SHELL
 .br
 .B mandible
+.B \-\-print\-selection
+.I TOOL
+.br
+.B mandible
+.B \-\-shell\-init
+.I SHELL
+.br
+.B mandible
 .RB [ \-h | \-\-help ]
 .RB [ \-V | \-\-version ]
 .SH DESCRIPTION
@@ -37,7 +45,9 @@ never executes
 itself, and never runs the command you're looking up. Its job ends the
 moment you have found the right flag and can copy its exact spelling
 with
-.BR y .
+.BR y ,
+or hand the composed command to your shell to edit with
+.BR \-\-print\-selection .
 .PP
 Structure and descriptions are assembled from whichever of several
 extraction tiers apply to
@@ -103,6 +113,42 @@ mandible \-\-completions zsh > ~/.zfunc/_mandible
 .fi
 .RE
 .TP
+.B \-\-print\-selection
+Browse as usual, but make
+.B Enter
+print the selected command \(em plus the selected flag, when search
+landed on one \(em to stdout and exit, instead of expanding the row.
+The TUI draws on stderr in this mode, so stdout carries the composed
+line and nothing else, which is what lets a shell put it on the prompt
+ready to edit. Quitting with
+.B q
+or
+.B Ctrl\-C
+prints nothing, leaving the line alone.
+.B Right arrow
+and
+.B l
+still expand.
+.TP
+.B \-\-shell\-init \fISHELL\fR
+Print the shell integration for
+.I SHELL
+.RB ( bash
+or
+.BR zsh )
+to stdout and exit: a widget that opens
+.B \-\-print\-selection
+on the word already on your command line and replaces the line with
+what you select, bound to
+.BR "Ctrl\-X m" .
+Add it to your shell's rc file:
+.RS
+.PP
+.nf
+eval "$(mandible \-\-shell\-init bash)"
+.fi
+.RE
+.TP
 .B \-h\fR,\fB \-\-help
 Print help and exit.
 .TP
@@ -117,6 +163,10 @@ Move the tree selection.
 .TP
 .BR "Right arrow" ", " Enter ", " l
 Expand the selected node (extracting its children on first expand).
+Under
+.BR \-\-print\-selection ,
+.B Enter
+prints the selection and exits instead; the other two still expand.
 .TP
 .BR "Left arrow" ", " h
 Collapse the selected node, or jump to its parent if already collapsed.

--- a/packaging/shell/mandible.bash
+++ b/packaging/shell/mandible.bash
@@ -1,0 +1,35 @@
+# mandible shell integration for bash.
+#
+#   eval "$(mandible --shell-init bash)"     # in ~/.bashrc
+#
+# Type a tool name, press Ctrl-X m, browse, press Enter: the command you
+# selected replaces the line, ready to edit. Quit with q or Ctrl-C and the
+# line is left exactly as it was.
+#
+# Requires bash 4.0 or newer: READLINE_LINE and READLINE_POINT are how a
+# `bind -x` function edits the line being typed, and they arrived in 4.0.
+
+_mandible_widget() {
+  local tool selection
+  # The first word of the line names the tool to open. Whatever else is
+  # already typed is replaced by what comes back, which is the point: this
+  # hands you a command to edit, not a fragment to splice into one.
+  tool=${READLINE_LINE%%[[:space:]]*}
+  [[ -n $tool ]] || return 0
+  # `</dev/tty` because a widget can run with stdin somewhere else. The UI
+  # draws on stderr, so the only thing arriving here is the selection --
+  # and nothing arrives at all if the user quit instead of choosing.
+  selection=$(mandible --print-selection -- "$tool" </dev/tty) || return 0
+  [[ -n $selection ]] || return 0
+  READLINE_LINE=$selection
+  READLINE_POINT=${#READLINE_LINE}
+}
+
+# Ctrl-X is readline's own extension prefix, so `\C-xm` takes nothing that
+# was already bound. To move it, bind your own key to the same function.
+# Bound in both keymaps so a vi-mode user gets it in insert mode too; only
+# in an interactive shell, since `bind` has nothing to bind in any other.
+if [[ $- == *i* ]]; then
+  bind -m emacs-standard -x '"\C-xm": _mandible_widget'
+  bind -m vi-insert -x '"\C-xm": _mandible_widget'
+fi

--- a/packaging/shell/mandible.zsh
+++ b/packaging/shell/mandible.zsh
@@ -1,0 +1,29 @@
+# mandible shell integration for zsh.
+#
+#   eval "$(mandible --shell-init zsh)"      # in ~/.zshrc
+#
+# Type a tool name, press Ctrl-X m, browse, press Enter: the command you
+# selected replaces the line, ready to edit. Quit with q or Ctrl-C and the
+# line is left exactly as it was.
+
+_mandible_widget() {
+  local tool selection
+  # `${(z)BUFFER}` splits the line the way the shell itself would, so a
+  # quoted or escaped first word arrives whole rather than in pieces.
+  tool=${${(z)BUFFER}[1]}
+  [[ -n $tool ]] || return 0
+  # `</dev/tty` because a widget can run with stdin somewhere else. The UI
+  # draws on stderr, so the only thing arriving here is the selection --
+  # and nothing arrives at all if the user quit instead of choosing.
+  selection=$(mandible --print-selection -- "$tool" </dev/tty) || return 0
+  [[ -n $selection ]] || return 0
+  BUFFER=$selection
+  CURSOR=${#BUFFER}
+  # The TUI left the alternate screen; this puts the prompt back under it.
+  zle reset-prompt
+}
+
+zle -N _mandible_widget
+# Ctrl-X is the conventional extension prefix, so `^Xm` takes nothing that
+# was already bound. To move it, `bindkey` your own key to _mandible_widget.
+bindkey '^Xm' _mandible_widget

--- a/spec.md
+++ b/spec.md
@@ -133,7 +133,7 @@ users actually need — the tree is for structure, search is for flags.
 | Key | Action |
 |---|---|
 | `↑`/`↓`, `k`/`j` | Move tree selection |
-| `→`/`Enter`/`l` | Expand (triggers lazy extraction if the subtree is unfilled) |
+| `→`/`Enter`/`l` | Expand (triggers lazy extraction if the subtree is unfilled). `Enter` accepts instead under `--print-selection`, below |
 | `←`/`h` | Collapse, or jump to parent if already collapsed |
 | `/` | Focus search |
 | `Esc` | Leave search, **keeping** the filter pinned; `Esc` again clears it |
@@ -166,6 +166,38 @@ staleness argument that removed the cache (§11). Rule 0 of §6 applies unchange
 `pkill --help` is shown, because that shape is measured harmless, but an
 interactive request does not widen what may be run — `pkill something --help`
 stays refused here exactly as it is in the extraction pipeline.
+
+**Handing the command over: `--print-selection`.** The journey `y` serves ends
+at the prompt, and the clipboard is one paste short of it. `mandible
+--print-selection <tool>` browses identically, except that `Enter` **accepts**:
+it prints the selected node's full command path — plus the selected flag's
+spelling, when search landed on one — to stdout, and exits. `→`/`l` still
+expand, so nothing becomes unreachable; `q`/`Ctrl-C` still quit, printing
+nothing at all, which is what leaves a shell binding's line untouched. Without
+the flag `Enter` is one of the three expand keys, unchanged.
+
+A TUI cannot type into the shell that launched it, so the shell reads the line
+back through a command substitution and puts it on its own prompt. That is what
+requires stdout to carry the composed line **and nothing else**, which in turn
+is a property of the whole program rather than of the renderer: the UI draws on
+**stderr** in this mode, and everything else that touches the terminal — the
+OSC-52 clipboard fallback, and the "is anything a terminal at the other end"
+half of the color check — is asked of the same stream the UI is drawn on
+(`mandible-tui`'s `terminal::Sink`). A stray escape sequence on stdout here is
+not a cosmetic defect; it is a corrupted command on someone's prompt.
+
+The spelling composed is the long one where the tool documents one, else the
+short letter, and always the affirmative form — `--color`, never the
+un-runnable `--[no-]color`, which documents two spellings rather than being one.
+No value placeholder is appended: the line is handed over to be *edited*, and a
+literal `FILE` in it is worse than a flag left unfinished.
+
+`mandible --shell-init bash|zsh` prints the binding that closes the loop: for
+bash a `bind -x` function assigning `READLINE_LINE`/`READLINE_POINT`, for zsh a
+zle widget assigning `BUFFER`/`CURSOR`, both on `Ctrl-X m` — readline's own
+extension prefix, which takes no key either shell had already bound. It reads
+the first word already on the line as the tool to open, and replaces the line
+with what comes back.
 
 ---
 
@@ -3869,7 +3901,8 @@ spec.md            This document
 .github/workflows/ ci.yml (fmt, clippy -D warnings, test, coverage-harness diff),
                    release.yml (tagged cross-platform binaries)
 xtask/             coverage harness, vendoring, packaging
-packaging/         debian/, rpm/, mandible.1 (man page for mandible itself)
+packaging/         debian/, rpm/, shell/ (the --shell-init snippets),
+                   mandible.1 (man page for mandible itself)
 ```
 
 **Cargo metadata.** Every crate carries `description`, `license`, `repository`,
@@ -3893,6 +3926,16 @@ the relationship clear.
   Fedora, where `vendor-completions` is. Every channel generates them from the
   built binary's own `--completions <shell>`, so there is one generator and no
   packaging path that can install a file the shell will not find.
+- The shell integration (§2's `--print-selection` binding) ships the same way
+  and is installed to no path at all: `mandible --shell-init <shell>` prints it,
+  from a snippet in `packaging/shell/` compiled into the binary, and the user
+  opts in with `eval "$(mandible --shell-init bash)"` in their rc file. The
+  one-generator rule applies for the same reason it does to completions — a
+  snippet that names flags the installed binary does not have is worse than no
+  snippet — but the *install* half does not: no shell auto-loads a key binding
+  the way it auto-loads completions, and a package that bound `Ctrl-X m` for
+  every user of a machine would be taking a key nobody asked it to. So every
+  channel is consistent by construction, because none of them install a file.
 - `cargo-deb` and `cargo-generate-rpm` metadata live in `mandible/Cargo.toml`.
 - Respect `$XDG_CACHE_HOME`/`$XDG_CONFIG_HOME`; never write outside them.
 


### PR DESCRIPTION
Stage 1 of #40.

- **`--print-selection`**: browse as usual; `Enter` composes the selection (command path, plus the selected flag's preferred spelling — long where documented, affirmative always: `--amend`, never `--[no-]amend`) and prints it to stdout. The UI draws on stderr through a startup-chosen sink, so stdout carries the selection and nothing else — proven with a real-pty pipe test (`cat -A` shows exactly `git commit --amend\n`). Threading the sink surfaced and fixed two latent stdout bugs: clipboard OSC-52 escapes and color detection both asked the wrong stream.
- **`--shell-init bash|zsh`**: prints the binding snippet (`Ctrl-X m`; `READLINE_LINE` / zle `BUFFER`). Opt-in via `eval "$(mandible --shell-init bash)"` — deliberately no packaged file on any channel: unlike completions, no shell auto-loads keybindings, and a package shouldn't take a key nobody asked it to.
- Default behavior byte-identical without the flag — pinned by tests.

Out of scope, by the staged plan: value placeholders and spelling preference (stage 2), multi-select (stage 3), fish (flagged, not half-shipped).

Gates: nextest 1332/1332, corpus 113 byte-identical, fmt/clippy clean (incl. aarch64-apple-darwin), 7 §3.4 plants each with a named red test. All commits GPG-signed.