### PR TITLE
fix(sections): label a usage stanza with its own description, not its head line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- A tool that documents each invocation form as a stanza — LVM's `vgchange`, `lvchange` and the rest of the family — now labels each stanza's flags with the description the tool wrote above it, so the dividers read `Activate or deactivate LVs` and `Start the lockspace of a shared VG in lvmlockd` instead of repeating the `Vgchange --lockstart` spelling already printed on the row beneath, and the stanza's head line is kept as a USAGE form rather than lost with the label it used to be; a stanza with no description above it keeps its head line as the label exactly as before (issue #11).
+
 - Quitting while moving the mouse no longer leaves fragments of mouse reports (`35;35;6M…`) on the shell prompt: the terminal processes the disable-mouse-capture sequence asynchronously, so reports could still arrive after the single zero-timeout drain had found an empty queue and given up, and the drain now waits up to 25ms per poll for one more report, ending at the first empty poll and capped at 250ms in total so exit can never turn into a wait.
 
 - `mandible` with no arguments now prints the program's real help — clap's own generated usage, arguments and every flag — instead of a single `Error: usage: mandible <tool> (or: …)` line that named three modes and no flags; it goes to stderr and still exits non-zero, because nothing was asked for, while `-h`/`--help` keep printing to stdout and exiting zero.

--- a/corpus/vgcfgrestore/2.03.16/expected.snap
+++ b/corpus/vgcfgrestore/2.03.16/expected.snap
@@ -1,0 +1,151 @@
+name: vgcfgrestore
+usage:
+- vgcfgrestore -f|--file String VG
+- vgcfgrestore -l|--list VG
+flags:
+- short: 'f'
+  long: file
+  value_name: String
+  value_kind: Required
+  group: Restore VG metadata from specified file.
+  provenance:
+    sources:
+    - help-text
+- short: 'l'
+  long: list
+  value_name: VG
+  value_kind: Required
+  group: List all VG metadata backups.
+  provenance:
+    sources:
+    - help-text
+- short: 'M'
+  long: metadatatype
+  value_name: lvm2
+  value_kind: Required
+  group: 'Common options for command:'
+  provenance:
+    sources:
+    - help-text
+- long: force
+  group: 'Common options for command:'
+  provenance:
+    sources:
+    - help-text
+- short: 'd'
+  long: debug
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'q'
+  long: quiet
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  long: verbose
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  long: yes
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  long: test
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: commandprofile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: config
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: driverloaded
+  value_name: y|n
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nolocking
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: lockopt
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: longhelp
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: profile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: version
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devicesfile
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: devices
+  value_name: PV
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: nohints
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+- long: journal
+  value_name: String
+  value_kind: Required
+  group: 'Common options for lvm:'
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/vgcfgrestore/2.03.16/help.stderr.txt
+++ b/corpus/vgcfgrestore/2.03.16/help.stderr.txt
@@ -1,0 +1,1 @@
+  WARNING: Running as a non-root user. Functionality may be unavailable.

--- a/corpus/vgcfgrestore/2.03.16/help.txt
+++ b/corpus/vgcfgrestore/2.03.16/help.txt
@@ -1,0 +1,44 @@
+  vgcfgrestore - Restore volume group configuration
+
+  Restore VG metadata from last backup.
+  vgcfgrestore VG
+	[ COMMON_OPTIONS ]
+
+  Restore VG metadata from specified file.
+  vgcfgrestore -f|--file String VG
+	[ COMMON_OPTIONS ]
+
+  List all VG metadata backups.
+  vgcfgrestore -l|--list VG
+	[ COMMON_OPTIONS ]
+
+  List one VG metadata backup file.
+  vgcfgrestore -l|--list -f|--file String
+	[ COMMON_OPTIONS ]
+	[ VG ]
+
+  Common options for command:
+	[ -M|--metadatatype lvm2 ]
+	[    --force ]
+
+  Common options for lvm:
+	[ -d|--debug ]
+	[ -h|--help ]
+	[ -q|--quiet ]
+	[ -v|--verbose ]
+	[ -y|--yes ]
+	[ -t|--test ]
+	[    --commandprofile String ]
+	[    --config String ]
+	[    --driverloaded y|n ]
+	[    --nolocking ]
+	[    --lockopt String ]
+	[    --longhelp ]
+	[    --profile String ]
+	[    --version ]
+	[    --devicesfile String ]
+	[    --devices PV ]
+	[    --nohints ]
+	[    --journal String ]
+
+  Use --longhelp to show all options and advanced commands.

--- a/corpus/vgcfgrestore/2.03.16/meta.toml
+++ b/corpus/vgcfgrestore/2.03.16/meta.toml
@@ -1,0 +1,83 @@
+# Regression fixture for the stanza-label rule's **retention** half
+# (fix/11-stanza-label-description, issue #11).
+#
+# `vgchange/2.03.16` pins the relabelling half — six stanzas whose group
+# divider stopped repeating the head line and started reading the tool's
+# own sentence. This tool pins the other direction, which no other
+# fixture reaches: a document whose usage block **never opens at all**,
+# so before this change its `usage` was empty and every stanza head line
+# existed in the tree only as a `group` label.
+#
+# Why the block never opens here: the unlabelled-synopsis entry point
+# (`sections::looks_like_bare_synopsis_head`) needs the line after a bare
+# own-name head to be unambiguous flag-row evidence, and every one of
+# this tool's four stanzas is continued by `[ COMMON_OPTIONS ]` alone — a
+# placeholder, not a flag row (`grammar::looks_like_bracket_flag_row`
+# requires the bracketed content to start with `-`). `vgck`'s first
+# stanza has a real `[ --reportformat basic|json ]` row and so does open
+# the block; this one has nothing but the placeholder, on all four.
+#
+# What the fix changes here, therefore:
+# - `usage` goes from empty to the two stanza heads whose label was
+#   adopted (`vgcfgrestore -f|--file String VG`, `vgcfgrestore -l|--list
+#   VG`), so the head line is not lost to the relabel and the pane grows
+#   a USAGE section it did not have.
+# - `-f`/`--file` and `-l`/`--list` carry their stanza's own sentence as
+#   `group` instead of the head line.
+#
+# Two of the four stanzas are deliberately **not** relabelled, and this
+# fixture pins that too — the strict recognizer's recorded misses:
+# - `vgcfgrestore VG` (stanza 1) names no flag at all, so it is not a
+#   stanza head (`recover_stanza_head_flag`) and "Restore VG metadata
+#   from last backup." is not adopted. That stanza reaches the tree
+#   through no path at all, before this fix or after it — a documented
+#   miss, not a regression, and the honest cost of anchoring the rule on
+#   a head that names its mode.
+# - `vgcfgrestore -l|--list -f|--file String` (stanza 4) names *two*
+#   flags, which `grammar::looks_like_stanza_head_flag` refuses by
+#   construction (it admits exactly one bare flag token), so "List one VG
+#   metadata backup file." is still dropped. Widening that predicate is
+#   not attempted here: it is the same predicate that keeps a worked
+#   example from being mined as a stanza head, and it has its own
+#   measurement.
+#
+# Captured on this machine's real `vgcfgrestore` (lvm2 2.03.16, Ubuntu
+# 24.04): help.txt is the tool's own stdout byte-exact, help.stderr.txt
+# the one non-root warning this environment always emits (stdout is
+# non-empty and help-shaped, so `help_text::pick_stream` reads it and the
+# warning never reaches the tree).
+#
+# Every recovered flag here is undescribed, same as every other LVM
+# fixture: the emitter documents individual flags only under
+# `--longhelp`, so `min_status` is `low-confidence`.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "vgcfgrestore"
+version = "2.03.16"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.5.0"
+
+[[capture]]
+argv = ["vgcfgrestore", "--help"]
+stdout = "help.txt"
+stderr = "help.stderr.txt"
+exit_code = 0
+
+[contract]
+expected_framework = "generic"
+min_status = "low-confidence"
+must_contain_flags = [
+  "-f", "--file",
+  "-l", "--list",
+  "-M", "--metadatatype",
+  "--force",
+  "-d", "--debug",
+  "--commandprofile",
+  "--journal",
+]
+# No `verdict_scope`: this bless is agent-reviewed (read against help.txt
+# above, stanza by stanza), not human-reviewed — see corpus/README.md's
+# "What `--bless` does and does not assert".

