### PR TITLE
fix(help-text): close the three obscured-Examples fence edges from #77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ once it reaches a published 0.1.0 release.
 
 - `dpkg --help`'s cross-reference sentence about `dpkg-deb` no longer becomes a section divider and a `-f, --field` option `dpkg` does not have (issue #80): a sentence that hard-wraps onto a hanging-indented line reads to the indentation-alone heading rule as a heading over a block, and when the wrap lands on a dash-led word that block parses as an options table, so the parser now recognizes the unfinished line by its own trailing comma and contains the whole wrapped region — bounded by the first blank line, dedent, or aligned column, so a genuine table beneath such a line is still parsed in full, with no tool-name-keyed logic.
 
+- The obscured-`Examples:` fence (issue #77, a follow-up to issue #71's `jar` fix) no longer loses a well-formed flag section indented deeper than the marker or written with no heading at all, no longer cancels a suppression a genuine earlier `EXAMPLES:` heading had already established when the fence itself closes, and no longer opens at all on an ordinary sentence like `Report bugs to <address>.` that merely happens to share vocabulary with a real `Examples:`/`Report bugs:` heading — the fence now reopens only on independently attested flag evidence, restores rather than clears the suppression state that preceded it, and triggers only on a heading-shaped, colon-terminated marker.
+
 ## [0.5.0] - 2026-08-30
 
 ### Added

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -521,13 +521,35 @@ pub(super) fn obscured_fence_reopens(lines: &[&str], idx: usize, marker_indent: 
 }
 
 /// Headingless counterpart of [`starts_attested_flag_section`]: `lines[idx]`
-/// itself already looks like a flag row ([`looks_like_flag_start`]), and the
-/// block it opens independently parses at least [`MIN_ATTESTED_SECTION_FLAGS`]
-/// rows. No heading vocabulary is required or possible here — the whole
-/// point is that there is no heading — so the row-count floor is the only
-/// evidence, same floor and same reasoning as the headed case.
+/// itself already looks like a flag row ([`looks_like_flag_start`]), no
+/// heading-shaped line immediately governs it, and the block it opens
+/// independently parses at least [`MIN_ATTESTED_SECTION_FLAGS`] rows.
+///
+/// The "no heading-shaped line immediately governs it" clause is load-
+/// bearing, not a stylistic nicety. `labels_inside_indented_examples_do_not_
+/// reopen_flag_parsing` (this file's sibling module) pins the shape that
+/// requires it: a worked example writes ` Input:`/` Output:` labels — real
+/// section headings by every structural test, just not ones naming CLI
+/// vocabulary — directly over sample rows that are themselves dash-led
+/// (`--fake-one VALUE   example input, not a supported option`). Dropping
+/// the "no governing heading" requirement would read every one of those
+/// rows as headingless and reopen on the same two-row floor, exactly
+/// reproducing the ambiguity [`names_flag_section`]'s own doc comment
+/// warns about — a label can govern `--flag`-shaped sample data as
+/// plausibly as it can govern real flags. A row is trusted as headingless
+/// only when nothing heading-shaped sits directly above it: `sed --help`'s
+/// own `Options:`-free block, whose entries start on line one with nothing
+/// above them at all, is the shape this clause is scoped to admit.
 pub(super) fn starts_attested_headingless_flag_block(lines: &[&str], idx: usize) -> bool {
     if !looks_like_flag_start(lines[idx].trim_start()) {
+        return false;
+    }
+    if lines[..idx]
+        .iter()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .is_some_and(|l| is_section_heading_line(l.trim()))
+    {
         return false;
     }
     let (_, entries, _) = scan_flags_block(lines, idx, false);

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -313,15 +313,21 @@ pub(super) const MIN_PROSE_SENTENCE_WORDS: usize = 5;
 /// [`parse_with_profile`], which stops a synopsis from swallowing
 /// `sg_emc_trespass`'s trailing sentences and mining `LUN`/`SP`/`EMC` out of
 /// them as fabricated positionals); two more only decide whether a heading
-/// may be copied into a flag's `group`. The section loop has one additional,
-/// deliberately subtractive use: a prose line followed by a more-indented
-/// [`is_ignorable_heading`] marker opens `obscured_ignorable_indent`, whose
-/// whole-region fence can remove entries fabricated from worked examples.
-/// It never recognizes a command heading or sets
-/// `CommandNode::heading_attested`, and its same-indent exit admits only an
-/// attested *flag* section, so it cannot widen the set of nodes eligible to
-/// become `<word> --help` probe argv. The jar and internal-`Commands:`
-/// regression tests beside the section parser pin that safety boundary;
+/// may be copied into a flag's `group`. The section loop has one additional
+/// use: a prose line followed by a more-indented `is_obscured_fence_marker`
+/// opens `obscured_ignorable_indent`, whose whole-region fence can remove
+/// entries fabricated from worked examples. It never recognizes a command
+/// heading or sets `CommandNode::heading_attested`, and its reopening exit
+/// (`obscured_fence_reopens`) admits only an independently attested *flag*
+/// section, so it cannot widen the set of nodes eligible to become `<word>
+/// --help` probe argv — but calling the whole use "subtractive" overstates
+/// what it guarantees: the fence's *close* restores whatever
+/// `in_ignorable_section` held immediately before it opened (issue #77 edge
+/// 2), rather than clearing it, because clearing unconditionally could
+/// cancel a suppression a genuine, non-obscured `EXAMPLES:` heading had
+/// already established earlier in the same document — a real restoration,
+/// not a pure subtraction. The jar and internal-`Commands:` regression
+/// tests beside the section parser pin the argv-eligibility boundary;
 /// `mandible-extract/tests/exec_policy.rs` separately pins the older,
 /// group-only call sites.
 pub(super) fn is_prose_sentence(heading: &str) -> bool {
@@ -456,6 +462,76 @@ pub(super) fn wrapped_prose_region_end(lines: &[&str], head: usize) -> Option<us
         end += 1;
     }
     (end > head + 1).then_some(end)
+}
+
+/// True when `heading` may open the obscured-marker whole-region fence
+/// (`obscured_ignorable_indent`) — issue #77 edge 3.
+///
+/// [`is_ignorable_heading`] is a per-heading test: at every one of its other
+/// call sites, a false positive suppresses at most the one heading's own
+/// block. Reused as the trigger for a *whole-region* fence, the same
+/// looseness stopped being bounded — a mid-document `Report bugs to
+/// <maintainer@example.com>.` line, sitting under a lower-indented prose
+/// sentence purely by document layout, fenced everything after it until the
+/// next physical dedent. That line is a sentence (period-terminated, with
+/// usage-grammar punctuation in the address), not a label, and no fence
+/// trigger should treat it as one.
+///
+/// This adds [`is_section_heading_line`]'s own bar — short, colon-terminated,
+/// plain-word label — on top of [`is_ignorable_heading`]'s vocabulary, so the
+/// fence only opens on something that is heading-*shaped* as well as
+/// heading-*worded*: `Examples:` and `Report bugs:` qualify; `Report bugs to
+/// <maintainer@example.com>.` does not. `is_ignorable_heading` itself is left
+/// untouched — it is correct at its other ~10 call sites, and this predicate
+/// exists precisely so the fence stops borrowing it instead of tightening it
+/// out from under them.
+pub(super) fn is_obscured_fence_marker(heading: &str) -> bool {
+    is_section_heading_line(heading) && is_ignorable_heading(heading)
+}
+
+/// Whether the obscured-marker fence (`obscured_ignorable_indent`) may close
+/// at `lines[idx]`, given the marker's own indent — issue #77 edge 1.
+///
+/// The fence's original exits were a physical dedent below the marker's
+/// indent, or [`starts_attested_flag_section`] at *exactly* the marker's
+/// indent. Both are too narrow: a well-formed, positively-evidenced flag
+/// section indented *deeper* than the marker, or a headingless flag block at
+/// any indent at or past the marker's, previously had no exit at all and
+/// stayed suppressed for the rest of the document.
+///
+/// The fix widens *which indents* may exit, while keeping the exit itself
+/// exactly as evidence-gated as before — a fence any indented line can
+/// reopen is not a fence:
+///
+/// - A physical dedent (`indent < marker_indent`) still exits unconditionally,
+///   as it always did.
+/// - [`starts_attested_flag_section`] — heading vocabulary plus
+///   [`MIN_ATTESTED_SECTION_FLAGS`] independently parsed rows below it — now
+///   qualifies at the marker's indent *or deeper*, not only at exactly it.
+/// - A headingless run of at least [`MIN_ATTESTED_SECTION_FLAGS`] flag rows
+///   ([`starts_attested_headingless_flag_block`]) is admitted as the same
+///   evidence, since a headingless block can never satisfy a heading-vocabulary
+///   test in the first place.
+pub(super) fn obscured_fence_reopens(lines: &[&str], idx: usize, marker_indent: usize) -> bool {
+    let indent = leading_whitespace(lines[idx]);
+    if indent < marker_indent {
+        return true;
+    }
+    starts_attested_flag_section(lines, idx) || starts_attested_headingless_flag_block(lines, idx)
+}
+
+/// Headingless counterpart of [`starts_attested_flag_section`]: `lines[idx]`
+/// itself already looks like a flag row ([`looks_like_flag_start`]), and the
+/// block it opens independently parses at least [`MIN_ATTESTED_SECTION_FLAGS`]
+/// rows. No heading vocabulary is required or possible here — the whole
+/// point is that there is no heading — so the row-count floor is the only
+/// evidence, same floor and same reasoning as the headed case.
+pub(super) fn starts_attested_headingless_flag_block(lines: &[&str], idx: usize) -> bool {
+    if !looks_like_flag_start(lines[idx].trim_start()) {
+        return false;
+    }
+    let (_, entries, _) = scan_flags_block(lines, idx, false);
+    entries.len() >= MIN_ATTESTED_SECTION_FLAGS
 }
 
 /// Longest label this will accept before a `:` still counts as a section

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -152,6 +152,16 @@ impl ParsedHelp {
     }
 }
 
