### PR TITLE
fix: three handoff/exit UX defects (search Enter, bare help, mouse litter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- Quitting while moving the mouse no longer leaves fragments of mouse reports (`35;35;6M…`) on the shell prompt: the terminal processes the disable-mouse-capture sequence asynchronously, so reports could still arrive after the single zero-timeout drain had found an empty queue and given up, and the drain now waits up to 25ms per poll for one more report, ending at the first empty poll and capped at 250ms in total so exit can never turn into a wait.
+
 - `mandible` with no arguments now prints the program's real help — clap's own generated usage, arguments and every flag — instead of a single `Error: usage: mandible <tool> (or: …)` line that named three modes and no flags; it goes to stderr and still exits non-zero, because nothing was asked for, while `-h`/`--help` keep printing to stdout and exiting zero.
 
 - `mandible --print-selection` no longer spends the search box's `Enter` on printing: while the search box has focus `Enter` means what it means without the flag — commit the query, move focus to the tree, keep the filter — and the selection is printed by `Enter` from the tree or detail pane, so the mode changes what accepting does without leaving `Esc`, which clears the filter on a second press, as the only way out of the search box.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- `mandible` with no arguments now prints the program's real help — clap's own generated usage, arguments and every flag — instead of a single `Error: usage: mandible <tool> (or: …)` line that named three modes and no flags; it goes to stderr and still exits non-zero, because nothing was asked for, while `-h`/`--help` keep printing to stdout and exiting zero.
+
 - `mandible --print-selection` no longer spends the search box's `Enter` on printing: while the search box has focus `Enter` means what it means without the flag — commit the query, move focus to the tree, keep the filter — and the selection is printed by `Enter` from the tree or detail pane, so the mode changes what accepting does without leaving `Esc`, which clears the filter on a second press, as the only way out of the search box.
 
 - `[ui] horizontal_scroll = false` now wraps the raw `--help` view (`t`) and the `unparsed` fallback instead of quietly cutting every line at the pane's edge: with sideways scrolling off there was no key that could reach the rest and no marker saying it existed, so the one view whose purpose is showing what the tool printed was the one losing it — a line that fits still arrives byte for byte, a longer one keeps the author's interior columns and its own indent on the rows it continues onto, breaks at a space where there is one and between characters where there is not, and the default `true` (sideways scrolling with `←`/`→`/`h`/`l`) is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- `mandible --print-selection` no longer spends the search box's `Enter` on printing: while the search box has focus `Enter` means what it means without the flag — commit the query, move focus to the tree, keep the filter — and the selection is printed by `Enter` from the tree or detail pane, so the mode changes what accepting does without leaving `Esc`, which clears the filter on a second press, as the only way out of the search box.
+
 - `[ui] horizontal_scroll = false` now wraps the raw `--help` view (`t`) and the `unparsed` fallback instead of quietly cutting every line at the pane's edge: with sideways scrolling off there was no key that could reach the rest and no marker saying it existed, so the one view whose purpose is showing what the tool printed was the one losing it — a line that fits still arrives byte for byte, a longer one keeps the author's interior columns and its own indent on the rows it continues onto, breaks at a space where there is one and between characters where there is not, and the default `true` (sideways scrolling with `←`/`→`/`h`/`l`) is unchanged.
 
 - The `y` clipboard fallback and the "is anything a terminal at the other end" colour check now both address the stream the UI is actually drawn on rather than reaching for stdout on their own, so the OSC-52 escape sequence can no longer be written into output another program is reading and a session whose stdout is redirected is no longer rendered monochrome while its terminal sits on stderr; a source lint keeps every path to a terminal inside `mandible-tui`'s one terminal module.

--- a/mandible-tui/src/event.rs
+++ b/mandible-tui/src/event.rs
@@ -50,17 +50,13 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
 fn handle_search_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
     match key.code {
         KeyCode::Esc => app.escape_search(),
-        // In `--print-selection` mode Enter accepts from the search box
-        // too, because that is where the flag journey ends: type part of a
-        // flag's name, the top hit selects its parent command and points
-        // the detail pane at the flag, and Enter hands the composed line
-        // back to the shell. Making it mean "move focus to the tree" there
-        // would put a second Enter between the user and the thing they came
-        // for. `Esc` still moves focus out while keeping the filter, which
-        // is what anyone who wanted the other meaning is reaching for.
-        KeyCode::Enter if app.print_selection => {
-            return app.selection_command().map(Effect::PrintSelection)
-        }
+        // Enter means what it means without `--print-selection` here: it
+        // commits the query and moves focus to the tree, keeping the filter
+        // (spec §2). Accepting from the box instead took the only key that
+        // closes search focus and left `Esc` — which also clears on a
+        // second press — as the only way out, so the mode changed how
+        // *searching* works rather than only what accepting does. The
+        // accept key is bound to browse focus, not to Enter globally.
         KeyCode::Enter => app.focus = Focus::Tree,
         KeyCode::Backspace => app.search_backspace(),
         // Arrows move the (filtered) tree selection without leaving the
@@ -87,6 +83,9 @@ fn handle_tree_key(app: &mut App, key: KeyEvent) -> Option<Effect> {
         KeyCode::Down | KeyCode::Char('j') => app.move_down(),
         KeyCode::Up | KeyCode::Char('k') => app.move_up(),
         // `--print-selection` only: Enter accepts the selection and quits.
+        // Bound here rather than in `handle_key` so accepting is a property
+        // of *browse* focus: while the search box has focus Enter keeps its
+        // ordinary meaning, and the mode changes only what accepting does.
         // Guarded rather than folded into the arm below so that with the
         // mode off this function is byte-for-byte the one that shipped —
         // `→`, `Enter` and `l` all expand, exactly as spec §2's table says.
@@ -225,6 +224,21 @@ mod tests {
         App::new("git".to_string(), root)
     }
 
+    /// A tree whose one subcommand carries one flag, for the tests that
+    /// compose a whole `--print-selection` line.
+    fn flag_app() -> App {
+        let mut root = CommandNode::new("git", Provenance::single(Source::HelpText));
+        let mut commit = CommandNode::new("commit", Provenance::single(Source::HelpText));
+        commit.entities.push(mandible_core::Entity::flag_long(
+            "amend",
+            Provenance::single(Source::HelpText),
+        ));
+        root.subcommands.push(commit);
+        let mut a = App::new("git".to_string(), root);
+        a.ensure_rows_fresh();
+        a
+    }
+
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
@@ -352,36 +366,50 @@ mod tests {
         );
     }
 
-    /// The end of the flag journey: search puts the tree on the flag's
-    /// parent command and remembers the flag (`App`'s own tests cover that
-    /// half), and `Enter` accepts from inside the search box — without the
-    /// detour through the tree an ordinary session takes, since that would
-    /// put a second `Enter` between the user and the thing they came for.
+    /// Accepting is bound to *browse* focus, not to `Enter` globally: with
+    /// the search box focused, `Enter` under `--print-selection` does what
+    /// it does without the flag — closes search focus, keeps the filter,
+    /// prints nothing. Otherwise the mode takes the only key that leaves
+    /// the box and leaves `Esc` (which clears the filter on a second press)
+    /// as the sole way out, changing how searching works rather than only
+    /// what accepting does.
+    ///
+    /// The second half of the test is the reason the first half is safe:
+    /// one more `Enter`, now from the tree, still accepts and still carries
+    /// the flag search landed on, so the journey ends where it always did.
     #[test]
-    fn enter_accepts_from_the_search_box_and_composes_the_flag() {
-        let mut root = CommandNode::new("git", Provenance::single(Source::HelpText));
-        let mut commit = CommandNode::new("commit", Provenance::single(Source::HelpText));
-        commit.entities.push(mandible_core::Entity::flag_long(
-            "amend",
-            Provenance::single(Source::HelpText),
-        ));
-        root.subcommands.push(commit);
-        let mut a = App::new("git".to_string(), root);
+    fn enter_keeps_its_search_meaning_under_print_selection() {
+        let mut a = flag_app();
         a.print_selection = true;
-        a.ensure_rows_fresh();
         a.select_index(1); // "commit"
         a.selected_flag = Some(mandible_core::FlagKey::Long("amend".to_string()));
 
         a.focus_search();
+        handle_key(&mut a, key(KeyCode::Char('a')));
         assert_eq!(a.focus, Focus::Search);
+
         assert_eq!(
             handle_key(&mut a, key(KeyCode::Enter)),
-            Some(Effect::PrintSelection("git commit --amend".to_string()))
+            None,
+            "Enter in the search box must not print"
+        );
+        assert_eq!(a.focus, Focus::Tree, "Enter closes search focus");
+        assert_eq!(
+            a.active_filter(),
+            Some("a"),
+            "and keeps the filter it committed"
+        );
+
+        assert_eq!(
+            handle_key(&mut a, key(KeyCode::Enter)),
+            Some(Effect::PrintSelection("git commit --amend".to_string())),
+            "Enter from browse focus accepts, flag and all"
         );
     }
 
-    /// …and with the mode off, that same `Enter` still just moves focus to
-    /// the tree, producing no effect at all.
+    /// …and with the mode off, that same `Enter` does exactly the same
+    /// thing, which is the point: the two focus states are indistinguishable
+    /// across the flag.
     #[test]
     fn enter_in_the_search_box_still_moves_focus_by_default() {
         let mut a = app();

--- a/mandible-tui/src/terminal.rs
+++ b/mandible-tui/src/terminal.rs
@@ -26,6 +26,7 @@ use crossterm::terminal::{
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io::{self, IsTerminal, Stderr, Stdout};
+use std::time::{Duration, Instant};
 
 /// A live terminal handle, backed by `crossterm`.
 pub type Term = Terminal<CrosstermBackend<SinkWriter>>;
@@ -122,16 +123,94 @@ pub fn init(sink: Sink) -> io::Result<Term> {
 /// raw*. The original order disabled raw mode first, leaving a window
 /// where the terminal was cooked but still reporting mouse motion — any
 /// movement during quit landed SGR report fragments (`35;24;9M…`) in the
-/// shell's input buffer, echoed after exit as garbage. The drain eats
-/// reports already in flight when the capture-off sequence was written;
-/// `poll` with a zero timeout never blocks, so this is safe even when
-/// [`init`] never got as far as raw mode.
+/// shell's input buffer, echoed after exit as garbage.
+///
+/// The drain eats those reports, and it waits for them rather than
+/// sampling once. The emulator processes the capture-off sequence
+/// asynchronously, so a report can still be on its way *after* the
+/// sequence was written: a zero-timeout drain finds an empty queue,
+/// returns, and the report arrives a millisecond later with nobody left
+/// to read it — the same litter, now from a narrower race. So each poll
+/// is given [`DRAIN_POLL`] to produce something, and the drain ends at
+/// the first poll that comes back empty. [`DRAIN_BUDGET`] caps the whole
+/// thing, because a terminal that never stops talking must not be able to
+/// stop mandible from exiting.
+///
+/// Safe to call when [`init`] never got as far as raw mode: `poll` on a
+/// stream that is not a terminal errors rather than blocking, and an
+/// error ends the drain.
 pub fn restore(sink: Sink) -> io::Result<()> {
     let mut writer = sink.writer();
     execute!(writer, DisableMouseCapture, LeaveAlternateScreen)?;
-    while crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
-        let _ = crossterm::event::read();
-    }
+    drain_pending_input();
     disable_raw_mode()?;
     Ok(())
+}
+
+/// How long one drain poll waits for a report still in transit. Long
+/// enough to cover an emulator's turnaround, short enough to be invisible
+/// on the way out.
+const DRAIN_POLL: Duration = Duration::from_millis(25);
+
+/// The drain's total budget. Quitting is not allowed to become a wait,
+/// however much the terminal has to say.
+const DRAIN_BUDGET: Duration = Duration::from_millis(250);
+
+/// Read and discard input until a poll comes back empty or the budget runs
+/// out. See [`restore`] for why the wait exists.
+fn drain_pending_input() {
+    let started = Instant::now();
+    while let Some(timeout) = drain_poll_timeout(started.elapsed()) {
+        match crossterm::event::poll(timeout) {
+            Ok(true) => {
+                let _ = crossterm::event::read();
+            }
+            // Empty (the drain is done) or no terminal to poll at all.
+            _ => return,
+        }
+    }
+}
+
+/// How long the next drain poll may block: at most [`DRAIN_POLL`], and
+/// never past what is left of [`DRAIN_BUDGET`]. `None` once the budget is
+/// spent, which is what bounds [`drain_pending_input`]'s loop.
+fn drain_poll_timeout(elapsed: Duration) -> Option<Duration> {
+    let left = DRAIN_BUDGET.checked_sub(elapsed)?;
+    if left.is_zero() {
+        return None;
+    }
+    Some(left.min(DRAIN_POLL))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The drain's bound, which is the half no terminal test can check:
+    /// every poll is short, and the sum of them cannot exceed the budget,
+    /// so `restore` returns even against a terminal that never goes quiet.
+    #[test]
+    fn the_drain_is_bounded_by_its_budget() {
+        assert_eq!(drain_poll_timeout(Duration::ZERO), Some(DRAIN_POLL));
+        assert_eq!(
+            drain_poll_timeout(DRAIN_BUDGET - DRAIN_POLL * 2),
+            Some(DRAIN_POLL),
+            "a poll well inside the budget gets a full slice"
+        );
+        assert_eq!(
+            drain_poll_timeout(DRAIN_BUDGET - Duration::from_millis(10)),
+            Some(Duration::from_millis(10)),
+            "the last poll is trimmed to what is left, never rounded up"
+        );
+        assert_eq!(
+            drain_poll_timeout(DRAIN_BUDGET),
+            None,
+            "a spent budget ends the loop"
+        );
+        assert_eq!(
+            drain_poll_timeout(DRAIN_BUDGET * 4),
+            None,
+            "and an overrun does not wrap around into another slice"
+        );
+    }
 }

--- a/mandible/src/main.rs
+++ b/mandible/src/main.rs
@@ -16,6 +16,7 @@ mod shell_init;
 use clap::{CommandFactory, Parser};
 use cli::Cli;
 use mandible_tui::terminal::Sink;
+use std::io::Write;
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -48,10 +49,23 @@ fn main() -> anyhow::Result<()> {
     }
 
     let Some(tool) = cli.target_tool() else {
-        anyhow::bail!(
-            "usage: mandible <tool>  (or: mandible --doctor <tool>, mandible --report <tool>, \
-             mandible --review <seed>)"
-        );
+        // A program whose whole job is showing people help answers a bare
+        // invocation with help, not with a one-line usage string: clap has
+        // already generated the real thing, listing every mode this
+        // paragraph would otherwise have to keep in sync by hand.
+        //
+        // On stderr, and exiting non-zero, because this *is* the error
+        // path — `-h`/`--help` remain the ways to ask for help on stdout,
+        // and nothing that reads mandible's stdout (a shell binding, a
+        // pipe) is handed a screen of text it did not ask for.
+        //
+        // The short line below is what carries the failing exit, since
+        // `std::process::exit` is confined to `mandible-extract/src/exec/`
+        // workspace-wide (see the `--doctor` note further down). It says
+        // only what is missing; the help above it says everything else.
+        let mut cmd = Cli::command();
+        write!(std::io::stderr(), "{}", cmd.render_help())?;
+        anyhow::bail!("no tool given");
     };
     let tool = tool.to_string();
 

--- a/mandible/tests/bare_invocation.rs
+++ b/mandible/tests/bare_invocation.rs
@@ -1,0 +1,73 @@
+//! What `mandible` alone does, checked at the process boundary because
+//! that is where the answer lives: which stream the text lands on and what
+//! the exit status is are properties of the program, not of a function.
+//!
+//! A tool whose whole job is showing people help owes a bare invocation
+//! real help. It used to answer with a single unstructured
+//! `Error: usage: mandible <tool> (or: …)` line, which named three of its
+//! modes and no flags at all.
+
+use std::process::Command;
+
+fn mandible() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_mandible"))
+}
+
+/// Bare `mandible`: clap's own help, on stderr, exiting non-zero.
+///
+/// Non-zero because nothing was asked for — a shell script that runs
+/// `mandible "$1"` with an empty argument must be able to tell that apart
+/// from a successful run. On stderr for the same reason: this is the error
+/// path, and stdout belongs to whoever is reading it (`--print-selection`'s
+/// shell binding most of all).
+#[test]
+fn a_bare_invocation_prints_help_and_fails() {
+    let out = mandible().output().expect("failed to run mandible");
+
+    assert!(!out.status.success(), "expected a non-zero exit");
+    assert_eq!(
+        out.stdout,
+        b"",
+        "stdout must stay empty: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Usage: mandible"),
+        "the generated usage line must be there: {stderr:?}"
+    );
+    // Structure, not a wall of prose: the shape only clap's own renderer
+    // produces, and the flags the hand-written line never mentioned.
+    for expected in ["Arguments:", "Options:", "--doctor", "--print-selection"] {
+        assert!(
+            stderr.contains(expected),
+            "help must contain {expected:?}: {stderr:?}"
+        );
+    }
+    assert!(
+        !stderr.contains("usage: mandible <tool>"),
+        "the old one-line usage string must be gone: {stderr:?}"
+    );
+}
+
+/// Asking for help is still a success on stdout. The fix moves the
+/// *unasked-for* help to the error path; it must not drag `-h` there with
+/// it, which would break anything piping `mandible --help`.
+#[test]
+fn asking_for_help_still_succeeds_on_stdout() {
+    for flag in ["-h", "--help"] {
+        let out = mandible().arg(flag).output().expect("failed to run");
+        assert!(out.status.success(), "{flag} should exit zero");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("Usage: mandible"),
+            "{flag} prints help on stdout: {stdout:?}"
+        );
+        assert!(
+            out.stderr.is_empty(),
+            "{flag}: stderr must stay empty, got {:?}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}

--- a/packaging/mandible.1
+++ b/packaging/mandible.1
@@ -128,7 +128,13 @@ prints nothing, leaving the line alone.
 .B Right arrow
 and
 .B l
-still expand.
+still expand. Accepting belongs to the tree and detail panes: while the
+search bar has focus,
+.B Enter
+does what it does without this flag \(em commits the query, moves focus
+to the tree, keeps the filter \(em and the next
+.B Enter
+prints.
 .TP
 .B \-\-shell\-init \fISHELL\fR
 Print the shell integration for
@@ -166,7 +172,9 @@ Expand the selected node (extracting its children on first expand).
 Under
 .BR \-\-print\-selection ,
 .B Enter
-prints the selection and exits instead; the other two still expand.
+prints the selection and exits instead \(em from the tree or detail
+pane, not from the search bar, where it still just commits the query;
+the other two still expand.
 .TP
 .BR "Left arrow" ", " h
 Collapse the selected node, or jump to its parent if already collapsed.

--- a/spec.md
+++ b/spec.md
@@ -176,6 +176,17 @@ expand, so nothing becomes unreachable; `q`/`Ctrl-C` still quit, printing
 nothing at all, which is what leaves a shell binding's line untouched. Without
 the flag `Enter` is one of the three expand keys, unchanged.
 
+**Accepting is bound to the focus, not to the key.** `Enter` accepts only from
+browse focus — the tree or the detail pane. While the **search box** has focus
+it does exactly what it does without the flag: commits the query, moves focus
+to the tree, keeps the filter. The mode changes what accepting does; it never
+changes how searching works, and a key that is a search box's only commit key
+cannot be spent on something else — reassigning it would leave `Esc`, which
+clears the filter on a second press, as the sole way out of the box. The flag
+journey therefore ends one `Enter` later than the tree selection it made: the
+first closes the search, the second accepts what search landed on, flag
+spelling and all.
+
 A TUI cannot type into the shell that launched it, so the shell reads the line
 back through a command substitution and puts it on its own prompt. That is what
 requires stdout to carry the composed line **and nothing else**, which in turn


### PR DESCRIPTION
Three small UX defects, one branch.

## 1. `Enter` keeps its search meaning under `--print-selection`

`--print-selection` bound the accept action to the **key**, in both
`handle_search_key` and `handle_tree_key`. So with the search box focused,
`Enter` printed and exited — taking the only key that closes search focus and
leaving `Esc`, which clears the filter on a second press, as the only way out.
The mode changed how *searching* works rather than only what accepting does.

Accepting is now bound to the **focus**: it lives in `handle_tree_key`
(and the detail pane) only. In the search box `Enter` does exactly what it does
without the flag — commits the query, moves focus to the tree, keeps the
filter. The flag journey ends one `Enter` later: the first closes the search,
the second accepts what search landed on, flag spelling and all.

`spec.md` §2's `--print-selection` section now states the focus rule, and
`packaging/mandible.1` says it in both places it described `Enter`.

**See it yourself** (in a venv with `pyte` installed):

```console
$ cargo build --release
$ .venv/bin/python scripts/pty_screenshot.py --keys '/amend,zz,<enter>,zz' \
      100 12 ./target/release/mandible --print-selection git
```

The search bar's prompt is the tell — `›` while it has focus, `(filter)` once
it does not:

```
### /amend                     (typing: the box has focus)
│› amend                                          │

### zz                         (still typing into the box)
│› amendzz                                        │

### <enter>                    (focus left the box, filter kept, still running)
│(filter) amendzz                                 │

### zz                         (keys no longer reach the box)
│(filter) amendzz                                 │
```

And the accept path, driving the real shape a shell binding uses (stdout on a
file, UI on the terminal):

```console
$ .venv/bin/python scripts/pty_screenshot.py --keys '/amend,<enter>,<enter>' \
      100 10 /bin/sh -c './target/release/mandible --print-selection git > sel.txt'
$ cat sel.txt
git commit --amend
```

With a single `<enter>` — search focus only — `sel.txt` is 0 bytes and the TUI
is still up (the harness then quits it with `q`, which prints nothing).

**Tests** (`mandible-tui/src/event.rs`):
`enter_keeps_its_search_meaning_under_print_selection` covers both focus
states in one session — `Enter` in the box returns no effect, moves focus,
keeps the filter; the next `Enter` returns
`PrintSelection("git commit --amend")`. The existing browse-focus and
mode-off tests are unchanged.

*Watched it fail (AGENTS §3.4):* re-added the deleted
`KeyCode::Enter if app.print_selection` arm to `handle_search_key` →

```
enter_keeps_its_search_meaning_under_print_selection ... FAILED
assertion `left == right` failed: Enter in the search box must not print
  left: Some(PrintSelection("git commit --amend"))
 right: None
```

Restored; green.

## 2. A bare `mandible` prints real help

`mandible` with no arguments printed one unstructured line:

```
Error: usage: mandible <tool>  (or: mandible --doctor <tool>, mandible --report <tool>, mandible --review <seed>)
```

— which named three of the modes and none of the flags, from a help-text tool.
It now renders clap's own generated help, which lists every argument and flag
and cannot drift from the parser.

To **stderr**, still exiting non-zero: nothing was asked for, so this is the
error path, and stdout stays free for whoever is reading it (a
`--print-selection` binding most of all). `-h`/`--help` are untouched — stdout,
exit zero. The failing exit is carried by a short final line (`Error: no tool
given`) rather than `std::process::exit`, which stays confined to
`mandible-extract/src/exec/` (spec §6, §8) — `no_process_outside_exec` is
green.

**Tests** (`mandible/tests/bare_invocation.rs`, new): a process-boundary test
spawning the binary with no args — non-zero exit, empty stdout, stderr
carrying `Usage: mandible`, `Arguments:`, `Options:`, `--doctor`,
`--print-selection`, and no trace of the old one-line string; plus one that
pins `-h`/`--help` to stdout and exit zero.

*Watched it fail (AGENTS §3.4):* put the old `anyhow::bail!` back →

```
a_bare_invocation_prints_help_and_fails ... FAILED
the generated usage line must be there: "Error: usage: mandible <tool>  (or: …)\n"
```

Restored; green.

## 3. Mouse-report litter on exit

`terminal::restore` disabled mouse capture and then drained pending events with
a single zero-timeout poll loop. The emulator processes the capture-off
sequence asynchronously, so a report can still be in transit *after* the
sequence is written: the drain samples an empty queue, returns, and the report
lands in the shell a moment later as `35;35;6M…` litter. Reproduced by moving
the mouse while quitting.

The drain now waits for those reports instead of sampling once: each poll gets
25ms to produce something and the drain ends at the first poll that comes back
empty, with a 250ms total budget so a terminal that never goes quiet cannot
turn quitting into a wait. `restore`'s doc comment describes the final
behavior, including why a zero-timeout drain is a narrower version of the same
race.

**Verification is by review and by running it in a real terminal** — this
cannot be tested here: there is no tty in the sandbox (AGENTS §3.2), and the
race is between a terminal emulator and a process, which no `TestBackend` can
stand in for. **Manual repro:** open `mandible git`, then press `q` while
moving the mouse over the window; before, that left `35;35;6M`-shaped
fragments on the shell prompt.

What *is* tested is the half that has no terminal in it: `drain_poll_timeout`'s
arithmetic, i.e. that every poll is short and their sum cannot exceed the
budget.

*Watched it fail (AGENTS §3.4):* made `drain_poll_timeout` return
`Some(DRAIN_POLL)` unconditionally — the unbounded drain —

```
the_drain_is_bounded_by_its_budget ... FAILED
assertion `left == right` failed: the last poll is trimmed to what is left, never rounded up
  left: Some(25ms)
 right: Some(10ms)
```

Restored; green.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo nextest run --workspace` (1387 passed, 0 skipped), `cargo
build --release`, `scripts/changelog_guard.sh` — all green. No extraction
change, so the corpus is untouched: `git status` shows no snapshot movement.
One CHANGELOG line per fix under `## [Unreleased]` → `### Fixed`.