--- a/corpus/vgchange/2.03.16/expected.snap
+++ b/corpus/vgchange/2.03.16/expected.snap
@@ -3,6 +3,12 @@ usage:
 - vgchange ( -l|--logicalvolume Number, -p|--maxphysicalvolumes Number, -u|--uuid, -s|--physicalextentsize Size[m|UNIT], -x|--resizeable y|n, --addtag Tag, --deltag Tag, --alloc contiguous|cling|cling_by_tags|normal|anywhere|inherit, --pvmetadatacopies 0|1|2, --vgmetadatacopies all|unmanaged|Number, --profile String, --detachprofile, --metadataprofile String, --setautoactivation y|n ) [ -A|--autobackup y|n ] [ -S|--select String ] [ -f|--force ] [    --poll y|n ] [    --ignoremonitoring ] [    --noudevsync ] [    --reportformat basic|json ] [ COMMON_OPTIONS ] [ VG|Tag|Select ... ]
 - vgchange --monitor y|n [ -A|--autobackup y|n ] [ -S|--select String ] [ -f|--force ] [    --sysinit ] [    --ignorelockingfailure ] [    --poll y|n ] [    --ignoremonitoring ] [    --noudevsync ] [    --reportformat basic|json ] [ COMMON_OPTIONS ] [ VG|Tag|Select ... ]
 - vgchange --poll y|n [ -A|--autobackup y|n ] [ -S|--select String ] [ -f|--force ] [    --ignorelockingfailure ] [    --ignoremonitoring ] [    --noudevsync ] [    --reportformat basic|json ] [ COMMON_OPTIONS ] [ VG|Tag|Select ... ]
+- vgchange -a|--activate y|n|ay
+- vgchange --refresh
+- vgchange --systemid String VG
+- vgchange --lockstart
+- vgchange --lockstop
+- vgchange --locktype sanlock|dlm|none VG
 positionals:
 - name: COMMON_OPTIONS
   required: true
@@ -14,19 +20,19 @@ flags:
   long: activate
   value_name: y|n|ay
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - short: 'K'
   long: ignoreactivationskip
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - short: 'P'
   long: partial
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
@@ -34,7 +40,7 @@ flags:
   long: autobackup
   value_name: y|n
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
@@ -42,78 +48,78 @@ flags:
   long: select
   value_name: String
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - short: 'f'
   long: force
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: activationmode
   value_name: partial|degraded|complete
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: sysinit
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: readonly
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: ignorelockingfailure
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: monitor
   value_name: y|n
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: poll
   value_name: y|n
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: autoactivation
   value_name: String
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: ignoremonitoring
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: noudevsync
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: reportformat
   value_name: basic|json
   value_kind: Required
-  group: vgchange -a|--activate y|n|ay
+  group: Activate or deactivate LVs.
   provenance:
     sources:
     - help-text
 - long: refresh
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
@@ -121,7 +127,7 @@ flags:
   long: autobackup
   value_name: y|n
   value_kind: Required
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
@@ -129,59 +135,59 @@ flags:
   long: select
   value_name: String
   value_kind: Required
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - short: 'f'
   long: force
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: sysinit
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: ignorelockingfailure
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: poll
   value_name: y|n
   value_kind: Required
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: ignoremonitoring
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: noudevsync
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: reportformat
   value_name: basic|json
   value_kind: Required
-  group: vgchange --refresh
+  group: Reactivate LVs using the latest metadata.
   provenance:
     sources:
     - help-text
 - long: systemid
   value_name: String
   value_kind: Required
-  group: vgchange --systemid String VG
+  group: Change the system ID of a VG.
   provenance:
     sources:
     - help-text
 - long: lockstart
-  group: vgchange --lockstart
+  group: Start the lockspace of a shared VG in lvmlockd.
   provenance:
     sources:
     - help-text
@@ -189,12 +195,12 @@ flags:
   long: select
   value_name: String
   value_kind: Required
-  group: vgchange --lockstart
+  group: Start the lockspace of a shared VG in lvmlockd.
   provenance:
     sources:
     - help-text
 - long: lockstop
-  group: vgchange --lockstop
+  group: Stop the lockspace of a shared VG in lvmlockd.
   provenance:
     sources:
     - help-text
@@ -202,14 +208,14 @@ flags:
   long: select
   value_name: String
   value_kind: Required
-  group: vgchange --lockstop
+  group: Stop the lockspace of a shared VG in lvmlockd.
   provenance:
     sources:
     - help-text
 - long: locktype
   value_name: sanlock|dlm|none
   value_kind: Required
-  group: vgchange --locktype sanlock|dlm|none VG
+  group: Change the lock type for a shared VG.
   provenance:
     sources:
     - help-text