+/// Minimum count of independently parsed flag rows a same-indent (or
+/// deeper) block must produce before it is trusted as real structure over
+/// worked-example prose. Shared by [`starts_attested_flag_section`] (a
+/// headed block) and `heading::starts_attested_headingless_flag_block` (a
+/// headingless one): both read this as the same evidence bar, just applied
+/// to different shapes of the same question — "is this row run cheap for
+/// an unrelated document to have produced, or does it need a real flag
+/// table to explain it."
+pub(super) const MIN_ATTESTED_SECTION_FLAGS: usize = 2;
+
 /// Section headings that introduce worked examples or prose, not
 /// structure — a general (not tool-specific) exclusion, since "Examples:"
 /// sections showing up as fake subcommands is a real failure mode (e.g.
@@ -211,8 +221,6 @@ fn names_flag_section(heading: &str) -> bool {
 /// enough: its following nonblank content must be more indented and must
 /// independently satisfy the existing bounded flag-block recognizer.
 fn starts_attested_flag_section(lines: &[&str], heading_idx: usize) -> bool {
-    const MIN_ATTESTED_SECTION_FLAGS: usize = 2;
-
     let heading = lines[heading_idx];
     if !names_flag_section(heading.trim()) {
         return false;
@@ -1068,18 +1076,26 @@ fn parse_body(
     // immediately before it.  The generic relative-indent engine otherwise
     // promotes that prose sentence to a heading and consumes the marker as
     // ordinary content, so `is_ignorable_heading` never gets to establish
-    // the section context at all.  While this is `Some(indent)`, the marker
-    // was found in exactly that obscured shape and the whole region is
-    // fenced before *any* headingless or headed emission path can see its
-    // rows.  A physical dedent always closes the region.  At the marker's
-    // own indent, only `starts_attested_flag_section` may close it; a plain
-    // `Input:`/`Output:` label inside the example may not.
+    // the section context at all.  While this is `Some((indent, _))`, the
+    // marker was found in exactly that obscured shape and the whole region
+    // is fenced before *any* headingless or headed emission path can see
+    // its rows.  A physical dedent always closes the region; short of one,
+    // only `obscured_fence_reopens` (issue #77 edge 1: an independently
+    // attested flag section, headed or not, at the marker's indent or
+    // deeper) may close it — a plain `Input:`/`Output:` label inside the
+    // example may not, and neither may a bare dedent-free row of
+    // unattested content.
     //
     // This state is deliberately separate from `in_ignorable_section`:
     // direct, correctly-recognized `Examples:` headings retain their
     // established behavior, while the stronger whole-region fence applies
-    // only to markers that the prose-parent quirk would otherwise hide.
-    let mut obscured_ignorable_indent: Option<usize> = None;
+    // only to markers that the prose-parent quirk would otherwise hide. The
+    // tuple's second field is the value `in_ignorable_section` held the
+    // instant before the fence opened — the close restores it (issue #77
+    // edge 2) rather than clearing it outright, so a fence opened *inside*
+    // an already-suppressed `EXAMPLES:` section cannot cancel that
+    // suppression when it closes.
+    let mut obscured_ignorable_indent: Option<(usize, bool)> = None;
 
     // 3. Section blocks: scan the rest of the output for a heading line
     // followed by more-indented content — or, if the very first content
@@ -1098,13 +1114,10 @@ fn parse_body(
             i += 1;
             continue;
         }
-        if let Some(marker_indent) = obscured_ignorable_indent {
-            let indent = leading_whitespace(line);
-            if indent < marker_indent
-                || (indent == marker_indent && starts_attested_flag_section(&lines, i))
-            {
+        if let Some((marker_indent, prior_ignorable)) = obscured_ignorable_indent {
+            if obscured_fence_reopens(&lines, i, marker_indent) {
                 obscured_ignorable_indent = None;
-                in_ignorable_section = false;
+                in_ignorable_section = prior_ignorable;
             } else {
                 i += 1;
                 continue;
@@ -1184,9 +1197,10 @@ fn parse_body(
             }
             if marker_idx < lines.len()
                 && leading_whitespace(lines[marker_idx]) > heading_indent
-                && is_ignorable_heading(lines[marker_idx].trim())
+                && is_obscured_fence_marker(lines[marker_idx].trim())
             {
-                obscured_ignorable_indent = Some(leading_whitespace(lines[marker_idx]));
+                obscured_ignorable_indent =
+                    Some((leading_whitespace(lines[marker_idx]), in_ignorable_section));
                 in_ignorable_section = true;
                 command_mode = false;
                 i = marker_idx + 1;
@@ -2211,6 +2225,130 @@ mod tests {
         assert!(!is_command_name_shaped("BYTES"));
         assert!(!is_command_name_shaped(""));
         assert!(!is_command_name_shaped("42start"));
+    }
+
+    // --- issue #77: obscured-`Examples:` fence edges ---------------------
+
+    /// Edge 1: a well-formed, positively-attested flag section indented
+    /// *deeper* than the obscured marker must still be recoverable — the
+    /// fence's only historical exits were a physical dedent, or an
+    /// attested flag section at *exactly* the marker's indent, so a real
+    /// `Options:` block sitting deeper than ` Examples:` (itself sitting
+    /// deeper than the prose sentence that obscures it) was silently lost
+    /// forever, with no dedent anywhere below to rescue it.
+    #[test]
+    fn obscured_fence_admits_a_deeper_attested_flag_section() {
+        let raw = "\
+This tool does many useful things for the busy user.
+  Examples:
+    widget run --now
+      runs immediately without prompting
+    widget stop
+      halts all processing at once
+    Options:
+      --now      run immediately without prompting
+      --stop     halt all processing at once
+";
+        let parsed = parse(raw);
+        let names: Vec<_> = parsed.flags.iter().map(|f| f.long()).collect();
+        assert!(
+            parsed.flags.iter().any(|f| f.long() == Some("now")),
+            "expected --now among {names:?}"
+        );
+        assert!(
+            parsed.flags.iter().any(|f| f.long() == Some("stop")),
+            "expected --stop among {names:?}"
+        );
+    }
+
+    /// Edge 1: the same widened exit admits a *headingless* flag block —
+    /// no heading vocabulary is possible when there is no heading, so the
+    /// row-count floor alone (`starts_attested_headingless_flag_block`)
+    /// must be the evidence.
+    #[test]
+    fn obscured_fence_admits_a_deeper_headingless_flag_block() {
+        let raw = "\
+This tool does many useful things for the busy user.
+  Examples:
+    widget run --now
+      runs immediately without prompting
+    --now      run immediately without prompting
+    --stop     halt all processing at once
+";
+        let parsed = parse(raw);
+        assert!(
+            parsed.flags.iter().any(|f| f.long() == Some("now")),
+            "expected --now among {:?}",
+            parsed.flags.iter().map(|f| f.long()).collect::<Vec<_>>()
+        );
+        assert!(
+            parsed.flags.iter().any(|f| f.long() == Some("stop")),
+            "expected --stop among {:?}",
+            parsed.flags.iter().map(|f| f.long()).collect::<Vec<_>>()
+        );
+    }
+
+    /// Edge 2: the fence's close must *restore* whatever `in_ignorable_section`
+    /// held before it opened, not clear it outright. Reproduced shape from
+    /// the issue: a real, non-obscured `EXAMPLES:` heading (which
+    /// legitimately suppresses `recover_stanza_head_flag` for the rest of
+    /// its section) contains a prose sentence with an obscured ` Examples:`
+    /// marker beneath it; the marker's own fence then closes on a physical
+    /// dedent back to a stanza-head-shaped example line
+    /// (`widget -x`). Clearing `in_ignorable_section` on that close cancels
+    /// the outer `EXAMPLES:` heading's own, entirely legitimate,
+    /// suppression — exactly the bpftrace fabrication class
+    /// `in_ignorable_section` exists to prevent — and the dedented example
+    /// line is misread as a real stanza head, fabricating a `-x` flag.
+    #[test]
+    fn obscured_fence_close_restores_rather_than_clears_suppression() {
+        let raw = "\
+EXAMPLES:
+
+This tool does many useful things for the busy user.
+  Examples:
+widget -x
+  run example x
+";
+        let parsed = parse_named(raw, "widget");
+        assert!(
+            !parsed.flags.iter().any(|f| f.short() == Some('x')),
+            "fence close must not fabricate -x from the example: {:?}",
+            parsed
+                .flags
+                .iter()
+                .map(|f| (f.short(), f.long()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Edge 3: the obscured-marker fence trigger must be stricter than
+    /// `is_ignorable_heading` — heading-shaped and colon-terminated, not
+    /// merely "starts with 'example' or contains 'report bugs'". Reproduced
+    /// shape from the issue: a mid-document `Report bugs to <address>.`
+    /// *sentence* (not a heading) sitting under a lower-indented prose
+    /// sentence must never open the whole-region fence; if it does, it
+    /// silently swallows every real command table after it (which the
+    /// edge-1 rescue cannot see, since it only recognizes flag evidence)
+    /// until a dedent that never comes.
+    #[test]
+    fn obscured_fence_trigger_requires_heading_shape() {
+        let raw = "\
+This tool supports many commands for the busy user.
+  Report bugs to <maintainer@example.com>.
+  start   begin processing
+  stop    end processing
+";
+        let parsed = parse(raw);
+        let names: Vec<_> = parsed.subcommands.iter().map(|c| &c.name).collect();
+        assert!(
+            parsed.subcommands.iter().any(|c| c.name == "start"),
+            "expected 'start' among {names:?}"
+        );
+        assert!(
+            parsed.subcommands.iter().any(|c| c.name == "stop"),
+            "expected 'stop' among {names:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #77

## Summary

Three recorded edges in the obscured-`Examples:` fence (issue #71's `jar` fix), all reachable only by construction — no real tool on a full-`PATH` sweep exhibits any of them:

1. **The fence could never reopen on a deeper or headingless attested flag section.** Its only exits were a physical dedent, or an attested flag section at *exactly* the marker's indent. A well-formed flag section indented deeper than the marker, or a headingless flag block at any indent at or past the marker's, stayed suppressed forever.
2. **Fence close cleared `in_ignorable_section` unconditionally**, which could cancel a suppression a genuine, earlier `EXAMPLES:` heading had already established — the exact bpftrace fabrication class `in_ignorable_section` exists to prevent.
3. **The fence trigger reused `is_ignorable_heading`**, whose per-heading looseness ("starts with 'example'" / "contains 'report bugs'") was safe when bounded to one heading's own block, but not as a whole-region fence opener: a mid-document `Report bugs to <address>.` *sentence* under a lower-indented prose sentence could fence everything after it until a dedent.

## Fix

- **Edge 1**: the fence's reopen test (`heading::obscured_fence_reopens`) now admits an attested flag section (`starts_attested_flag_section`, unchanged: heading vocabulary + ≥2 independently parsed rows) at the marker's indent *or deeper*, and adds a headingless counterpart (`starts_attested_headingless_flag_block`) for a block with no heading at all — same ≥2-row evidence bar, and additionally refusing to fire when a heading-shaped line immediately precedes the row (see below).
- **Edge 2**: `obscured_ignorable_indent` now carries the `in_ignorable_section` value from the instant before it opened, and the fence's close restores that value instead of hard-clearing it.
- **Edge 3**: a new predicate, `heading::is_obscured_fence_marker`, gates the fence-open site — heading-shaped (`is_section_heading_line`: short, colon-terminated, plain words) *and* `is_ignorable_heading`'s existing vocabulary. `is_ignorable_heading` itself is untouched and still used exactly as before at its ~10 other call sites.
- Tightened `is_prose_sentence`'s doc comment, which called its obscured-fence use "deliberately subtractive" — edge 2 is exactly the path where that overstated the guarantee (a close that clears unconditionally is a restoration, not a subtraction, when it goes wrong).

**A defect found and fixed during this work, not filed as a separate issue** (AGENTS §5, "fix the defect you found"): the first cut of edge 1's headingless rescue reopened on a worked example's own `Input:`/`Output:` labels sitting directly over dash-led sample rows (`--fake-one VALUE   example input, not a supported option`) — exactly the ambiguity `names_flag_section`'s doc comment warns about, and exactly what the existing `labels_inside_indented_examples_do_not_reopen_flag_parsing` test pins against. `starts_attested_headingless_flag_block` now also requires that no heading-shaped line immediately precedes the candidate row, scoping the rescue to sed's own no-heading-at-all shape.

## Regression tests (issue #77 shapes)

Four new tests in `mandible-extract/src/help_text/sections/mod.rs`, one per edge (two for edge 1 — headed and headingless):

- `obscured_fence_admits_a_deeper_attested_flag_section`
- `obscured_fence_admits_a_deeper_headingless_flag_block`
- `obscured_fence_close_restores_rather_than_clears_suppression`
- `obscured_fence_trigger_requires_heading_shape`

Each was watched failing against the unfixed parser before the fix landed, and again after fixing edge 1 to confirm the new "no governing heading" clause is load-bearing (planted by reverting each change in isolation, run, confirm the failure names the missing/fabricated flag or subcommand, then `git checkout --` to restore — commit-before-attack per AGENTS §3.4/§5 in all cases). Failure texts:

```
obscured_fence_admits_a_deeper_attested_flag_section: expected --now among []
obscured_fence_admits_a_deeper_headingless_flag_block: expected --now among []
obscured_fence_close_restores_rather_than_clears_suppression:
  fence close must not fabricate -x from the example: [(Some('x'), None)]
obscured_fence_trigger_requires_heading_shape: expected 'start' among []
labels_inside_indented_examples_do_not_reopen_flag_parsing (pre-existing, replanted):
  left: ["fake-one", "fake-two", "fake-result", "fake-option", "real", "verbose"]
  right: ["real", "verbose"]
```

## Fleet sweep (required by the task: zero movement anywhere)

Built `--release` on base commit `87c6d6fde6b28086779fce369e56e0fb01cf845a` and on this branch, swept full `PATH` (2,258 tools matched on each side after the truncated-name drop) with each, and diffed:

```
overall: IDENTICAL
sweep transition: 2258 -> 2258 tools, 2258 matched, 0 appeared, 0 disappeared, 39 excluded (near 10s cap)

# status transitions
(none)

# flag-count losses (the bar — never netted): 0 lost across 0 tool(s)
# flag-count gains: 0 gained across 0 tool(s)
# field-level changes: 0 tool(s) (adds/removes/changes, never just a count)
# appeared (0):
# disappeared (0):

# excluded, near 10s timeout cap (39)
  bitesize-bpfcc: verbatim@7879ms -> verbatim@11635ms
  byobu-status-detail: verbatim@12130ms -> verbatim@12060ms
  claude: ok@11670ms -> ok@10271ms
  dockerd: ok@8438ms -> ok@7847ms
  instmodsh: ok@13444ms -> ok@14606ms
  jconsole: ok@22160ms -> ok@22195ms
  keep-one-running: verbatim@12082ms -> verbatim@12075ms
  llvm-PerfectShuffle-18: verbatim@12067ms -> verbatim@12077ms
  llvm-exegesis-18: ok@8718ms -> ok@7250ms
  lxd.check-kernel: verbatim@4735ms -> verbatim@5347ms
  lxd.lxc: verbatim@4365ms -> verbatim@5318ms
  mariadbd: ok@5235ms -> ok@4727ms
  mdflush-bpfcc: ok@22288ms -> ok@22374ms
  node: ok@5206ms -> ok@7770ms
  nodejs: ok@7860ms -> ok@9172ms
  nvidia-detector: verbatim@5120ms -> verbatim@6028ms
  oomkill-bpfcc: ok@22253ms -> ok@22221ms
  opencode: ok@16524ms -> ok@14401ms
  pam-auth-update: low-confidence@12395ms -> low-confidence@12387ms
  pam_extrausers_chkpwd: verbatim@12051ms -> verbatim@12061ms
  pam_extrausers_update: verbatim@12058ms -> verbatim@12074ms
  pbput: ok@22111ms -> ok@22150ms
  pbputs: verbatim@12096ms -> verbatim@12061ms
  pidpersec-bpfcc: verbatim@7038ms -> verbatim@7907ms
  pip: ok@5538ms -> ok@4619ms
  pip3: ok@6345ms -> ok@4554ms
  pip3.12: ok@5051ms -> ok@4408ms
  run-one-constantly: verbatim@12076ms -> verbatim@12088ms
  run-one-until-success: verbatim@12064ms -> verbatim@12067ms
  rust-lldb: ok@4632ms -> ok@6646ms
  threadsnoop-bpfcc: verbatim@8969ms -> verbatim@10772ms
  ua: verbatim@4865ms -> verbatim@5355ms
  ubuntu-advantage: verbatim@4400ms -> verbatim@5055ms
  ubuntu-security-status: verbatim@4812ms -> verbatim@5544ms
  unified-monitoring-agent: ok@5204ms -> ok@4772ms
  unix_chkpwd: verbatim@12064ms -> verbatim@12084ms
  unix_update: verbatim@12060ms -> verbatim@12085ms
  vimtutor: verbatim@12065ms -> verbatim@12062ms
  wifi-status: verbatim@12089ms -> verbatim@12080ms
```

Every excluded-near-cap tool carries the *same* status on both sides (timing jitter only, no `verbatim -> ok` or similar hiding in the exclusion), so this is a genuine zero-movement result, not one that happens to exclude the interesting cases.

A `--tools`-pinned cross-check (reproduces full-`PATH` numbers exactly, per AGENTS §5.2) on `jar`, `bpftrace`, and the borderline/near-cap set (`oomkill-bpfcc`, `mdflush-bpfcc`, `threadsnoop-bpfcc`, `pidpersec-bpfcc`, `node`, `pip`, `jconsole`, `claude`) also came back `overall: IDENTICAL`, 0 status transitions, 0 field-level changes — `jar` and `bpftrace` weren't even near the timeout cap in that run.

## Visual verification

`jar` and `bpftrace` are the two tools the original fence work touched (`jar` was the one measured change when the fence landed; `bpftrace` is the fabrication class `in_ignorable_section` exists to prevent). Both render byte-identically before and after this fix (`diff` on the captured screens is empty).

<details>
<summary><code>mandible bpftrace</code> — unchanged</summary>

```
╭ commands (1) ─────────────────────────────╮╭ bpftrace ─────────────────────────────────╮
│  bpftrace                                 ││ USAGE ─────────────────────────────────── │
│                                           ││   bpftrace                                │
│                                           ││   bpftrace [options] filename             │
│                                           ││   bpftrace [options] - <stdin input>      │
│                                           ││   bpftrace [options] -e 'program'         │
│                                           ││                                           │
│                                           ││                                           │
│                                           ││ FLAGS (24) ────────────────────────────── │
│                                           ││ -B MODE      output buffering mode        │
│                                           ││              ('full', 'none')             │
│                                           ││ -f FORMAT    output format ('text',       │
│                                           ││              'json')                      │
│                                           ││ -o file      redirect bpftrace output to  │
│                                           ││              file                         │
│                                           ││ -e 'program' execute this program         │
│                                           ││ -h, --help   show this help message       │
│                                           ││ -I DIR       add the directory to the     │
│                                           ││              include search path          │
│                                           ││     --include FILE                        │
│                                           ││ -l [search]  list probes                  │
│                                           ││ -p PID       enable USDT probes on PID    │
│                                           ││ -c 'CMD'     run CMD and enable USDT      │
│                                           ││              probes on resulting process  │
│                                           ││     --usdt-file-activation activate usdt  │
╰───────────────────────────────────────────╯╰───────────────────────────────────────────╯
  ↑↓ move    ←→ expand/scroll    / search    Tab pane    ? help    ^C quit     help-text
```

</details>

<details>
<summary><code>mandible jar</code> — unchanged</summary>

```
╭ commands (1) · GNU argp/getopt_long ──────╮╭ jar ─────────────────────────────────────→╮
│  jar                                      ││ DESCRIPTION ───────────────────────────── │
│                                           ││ restore individual classes or resources   │
│                                           ││ from an archive.                          │
│                                           ││                                           │
│                                           ││                                           │
│                                           ││ USAGE ─────────────────────────────────── │
│                                           ││   jar [OPTION...] [ [--release VERSION] [>│
│                                           ││   jar creates an archive for classes and >│
│                                           ││                                           │
│                                           ││                                           │
│                                           ││ FLAGS (23) ────────────────────────────── │
│                                           ││ Main operation mode                       │
│                                           ││ -c, --create Create the archive           │
```

</details>

### See it yourself

From a fresh clone, in a venv with `pyte` installed:

```sh
cargo build --release
python scripts/pty_screenshot.py --keys 'jjjjj' 90 30 ./target/release/mandible bpftrace
python scripts/pty_screenshot.py --keys 'jjjjj' 90 30 ./target/release/mandible jar
```

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace` (1415 passed), `cargo build --release`, `scripts/changelog_guard.sh`, `cargo run -p xtask -- corpus` (116 fixtures, 0 failed, no invented xfail snapshots) — all green.
