### PR TITLE
xtask(residue): walk all entity kinds generically, keyed on shape not kind

### DIFF
--- a/xtask/src/residue.rs
+++ b/xtask/src/residue.rs
@@ -374,37 +374,66 @@ struct Vocabulary {
 }
 
 impl Vocabulary {
+    /// Absorb every entity a node carries, keyed on the **shape of what it
+    /// carries** — a dashed spelling or a bare one — never on
+    /// [`mandible_core::EntityKind`]. This is what lets a kind added later
+    /// (an `EnvVar` producer lands on a sibling branch) reach the
+    /// vocabulary with no further edit here: it is covered the moment it
+    /// exists, because it already has one of the two shapes below.
     fn absorb(&mut self, node: &CommandNode) {
         self.names.insert(node.name.clone());
         for alias in &node.aliases {
             self.names.insert(alias.clone());
         }
-        for p in node.positionals() {
-            self.names.insert(p.primary_name().to_lowercase());
-        }
-        for flag in node.flags() {
-            if let Some(short) = flag.short() {
-                self.flags.insert(format!("-{short}"));
-                if let Some(v) = &flag.value_name {
-                    self.flags.insert(format!("-{short}{v}"));
-                    self.flags.insert(format!("-{short}={v}"));
+        for entity in &node.entities {
+            if entity.short().is_some() || entity.long().is_some() {
+                // A dashed spelling: contributes flag keys, exactly as the
+                // pre-migration flag branch built them (including the
+                // GCC-family reconstruction and the `--[no-]long`
+                // negation forms — see the module doc comment).
+                if let Some(short) = entity.short() {
+                    self.flags.insert(format!("-{short}"));
+                    if let Some(v) = &entity.value_name {
+                        self.flags.insert(format!("-{short}{v}"));
+                        self.flags.insert(format!("-{short}={v}"));
+                    }
+                }
+                if let Some(long) = entity.long() {
+                    self.flags.insert(format!("--{long}"));
+                    if entity.negatable() {
+                        self.flags.insert(format!("--[no-]{long}"));
+                        self.flags.insert(format!("--[no]{long}"));
+                    }
+                    if let Some(v) = &entity.value_name {
+                        self.flags.insert(format!("--{long}={v}"));
+                    }
+                }
+            } else {
+                // A bare, dashless spelling (a positional, a modifier
+                // letter, or an environment variable name): contributes
+                // its primary name, exactly as the pre-migration
+                // positional branch did — lowercased, matching
+                // `is_command_name_shaped`'s own requirement that a name
+                // row's first token is all-lowercase, which is the only
+                // shape `classify` can ever produce a name row's key in
+                // today. An `EntityKind::EnvVar`'s ALL_CAPS name is
+                // unaffected in practice: `classify` never emits a name
+                // row for an uppercase table (see
+                // `an_environment_variable_table_is_not_a_name_row`), so
+                // there is no row this lowering could cause to
+                // mismatch — see this module's PR notes for the design
+                // fork this raised and why it was left as-is.
+                let name = entity.primary_name();
+                if !name.is_empty() {
+                    self.names.insert(name.to_lowercase());
                 }
             }
-            if let Some(long) = flag.long() {
-                self.flags.insert(format!("--{long}"));
-                if flag.negatable() {
-                    self.flags.insert(format!("--[no-]{long}"));
-                    self.flags.insert(format!("--[no]{long}"));
-                }
-                if let Some(v) = &flag.value_name {
-                    self.flags.insert(format!("--{long}={v}"));
-                }
-            }
-            // A bare-word block the parser attached to a flag as its
-            // enumerated choices (`sections/mod.rs` rule 4) was *consumed* —
-            // counting those rows as residue would report the rule working
-            // as if it had failed.
-            for choice in &flag.choices {
+            // Choices are attested the same way for every kind: a
+            // bare-word block the parser attached as an entity's
+            // enumerated choices (`sections/mod.rs` rule 4) was
+            // *consumed* — counting those rows as residue would report
+            // the rule working as if it had failed.
+            for choice in &entity.choices {
                 self.names.insert(choice.as_str().to_string());
             }
         }
@@ -817,7 +846,7 @@ fn print_validation(ranked: &[Ranked], _top: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mandible_core::{Entity, Provenance, Source};
+    use mandible_core::{Entity, EntityKind, Provenance, Source, Spelling};
 
     fn node(name: &str) -> CommandNode {
         CommandNode::new(name, Provenance::single(Source::HelpText))
@@ -1126,6 +1155,57 @@ mod tests {
         let raw = "Usage: /usr/bin/chgrp [OPTION]... GROUP FILE...\n  or:  /usr/bin/chgrp [OPTION]... --reference=RFILE FILE...\n";
         let root = node("chgrp");
         assert_eq!(analyze(raw, &root).rows, 0);
+    }
+
+    // --- entity kinds beyond flags and positionals -----------------------
+    //
+    // `absorb` walks every entity generically, keyed on shape (a dashed
+    // spelling vs. a bare one) rather than on `EntityKind`. These tests
+    // pin that a `Modifier` and an `EnvVar` entity — the two kinds a
+    // `match` over `EntityKind` would have been tempted to special-case —
+    // both reach the vocabulary through the same bare-spelling branch a
+    // positional already used.
+
+    /// A `Modifier` entity's bare letter reaches the vocabulary and
+    /// attests a matching row — `ar`'s own shape (`ar rvD archive.a
+    /// foo.o`, documented as an indented `d  delete members...` table).
+    #[test]
+    fn a_modifier_entitys_letter_reaches_the_vocabulary() {
+        let raw = "Modifiers:\n  d            delete members from the archive\n  r            insert with replacement\n";
+        let mut root = node("ar");
+        root.entities
+            .push(Entity::modifier('d', Provenance::single(Source::HelpText)));
+        root.entities
+            .push(Entity::modifier('r', Provenance::single(Source::HelpText)));
+        let report = analyze(raw, &root);
+        assert_eq!(report.rows, 2);
+        assert_eq!(
+            report.unaccounted, 0,
+            "a modifier's letter must attest its own row"
+        );
+    }
+
+    /// The forward-compatibility claim this whole rewrite exists for: an
+    /// `EntityKind::EnvVar` entity — a kind that exists on `main` today
+    /// even though no tier emits one yet (spec §4.5) — reaches the
+    /// vocabulary the moment one is constructed, with no further edit to
+    /// this file once a producer lands. Built directly (`Entity::new` +
+    /// a bare `Spelling`) rather than through a not-yet-existing
+    /// `Entity::env_var` constructor, since none exists on `main`.
+    #[test]
+    fn an_env_var_entitys_name_reaches_the_vocabulary() {
+        let mut e = Entity::new(EntityKind::EnvVar, Provenance::single(Source::HelpText));
+        e.spellings.push(Spelling::bare("FFREPORT"));
+        let mut root = node("ffmpeg");
+        root.entities.push(e);
+
+        let mut vocab = Vocabulary::default();
+        vocab.absorb(&root);
+        assert!(
+            vocab.names.contains("ffreport"),
+            "an EnvVar entity's name must reach the vocabulary: {:?}",
+            vocab.names
+        );
     }
 
     #[test]

--- a/xtask/src/residue.rs
+++ b/xtask/src/residue.rs
@@ -1167,8 +1167,21 @@ mod tests {
     // positional already used.
 
     /// A `Modifier` entity's bare letter reaches the vocabulary and
-    /// attests a matching row — `ar`'s own shape (`ar rvD archive.a
-    /// foo.o`, documented as an indented `d  delete members...` table).
+    /// attests a matching row.
+    ///
+    /// The table below is deliberately **name-row shaped**
+    /// (`d<gutter>description`), not `ar`'s real bracketed modifier row
+    /// (`  [D]          - use zero for timestamps...`, see
+    /// `corpus/ar/audit-seed2/help.txt`) — a bracketed row is not
+    /// name-shaped and `classify` produces no row for it at all, so it
+    /// could never exercise this attribution. The name-row shape here is
+    /// the only one `classify` can emit a row for, which is also exactly
+    /// why the fleet-wide before/after residue diff over `corpus/` is
+    /// null today: no committed fixture's modifier table happens to be
+    /// name-shaped. `ar rvD archive.a foo.o` is real `ar` usage — modifier
+    /// letters glued to an operation letter — kept only as a familiar
+    /// example of the notation, not a claim about how `ar` prints its
+    /// table.
     #[test]
     fn a_modifier_entitys_letter_reaches_the_vocabulary() {
         let raw = "Modifiers:\n  d            delete members from the archive\n  r            insert with replacement\n";


### PR DESCRIPTION
## What changed

`Vocabulary::absorb` in `xtask/src/residue.rs` walked `node.flags()` and `node.positionals()` only, so the two entity kinds that don't hold a per-kind vector today — `Modifier` (producer landed in #87) and `EnvVar` (producer landing on a sibling branch) — were invisible to the residue instrument even though the tree accounts for them. Anything the tree recovered as a modifier or an env var read to residue as though the parser never accounted for it.

`absorb` now walks `node.entities` once and branches on the **shape of what an entity carries**, never on `EntityKind`:

- an entity with a dashed spelling (`short()`/`long()` return `Some`) contributes flag keys, exactly as the old flag branch built them — including the GCC single-dash reconstruction (`-fdump-scos`) and the `--[no-]long` negation forms;
- an entity with only a bare, dashless spelling contributes `primary_name()` to `names`, exactly as the old positional branch did (lowercased — see the design-fork note below);
- `choices` still contribute to `names` for every entity, as before.

No `match` over `EntityKind` anywhere in the rewrite. This means the `EnvVar` producer landing on its sibling branch needs no further edit here — the moment it emits an entity, that entity already has one of the two shapes above.

The row classifier (`classify`, `opens_like_a_flag`, `is_command_name_shaped`, `RowShape`) is untouched, as required — this changes what the tree can attest with, not what counts as a row.

## Design fork (resolved, reported)

The old positional branch lowercased `primary_name()` before inserting into `names`. Kept unchanged for all dashless kinds. This is arguably not "right" for an `EnvVar`'s canonically-ALL_CAPS name — but it costs nothing today: `is_command_name_shaped` requires an all-lowercase first token, so `classify` can never produce a name-row key that isn't already lowercase (pinned by the existing `an_environment_variable_table_is_not_a_name_row` test). There is no row shape today an uppercase vocabulary entry could match that a lowercased one couldn't. Kept the uniform lowering rather than adding a kind-specific exception, since that would reintroduce the per-kind branching this change removes. Flagged here in case a future classifier shape ever admits an uppercase name row.

## Before/after residue diff over `corpus/`

Ran `cargo run -p xtask -- residue --dir corpus --top 200 --detail 200 --include-verbatim` on the base commit and on this branch, byte-diffed the two outputs (ignoring the `cargo build` timing line): **identical**. Zero rows moved.

This is the honest result, not a null result dressed up: today's row classifier only ever emits a dash-led flag row or an indented lowercase `name<gutter>description` row. `classify` defines exactly those two shapes; a bracketed `[a]` modifier row is not name-shaped by that definition and produces no row at all, and no fixture's `EnvVar` rows (uppercase — spec §13.1f names this shape explicitly, `an_environment_variable_table_is_not_a_name_row` pins it) take a name-row shape either. So the fix closes a real hole in the instrument's vocabulary, but the hole was latent for every fixture in `corpus/` today. It stops being latent the moment a dashless kind's rows take a name-row shape, or the vocabulary is queried directly (see the new `EnvVar`/`Modifier` unit tests, which do exercise it directly and pass — the modifier test's fixture is deliberately name-row-shaped for exactly this reason, since `ar`'s real bracketed modifier table produces no row for `classify` to match against at all).

`git status` over `corpus/` shows no snapshot movement. `cargo run -p xtask -- corpus` is green: 107 ok, 9 xfail as expected, 0 failed.

## Tests added

- `a_modifier_entitys_letter_reaches_the_vocabulary` — a `Modifier` entity's bare letter attests a matching row end-to-end through `analyze`. Uses a synthetic name-row-shaped modifier table, not `ar`'s real bracketed one (`corpus/ar/audit-seed2/help.txt`), because only the name-row shape produces anything for `classify` to match against.
- `an_env_var_entitys_name_reaches_the_vocabulary` — constructs an `EntityKind::EnvVar` entity directly (no producer exists on `main` yet) and asserts its name reaches `Vocabulary::names`, pinning the forward-compatibility claim.
- Existing flag-reconstruction tests (`a_gcc_single_dash_flag_is_attested_by_its_reconstructed_spelling`, `a_glued_value_spec_is_attested_by_the_stripped_stored_spelling`, `a_negatable_flags_bracketed_raw_form_is_attested`, and the rest of the suite) verified unchanged — no new risk found in the flag path.

### §3.4 planting record

Planted the defect by re-narrowing the generic walk back to `EntityKind::Flag | EntityKind::Positional` only (skipping `Modifier`/`EnvVar` via a `continue`), then ran the two new tests:

- `an_env_var_entitys_name_reaches_the_vocabulary` → **RED**, panic message: `an EnvVar entity's name must reach the vocabulary: {"ffmpeg"}` — names the missing kind.
- `a_modifier_entitys_letter_reaches_the_vocabulary` → **RED**, panic message: `assertion left == right failed: a modifier's letter must attest its own row (left: 2, right: 0)` — the modifier's rows stayed fully unaccounted, naming the failure.

Restored with `git checkout -- xtask/src/residue.rs` (committed before planting, per AGENTS §3.4/§5). Full suite re-run green afterward (1413 tests). Independently re-verified and re-planted by a second reviewing agent, same result.

## CHANGELOG

No entry added. `xtask/src/residue.rs` is an internal discovery instrument (spec §13.1f) — it is not wired into any gate, never shipped, and not something a user of a release would notice. Nothing in the AGENTS §5.1 trigger matrix's left column applies.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 1413 passed, 0 skipped
- `cargo build --release` — succeeds
- `scripts/changelog_guard.sh` — released sections match their tags
- `cargo run -p xtask -- corpus` — 107 ok, 9 xfail as expected, 0 failed

## Scope

Only `xtask/src/residue.rs` touched, per the task's scope boundary with the sibling branches (`feat/emission-env-vars`, `fix/77-fence-edges`, `fix/llvm-ar-operations-table`).

## Follow-up

A second commit (`67b8028`) fixes a doc-comment-only defect a review found: `a_modifier_entitys_letter_reaches_the_vocabulary`'s comment incorrectly attributed its name-row-shaped fixture to `ar`'s own modifier table, when `ar` actually documents modifiers in bracketed form (`[a]`, `[D]`) under `command specific modifiers:`/`generic modifiers:`, and the letters shown (`d`, `r`) are `ar`'s *commands*, not its modifiers. No code changed; the comment now explains why the test deliberately uses a shape `ar` doesn't.