--- a/corpus/vgchange/2.03.16/meta.toml
+++ b/corpus/vgchange/2.03.16/meta.toml
@@ -53,15 +53,27 @@
 #   `MIN_PROSE_SENTENCE_WORDS` (5) words. `vgchange`'s own stanza-4
 #   description, "Activate or deactivate LVs." (4 words), fails that
 #   floor, so the lookahead never reaches the `vgchange -a|--activate
-#   y|n|ay` head beneath it and the *entire* usage block ends there —
+#   y|n|ay` head beneath it and the *entire* usage block ends there.
 #   `-a`/`--activate` and every stanza after it (`--refresh`,
-#   `--systemid`, `--lockstart`, `--lockstop`, `--locktype`) are absent
-#   from `usage` and from the flag list (their own `[...]` bracket rows
-#   still surface separately, via the generic headingless-block scanner,
-#   with the stanza's own head line as a `group` label rather than a real
-#   flag — visible below as `group: 'vgchange -a|--activate y|n|ay'` with
-#   no accompanying `-a`/`--activate` flag entry). Not claimed by
-#   `must_contain_flags`.
+#   `--systemid`, `--lockstart`, `--lockstop`, `--locktype`) therefore
+#   reach the generic section scanner instead, which reads each stanza's
+#   head line as the heading governing that stanza's `[...]` bracket
+#   rows. That is still the path they take here, and it is what makes
+#   this fixture the specimen for the stanza-label rule below.
+#
+# fix/11-stanza-label-description gives those six stanzas the label the
+# tool actually wrote for them: a stanza whose head line is immediately
+# preceded by a lone description sentence takes that sentence as its
+# `group` (`sections::stanza_description_above`), so the pane's dividers
+# read "Activate or deactivate LVs" and "Start the lockspace of a shared
+# VG in lvmlockd" rather than repeating the spelling already printed on
+# the row beneath them, and the sentence — previously consumed by nothing
+# and dropped — is in the tree at all. The head line is not lost to the
+# swap: it is a usage form, so each of the six now appears in `usage`
+# beside the three the usage block itself reached. `-l`/`--logicalvolume`
+# and the rest of the paren group keep their `help-text-synopsis`
+# provenance and no group, unchanged — they are the first stanza's, which
+# the usage block did read.
 
 [bless]
 provenance = "agent"

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -1352,8 +1352,40 @@ fn parse_body(
         // `bpftrace`'s own `Options:` block. See `in_ignorable_section`'s
         // own doc comment for why this has to be section context rather
         // than a per-line check.
+        //
+        // A stanza that carries its own description sentence directly
+        // above its head line labels its group with that sentence instead
+        // of the head line ([`stanza_description_above`] has the rule and
+        // every clause's reasoning). The head line is not lost by that
+        // swap: it is a usage form, so it goes where usage forms go —
+        // `result.usage`, the verbatim synopsis section (§4.5) — which is
+        // exactly where the stanzas this document's usage block *did*
+        // reach already sit. Pushed here rather than in that block because
+        // this is the one place that knows the head line was a stanza head
+        // and that its own text is about to stop being the group label;
+        // `extract_positionals` has already run by now, so nothing is
+        // mined out of the added line.
+        //
+        // Capped, not deduplicated. `i` only ever advances, so no physical
+        // line becomes `heading` twice and one document cannot repeat
+        // itself here; two identical entries mean the tool printed the
+        // stanza twice, which the synopsis section should say. A scan of
+        // `usage` per heading would meanwhile be the quadratic shape
+        // `MAX_RECOVERED_ENTRIES` exists for (`instmodsh`'s 8 MiB of
+        // repeated banner).
+        let stanza_label = if in_ignorable_section {
+            None
+        } else {
+            stanza_description_above(&lines, heading_idx, tool_name).map(str::to_string)
+        };
+        if stanza_label.is_some() && result.usage.len() < MAX_RECOVERED_ENTRIES {
+            result.usage.push(heading.clone());
+        }
         if !in_ignorable_section {
-            if let Some(flag) = recover_stanza_head_flag(&heading, tool_name) {
+            if let Some(mut flag) = recover_stanza_head_flag(&heading, tool_name) {
+                if let Some(label) = stanza_label.clone() {
+                    flag.group = Some(label);
+                }
                 if result.flags.len() < MAX_RECOVERED_ENTRIES {
                     result.flags.push(flag);
                 }
@@ -1424,14 +1456,23 @@ fn parse_body(
             // evidence we are not (or no longer) inside an examples-shaped
             // section. See `in_ignorable_section`'s own doc comment.
             in_ignorable_section = false;
+            // A stanza's own description sentence outranks its head line
+            // as the group's label — and only there: every other block in
+            // the document still takes `meaningful_flag_group`'s answer
+            // unchanged, including one whose heading merely happens to be
+            // prose (which that predicate deliberately refuses to name a
+            // group with, since a sentence promoted to a heading by
+            // indentation alone is a defect rather than a label).
+            let group = stanza_label
+                .clone()
+                .or_else(|| meaningful_flag_group(heading));
             if packed {
                 let seen = entries.len();
-                emit_packed_flags(meaningful_flag_group(heading), entries, &mut result);
+                emit_packed_flags(group, entries, &mut result);
                 total_entries += seen;
                 clean_entries += seen;
             } else {
-                let (seen, clean) =
-                    emit_flags(meaningful_flag_group(heading), entries, &mut result);
+                let (seen, clean) = emit_flags(group, entries, &mut result);
                 total_entries += seen;
                 clean_entries += clean;
             }

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -306,6 +306,127 @@ pub(super) fn recover_stanza_head_flag(heading: &str, tool_name: Option<&str>) -
     Some(flag)
 }
 
+/// Fewest whitespace-separated words the line above a stanza head must
+/// carry before [`stanza_description_above`] adopts it as that stanza's
+/// label.
+///
+/// Three, deliberately not [`MIN_PROSE_SENTENCE_WORDS`]'s five. The two
+/// numbers answer different questions and are not interchangeable. Five
+/// answers "is this indentation-promoted line prose rather than a section
+/// heading?", asked of any line anywhere in a document, where a two- or
+/// three-word *heading* is the thing that must never be claimed. This one
+/// is asked in a single, fully-bracketed slot — a lone line between a
+/// blank and a confirmed stanza head — where a heading and a description
+/// both name the block below and either is a better label than the
+/// invocation line. What the floor still has to keep out is a one- or
+/// two-word fragment, and three is the shortest real specimen in the
+/// measured family: `vgchange`'s own `Activate or deactivate LVs.` is
+/// four words, and a five-word floor would leave that one stanza — the
+/// tool's most-used mode — labelled by its head line while its five
+/// siblings carried their descriptions.
+pub(super) const MIN_STANZA_DESCRIPTION_WORDS: usize = 3;
+
+/// The description sentence a multi-variant tool writes directly above a
+/// usage stanza's head line, when `lines[head_idx]` is such a head and the
+/// line above it is such a sentence — LVM's own emitter, one stanza per
+/// invocation form:
+///
+/// ```text
+///   Start the lockspace of a shared VG in lvmlockd.
+///   vgchange --lockstart
+/// \t[ -S|--select String ]
+/// \t[ COMMON_OPTIONS ]
+/// ```
+///
+/// # The defect
+///
+/// The section loop reads `vgchange --lockstart` as the heading governing
+/// the bracket rows beneath it, so every flag in the stanza takes that
+/// head line as its [`mandible_core::Entity::group`] and the pane draws
+/// `Vgchange --lockstart ─────`. The sentence above it — the only
+/// human-meaningful thing the tool says about this invocation form — is
+/// consumed by nothing and dropped outright. A divider that repeats the
+/// spelling already printed on the row beneath it names the group with
+/// information the reader can already see, while the sentence that would
+/// have told them what the mode *does* is not in the tree at all.
+///
+/// # The rule, and what each clause keeps out
+///
+/// The head is the anchor, and it is the strongest one available:
+/// [`recover_stanza_head_flag`] must already have accepted
+/// `lines[head_idx]` as a stanza head — the tool's own name at a word
+/// boundary followed by exactly one bare flag token
+/// ([`looks_like_stanza_head_flag`]), never an ignorable heading. Nothing
+/// here is tried against an ordinary heading, so the question is only ever
+/// asked about a line that is already known to open an invocation form.
+/// Given that anchor, the line above must:
+///
+/// - **Sit at the head's own column.** A more-indented line is the head's
+///   own content and a less-indented one governs the head rather than
+///   describing it; only a line the author set flush with the head is
+///   writing about that head.
+/// - **Stand alone** — the line above *it* is blank, or absent. This is
+///   the anti-paragraph clause: a description that hard-wraps, or a
+///   trailing sentence of an unrelated paragraph that happens to end just
+///   above a stanza, has a non-blank neighbour above it, and adopting its
+///   last physical line would label the group with half a sentence.
+///   Refuse the whole shape rather than take the fragment.
+/// - **End in a full stop, and not an ellipsis** — the same terminator
+///   test [`is_prose_sentence`] uses, for the same two reasons: a label
+///   the author wrote as a label does not end in one, and a trailing
+///   `...` is docopt repetition notation rather than a sentence.
+/// - **Be a single field** ([`find_multi_space_gap`]) — a line with an
+///   aligned column is a table row, not a sentence.
+/// - **Not open with the tool's own name** ([`starts_with_tool_name`]) —
+///   so a stanza head that happens to end in a period can never become
+///   the label of the stanza beneath it, and neither can a worked-example
+///   invocation.
+/// - **Not open with flag or usage notation** — belt and braces beside
+///   the terminator test, so a bracket row or a flag line is refused on
+///   its shape as well as its punctuation.
+/// - **Carry at least [`MIN_STANZA_DESCRIPTION_WORDS`] words**, and not
+///   be an [`is_ignorable_heading`] marker.
+///
+/// Returns the sentence exactly as the tool wrote it, terminator included
+/// — the display layer strips a label's source punctuation (spec §9.3),
+/// the same way it already strips a heading's trailing colon.
+pub(super) fn stanza_description_above<'a>(
+    lines: &[&'a str],
+    head_idx: usize,
+    tool_name: Option<&str>,
+) -> Option<&'a str> {
+    let name = tool_name?;
+    if head_idx == 0 {
+        return None;
+    }
+    recover_stanza_head_flag(lines[head_idx].trim(), Some(name))?;
+    if head_idx >= 2 && !lines[head_idx - 2].trim().is_empty() {
+        return None;
+    }
+    let raw = lines[head_idx - 1];
+    if leading_whitespace(raw) != leading_whitespace(lines[head_idx]) {
+        return None;
+    }
+    let text = raw.trim();
+    if text.is_empty() || !text.ends_with('.') || text.ends_with("...") {
+        return None;
+    }
+    if text.split_whitespace().count() < MIN_STANZA_DESCRIPTION_WORDS {
+        return None;
+    }
+    if find_multi_space_gap(raw).is_some() {
+        return None;
+    }
+    if starts_with_tool_name(text, name)
+        || looks_like_flag_start(text)
+        || looks_like_usage_fragment(text)
+        || is_ignorable_heading(text)
+    {
+        return None;
+    }
+    Some(text)
+}
+
 /// Pull placeholder tokens (`<value>`, bare `UPPERCASE` words not preceded
 /// by `-`) out of usage lines as positionals. Best-effort: usage-line
 /// grammar is genuinely varied (docopt-style `[OPTIONS]`, `<required>`,
@@ -1441,7 +1562,20 @@ mod tests {
         assert_eq!(activate.short(), Some('a'));
         assert_eq!(activate.value_name.as_deref(), Some("y|n|ay"));
         assert_eq!(activate.value_kind, ValueKind::Required);
-        assert_eq!(activate.group.as_deref(), Some("tool -a|--activate y|n|ay"));
+        // `Do a thing.` is this stanza's own description, so it is the
+        // group's label and the head line is retained as a usage form
+        // instead ([`stanza_description_above`]); the assertion the shape
+        // this test exists for still makes is that the head flag and its
+        // block agree on whatever that label is.
+        assert_eq!(activate.group.as_deref(), Some("Do a thing."));
+        assert!(
+            parsed
+                .usage
+                .iter()
+                .any(|u| u == "tool -a|--activate y|n|ay"),
+            "usage: {:?}",
+            parsed.usage
+        );
         assert!(
             !activate.required,
             "not attempted: no fabricated required-ness"
@@ -2425,6 +2559,153 @@ mod tests {
     fn usage_synopsis_with_no_dash_tokens_yields_zero_flags() {
         let parsed = parse("Usage: mytool [FILE]... <target>\n");
         assert!(parsed.flags.is_empty(), "{:?}", parsed.flags);
+    }
+
+    // --- the stanza's own description as its group label ----------------
+
+    /// The one document shape that reaches this rule at all, spelled out
+    /// once here because it is not obvious and every test below reuses it:
+    /// a stanza is labelled by the **section** loop only after the usage
+    /// block has already ended, since a stanza the block itself reaches
+    /// becomes a `usage` entry with no group. So the preamble is a first
+    /// stanza that anchors the block, then a description too short for
+    /// `is_prose_sentence` to skip (`MIN_PROSE_SENTENCE_WORDS`, spec §7's
+    /// own recorded gap) which ends it, and only then the stanzas this
+    /// rule labels. Real `vgchange` has exactly this shape, and it is why
+    /// the two floors are separate numbers.
+    const STANZA_PREAMBLE: &str =
+        "tool\n\t[ -x|--xflag ]\n\nDo a thing.\ntool -a|--activate y|n|ay\n\t[ -f|--force ]\n";
+
+    /// A stanza reached by the section loop (its own head line read as the
+    /// heading governing the bracket rows beneath it) is labelled by the
+    /// description sentence above the head, its head flag and its bracket
+    /// rows agree on that label, and the head line itself is kept as a
+    /// usage form rather than discarded along with the label it used to be.
+    #[test]
+    fn stanza_group_label_is_the_description_above_its_head() {
+        let help = format!(
+            "{STANZA_PREAMBLE}\nStart the lockspace of a shared VG in lvmlockd.\ntool --lockstart\n\t[ -S|--select String ]\n\t[ COMMON_OPTIONS ]\n"
+        );
+        let parsed = parse_with_profile(&help, None, Some("tool"));
+        let label = Some("Start the lockspace of a shared VG in lvmlockd.");
+        let select = parsed
+            .flags
+            .iter()
+            .find(|f| f.long() == Some("select"))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(select.group.as_deref(), label, "flags: {:?}", parsed.flags);
+        let lockstart = parsed
+            .flags
+            .iter()
+            .find(|f| f.long() == Some("lockstart"))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(
+            lockstart.group.as_deref(),
+            label,
+            "the stanza's own head flag and its bracket rows must agree"
+        );
+        assert!(
+            parsed.usage.iter().any(|u| u == "tool --lockstart"),
+            "the head line must survive the relabel as a usage form: {:?}",
+            parsed.usage
+        );
+    }
+
+    /// The no-description fallback, which this change must not regress: a
+    /// stanza with a blank line above its head keeps the head line as its
+    /// label exactly as before, and contributes no usage entry.
+    #[test]
+    fn stanza_without_a_description_keeps_its_head_line_label() {
+        let help = format!(
+            "{STANZA_PREAMBLE}\ntool --lockstart\n\t[ -S|--select String ]\n\t[ COMMON_OPTIONS ]\n"
+        );
+        let parsed = parse_with_profile(&help, None, Some("tool"));
+        let select = parsed
+            .flags
+            .iter()
+            .find(|f| f.long() == Some("select"))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(select.group.as_deref(), Some("tool --lockstart"));
+        assert!(
+            !parsed.usage.iter().any(|u| u == "tool --lockstart"),
+            "no relabel, so nothing to retain: {:?}",
+            parsed.usage
+        );
+    }
+
+    /// The anti-paragraph clause. A sentence that is the *last line of a
+    /// paragraph* — something above it, no blank between — is not a
+    /// description of the stanza beneath it, and adopting it would label
+    /// the group with the tail of unrelated prose. Refused whole; the head
+    /// line keeps the label.
+    #[test]
+    fn trailing_line_of_a_paragraph_is_not_adopted_as_a_stanza_label() {
+        let help = format!(
+            "{STANZA_PREAMBLE}\nThis tool changes volume group attributes and is\ndocumented at length in the lvm manual page.\ntool --lockstart\n\t[ -S|--select String ]\n"
+        );
+        let parsed = parse_with_profile(&help, None, Some("tool"));
+        let select = parsed
+            .flags
+            .iter()
+            .find(|f| f.long() == Some("select"))
+            .unwrap_or_else(|| panic!("flags: {:?}", parsed.flags));
+        assert_eq!(
+            select.group.as_deref(),
+            Some("tool --lockstart"),
+            "flags: {:?}",
+            parsed.flags
+        );
+    }
+
+    /// Every remaining clause of the recognizer, each refused on its own:
+    /// a differently-indented neighbour, a two-column table row, a line
+    /// opening with the tool's own name, an ellipsis, and a head that
+    /// names no flag at all (a bare `<tool>` invocation, which is not a
+    /// stanza head).
+    #[test]
+    fn stanza_description_recognizer_refuses_every_near_miss() {
+        let lines = [
+            "",
+            "  Start the lockspace of a VG.",
+            "  vgchange --lockstart",
+        ];
+        assert_eq!(
+            stanza_description_above(&lines, 2, Some("vgchange")),
+            Some("Start the lockspace of a VG.")
+        );
+        for near_miss in [
+            // Not at the head's own column.
+            "      Start the lockspace of a VG.",
+            // A two-column table row, not a sentence.
+            "  lockstart          Start the lockspace of a VG.",
+            // The tool's own name: another invocation line, never a label.
+            "  vgchange starts the lockspace of a VG.",
+            // Repetition notation, not a sentence terminator.
+            "  Start the lockspace of a VG...",
+            // No terminator at all.
+            "  Start the lockspace of a VG",
+            // Under the word floor.
+            "  Lockstart.",
+        ] {
+            let lines = ["", near_miss, "  vgchange --lockstart"];
+            assert_eq!(
+                stanza_description_above(&lines, 2, Some("vgchange")),
+                None,
+                "adopted {near_miss:?}"
+            );
+        }
+        // A bare own-name head names no mode, so it is not a stanza head
+        // and nothing above it is a stanza description.
+        let lines = ["", "  Read information about a VG.", "  vgchange"];
+        assert_eq!(stanza_description_above(&lines, 2, Some("vgchange")), None);
+        // No resolved tool name: the head line cannot be known to be an
+        // invocation of *this* tool rather than a coincidence.
+        let lines = [
+            "",
+            "  Start the lockspace of a VG.",
+            "  vgchange --lockstart",
+        ];
+        assert_eq!(stanza_description_above(&lines, 2, None), None);
     }
 
     /// A malformed/unmatched bracket in a usage line (never seen from a

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -1154,18 +1154,31 @@ fn break_overlong_word(word: &str, width: usize) -> Vec<String> {
 }
 
 /// A group heading with its source's punctuation stripped: single-lined,
-/// trimmed, and without the trailing colon a help-text heading carries
-/// (`"GLOBAL OPTIONS:"` → `"GLOBAL OPTIONS"`).
+/// trimmed, and without the trailing terminator a help-text heading
+/// carries — the colon of `"GLOBAL OPTIONS:"`, and the full stop of a
+/// group whose label is a whole sentence the tool wrote
+/// (`"Start the lockspace of a shared VG in lvmlockd."`, LVM's own
+/// per-stanza description, which spec §7 Tier B makes that stanza's
+/// group label).
+///
+/// A divider is furniture: its label runs straight into the rule beside
+/// it, and a terminator stranded between the two reads as a mark on the
+/// line rather than as the end of a sentence — the same reason the colon
+/// goes. One trailing stop only, and never an ellipsis, which is docopt
+/// repetition notation rather than punctuation (a group named
+/// `"FILE..."` keeps its meaning).
 ///
 /// The casing is left exactly as the tool wrote it — that is
 /// [`group_label`]'s and [`group_key`]'s business, and they want different
 /// answers.
 fn strip_group_punctuation(raw: &str) -> String {
-    defensive_single_line(raw)
-        .trim()
-        .trim_end_matches(':')
-        .trim()
-        .to_string()
+    let single = defensive_single_line(raw);
+    let trimmed = single.trim().trim_end_matches(':').trim();
+    let unterminated = match trimmed.strip_suffix('.') {
+        Some(head) if !trimmed.ends_with("...") => head.trim_end(),
+        _ => trimmed,
+    };
+    unterminated.to_string()
 }
 
 /// The identity a group is collected under: case-folded, so that
@@ -2848,6 +2861,33 @@ mod tests {
                 "a group label must not read as a section header: {label:?}"
             );
         }
+    }
+
+    /// A group whose label is a whole sentence the tool wrote — LVM's
+    /// per-stanza description, which spec §7 Tier B makes that stanza's
+    /// group label — loses its full stop the same way a heading loses its
+    /// colon: the label runs straight into the divider's rule, and a
+    /// terminator between the two reads as a stray mark rather than as the
+    /// end of a sentence. One stop only, and never an ellipsis, which is
+    /// repetition notation rather than punctuation.
+    #[test]
+    fn group_labels_drop_a_sentence_terminator_like_a_heading_colon() {
+        assert_eq!(
+            group_label("Start the lockspace of a shared VG in lvmlockd."),
+            "Start the lockspace of a shared VG in lvmlockd"
+        );
+        assert_eq!(
+            group_label("Activate or deactivate LVs."),
+            "Activate or deactivate LVs"
+        );
+        // Not punctuation: docopt repetition notation stays.
+        assert_eq!(group_label("FILE..."), "File...");
+        // The colon rule is unchanged, and the two collapse to one key.
+        assert_eq!(group_label("Main operation mode:"), "Main operation mode");
+        assert_eq!(
+            group_key("Activate or deactivate LVs."),
+            group_key("Activate or deactivate LVs")
+        );
     }
 
     /// Spec §9.3: a value placeholder is fused onto the spelling it

--- a/spec.md
+++ b/spec.md
@@ -1689,6 +1689,63 @@ The generic fallback parser (step 2) is built with `winnow`:
   comma-terminated line is still parsed in full. Colon- and
   period-terminated lines are excluded by construction, so this neither
   overlaps nor widens shapes 1 and 2 or `is_section_heading_line`.
+- **A usage stanza is labelled by its own description, not by its head
+  line.** A multi-variant tool documents each invocation form as a
+  *stanza*: a description sentence, then the form's head line, then that
+  form's option rows. LVM's whole `lv*`/`vg*`/`pv*` family writes every
+  mode this way —
+
+  ```text
+    Start the lockspace of a shared VG in lvmlockd.
+    vgchange --lockstart
+  \t[ -S|--select String ]
+  \t[ COMMON_OPTIONS ]
+  ```
+
+  — and where the usage block itself does not reach the stanza (it ends
+  at the first description too short for `is_prose_sentence`), the section
+  scanner reads the head line as the heading governing the rows beneath
+  it. Every flag in the stanza then takes the head line as its `group`,
+  and the sentence above is consumed by nothing. Both halves of that are
+  wrong: a divider reading `Vgchange --lockstart ────` names the group
+  with a spelling already printed on the row beneath it, while the one
+  human-meaningful thing the tool says about the mode is not in the tree
+  at all.
+
+  **The sentence becomes the group's label, and the head line becomes a
+  `usage` entry.** Nothing is traded away in either direction: the label
+  says what the mode does, and the head line is a verbatim invocation
+  form, which is what §4.5's `usage` holds — the same section the stanzas
+  the usage block *did* reach already occupy.
+
+  The rule is anchored on the head, not on the prose
+  (`sections::stanza_description_above`). The head must already be a
+  recognized stanza head — the tool's own name at a word boundary
+  followed by exactly one bare flag token, `recover_stanza_head_flag`'s
+  own test — so the question is never asked about an ordinary heading.
+  The line above it must then be a lone sentence: at the head's exact
+  column, with a blank line or nothing above it, terminated by a full
+  stop that is not an ellipsis, a single field with no aligned column, at
+  least three words, and neither the tool's own name nor flag or bracket
+  notation. **With no such line the head-line label stands unchanged**,
+  which is also what a stanza whose description hard-wraps across two
+  physical lines gets: the anti-paragraph clause refuses the whole shape
+  rather than label a group with the tail of a sentence.
+
+  The three-word floor is deliberately not `MIN_PROSE_SENTENCE_WORDS`'s
+  five, and the two are not interchangeable. Five answers "is this
+  indentation-promoted line prose rather than a section heading?", asked
+  of any line anywhere, where a short *heading* is the thing that must
+  never be claimed. This one is asked in a single fully-bracketed slot
+  where a heading and a description both name the block below and either
+  beats the invocation line; what remains to keep out is a one- or
+  two-word fragment. `vgchange`'s own `Activate or deactivate LVs.` is
+  four words, and a five-word floor would leave that one stanza — the
+  tool's most-used mode — labelled by its head line while its five
+  siblings carried their sentences.
+
+  A group label is displayed with its source's terminator stripped, the
+  full stop of a sentence exactly as the colon of a heading (§9.3).
 - **Never invent subcommands.** This tier shipped a bug where wrapped
   description continuation lines and enum value lists were parsed as commands:
   `tar` gained 39 phantom subcommands named *"treat them as errors"* and
@@ -2551,6 +2608,14 @@ Rules:
   row and every section-opening divider otherwise share. Section headers
   are CAPS with a count, group dividers mixed-case without one: the shape
   distinction survives a terminal that ignores dimming, per §9.2.
+  - **A label drops the terminator its source gave it** — the colon of
+    `GLOBAL OPTIONS:`, and the full stop of a label that is a whole
+    sentence the tool wrote (§7 Tier B makes a usage stanza's own
+    description that stanza's group label). The label runs straight into
+    the rule beside it, so a terminator stranded between the two reads as
+    a mark on the line rather than as the end of a sentence. One stop,
+    never an ellipsis: `...` is docopt repetition notation rather than
+    punctuation.
   - **Three neutral steps, brightest first: pane borders, section header,
     group divider.** The borders keep the terminal's own default
     foreground and are not touched; the section header's rule is a clear


### PR DESCRIPTION
Fixes #11.

A multi-variant tool documents each invocation form as a **stanza**: a
description sentence, the form's head line, then that form's option rows. LVM's
whole `lv*`/`vg*`/`pv*` family writes every mode this way.

```text
  Start the lockspace of a shared VG in lvmlockd.
  vgchange --lockstart
	[ -S|--select String ]
	[ COMMON_OPTIONS ]
```

Where the usage block does not reach the stanza, the section scanner reads the
head line as the heading governing the rows beneath it. Every flag then took the
head line as its `group`, and the sentence above was consumed by nothing. Both
halves of that were wrong: the divider read `Vgchange --lockstart ────`, naming
the group with a spelling already printed on the row beneath it, while the one
human-meaningful thing the tool says about the mode was not in the tree at all.

**The sentence becomes the label, and the head line becomes a `usage` entry** —
neither half is traded for the other. A stanza head is a verbatim invocation
form, which is what USAGE holds, and it is where the stanzas the usage block
*did* reach already sit.

## The rule

Anchored on the head, not on the prose (`sections::stanza_description_above`).
The head must already be a recognized stanza head — the tool's own name at a word
boundary followed by exactly one bare flag token, `recover_stanza_head_flag`'s
own test — so the question is never asked about an ordinary heading. The line
above it must then be a lone sentence:

- at the head's **exact column**;
- with a **blank line, or nothing, above it** — the anti-paragraph clause;
- terminated by a **full stop that is not an ellipsis**;
- a **single field**, no aligned column, so a table row is never a sentence;
- **at least three words**;
- and **not** the tool's own name, flag notation, bracket notation, or an
  ignorable heading.

**No-description fallback:** the head-line label stands exactly as before. So
does a stanza whose description hard-wraps across two physical lines — the
anti-paragraph clause refuses the whole shape rather than label a group with the
tail of a sentence.

**Why three words and not `MIN_PROSE_SENTENCE_WORDS`'s five.** The two answer
different questions and stay separate numbers. Five answers "is this
indentation-promoted line prose rather than a section heading?", asked of any
line anywhere, where a short *heading* is the thing that must never be claimed.
This one is asked in a single fully-bracketed slot where a heading and a
description both name the block below and either beats the invocation line; what
is left to keep out is a one- or two-word fragment. `vgchange`'s own
`Activate or deactivate LVs.` is four words, and a five-word floor would leave
that one stanza — the tool's most-used mode — labelled by its head line while its
five siblings carried their sentences.

Display side: a group divider now drops the terminator its source gave it, the
full stop of a sentence exactly as the colon of a heading, so the label runs into
the rule without a stray mark between them.

Spec amended: §7 Tier B for the rule, §9.3 for the label's terminator.

## Recorded misses (strict by choice)

The recognizer is kept strict rather than widened, so three real shapes keep
their head-line label. Each is pinned by `corpus/vgcfgrestore/2.03.16` or a unit
test rather than only described:

1. **A head naming no flag** — `vgcfgrestore VG`, `vgck`'s own bare head. Not a
   stanza head, so nothing above it is adopted.
2. **A head naming two flags** — `vgcfgrestore -l|--list -f|--file String`,
   `lvchange -M|--persistent y --minor Number LV`, `lvconvert --type thin
   --thinpool LV LV`. `grammar::looks_like_stanza_head_flag` admits exactly one
   bare flag token by construction, and it is the same predicate that stops a
   worked example from being mined as a stanza head.
3. **A description that hard-wraps** — `lvchange --resync`, whose two-line
   description ("Resyncronize a mirror or raid LV." / "Use to reset 'R'
   attribute on a not initially synchronized LV.") is refused whole.

## See it yourself

From a fresh clone, with `lvm2` installed:

```console
$ cargo build --release
$ ./target/release/mandible vgchange
```

`Tab` into the detail pane and scroll past `FLAGS`. Six dividers that read
`Vgchange -a|--activate y|n|ay`, `Vgchange --refresh`, `Vgchange --systemid
String VG`, `Vgchange --lockstart`, `Vgchange --lockstop` and `Vgchange
--locktype sanlock|dlm|none VG` now read the tool's own sentences, and USAGE
lists nine invocation forms instead of three. `mandible vgcfgrestore` gains a
USAGE section it never had. `mandible vgck` is unchanged — its usage block
reaches both its stanzas, so neither ever became a group.

The same screens without a terminal, in a venv with `pyte` installed:

```console
$ python scripts/pty_screenshot.py 96 100 ./target/release/mandible vgchange
```

### Before

```text
╭ commands (1) ────────────────────────────────╮╭ vgchange ───────────────────────────────────→╮
│  vgchange                                    ││ USAGE ────────────────────────────────────── │
│                                              ││   vgchange ( -l|--logicalvolume Number, -p|->│
│                                              ││   vgchange --monitor y|n [ -A|--autobackup y>│
│                                              ││   vgchange --poll y|n [ -A|--autobackup y|n >│
│                                              ││                                              │
│                                              ││     --ignorelockingfailure                   │
│                                              ││     --monitor y|n                            │
│                                              ││     --poll y|n                               │
│                                              ││     --autoactivation String                  │
│                                              ││     --ignoremonitoring                       │
│                                              ││     --noudevsync                             │
│                                              ││     --reportformat basic|json                │
│                                              ││                                              │
│                                              ││ Vgchange --refresh ───────────────────────── │
│                                              ││     --refresh                                │
│                                              ││                                              │
│                                              ││ Vgchange --systemid String VG ────────────── │
│                                              ││     --systemid String                        │
│                                              ││                                              │
│                                              ││ Vgchange --lockstart ─────────────────────── │
│                                              ││     --lockstart                              │
│                                              ││                                              │
│                                              ││ Vgchange --lockstop ──────────────────────── │
│                                              ││     --lockstop                               │
│                                              ││                                              │
│                                              ││ Vgchange --locktype sanlock|dlm|none VG ──── │
│                                              ││     --locktype sanlock|dlm|none              │
│                                              ││                                              │
│                                              ││ Common options for lvm ───────────────────── │
│                                              ││ -d, --debug                                  │
│                                              ││ -h, --help                                   │
│                                              ││ -q, --quiet                                  │
│                                              ││ -v, --verbose                                │
│                                              ││ -y, --yes                                    │
│                                              ││ -t, --test                                   │
│                                              ││     --commandprofile String                  │
│                                              ││     --config String                          │
│                                              ││     --driverloaded y|n                       │
│                                              ││     --nolocking                              │
│                                              ││     --lockopt String                         │
```

### After

```text
╭ commands (1) ────────────────────────────────╮╭ vgchange ───────────────────────────────────→╮
│  vgchange                                    ││ USAGE ────────────────────────────────────── │
│                                              ││   vgchange ( -l|--logicalvolume Number, -p|->│
│                                              ││   vgchange --monitor y|n [ -A|--autobackup y>│
│                                              ││   vgchange --poll y|n [ -A|--autobackup y|n >│
│                                              ││   vgchange -a|--activate y|n|ay              │
│                                              ││   vgchange --refresh                         │
│                                              ││   vgchange --systemid String VG              │
│                                              ││   vgchange --lockstart                       │
│                                              ││   vgchange --lockstop                        │
│                                              ││   vgchange --locktype sanlock|dlm|none VG    │
│                                              ││     --readonly                               │
│                                              ││     --ignorelockingfailure                   │
│                                              ││     --monitor y|n                            │
│                                              ││     --poll y|n                               │
│                                              ││     --autoactivation String                  │
│                                              ││     --ignoremonitoring                       │
│                                              ││     --noudevsync                             │
│                                              ││     --reportformat basic|json                │
│                                              ││                                              │
│                                              ││ Reactivate LVs using the latest metadata ─── │
│                                              ││     --refresh                                │
│                                              ││                                              │
│                                              ││ Change the system ID of a VG ─────────────── │
│                                              ││     --systemid String                        │
│                                              ││                                              │
│                                              ││ Start the lockspace of a shared VG in… ───── │
│                                              ││     --lockstart                              │
│                                              ││                                              │
│                                              ││ Stop the lockspace of a shared VG in… ────── │
│                                              ││     --lockstop                               │
│                                              ││                                              │
│                                              ││ Change the lock type for a shared VG ─────── │
│                                              ││     --locktype sanlock|dlm|none              │
│                                              ││                                              │
│                                              ││ Common options for lvm ───────────────────── │
│                                              ││ -d, --debug                                  │
│                                              ││ -h, --help                                   │
│                                              ││ -q, --quiet                                  │
│                                              ││ -v, --verbose                                │
│                                              ││ -y, --yes                                    │
```

## Verification

**Gates.** `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets
-- -D warnings`, `cargo nextest run --workspace` (1392 passed, 0 skipped),
`cargo build --release`, `scripts/changelog_guard.sh`. Also
`cargo clippy --workspace --target aarch64-apple-darwin --all-targets -- -D
warnings`, clean.

**Corpus.** 115 fixtures, 106 ok / 9 xfail / 0 failed. Exactly one existing
fixture's tree moved — `vgchange/2.03.16`, reblessed and reviewed line by line
against `help.txt`. The other 113 are byte-identical, which is the label-level
measurement the sweep fingerprint cannot make. `vgcfgrestore/2.03.16` is new.

**Full-`PATH` sweep**, base `d89a8d7` vs this branch, each side its own checkout
and target directory, run sequentially on one machine:

```text
overall: IDENTICAL
sweep transition: 2258 -> 2258 tools, 2258 matched, 0 appeared, 0 disappeared, 30 excluded (near 10s cap)
# status transitions
(none)
# flag-count losses (the bar — never netted): 0 lost across 0 tool(s)
# flag-count gains: 0 gained across 0 tool(s)
# field-level changes: 0 tool(s) (adds/removes/changes, never just a count)
```

The two aggregates differ only in `verbatim` 259 → 262 and `ok-with-zero-flags`
144 → 141, and those three tools are `bitesize-bpfcc`, `mdflush-bpfcc` and
`oomkill-bpfcc` — all in the 30 `sweep-diff` excludes as near the 10s wall-clock
cap (22.2s → 4.9s, 22.3s → 7.9s, 22.2s → 5.4s), i.e. the same tools landing on
either side of the cap between runs, not a parse change.

**Which tools' labels moved.** `sweep-diff`'s per-tool fingerprint carries
spellings, descriptions and values, not `group`, so the sweep proves the safety
property and cannot show the intended one. Measured separately by rendering the
whole detail pane for 67 tools — every `lv*`/`vg*`/`pv*` binary on `PATH` (45),
the other known multi-stanza shapes (`mdadm`, `pydoc3`, `adduser`, `deluser`),
and 18 unrelated controls (`git`, `docker`, `tar`, `curl`, `du`, `ip`, `btrfs`,
`dpkg`, `apt-get`, `systemctl`, `openssl`, `ssh`, `rsync`, `gcc`, `find`,
`grep`, `sed`, `awk`) — and diffing the two sides. All 67 rendered on both.

| tool | stanzas relabelled | of which change a visible divider |
|---|---|---|
| `lvconvert` | 13 | 9 |
| `lvchange` | 6 | 4 |
| `vgchange` | 6 | 6 |
| `vgcfgrestore` | 2 | 2 |
| `lvcreate` | 1 | 1 |
| `vgexport` | 1 | 1 |
| `vgimport` | 1 | 1 |
| `vgsplit` | 1 | 1 |

Eight tools, 31 stanzas relabelled and 31 head lines retained in USAGE (one per
relabel, by construction). Six of those 31 change no divider text: their stanza's
flags are all spellings an earlier group already carries, so the group has no
rows of its own to head. Every other tool in the set — including all four other
multi-stanza specimens and all 18 controls — renders byte-identically.

**Guards watched failing** (§3.4). Each defect planted against the committed
tree, then restored:

| planted | went red naming |
|---|---|
| label adoption removed at the call site | `stanza_group_label_is_the_description_above_its_head`, `stanza_head_multi_alias_flag_reads_as_one_flag_with_its_value`, and `corpus vgchange/2.03.16` |
| the blank-line-above (anti-paragraph) clause removed | `trailing_line_of_a_paragraph_is_not_adopted_as_a_stanza_label` |
| the single-field (table-row) clause removed | `stanza_description_recognizer_refuses_every_near_miss` |
| the `meaningful_flag_group` fallback removed | `stanza_without_a_description_keeps_its_head_line_label` plus 5 pre-existing group tests |
| the terminator strip reverted in the TUI | `group_labels_drop_a_sentence_terminator_like_a_heading_colon` |
