### PR TITLE
detail pane: per-choice descriptions as a values sub-table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ once it reaches a published 0.1.0 release.
 
 - The detail pane no longer appends a flag's `choices` to its description as `[a, b, c]`; they now render as their own `values: a, b, c` line under the description, indented two columns past the shared description column in the pane's derived-metadata style, so the description stays the tool's own prose and a placeholder like `tar --format`'s `FORMAT` keeps the spelling column verbatim.
 
+- A flag's `choices` now carry their own per-value description when the tool documents one, instead of smearing it into the flag's own description or dropping it outright: `mandible ffplay`'s `-flags` row used to fold ffmpeg's whole AVOption sub-table (`unaligned`, `gray`, `bitexact`, …) into `-flags`' own description as one run-on sentence, and `mandible tar`'s `--format`/`--backup` enum values silently lost the one-line explanation next to each — both now render as a `values:` header followed by one indented `name  description` row per choice.
+
 ### Fixed
 
 - A tool that documents each invocation form as a stanza — LVM's `vgchange`, `lvchange` and the rest of the family — now labels each stanza's flags with the description the tool wrote above it, so the dividers read `Activate or deactivate LVs` and `Start the lockspace of a shared VG in lvmlockd` instead of repeating the `Vgchange --lockstart` spelling already printed on the row beneath, and the stanza's head line is kept as a USAGE form rather than lost with the label it used to be; a stanza with no description above it keeps its head line as the label exactly as before (issue #11).

--- a/corpus/ffplay/6.1.1-3ubuntu5/expected.snap
+++ b/corpus/ffplay/6.1.1-3ubuntu5/expected.snap
@@ -1,0 +1,11520 @@
+name: ffplay
+description: Simple media player
+usage:
+- 'usage: ffplay [options] input_file'
+flags:
+- short: 'L'
+  description: show license
+  provenance:
+    sources:
+    - help-text
+- short: 'h'
+  long: help
+  value_name: topic
+  value_kind: Required
+  description: show help
+  provenance:
+    sources:
+    - help-text
+- short: '?'
+  value_name: topic
+  value_kind: Required
+  description: show help
+  provenance:
+    sources:
+    - help-text
+- long: help
+  single_dash: true
+  description: show help
+  provenance:
+    sources:
+    - help-text
+- long: version
+  single_dash: true
+  description: show version
+  provenance:
+    sources:
+    - help-text
+- long: buildconf
+  single_dash: true
+  description: show build configuration
+  provenance:
+    sources:
+    - help-text
+- long: formats
+  single_dash: true
+  description: show available formats
+  provenance:
+    sources:
+    - help-text
+- long: muxers
+  single_dash: true
+  description: show available muxers
+  provenance:
+    sources:
+    - help-text
+- long: demuxers
+  single_dash: true
+  description: show available demuxers
+  provenance:
+    sources:
+    - help-text
+- long: devices
+  single_dash: true
+  description: show available devices
+  provenance:
+    sources:
+    - help-text
+- long: codecs
+  single_dash: true
+  description: show available codecs
+  provenance:
+    sources:
+    - help-text
+- long: decoders
+  single_dash: true
+  description: show available decoders
+  provenance:
+    sources:
+    - help-text
+- long: encoders
+  single_dash: true
+  description: show available encoders
+  provenance:
+    sources:
+    - help-text
+- long: bsfs
+  single_dash: true
+  description: show available bit stream filters
+  provenance:
+    sources:
+    - help-text
+- long: protocols
+  single_dash: true
+  description: show available protocols
+  provenance:
+    sources:
+    - help-text
+- long: filters
+  single_dash: true
+  description: show available filters
+  provenance:
+    sources:
+    - help-text
+- long: pix_fmts
+  single_dash: true
+  description: show available pixel formats
+  provenance:
+    sources:
+    - help-text
+- long: layouts
+  single_dash: true
+  description: show standard channel layouts
+  provenance:
+    sources:
+    - help-text
+- long: sample_fmts
+  single_dash: true
+  description: show available audio sample formats
+  provenance:
+    sources:
+    - help-text
+- long: dispositions
+  single_dash: true
+  description: show available stream dispositions
+  provenance:
+    sources:
+    - help-text
+- long: colors
+  single_dash: true
+  description: show available color names
+  provenance:
+    sources:
+    - help-text
+- long: loglevel
+  single_dash: true
+  description: set logging level
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  value_name: loglevel
+  value_kind: Required
+  description: set logging level
+  provenance:
+    sources:
+    - help-text
+- long: report
+  single_dash: true
+  description: generate a report
+  provenance:
+    sources:
+    - help-text
+- long: max_alloc
+  single_dash: true
+  description: set maximum size of a single allocated block
+  provenance:
+    sources:
+    - help-text
+- long: sources
+  single_dash: true
+  description: list sources of the input device
+  provenance:
+    sources:
+    - help-text
+- long: sinks
+  single_dash: true
+  description: list sinks of the output device
+  provenance:
+    sources:
+    - help-text
+- short: 'x'
+  value_name: width
+  value_kind: Required
+  description: force displayed width
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  value_name: height
+  value_kind: Required
+  description: force displayed height
+  provenance:
+    sources:
+    - help-text
+- short: 'f'
+  value_name: s
+  value_kind: Required
+  description: force full screen
+  provenance:
+    sources:
+    - help-text
+- short: 'a'
+  value_name: n
+  value_kind: Required
+  description: disable audio
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  value_name: n
+  value_kind: Required
+  description: disable video
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  value_name: n
+  value_kind: Required
+  description: disable subtitling
+  provenance:
+    sources:
+    - help-text
+- short: 's'
+  value_name: s
+  value_kind: Required
+  description: seek to a given position in seconds
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  value_name: duration
+  value_kind: Required
+  description: play "duration" seconds of audio/video
+  provenance:
+    sources:
+    - help-text
+- long: bytes
+  single_dash: true
+  description: seek by bytes 0=off 1=on -1=auto
+  provenance:
+    sources:
+    - help-text
+- long: seek_interval
+  single_dash: true
+  description: set seek interval for left/right keys, in seconds
+  provenance:
+    sources:
+    - help-text
+- long: nodisp
+  single_dash: true
+  description: disable graphical display
+  provenance:
+    sources:
+    - help-text
+- long: noborder
+  single_dash: true
+  description: borderless window
+  provenance:
+    sources:
+    - help-text
+- long: alwaysontop
+  single_dash: true
+  description: window always on top
+  provenance:
+    sources:
+    - help-text
+- long: volume
+  single_dash: true
+  description: set startup volume 0=min 100=max
+  provenance:
+    sources:
+    - help-text
+- short: 'f'
+  value_name: fmt
+  value_kind: Required
+  description: force format
+  provenance:
+    sources:
+    - help-text
+- long: window_title
+  single_dash: true
+  description: set window title
+  provenance:
+    sources:
+    - help-text
+- short: 'a'
+  value_name: f
+  value_kind: Required
+  description: set audio filters
+  provenance:
+    sources:
+    - help-text
+- long: showmode
+  single_dash: true
+  description: select show mode (0 = video, 1 = waves, 2 = RDFT)
+  provenance:
+    sources:
+    - help-text
+- short: 'i'
+  value_name: input_file
+  value_kind: Required
+  description: read specified file
+  provenance:
+    sources:
+    - help-text
+- long: codec
+  single_dash: true
+  description: force decoder
+  provenance:
+    sources:
+    - help-text
+- long: autorotate
+  single_dash: true
+  description: automatically rotate video
+  provenance:
+    sources:
+    - help-text
+- long: cpuflags
+  single_dash: true
+  description: force specific cpu flags
+  provenance:
+    sources:
+    - help-text
+- long: cpucount
+  single_dash: true
+  description: force specific cpu count
+  provenance:
+    sources:
+    - help-text
+- long: hide_banner
+  single_dash: true
+  description: do not show program banner
+  provenance:
+    sources:
+    - help-text
+- long: ast
+  single_dash: true
+  description: select desired audio stream
+  provenance:
+    sources:
+    - help-text
+- long: vst
+  single_dash: true
+  description: select desired video stream
+  provenance:
+    sources:
+    - help-text
+- long: sst
+  single_dash: true
+  description: select desired subtitle stream
+  provenance:
+    sources:
+    - help-text
+- long: stats
+  single_dash: true
+  description: show status
+  provenance:
+    sources:
+    - help-text
+- long: fast
+  single_dash: true
+  description: non spec compliant optimizations
+  provenance:
+    sources:
+    - help-text
+- long: genpts
+  single_dash: true
+  description: generate pts
+  provenance:
+    sources:
+    - help-text
+- long: drp
+  single_dash: true
+  description: let decoder reorder pts 0=off 1=on -1=auto
+  provenance:
+    sources:
+    - help-text
+- long: lowres
+  single_dash: true
+  provenance:
+    sources:
+    - help-text
+- long: sync
+  single_dash: true
+  description: set audio-video sync. type (type=audio/video/ext)
+  provenance:
+    sources:
+    - help-text
+- long: autoexit
+  single_dash: true
+  description: exit at the end
+  provenance:
+    sources:
+    - help-text
+- long: exitonkeydown
+  single_dash: true
+  description: exit on key down
+  provenance:
+    sources:
+    - help-text
+- long: exitonmousedown
+  single_dash: true
+  description: exit on mouse down
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  description: set number of times the playback shall be looped
+  provenance:
+    sources:
+    - help-text
+- long: framedrop
+  single_dash: true
+  description: drop frames when cpu is too slow
+  provenance:
+    sources:
+    - help-text
+- long: infbuf
+  single_dash: true
+  description: don't limit the input buffer size (useful with realtime streams)
+  provenance:
+    sources:
+    - help-text
+- long: left
+  single_dash: true
+  description: set the x position for the left of the window
+  provenance:
+    sources:
+    - help-text
+- long: top
+  single_dash: true
+  description: set the y position for the top of the window
+  provenance:
+    sources:
+    - help-text
+- short: 'v'
+  value_name: f
+  value_kind: Required
+  description: set video filters
+  provenance:
+    sources:
+    - help-text
+- long: rdftspeed
+  single_dash: true
+  description: rdft speed
+  provenance:
+    sources:
+    - help-text
+- long: acodec
+  single_dash: true
+  description: force audio decoder
+  provenance:
+    sources:
+    - help-text
+- long: scodec
+  single_dash: true
+  description: force subtitle decoder
+  provenance:
+    sources:
+    - help-text
+- long: vcodec
+  single_dash: true
+  description: force video decoder
+  provenance:
+    sources:
+    - help-text
+- long: find_stream_info
+  single_dash: true
+  description: read and decode the streams to fill missing information with heuristics
+  provenance:
+    sources:
+    - help-text
+- long: filter_threads
+  single_dash: true
+  description: number of filter threads per graph
+  provenance:
+    sources:
+    - help-text
+- long: flags
+  choices:
+  - name: unaligned
+    description: .D.V....... allow decoders to produce unaligned output
+  - name: gray
+    description: ED.V....... only decode/encode grayscale
+  - name: low_delay
+    description: ED.V....... force low delay
+  - name: bitexact
+    description: ED.VAS..... use only bitexact functions (except (I)DCT)
+  - name: output_corrupt
+    description: .D.V....... Output even potentially corrupted frames
+  - name: drop_changed
+    description: .D.VA.....P Drop frames whose parameters differ from first decoded frame
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> ED.VAS..... (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: flags2
+  choices:
+  - name: ignorecrop
+    description: .D.V....... ignore cropping information from sps
+  - name: chunks
+    description: .D.V....... Frame data might be split into multiple chunks
+  - name: showall
+    description: .D.V....... Show all frames before the first keyframe
+  - name: export_mvs
+    description: .D.V....... export motion vectors through frame side data
+  - name: skip_manual
+    description: .D..A...... do not skip samples and export skip information as frame side data
+  - name: ass_ro_flush_noop
+    description: .D...S..... do not reset ASS ReadOrder field on flush
+  - name: icc_profiles
+    description: .D...S..... generate/parse embedded ICC profiles from/to colorimetry tags
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> ED.VAS..... (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: export_side_data
+  choices:
+  - name: mvs
+    description: .D.V....... export motion vectors through frame side data
+  - name: venc_params
+    description: .D.V....... export video encoding parameters through frame side data
+  - name: film_grain
+    description: .D.V....... export film grain parameters through frame side data
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> ED.VAS..... Export metadata as side data (default 0)
+  provenance:
+    sources:
+    - help-text
+- short: 'a'
+  value_name: r
+  value_kind: Required
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED..A...... set audio sampling rate (in Hz) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- short: 'a'
+  value_name: c
+  value_kind: Required
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED..A...... set number of audio channels (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: bug
+  choices:
+  - name: autodetect
+    description: .D.V.......
+  - name: xvid_ilace
+    description: .D.V....... Xvid interlacing bug (autodetected if FOURCC == XVIX)
+  - name: ump4
+    description: .D.V....... (autodetected if FOURCC == UMP4)
+  - name: no_padding
+    description: .D.V....... padding bug (autodetected)
+  - name: amv
+    description: .D.V.......
+  - name: qpel_chroma
+    description: .D.V.......
+  - name: std_qpel
+    description: .D.V....... old standard qpel (autodetected per FOURCC/version)
+  - name: qpel_chroma2
+    description: .D.V.......
+  - name: direct_blocksize
+    description: .D.V....... direct-qpel-blocksize bug (autodetected per FOURCC/version)
+  - name: edge
+    description: .D.V....... edge padding bug (autodetected per FOURCC/version)
+  - name: hpel_chroma
+    description: .D.V.......
+  - name: dc_clip
+    description: .D.V.......
+  - name: ms
+    description: .D.V....... work around various bugs in Microsoft's broken decoders
+  - name: trunc
+    description: .D.V....... truncated frames
+  - name: iedge
+    description: .D.V.......
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> .D.V....... work around not autodetected encoder bugs (default autodetect)
+  provenance:
+    sources:
+    - help-text
+- long: strict
+  choices:
+  - name: very
+    description: 2 ED.VA...... strictly conform to a older more strict version of the spec or reference software
+  - name: strict
+    description: 1 ED.VA...... strictly conform to all the things in the spec no matter what the consequences
+  - name: normal
+    description: 0 ED.VA......
+  - name: unofficial
+    description: -1 ED.VA...... allow unofficial extensions
+  - name: experimental
+    description: -2 ED.VA...... allow non-standardized experimental things
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.VA...... how strictly to follow the standards (from INT_MIN to INT_MAX) (default normal)
+  provenance:
+    sources:
+    - help-text
+- long: err_detect
+  choices:
+  - name: crccheck
+    description: ED.VAS..... verify embedded CRCs
+  - name: bitstream
+    description: ED.VAS..... detect bitstream specification deviations
+  - name: buffer
+    description: ED.VAS..... detect improper bitstream length
+  - name: explode
+    description: ED.VAS..... abort decoding on minor error detection
+  - name: ignore_err
+    description: ED.VAS..... ignore errors
+  - name: careful
+    description: ED.VAS..... consider things that violate the spec, are fast to check and have not been seen in the wild as errors
+  - name: compliant
+    description: ED.VAS..... consider all spec non compliancies as errors
+  - name: aggressive
+    description: ED.VAS..... consider things that a sane encoder should not do as an error
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> ED.VAS..... set error detection flags (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: idct
+  choices:
+  - name: auto
+    description: 0 ED.V.......
+  - name: int
+    description: 1 ED.V.......
+  - name: simple
+    description: 2 ED.V.......
+  - name: simplemmx
+    description: 3 ED.V.......
+  - name: arm
+    description: 7 ED.V.......
+  - name: altivec
+    description: 8 ED.V.......
+  - name: simplearm
+    description: 10 ED.V.......
+  - name: simplearmv5te
+    description: 16 ED.V.......
+  - name: simplearmv6
+    description: 17 ED.V.......
+  - name: simpleneon
+    description: 22 ED.V.......
+  - name: xvid
+    description: 14 ED.V.......
+  - name: xvidmmx
+    description: 14 ED.V....... deprecated, for compatibility only
+  - name: faani
+    description: 20 ED.V....... floating point AAN IDCT
+  - name: simpleauto
+    description: 128 ED.V.......
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.V....... select IDCT implementation (from 0 to INT_MAX) (default auto)
+  provenance:
+    sources:
+    - help-text
+- short: 'e'
+  value_name: c
+  value_kind: Required
+  choices:
+  - name: guess_mvs
+    description: .D.V....... iterative motion vector (MV) search (slow)
+  - name: deblock
+    description: .D.V....... use strong deblock filter for damaged MBs
+  - name: favor_inter
+    description: .D.V....... favor predicting from the previous frame
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> .D.V....... set error concealment strategy (default guess_mvs+deblock)
+  provenance:
+    sources:
+    - help-text
+- long: debug
+  choices:
+  - name: pict
+    description: .D.V....... picture info
+  - name: bitstream
+    description: .D.V.......
+  - name: mb_type
+    description: .D.V....... macroblock (MB) type
+  - name: qp
+    description: .D.V....... per-block quantization parameter (QP)
+  - name: dct_coeff
+    description: .D.V.......
+  - name: green_metadata
+    description: .D.V.......
+  - name: skip
+    description: .D.V.......
+  - name: startcode
+    description: .D.V.......
+  - name: er
+    description: .D.V....... error recognition
+  - name: mmco
+    description: .D.V....... memory management control operations (H.264)
+  - name: bugs
+    description: .D.V.......
+  - name: buffers
+    description: .D.V....... picture buffer allocations
+  - name: thread_ops
+    description: .D.VA...... threading operations
+  - name: nomc
+    description: .D.VA...... skip motion compensation
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> ED.VAS..... print specific debug info (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: threads
+  choices:
+  - name: auto
+    description: 0 ED.V....... autodetect a suitable number of threads to use
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.VA...... set the number of threads (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: skip_top
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.V....... number of macroblock rows at the top which are skipped (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: skip_bottom
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.V....... number of macroblock rows at the bottom which are skipped (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: lowres
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.VA...... decode at 1= 1/2, 2=1/4, 3=1/8 resolutions (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: skip_loop_filter
+  choices:
+  - name: none
+    description: -16 .D.V....... discard no frame
+  - name: default
+    description: 0 .D.V....... discard useless frames
+  - name: noref
+    description: 8 .D.V....... discard all non-reference frames
+  - name: bidir
+    description: 16 .D.V....... discard all bidirectional frames
+  - name: nointra
+    description: 24 .D.V....... discard all frames except I frames
+  - name: nokey
+    description: 32 .D.V....... discard all frames except keyframes
+  - name: all
+    description: 48 .D.V....... discard all frames
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.V....... skip loop filtering process for the selected frames (from INT_MIN to INT_MAX) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: skip_idct
+  choices:
+  - name: none
+    description: -16 .D.V....... discard no frame
+  - name: default
+    description: 0 .D.V....... discard useless frames
+  - name: noref
+    description: 8 .D.V....... discard all non-reference frames
+  - name: bidir
+    description: 16 .D.V....... discard all bidirectional frames
+  - name: nointra
+    description: 24 .D.V....... discard all frames except I frames
+  - name: nokey
+    description: 32 .D.V....... discard all frames except keyframes
+  - name: all
+    description: 48 .D.V....... discard all frames
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.V....... skip IDCT/dequantization for the selected frames (from INT_MIN to INT_MAX) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: skip_frame
+  choices:
+  - name: none
+    description: -16 .D.V....... discard no frame
+  - name: default
+    description: 0 .D.V....... discard useless frames
+  - name: noref
+    description: 8 .D.V....... discard all non-reference frames
+  - name: bidir
+    description: 16 .D.V....... discard all bidirectional frames
+  - name: nointra
+    description: 24 .D.V....... discard all frames except I frames
+  - name: nokey
+    description: 32 .D.V....... discard all frames except keyframes
+  - name: all
+    description: 48 .D.V....... discard all frames
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.V....... skip decoding for the selected frames (from INT_MIN to INT_MAX) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <channel_layout> ED..A......
+  provenance:
+    sources:
+    - help-text
+- long: channel_layout
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <channel_layout> ED..A...... (default 0x0)
+  provenance:
+    sources:
+    - help-text
+- long: request_channel_layout
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: .D..A...... (default 0x0)
+  provenance:
+    sources:
+    - help-text
+- long: ticks_per_frame
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.VA...... (from 1 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: color_primaries
+  choices:
+  - name: bt709
+    description: 1 ED.V....... BT.709
+  - name: unknown
+    description: 2 ED.V....... Unspecified
+  - name: bt470m
+    description: 4 ED.V....... BT.470 M
+  - name: bt470bg
+    description: 5 ED.V....... BT.470 BG
+  - name: smpte170m
+    description: 6 ED.V....... SMPTE 170 M
+  - name: smpte240m
+    description: 7 ED.V....... SMPTE 240 M
+  - name: film
+    description: 8 ED.V....... Film
+  - name: bt2020
+    description: 9 ED.V....... BT.2020
+  - name: smpte428
+    description: 10 ED.V....... SMPTE 428-1
+  - name: smpte428_1
+    description: 10 ED.V....... SMPTE 428-1
+  - name: smpte431
+    description: 11 ED.V....... SMPTE 431-2
+  - name: smpte432
+    description: 12 ED.V....... SMPTE 422-1
+  - name: jedec-p22
+    description: 22 ED.V....... JEDEC P22
+  - name: ebu3213
+    description: 22 ED.V....... EBU 3213-E
+  - name: unspecified
+    description: 2 ED.V....... Unspecified
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.V....... color primaries (from 1 to INT_MAX) (default unknown)
+  provenance:
+    sources:
+    - help-text
+- long: color_trc
+  choices:
+  - name: bt709
+    description: 1 ED.V....... BT.709
+  - name: unknown
+    description: 2 ED.V....... Unspecified
+  - name: gamma22
+    description: 4 ED.V....... BT.470 M
+  - name: gamma28
+    description: 5 ED.V....... BT.470 BG
+  - name: smpte170m
+    description: 6 ED.V....... SMPTE 170 M
+  - name: smpte240m
+    description: 7 ED.V....... SMPTE 240 M
+  - name: linear
+    description: 8 ED.V....... Linear
+  - name: log100
+    description: 9 ED.V....... Log
+  - name: log316
+    description: 10 ED.V....... Log square root
+  - name: iec61966-2-4
+    description: 11 ED.V....... IEC 61966-2-4
+  - name: bt1361e
+    description: 12 ED.V....... BT.1361
+  - name: iec61966-2-1
+    description: 13 ED.V....... IEC 61966-2-1
+  - name: bt2020-10
+    description: 14 ED.V....... BT.2020 - 10 bit
+  - name: bt2020-12
+    description: 15 ED.V....... BT.2020 - 12 bit
+  - name: smpte2084
+    description: 16 ED.V....... SMPTE 2084
+  - name: smpte428
+    description: 17 ED.V....... SMPTE 428-1
+  - name: arib-std-b67
+    description: 18 ED.V....... ARIB STD-B67
+  - name: unspecified
+    description: 2 ED.V....... Unspecified
+  - name: log
+    description: 9 ED.V....... Log
+  - name: log_sqrt
+    description: 10 ED.V....... Log square root
+  - name: iec61966_2_4
+    description: 11 ED.V....... IEC 61966-2-4
+  - name: bt1361
+    description: 12 ED.V....... BT.1361
+  - name: iec61966_2_1
+    description: 13 ED.V....... IEC 61966-2-1
+  - name: bt2020_10bit
+    description: 14 ED.V....... BT.2020 - 10 bit
+  - name: bt2020_12bit
+    description: 15 ED.V....... BT.2020 - 12 bit
+  - name: smpte428_1
+    description: 17 ED.V....... SMPTE 428-1
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.V....... color transfer characteristics (from 1 to INT_MAX) (default unknown)
+  provenance:
+    sources:
+    - help-text
+- long: colorspace
+  choices:
+  - name: rgb
+    description: 0 ED.V....... RGB
+  - name: bt709
+    description: 1 ED.V....... BT.709
+  - name: unknown
+    description: 2 ED.V....... Unspecified
+  - name: fcc
+    description: 4 ED.V....... FCC
+  - name: bt470bg
+    description: 5 ED.V....... BT.470 BG
+  - name: smpte170m
+    description: 6 ED.V....... SMPTE 170 M
+  - name: smpte240m
+    description: 7 ED.V....... SMPTE 240 M
+  - name: ycgco
+    description: 8 ED.V....... YCGCO
+  - name: bt2020nc
+    description: 9 ED.V....... BT.2020 NCL
+  - name: bt2020c
+    description: 10 ED.V....... BT.2020 CL
+  - name: smpte2085
+    description: 11 ED.V....... SMPTE 2085
+  - name: ictcp
+    description: 14 ED.V....... ICtCp
+  - name: unspecified
+    description: 2 ED.V....... Unspecified
+  - name: ycocg
+    description: 8 ED.V....... YCGCO
+  - name: bt2020_ncl
+    description: 9 ED.V....... BT.2020 NCL
+  - name: bt2020_cl
+    description: 10 ED.V....... BT.2020 CL
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.V....... color space (from 0 to INT_MAX) (default unknown) chroma-derived-nc 12 ED.V....... Chroma-derived NCL chroma-derived-c 13 ED.V....... Chroma-derived CL
+  provenance:
+    sources:
+    - help-text
+- long: color_range
+  choices:
+  - name: unknown
+    description: 0 ED.V....... Unspecified
+  - name: tv
+    description: 1 ED.V....... MPEG (219*2^(n-8))
+  - name: pc
+    description: 2 ED.V....... JPEG (2^n-1)
+  - name: unspecified
+    description: 0 ED.V....... Unspecified
+  - name: mpeg
+    description: 1 ED.V....... MPEG (219*2^(n-8))
+  - name: jpeg
+    description: 2 ED.V....... JPEG (2^n-1)
+  - name: limited
+    description: 1 ED.V....... MPEG (219*2^(n-8))
+  - name: full
+    description: 2 ED.V....... JPEG (2^n-1)
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.V....... color range (from 0 to INT_MAX) (default unknown)
+  provenance:
+    sources:
+    - help-text
+- long: chroma_sample_location
+  choices:
+  - name: unknown
+    description: 0 ED.V....... Unspecified
+  - name: left
+    description: 1 ED.V....... Left
+  - name: center
+    description: 2 ED.V....... Center
+  - name: topleft
+    description: 3 ED.V....... Top-left
+  - name: top
+    description: 4 ED.V....... Top
+  - name: bottomleft
+    description: 5 ED.V....... Bottom-left
+  - name: bottom
+    description: 6 ED.V....... Bottom
+  - name: unspecified
+    description: 0 ED.V....... Unspecified
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: ED.V....... chroma sample location (from 0 to INT_MAX) (default unknown)
+  provenance:
+    sources:
+    - help-text
+- long: thread_type
+  choices:
+  - name: slice
+    description: ED.V.......
+  - name: frame
+    description: ED.V.......
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> ED.VA...... select multithreading type (default slice+frame)
+  provenance:
+    sources:
+    - help-text
+- long: request_sample_fmt
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: .D..A...... sample format audio decoders should prefer (default none)
+  provenance:
+    sources:
+    - help-text
+- long: sub_charenc
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <string> .D...S..... set input text subtitles character encoding
+  provenance:
+    sources:
+    - help-text
+- long: sub_charenc_mode
+  choices:
+  - name: do_nothing
+    description: .D...S.....
+  - name: auto
+    description: .D...S.....
+  - name: pre_decoder
+    description: .D...S.....
+  - name: ignore
+    description: .D...S.....
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> .D...S..... set input text subtitles character encoding mode (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: apply_cropping
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <boolean> .D.V....... (default true)
+  provenance:
+    sources:
+    - help-text
+- long: skip_alpha
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <boolean> .D.V....... Skip processing alpha (default false)
+  provenance:
+    sources:
+    - help-text
+- long: field_order
+  choices:
+  - name: progressive
+    description: 1 ED.V.......
+  - name: tt
+    description: 2 ED.V.......
+  - name: bb
+    description: 3 ED.V.......
+  - name: tb
+    description: 4 ED.V.......
+  - name: bt
+    description: 5 ED.V.......
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> ED.V....... Field order (from 0 to 5) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: dump_separator
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <string> ED.VAS..... set information dump field separator
+  provenance:
+    sources:
+    - help-text
+- long: codec_whitelist
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <string> .D.VAS..... List of decoders that are allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: max_pixels
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int64> ED.VAS..... Maximum number of pixels (from 0 to INT_MAX) (default INT_MAX)
+  provenance:
+    sources:
+    - help-text
+- long: max_samples
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int64> ED..A...... Maximum number of samples (from 0 to INT_MAX) (default INT_MAX)
+  provenance:
+    sources:
+    - help-text
+- long: hwaccel_flags
+  choices:
+  - name: ignore_level
+    description: .D.V....... ignore level even if the codec level used is unknown or higher than the maximum supported level reported by the hardware driver
+  - name: allow_high_depth
+    description: .D.V....... allow to output YUV pixel formats with a different chroma sampling than 4:2:0 and/or other than 8 bits per component
+  - name: allow_profile_mismatch
+    description: .D.V....... attempt to decode anyway if HW accelerated decoder's supported profiles do not exactly match the stream
+  - name: unsafe_output
+    description: .D.V....... allow potentially unsafe hwaccel frame output that might require special care to process successfully
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <flags> .D.V....... (default ignore_level)
+  provenance:
+    sources:
+    - help-text
+- long: extra_hw_frames
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: <int> .D.V....... Number of extra hardware frames to allocate for the user (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: discard_damaged_percentage
+  single_dash: true
+  group: 'AVCodecContext AVOptions:'
+  description: .D.V....... Percentage of damaged samples to discard a frame (from 0 to 100) (default 95)
+  provenance:
+    sources:
+    - help-text
+- long: layer
+  single_dash: true
+  group: 'EXR AVOptions:'
+  description: <string> .D.V....... Set the decoding layer (default "")
+  provenance:
+    sources:
+    - help-text
+- long: part
+  single_dash: true
+  group: 'EXR AVOptions:'
+  description: <int> .D.V....... Set the decoding part (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: gamma
+  single_dash: true
+  group: 'EXR AVOptions:'
+  description: <float> .D.V....... Set the float gamma value when decoding (from 0.001 to FLT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: apply_trc
+  choices:
+  - name: bt709
+    description: 1 .D.V....... BT.709
+  - name: gamma
+    description: 2 .D.V....... gamma
+  - name: gamma22
+    description: 4 .D.V....... BT.470 M
+  - name: gamma28
+    description: 5 .D.V....... BT.470 BG
+  - name: smpte170m
+    description: 6 .D.V....... SMPTE 170 M
+  - name: smpte240m
+    description: 7 .D.V....... SMPTE 240 M
+  - name: linear
+    description: 8 .D.V....... Linear
+  - name: log
+    description: 9 .D.V....... Log
+  - name: log_sqrt
+    description: 10 .D.V....... Log square root
+  - name: iec61966_2_4
+    description: 11 .D.V....... IEC 61966-2-4
+  - name: bt1361
+    description: 12 .D.V....... BT.1361
+  - name: iec61966_2_1
+    description: 13 .D.V....... IEC 61966-2-1
+  - name: bt2020_10bit
+    description: 14 .D.V....... BT.2020 - 10 bit
+  - name: bt2020_12bit
+    description: 15 .D.V....... BT.2020 - 12 bit
+  - name: smpte2084
+    description: 16 .D.V....... SMPTE ST 2084
+  - name: smpte428_1
+    description: 17 .D.V....... SMPTE ST 428-1
+  single_dash: true
+  group: 'EXR AVOptions:'
+  description: <int> .D.V....... color transfer characteristics to apply to EXR linear input (from 1 to 18) (default gamma)
+  provenance:
+    sources:
+    - help-text
+- long: skip_cursor
+  single_dash: true
+  group: 'FIC decoder AVOptions:'
+  description: <boolean> .D.V....... skip the cursor (default false)
+  provenance:
+    sources:
+    - help-text
+- long: blank_value
+  single_dash: true
+  group: 'FITS decoder AVOptions:'
+  description: <int> .D.V....... value that is used to replace BLANK pixels in data array (from 0 to 65535) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: change_field_order
+  single_dash: true
+  group: 'frwu Decoder AVOptions:'
+  description: .D.V....... Change field order (default false)
+  provenance:
+    sources:
+    - help-text
+- long: trans_color
+  single_dash: true
+  group: 'gif decoder AVOptions:'
+  description: <int> .D.V....... color value (ARGB) that is used instead of transparent color (from 0 to UINT32_MAX) (default 16777215)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'h263_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'h263_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: is_avc
+  single_dash: true
+  group: 'H264 Decoder AVOptions:'
+  description: <boolean> .D.V..X.... is avc (default false)
+  provenance:
+    sources:
+    - help-text
+- long: nal_length_size
+  single_dash: true
+  group: 'H264 Decoder AVOptions:'
+  description: <int> .D.V..X.... nal_length_size (from 0 to 4) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: enable_er
+  single_dash: true
+  group: 'H264 Decoder AVOptions:'
+  description: <boolean> .D.V....... Enable error resilience on damaged frames (unsafe) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: x264_build
+  single_dash: true
+  group: 'H264 Decoder AVOptions:'
+  description: <int> .D.V....... Assume this x264 version if no x264 version found in any SEI (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'h264_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'h264_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: apply_defdispwin
+  single_dash: true
+  group: 'HEVC decoder AVOptions:'
+  description: <boolean> .D.V....... Apply default display window from VUI (default false)
+  provenance:
+    sources:
+    - help-text
+- long: strict-displaywin
+  single_dash: true
+  group: 'HEVC decoder AVOptions:'
+  description: .D.V....... stricly apply default display window size (default false)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'hevc_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'hevc_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: lowres
+  single_dash: true
+  group: 'jpeg2000 AVOptions:'
+  description: <int> .D.V....... Lower the decoding resolution by a power of two (from 0 to 33) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: extern_huff
+  single_dash: true
+  group: 'MJPEG decoder AVOptions:'
+  description: <boolean> .D.V....... Use external huffman table. (default false)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'mpeg4_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'mpeg4_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'mpeg1_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'mpeg1_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'mpeg2_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'mpeg2_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: lowres
+  single_dash: true
+  group: 'photocd AVOptions:'
+  description: <int> .D.V....... Lower the decoding resolution by a power of two (from 0 to 4) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: skip_cursor
+  single_dash: true
+  group: 'rasc decoder AVOptions:'
+  description: <boolean> .D.V....... skip the cursor (default false)
+  provenance:
+    sources:
+    - help-text
+- long: top
+  single_dash: true
+  group: 'rawdec AVOptions:'
+  description: <boolean> .D.V....... top field first (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: non_pcm_mode
+  choices:
+  - name: copy
+    description: 0 .D..A...... Pass NON-PCM through unchanged
+  - name: drop
+    description: 1 .D..A...... Drop NON-PCM
+  - name: decode_copy
+    description: 2 .D..A...... Decode if possible else passthrough
+  - name: decode_drop
+    description: 3 .D..A...... Decode if possible else drop
+  single_dash: true
+  group: 'SMPTE 302M Decoder AVOptions:'
+  description: <int> .D..A...... Chooses what to do with NON-PCM (from 0 to 3) (default decode_drop)
+  provenance:
+    sources:
+    - help-text
+- long: subimage
+  single_dash: true
+  group: 'TIFF decoder AVOptions:'
+  description: <boolean> .D.V....... decode subimage instead if available (default false)
+  provenance:
+    sources:
+    - help-text
+- long: thumbnail
+  single_dash: true
+  group: 'TIFF decoder AVOptions:'
+  description: <boolean> .D.V....... decode embedded thumbnail subimage instead if available (default false)
+  provenance:
+    sources:
+    - help-text
+- long: page
+  single_dash: true
+  group: 'TIFF decoder AVOptions:'
+  description: <int> .D.V....... page number of multi-page image to decode (starting from 1) (from 0 to 65535) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: custom_stride
+  single_dash: true
+  group: 'V210 Decoder AVOptions:'
+  description: <int> .D.V....... Custom V210 stride (from -1 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'vc1_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'vc1_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'vp8_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'vp8_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: num_output_buffers
+  single_dash: true
+  group: 'vp9_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: num_capture_buffers
+  single_dash: true
+  group: 'vp9_v4l2m2m_decoder AVOptions:'
+  description: .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+  provenance:
+    sources:
+    - help-text
+- long: dual_mono_mode
+  choices:
+  - name: auto
+    description: -1 .D..A...... autoselection
+  - name: main
+    description: 1 .D..A...... Select Main/Left channel
+  - name: sub
+    description: 2 .D..A...... Select Sub/Right channel
+  - name: both
+    description: 0 .D..A...... Select both channels
+  single_dash: true
+  group: 'AAC decoder AVOptions:'
+  description: <int> .D..A...... Select the channel to decode for dual mono (from -1 to 2) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: channel_order
+  choices:
+  - name: default
+    description: 0 .D..A...... normal libavcodec channel order
+  - name: coded
+    description: 1 .D..A...... order in which the channels are coded in the bitstream
+  single_dash: true
+  group: 'AAC decoder AVOptions:'
+  description: <int> .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: dual_mono_mode
+  choices:
+  - name: auto
+    description: -1 .D..A...... autoselection
+  - name: main
+    description: 1 .D..A...... Select Main/Left channel
+  - name: sub
+    description: 2 .D..A...... Select Sub/Right channel
+  - name: both
+    description: 0 .D..A...... Select both channels
+  single_dash: true
+  group: 'AAC decoder AVOptions:'
+  description: <int> .D..A...... Select the channel to decode for dual mono (from -1 to 2) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: channel_order
+  choices:
+  - name: default
+    description: 0 .D..A...... normal libavcodec channel order
+  - name: coded
+    description: 1 .D..A...... order in which the channels are coded in the bitstream
+  single_dash: true
+  group: 'AAC decoder AVOptions:'
+  description: <int> .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: cons_noisegen
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <boolean> .D..A...... enable consistent noise generation (default false)
+  provenance:
+    sources:
+    - help-text
+- long: drc_scale
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <float> .D..A...... percentage of dynamic range compression to apply (from 0 to 6) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: heavy_compr
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <boolean> .D..A...... enable heavy dynamic range compression (default false)
+  provenance:
+    sources:
+    - help-text
+- long: target_level
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <int> .D..A...... target level in -dBFS (0 not applied) (from -31 to 0) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: downmix
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <channel_layout> .D..A...... Request a specific channel layout from the decoder
+  provenance:
+    sources:
+    - help-text
+- long: cons_noisegen
+  single_dash: true
+  group: 'Fixed-Point AC-3 Decoder AVOptions:'
+  description: <boolean> .D..A...... enable consistent noise generation (default false)
+  provenance:
+    sources:
+    - help-text
+- long: drc_scale
+  single_dash: true
+  group: 'Fixed-Point AC-3 Decoder AVOptions:'
+  description: <float> .D..A...... percentage of dynamic range compression to apply (from 0 to 6) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: heavy_compr
+  single_dash: true
+  group: 'Fixed-Point AC-3 Decoder AVOptions:'
+  description: <boolean> .D..A...... enable heavy dynamic range compression (default false)
+  provenance:
+    sources:
+    - help-text
+- long: downmix
+  single_dash: true
+  group: 'Fixed-Point AC-3 Decoder AVOptions:'
+  description: <channel_layout> .D..A...... Request a specific channel layout from the decoder
+  provenance:
+    sources:
+    - help-text
+- long: extra_bits_bug
+  single_dash: true
+  group: 'alac AVOptions:'
+  description: <boolean> .D..A...... Force non-standard decoding process (default false)
+  provenance:
+    sources:
+    - help-text
+- long: max_samples
+  choices:
+  - name: all
+    description: 2147483647 .D..A...... no maximum. decode all samples for each packet at once
+  single_dash: true
+  group: 'APE decoder AVOptions:'
+  description: <int> .D..A...... maximum number of samples decoded per call (from 1 to INT_MAX) (default 4608)
+  provenance:
+    sources:
+    - help-text
+- long: core_only
+  single_dash: true
+  group: 'DCA decoder AVOptions:'
+  description: <boolean> .D..A...... Decode core only without extensions (default false)
+  provenance:
+    sources:
+    - help-text
+- long: channel_order
+  choices:
+  - name: default
+    description: 0 .D..A...... normal libavcodec channel order
+  - name: coded
+    description: 1 .D..A...... order in which the channels are coded in the bitstream
+  single_dash: true
+  group: 'DCA decoder AVOptions:'
+  description: <int> .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: downmix
+  single_dash: true
+  group: 'DCA decoder AVOptions:'
+  description: <channel_layout> .D..A...... Request a specific channel layout from the decoder
+  provenance:
+    sources:
+    - help-text
+- long: channel_order
+  choices:
+  - name: default
+    description: 0 .D..A...... normal libavcodec channel order
+  - name: coded
+    description: 1 .D..A...... order in which the channels are coded in the bitstream
+  single_dash: true
+  group: 'Dolby E decoder AVOptions:'
+  description: <int> .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: cons_noisegen
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <boolean> .D..A...... enable consistent noise generation (default false)
+  provenance:
+    sources:
+    - help-text
+- long: drc_scale
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <float> .D..A...... percentage of dynamic range compression to apply (from 0 to 6) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: heavy_compr
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <boolean> .D..A...... enable heavy dynamic range compression (default false)
+  provenance:
+    sources:
+    - help-text
+- long: target_level
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <int> .D..A...... target level in -dBFS (0 not applied) (from -31 to 0) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: downmix
+  single_dash: true
+  group: '(E-)AC3 decoder AVOptions:'
+  description: <channel_layout> .D..A...... Request a specific channel layout from the decoder
+  provenance:
+    sources:
+    - help-text
+- long: postfilter
+  single_dash: true
+  group: 'evrc AVOptions:'
+  description: <boolean> .D..A...... enable postfilter (default true)
+  provenance:
+    sources:
+    - help-text
+- long: use_buggy_lpc
+  single_dash: true
+  group: 'FLAC decoder AVOptions:'
+  description: <boolean> .D..A...... emulate old buggy lavc behavior (default false)
+  provenance:
+    sources:
+    - help-text
+- long: postfilter
+  single_dash: true
+  group: 'G.723.1 decoder AVOptions:'
+  description: <boolean> .D..A...... enable postfilter (default true)
+  provenance:
+    sources:
+    - help-text
+- long: downmix
+  single_dash: true
+  group: 'MLP decoder AVOptions:'
+  description: <channel_layout> .D..A...... Request a specific channel layout from the decoder
+  provenance:
+    sources:
+    - help-text
+- long: apply_phase_inv
+  single_dash: true
+  group: 'Opus Decoder AVOptions:'
+  description: <boolean> .D..A...... Apply intensity stereo phase inversion (default true)
+  provenance:
+    sources:
+    - help-text
+- long: downmix
+  single_dash: true
+  group: 'TrueHD decoder AVOptions:'
+  description: <channel_layout> .D..A...... Request a specific channel layout from the decoder
+  provenance:
+    sources:
+    - help-text
+- long: password
+  single_dash: true
+  group: 'TTA Decoder AVOptions:'
+  description: <string> .D..A...... Set decoding password
+  provenance:
+    sources:
+    - help-text
+- long: bits_per_codeword
+  single_dash: true
+  group: 'g722 decoder AVOptions:'
+  description: .D..A...... Bits per G722 codeword (from 6 to 8) (default 8)
+  provenance:
+    sources:
+    - help-text
+- long: real_time
+  single_dash: true
+  group: 'Closed caption Decoder AVOptions:'
+  description: <boolean> .D...S..... emit subtitle events as they are decoded for real-time display (default false)
+  provenance:
+    sources:
+    - help-text
+- long: real_time_latency_msec
+  single_dash: true
+  group: 'Closed caption Decoder AVOptions:'
+  description: .D...S..... minimum elapsed time between emitting real-time subtitle events (from 0 to 500) (default 200)
+  provenance:
+    sources:
+    - help-text
+- long: data_field
+  choices:
+  - name: auto
+    description: -1 .D...S..... pick first one that appears
+  - name: first
+    description: 0 .D...S.....
+  - name: second
+    description: 1 .D...S.....
+  single_dash: true
+  group: 'Closed caption Decoder AVOptions:'
+  description: <int> .D...S..... select data field (from -1 to 1) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: compute_edt
+  single_dash: true
+  group: 'DVB Sub Decoder AVOptions:'
+  description: <boolean> .D...S..... compute end of time using pts or timeout (default false)
+  provenance:
+    sources:
+    - help-text
+- long: compute_clut
+  single_dash: true
+  group: 'DVB Sub Decoder AVOptions:'
+  description: <boolean> .D...S..... compute clut when not available(-1) or only once (-2) or always(1) or never(0) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: dvb_substream
+  single_dash: true
+  group: 'DVB Sub Decoder AVOptions:'
+  description: <int> .D...S..... (from -1 to 63) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: palette
+  single_dash: true
+  group: 'dvdsubdec AVOptions:'
+  description: <string> .D...S..... set the global palette
+  provenance:
+    sources:
+    - help-text
+- long: ifo_palette
+  single_dash: true
+  group: 'dvdsubdec AVOptions:'
+  description: <string> .D...S..... obtain the global palette from .IFO file
+  provenance:
+    sources:
+    - help-text
+- long: forced_subs_only
+  single_dash: true
+  group: 'dvdsubdec AVOptions:'
+  description: <boolean> .D...S..... Only show forced subtitles (default false)
+  provenance:
+    sources:
+    - help-text
+- long: width
+  single_dash: true
+  group: 'MOV text decoder AVOptions:'
+  description: <int> .D...S..... Frame width, usually video width (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: height
+  single_dash: true
+  group: 'MOV text decoder AVOptions:'
+  description: <int> .D...S..... Frame height, usually video height (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: forced_subs_only
+  single_dash: true
+  group: 'PGS subtitle decoder AVOptions:'
+  description: <boolean> .D...S..... Only show forced subtitles (default false)
+  provenance:
+    sources:
+    - help-text
+- long: keep_ass_markup
+  single_dash: true
+  group: 'text/vplayer/stl/pjs/subviewer1 decoder AVOptions:'
+  description: <boolean> .D...S..... Set if ASS tags must be escaped (default false)
+  provenance:
+    sources:
+    - help-text
+- long: keep_ass_markup
+  single_dash: true
+  group: 'text/vplayer/stl/pjs/subviewer1 decoder AVOptions:'
+  description: <boolean> .D...S..... Set if ASS tags must be escaped (default false)
+  provenance:
+    sources:
+    - help-text
+- long: keep_ass_markup
+  single_dash: true
+  group: 'text/vplayer/stl/pjs/subviewer1 decoder AVOptions:'
+  description: <boolean> .D...S..... Set if ASS tags must be escaped (default false)
+  provenance:
+    sources:
+    - help-text
+- long: keep_ass_markup
+  single_dash: true
+  group: 'text/vplayer/stl/pjs/subviewer1 decoder AVOptions:'
+  description: <boolean> .D...S..... Set if ASS tags must be escaped (default false)
+  provenance:
+    sources:
+    - help-text
+- long: keep_ass_markup
+  single_dash: true
+  group: 'text/vplayer/stl/pjs/subviewer1 decoder AVOptions:'
+  description: <boolean> .D...S..... Set if ASS tags must be escaped (default false)
+  provenance:
+    sources:
+    - help-text
+- long: tilethreads
+  single_dash: true
+  group: 'libdav1d decoder AVOptions:'
+  description: <int> .D.V......P Tile threads (from 0 to 256) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framethreads
+  single_dash: true
+  group: 'libdav1d decoder AVOptions:'
+  description: <int> .D.V......P Frame threads (from 0 to 256) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: max_frame_delay
+  single_dash: true
+  group: 'libdav1d decoder AVOptions:'
+  description: <int> .D.V....... Max frame delay (from 0 to 256) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: filmgrain
+  single_dash: true
+  group: 'libdav1d decoder AVOptions:'
+  description: <boolean> .D.V......P Apply Film Grain (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: oppoint
+  single_dash: true
+  group: 'libdav1d decoder AVOptions:'
+  description: <int> .D.V....... Select an operating point of the scalable bitstream (from -1 to 31) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: alllayers
+  single_dash: true
+  group: 'libdav1d decoder AVOptions:'
+  description: <boolean> .D.V....... Output all spatial layers (default false)
+  provenance:
+    sources:
+    - help-text
+- long: apply_phase_inv
+  single_dash: true
+  group: 'libopusdec AVOptions:'
+  description: <boolean> .D..A...... Apply intensity stereo phase inversion (default true)
+  provenance:
+    sources:
+    - help-text
+- long: width
+  single_dash: true
+  group: 'Librsvg AVOptions:'
+  description: <int> .D.V....... Width to render to (0 for default) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: height
+  single_dash: true
+  group: 'Librsvg AVOptions:'
+  description: <int> .D.V....... Height to render to (0 for default) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: keep_ar
+  single_dash: true
+  group: 'Librsvg AVOptions:'
+  description: <boolean> .D.V....... Keep aspect ratio with custom width/height (default true)
+  provenance:
+    sources:
+    - help-text
+- long: txt_page
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <string> .D...S..... page numbers to decode, subtitle for subtitles, * for all (default "*")
+  provenance:
+    sources:
+    - help-text
+- long: txt_default_region
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: .D...S..... default G0 character set used for decoding (from -1 to 87) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: txt_chop_top
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... discards the top teletext line (from 0 to 1) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: txt_format
+  choices:
+  - name: bitmap
+    description: 0 .D...S.....
+  - name: text
+    description: 1 .D...S.....
+  - name: ass
+    description: 2 .D...S.....
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... format of the subtitles (bitmap or text or ass) (from 0 to 2) (default bitmap)
+  provenance:
+    sources:
+    - help-text
+- long: txt_left
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... x offset of generated bitmaps (from 0 to 65535) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: txt_top
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... y offset of generated bitmaps (from 0 to 65535) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: txt_chop_spaces
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... chops leading and trailing spaces from text (from 0 to 1) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: txt_duration
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... display duration of teletext pages in msecs (from -1 to 8.64e+07) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: txt_transparent
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... force transparent background of the teletext (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: txt_opacity
+  single_dash: true
+  group: 'libzvbi_teletextdec AVOptions:'
+  description: <int> .D...S..... set opacity of the transparent background (from -1 to 255) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: operating_point
+  single_dash: true
+  group: 'AV1 decoder AVOptions:'
+  description: <int> .D.V....... Select an operating point of the scalable bitstream (from 0 to 31) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'av1_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'av1_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'av1_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'av1_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'av1_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'av1_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'h264_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'h264_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'h264_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'h264_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'h264_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'h264_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'hevc_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'hevc_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'hevc_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'hevc_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'hevc_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'hevc_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'mjpeg_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'mjpeg_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'mjpeg_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'mjpeg_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'mjpeg_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'mjpeg_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'mpeg1_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'mpeg1_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'mpeg1_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'mpeg1_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'mpeg1_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'mpeg1_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'mpeg2_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'mpeg2_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'mpeg2_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'mpeg2_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'mpeg2_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'mpeg2_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'mpeg4_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'mpeg4_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'mpeg4_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'mpeg4_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'mpeg4_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'mpeg4_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'vc1_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'vc1_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'vc1_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'vc1_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'vc1_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'vc1_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'vp8_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'vp8_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'vp8_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'vp8_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'vp8_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'vp8_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: deint
+  choices:
+  - name: weave
+    description: 0 .D.V....... Weave deinterlacing (do nothing)
+  - name: bob
+    description: 1 .D.V....... Bob deinterlacing
+  - name: adaptive
+    description: 2 .D.V....... Adaptive deinterlacing
+  single_dash: true
+  group: 'vp9_cuvid AVOptions:'
+  description: <int> .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+  provenance:
+    sources:
+    - help-text
+- long: gpu
+  single_dash: true
+  group: 'vp9_cuvid AVOptions:'
+  description: <string> .D.V....... GPU to be used for decoding
+  provenance:
+    sources:
+    - help-text
+- long: surfaces
+  single_dash: true
+  group: 'vp9_cuvid AVOptions:'
+  description: <int> .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: drop_second_field
+  single_dash: true
+  group: 'vp9_cuvid AVOptions:'
+  description: .D.V....... Drop second field when deinterlacing (default false)
+  provenance:
+    sources:
+    - help-text
+- long: crop
+  single_dash: true
+  group: 'vp9_cuvid AVOptions:'
+  description: <string> .D.V....... Crop (top)x(bottom)x(left)x(right)
+  provenance:
+    sources:
+    - help-text
+- long: resize
+  single_dash: true
+  group: 'vp9_cuvid AVOptions:'
+  description: <string> .D.V....... Resize (width)x(height)
+  provenance:
+    sources:
+    - help-text
+- long: avioflags
+  choices:
+  - name: direct
+    description: ED......... reduce buffering
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <flags> ED......... (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: probesize
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int64> .D......... set probing size (from 32 to I64_MAX) (default 5000000)
+  provenance:
+    sources:
+    - help-text
+- long: formatprobesize
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> .D......... number of bytes to probe file format (from 0 to 2.14748e+09) (default 1048576)
+  provenance:
+    sources:
+    - help-text
+- long: fflags
+  choices:
+  - name: ignidx
+    description: .D......... ignore index
+  - name: genpts
+    description: .D......... generate pts
+  - name: nofillin
+    description: .D......... do not fill in missing values that can be exactly calculated
+  - name: noparse
+    description: .D......... disable AVParsers, this needs nofillin too
+  - name: igndts
+    description: .D......... ignore dts
+  - name: discardcorrupt
+    description: .D......... discard corrupted frames
+  - name: sortdts
+    description: .D......... try to interleave outputted packets by dts
+  - name: fastseek
+    description: .D......... fast but inaccurate seeks
+  - name: nobuffer
+    description: .D......... reduce the latency introduced by optional buffering
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <flags> ED......... (default autobsf)
+  provenance:
+    sources:
+    - help-text
+- long: seek2any
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <boolean> .D......... allow seeking to non-keyframes on demuxer level when supported (default false)
+  provenance:
+    sources:
+    - help-text
+- long: analyzeduration
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int64> .D......... specify how many microseconds are analyzed to probe the input (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: cryptokey
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <binary> .D......... decryption key
+  provenance:
+    sources:
+    - help-text
+- long: indexmem
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> .D......... max memory used for timestamp index (per stream) (from 0 to INT_MAX) (default 1048576)
+  provenance:
+    sources:
+    - help-text
+- long: rtbufsize
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> .D......... max memory used for buffering real-time frames (from 0 to INT_MAX) (default 3041280)
+  provenance:
+    sources:
+    - help-text
+- long: fdebug
+  choices:
+  - name: ts
+    description: ED.........
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <flags> ED......... print specific debug info (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: max_delay
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> ED......... maximum muxing or demuxing delay in microseconds (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: fpsprobesize
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> .D......... number of frames used to probe fps (from -1 to 2.14748e+09) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: f_err_detect
+  choices:
+  - name: crccheck
+    description: .D......... verify embedded CRCs
+  - name: bitstream
+    description: .D......... detect bitstream specification deviations
+  - name: buffer
+    description: .D......... detect improper bitstream length
+  - name: explode
+    description: .D......... abort decoding on minor error detection
+  - name: ignore_err
+    description: .D......... ignore errors
+  - name: careful
+    description: .D......... consider things that violate the spec, are fast to check and have not been seen in the wild as errors
+  - name: compliant
+    description: .D......... consider all spec non compliancies as errors
+  - name: aggressive
+    description: .D......... consider things that a sane encoder shouldn't do as an error
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <flags> .D......... set error detection flags (deprecated; use err_detect, save via avconv) (default crccheck)
+  provenance:
+    sources:
+    - help-text
+- long: err_detect
+  choices:
+  - name: crccheck
+    description: .D......... verify embedded CRCs
+  - name: bitstream
+    description: .D......... detect bitstream specification deviations
+  - name: buffer
+    description: .D......... detect improper bitstream length
+  - name: explode
+    description: .D......... abort decoding on minor error detection
+  - name: ignore_err
+    description: .D......... ignore errors
+  - name: careful
+    description: .D......... consider things that violate the spec, are fast to check and have not been seen in the wild as errors
+  - name: compliant
+    description: .D......... consider all spec non compliancies as errors
+  - name: aggressive
+    description: .D......... consider things that a sane encoder shouldn't do as an error
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <flags> .D......... set error detection flags (default crccheck)
+  provenance:
+    sources:
+    - help-text
+- long: use_wallclock_as_timestamps
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... use wallclock as timestamps (default false)
+  provenance:
+    sources:
+    - help-text
+- long: skip_initial_bytes
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... set number of bytes to skip before reading header and frames (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: correct_ts_overflow
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... correct single timestamp overflows (default true)
+  provenance:
+    sources:
+    - help-text
+- long: f_strict
+  choices:
+  - name: very
+    description: 2 ED......... strictly conform to a older more strict version of the spec or reference software
+  - name: strict
+    description: 1 ED......... strictly conform to all the things in the spec no matter what the consequences
+  - name: normal
+    description: 0 ED.........
+  - name: unofficial
+    description: -1 ED......... allow unofficial extensions
+  - name: experimental
+    description: -2 ED......... allow non-standardized experimental variants
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> ED......... how strictly to follow the standards (deprecated; use strict, save via avconv) (from INT_MIN to INT_MAX) (default normal)
+  provenance:
+    sources:
+    - help-text
+- long: strict
+  choices:
+  - name: very
+    description: 2 ED......... strictly conform to a older more strict version of the spec or reference software
+  - name: strict
+    description: 1 ED......... strictly conform to all the things in the spec no matter what the consequences
+  - name: normal
+    description: 0 ED.........
+  - name: unofficial
+    description: -1 ED......... allow unofficial extensions
+  - name: experimental
+    description: -2 ED......... allow non-standardized experimental variants
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> ED......... how strictly to follow the standards (from INT_MIN to INT_MAX) (default normal)
+  provenance:
+    sources:
+    - help-text
+- long: max_ts_probe
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> .D......... maximum number of packets to read while waiting for the first timestamp (from 0 to INT_MAX) (default 50)
+  provenance:
+    sources:
+    - help-text
+- long: dump_separator
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <string> ED......... set information dump field separator (default ", ")
+  provenance:
+    sources:
+    - help-text
+- long: codec_whitelist
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <string> .D......... List of decoders that are allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: format_whitelist
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <string> .D......... List of demuxers that are allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: protocol_whitelist
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... List of protocols that are allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: protocol_blacklist
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... List of protocols that are not allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: max_streams
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: <int> .D......... maximum number of streams (from 0 to INT_MAX) (default 1000)
+  provenance:
+    sources:
+    - help-text
+- long: skip_estimate_duration_from_pts
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... skip duration calculation in estimate_timings_from_pts (default false)
+  provenance:
+    sources:
+    - help-text
+- long: max_probe_packets
+  single_dash: true
+  group: 'AVFormatContext AVOptions:'
+  description: .D......... Maximum number of packets to probe a codec (from 0 to INT_MAX) (default 2500)
+  provenance:
+    sources:
+    - help-text
+- long: protocol_whitelist
+  single_dash: true
+  group: 'AVIOContext AVOptions:'
+  description: .D......... List of protocols that are allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: protocol_whitelist
+  single_dash: true
+  group: 'URLContext AVOptions:'
+  description: .D......... List of protocols that are allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: protocol_blacklist
+  single_dash: true
+  group: 'URLContext AVOptions:'
+  description: .D......... List of protocols that are not allowed to be used
+  provenance:
+    sources:
+    - help-text
+- long: rw_timeout
+  single_dash: true
+  group: 'URLContext AVOptions:'
+  description: <int64> ED......... Timeout for IO operations (in microseconds) (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: playlist
+  single_dash: true
+  group: 'bluray AVOptions:'
+  description: <int> .D......... (from -1 to 99999) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: angle
+  single_dash: true
+  group: 'bluray AVOptions:'
+  description: <int> .D......... (from 0 to 254) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: chapter
+  single_dash: true
+  group: 'bluray AVOptions:'
+  description: <int> .D......... (from 1 to 65534) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: read_ahead_limit
+  single_dash: true
+  group: 'cache AVOptions:'
+  description: <int> .D......... Amount in bytes that may be read ahead when seeking isn't supported, -1 for unlimited (from -1 to INT_MAX) (default 65536)
+  provenance:
+    sources:
+    - help-text
+- long: key
+  single_dash: true
+  group: 'crypto AVOptions:'
+  description: <binary> ED......... AES encryption/decryption key
+  provenance:
+    sources:
+    - help-text
+- short: 'i'
+  value_name: v
+  value_kind: Required
+  group: 'crypto AVOptions:'
+  description: <binary> ED......... AES encryption/decryption initialization vector
+  provenance:
+    sources:
+    - help-text
+- long: decryption_key
+  single_dash: true
+  group: 'crypto AVOptions:'
+  description: <binary> .D......... AES decryption key
+  provenance:
+    sources:
+    - help-text
+- long: decryption_iv
+  single_dash: true
+  group: 'crypto AVOptions:'
+  description: <binary> .D......... AES decryption initialization vector
+  provenance:
+    sources:
+    - help-text
+- long: ffrtmphttp_tls
+  single_dash: true
+  group: 'ffrtmphttp AVOptions:'
+  description: <boolean> .D......... Use a HTTPS tunneling connection (RTMPTS). (default false)
+  provenance:
+    sources:
+    - help-text
+- long: follow
+  single_dash: true
+  group: 'file AVOptions:'
+  description: <int> .D......... Follow a file as it is being written (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: seekable
+  single_dash: true
+  group: 'file AVOptions:'
+  description: <int> ED......... Sets if the file is seekable (from -1 to 0) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'ftp AVOptions:'
+  description: <int> ED......... set timeout of socket I/O operations (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: ftp-anonymous-password
+  single_dash: true
+  group: 'ftp AVOptions:'
+  description: ED......... password for anonymous login. E-mail address should be used.
+  provenance:
+    sources:
+    - help-text
+- long: ftp-user
+  single_dash: true
+  group: 'ftp AVOptions:'
+  description: <string> ED......... user for FTP login. Overridden by whatever is in the URL.
+  provenance:
+    sources:
+    - help-text
+- long: ftp-password
+  single_dash: true
+  group: 'ftp AVOptions:'
+  description: <string> ED......... password for FTP login. Overridden by whatever is in the URL.
+  provenance:
+    sources:
+    - help-text
+- long: seekable
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <boolean> .D......... control seekability of connection (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: http_proxy
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> ED......... set HTTP proxy to tunnel through
+  provenance:
+    sources:
+    - help-text
+- long: headers
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> ED......... set custom HTTP headers, can override built in default headers
+  provenance:
+    sources:
+    - help-text
+- long: content_type
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> ED......... set a specific content type for the POST messages
+  provenance:
+    sources:
+    - help-text
+- long: user_agent
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> .D......... override User-Agent header (default "Lavf/60.16.100")
+  provenance:
+    sources:
+    - help-text
+- long: referer
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> .D......... override referer header
+  provenance:
+    sources:
+    - help-text
+- long: multiple_requests
+  single_dash: true
+  group: 'http AVOptions:'
+  description: ED......... use persistent connections (default false)
+  provenance:
+    sources:
+    - help-text
+- long: post_data
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <binary> ED......... set custom HTTP post data
+  provenance:
+    sources:
+    - help-text
+- long: cookies
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> .D......... set cookies to be sent in applicable future requests, use newline delimited Set-Cookie HTTP field value syntax
+  provenance:
+    sources:
+    - help-text
+- long: icy
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <boolean> .D......... request ICY metadata (default true)
+  provenance:
+    sources:
+    - help-text
+- long: auth_type
+  choices:
+  - name: none
+    description: 0 ED......... No auth method set, autodetect
+  - name: basic
+    description: 1 ED......... HTTP basic authentication
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <int> ED......... HTTP authentication type (from 0 to 1) (default none)
+  provenance:
+    sources:
+    - help-text
+- long: location
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> ED......... The actual location of the data received
+  provenance:
+    sources:
+    - help-text
+- long: offset
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <int64> .D......... initial byte offset (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: end_offset
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <int64> .D......... try to limit the request to bytes preceding this offset (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: method
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <string> ED......... Override the HTTP method or set the expected HTTP method from a client
+  provenance:
+    sources:
+    - help-text
+- long: reconnect
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <boolean> .D......... auto reconnect after disconnect before EOF (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_at_eof
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <boolean> .D......... auto reconnect at EOF (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_on_network_error
+  single_dash: true
+  group: 'http AVOptions:'
+  description: .D......... auto reconnect in case of tcp/tls error during connect (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_on_http_error
+  single_dash: true
+  group: 'http AVOptions:'
+  description: .D......... list of http status codes to reconnect on
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_streamed
+  single_dash: true
+  group: 'http AVOptions:'
+  description: .D......... auto reconnect streamed / non seekable streams (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_delay_max
+  single_dash: true
+  group: 'http AVOptions:'
+  description: .D......... max reconnect delay in seconds after which to give up (from 0 to 4294) (default 120)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <int> ED......... listen on HTTP (from 0 to 2) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: short_seek_size
+  single_dash: true
+  group: 'http AVOptions:'
+  description: <int> .D......... Threshold to favor readahead over seek. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: seekable
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <boolean> .D......... control seekability of connection (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: http_proxy
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> ED......... set HTTP proxy to tunnel through
+  provenance:
+    sources:
+    - help-text
+- long: headers
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> ED......... set custom HTTP headers, can override built in default headers
+  provenance:
+    sources:
+    - help-text
+- long: content_type
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> ED......... set a specific content type for the POST messages
+  provenance:
+    sources:
+    - help-text
+- long: user_agent
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> .D......... override User-Agent header (default "Lavf/60.16.100")
+  provenance:
+    sources:
+    - help-text
+- long: referer
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> .D......... override referer header
+  provenance:
+    sources:
+    - help-text
+- long: multiple_requests
+  single_dash: true
+  group: 'https AVOptions:'
+  description: ED......... use persistent connections (default false)
+  provenance:
+    sources:
+    - help-text
+- long: post_data
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <binary> ED......... set custom HTTP post data
+  provenance:
+    sources:
+    - help-text
+- long: cookies
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> .D......... set cookies to be sent in applicable future requests, use newline delimited Set-Cookie HTTP field value syntax
+  provenance:
+    sources:
+    - help-text
+- long: icy
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <boolean> .D......... request ICY metadata (default true)
+  provenance:
+    sources:
+    - help-text
+- long: auth_type
+  choices:
+  - name: none
+    description: 0 ED......... No auth method set, autodetect
+  - name: basic
+    description: 1 ED......... HTTP basic authentication
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <int> ED......... HTTP authentication type (from 0 to 1) (default none)
+  provenance:
+    sources:
+    - help-text
+- long: location
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> ED......... The actual location of the data received
+  provenance:
+    sources:
+    - help-text
+- long: offset
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <int64> .D......... initial byte offset (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: end_offset
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <int64> .D......... try to limit the request to bytes preceding this offset (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: method
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <string> ED......... Override the HTTP method or set the expected HTTP method from a client
+  provenance:
+    sources:
+    - help-text
+- long: reconnect
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <boolean> .D......... auto reconnect after disconnect before EOF (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_at_eof
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <boolean> .D......... auto reconnect at EOF (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_on_network_error
+  single_dash: true
+  group: 'https AVOptions:'
+  description: .D......... auto reconnect in case of tcp/tls error during connect (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_on_http_error
+  single_dash: true
+  group: 'https AVOptions:'
+  description: .D......... list of http status codes to reconnect on
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_streamed
+  single_dash: true
+  group: 'https AVOptions:'
+  description: .D......... auto reconnect streamed / non seekable streams (default false)
+  provenance:
+    sources:
+    - help-text
+- long: reconnect_delay_max
+  single_dash: true
+  group: 'https AVOptions:'
+  description: .D......... max reconnect delay in seconds after which to give up (from 0 to 4294) (default 120)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <int> ED......... listen on HTTP (from 0 to 2) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: short_seek_size
+  single_dash: true
+  group: 'https AVOptions:'
+  description: <int> .D......... Threshold to favor readahead over seek. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_app
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> ED......... Name of application to connect to on the RTMP server
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_buffer
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_conn
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> ED......... Append arbitrary AMF data to the Connect message
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_flashver
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> ED......... Version of the Flash plugin used to run the SWF player.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_live
+  choices:
+  - name: any
+    description: -2 .D......... both
+  - name: live
+    description: -1 .D......... live stream
+  - name: recorded
+    description: 0 .D......... recorded stream
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_pageurl
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_playpath
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> ED......... Stream identifier to play or to publish
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_subscribe
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfhash
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <binary> .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfsize
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfurl
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> ED......... URL of the SWF player. By default no value will be sent
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfverify
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> .D......... URL to player swf file, compute hash/size automatically.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_tcurl
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <string> ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_listen
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: tcp_nodelay
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'rtmp AVOptions:'
+  description: <int> .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_app
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> ED......... Name of application to connect to on the RTMP server
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_buffer
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_conn
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> ED......... Append arbitrary AMF data to the Connect message
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_flashver
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> ED......... Version of the Flash plugin used to run the SWF player.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_live
+  choices:
+  - name: any
+    description: -2 .D......... both
+  - name: live
+    description: -1 .D......... live stream
+  - name: recorded
+    description: 0 .D......... recorded stream
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_pageurl
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_playpath
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> ED......... Stream identifier to play or to publish
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_subscribe
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfhash
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <binary> .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfsize
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfurl
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> ED......... URL of the SWF player. By default no value will be sent
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfverify
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> .D......... URL to player swf file, compute hash/size automatically.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_tcurl
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <string> ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_listen
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: tcp_nodelay
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'rtmps AVOptions:'
+  description: <int> .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_app
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> ED......... Name of application to connect to on the RTMP server
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_buffer
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_conn
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> ED......... Append arbitrary AMF data to the Connect message
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_flashver
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> ED......... Version of the Flash plugin used to run the SWF player.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_live
+  choices:
+  - name: any
+    description: -2 .D......... both
+  - name: live
+    description: -1 .D......... live stream
+  - name: recorded
+    description: 0 .D......... recorded stream
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_pageurl
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_playpath
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> ED......... Stream identifier to play or to publish
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_subscribe
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfhash
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <binary> .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfsize
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfurl
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> ED......... URL of the SWF player. By default no value will be sent
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfverify
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> .D......... URL to player swf file, compute hash/size automatically.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_tcurl
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <string> ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_listen
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: tcp_nodelay
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'rtmpt AVOptions:'
+  description: <int> .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_app
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> ED......... Name of application to connect to on the RTMP server
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_buffer
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_conn
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> ED......... Append arbitrary AMF data to the Connect message
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_flashver
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> ED......... Version of the Flash plugin used to run the SWF player.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_live
+  choices:
+  - name: any
+    description: -2 .D......... both
+  - name: live
+    description: -1 .D......... live stream
+  - name: recorded
+    description: 0 .D......... recorded stream
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_pageurl
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_playpath
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> ED......... Stream identifier to play or to publish
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_subscribe
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfhash
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <binary> .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfsize
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfurl
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> ED......... URL of the SWF player. By default no value will be sent
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_swfverify
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> .D......... URL to player swf file, compute hash/size automatically.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_tcurl
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <string> ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  provenance:
+    sources:
+    - help-text
+- long: rtmp_listen
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: tcp_nodelay
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'rtmpts AVOptions:'
+  description: <int> .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: ttl
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... Time to live (multicast only) (from -1 to 255) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... Send/Receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: rtcp_port
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... Custom rtcp port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: local_rtpport
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... Local rtp port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: local_rtcpport
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... Local rtcp port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: connect
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <boolean> ED......... Connect socket (default false)
+  provenance:
+    sources:
+    - help-text
+- long: write_to_source
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <boolean> ED......... Send packets to the source address of the latest received packet (default false)
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... Maximum packet size (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: dscp
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int> ED......... DSCP class (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <int64> ED......... set timeout (in microseconds) of socket I/O operations (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: sources
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <string> ED......... Source list
+  provenance:
+    sources:
+    - help-text
+- long: block
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <string> ED......... Block list
+  provenance:
+    sources:
+    - help-text
+- long: localaddr
+  single_dash: true
+  group: 'rtp AVOptions:'
+  description: <string> ED......... Local address
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'sctp AVOptions:'
+  description: <boolean> ED......... Listen for incoming connections (default false)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'sctp AVOptions:'
+  description: <int> ED......... Connection timeout (in milliseconds) (from INT_MIN to INT_MAX) (default 10000)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'sctp AVOptions:'
+  description: <int> ED......... Bind timeout (in milliseconds) (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: max_streams
+  single_dash: true
+  group: 'sctp AVOptions:'
+  description: <int> ED......... Max stream to allocate (from 0 to 32767) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: srtp_in_suite
+  single_dash: true
+  group: 'srtp AVOptions:'
+  description: <string> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: srtp_in_params
+  single_dash: true
+  group: 'srtp AVOptions:'
+  description: <string> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: start
+  single_dash: true
+  group: 'subfile AVOptions:'
+  description: <int64> .D......... start offset (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: end
+  single_dash: true
+  group: 'subfile AVOptions:'
+  description: <int64> .D......... end offset (from 0 to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <int> ED......... Listen for incoming connections (from 0 to 2) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: local_port
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <string> ED......... Local port
+  provenance:
+    sources:
+    - help-text
+- long: local_addr
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <string> ED......... Local address
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <int> ED......... set timeout (in microseconds) of socket I/O operations (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <int> ED......... Connection awaiting timeout (in milliseconds) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: send_buffer_size
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <int> ED......... Socket send buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: recv_buffer_size
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <int> ED......... Socket receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: tcp_nodelay
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <boolean> ED......... Use TCP_NODELAY to disable nagle's algorithm (default false)
+  provenance:
+    sources:
+    - help-text
+- long: tcp_mss
+  single_dash: true
+  group: 'tcp AVOptions:'
+  description: <int> ED......... Maximum segment size for outgoing TCP packets (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: ca_file
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <string> ED......... Certificate Authority database file
+  provenance:
+    sources:
+    - help-text
+- long: cafile
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <string> ED......... Certificate Authority database file
+  provenance:
+    sources:
+    - help-text
+- long: tls_verify
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <int> ED......... Verify the peer certificate (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: cert_file
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <string> ED......... Certificate file
+  provenance:
+    sources:
+    - help-text
+- long: key_file
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <string> ED......... Private key file
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <int> ED......... Listen for incoming connections (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: verifyhost
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <string> ED......... Verify against a specific hostname
+  provenance:
+    sources:
+    - help-text
+- long: http_proxy
+  single_dash: true
+  group: 'tls AVOptions:'
+  description: <string> ED......... Set proxy to tunnel through
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> ED......... System data size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: localport
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> ED......... Local port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: local_port
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> ED......... Local port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: localaddr
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <string> ED......... Local address
+  provenance:
+    sources:
+    - help-text
+- long: udplite_coverage
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> ED......... choose UDPLite head size which should be validated by checksum (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> ED......... Maximum UDP packet size (from -1 to INT_MAX) (default 1472)
+  provenance:
+    sources:
+    - help-text
+- long: reuse
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <boolean> ED......... explicitly allow reusing UDP sockets (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: reuse_socket
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <boolean> ED......... explicitly allow reusing UDP sockets (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: connect
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <boolean> ED......... set if connect() should be called on socket (default false)
+  provenance:
+    sources:
+    - help-text
+- long: fifo_size
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> .D......... set the UDP receiving circular buffer size, expressed as a number of packets with size of 188 bytes (from 0 to INT_MAX) (default 28672)
+  provenance:
+    sources:
+    - help-text
+- long: overrun_nonfatal
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <boolean> .D......... survive in case of UDP receiving circular buffer overrun (default false)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <int> .D......... set raise error timeout, in microseconds (only in read mode) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: sources
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <string> ED......... Source list
+  provenance:
+    sources:
+    - help-text
+- long: block
+  single_dash: true
+  group: 'udp AVOptions:'
+  description: <string> ED......... Block list
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> ED......... System data size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: localport
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> ED......... Local port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: local_port
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> ED......... Local port (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: localaddr
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <string> ED......... Local address
+  provenance:
+    sources:
+    - help-text
+- long: udplite_coverage
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> ED......... choose UDPLite head size which should be validated by checksum (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> ED......... Maximum UDP packet size (from -1 to INT_MAX) (default 1472)
+  provenance:
+    sources:
+    - help-text
+- long: reuse
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <boolean> ED......... explicitly allow reusing UDP sockets (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: reuse_socket
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <boolean> ED......... explicitly allow reusing UDP sockets (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: connect
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <boolean> ED......... set if connect() should be called on socket (default false)
+  provenance:
+    sources:
+    - help-text
+- long: fifo_size
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> .D......... set the UDP receiving circular buffer size, expressed as a number of packets with size of 188 bytes (from 0 to INT_MAX) (default 28672)
+  provenance:
+    sources:
+    - help-text
+- long: overrun_nonfatal
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <boolean> .D......... survive in case of UDP receiving circular buffer overrun (default false)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <int> .D......... set raise error timeout, in microseconds (only in read mode) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: sources
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <string> ED......... Source list
+  provenance:
+    sources:
+    - help-text
+- long: block
+  single_dash: true
+  group: 'udplite AVOptions:'
+  description: <string> ED......... Block list
+  provenance:
+    sources:
+    - help-text
+- long: listen
+  single_dash: true
+  group: 'unix AVOptions:'
+  description: <boolean> ED......... Open socket for listening (default false)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'unix AVOptions:'
+  description: <int> ED......... Timeout in ms (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: type
+  choices:
+  - name: stream
+    description: 1 ED......... Stream (reliable stream-oriented)
+  - name: datagram
+    description: 2 ED......... Datagram (unreliable packet-oriented)
+  - name: seqpacket
+    description: 5 ED......... Seqpacket (reliable packet-oriented
+  single_dash: true
+  group: 'unix AVOptions:'
+  description: <int> ED......... Socket type (from INT_MIN to INT_MAX) (default stream)
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  single_dash: true
+  group: 'amqp AVOptions:'
+  description: <int> ED......... Maximum send/read packet size (from 4096 to INT_MAX) (default 131072)
+  provenance:
+    sources:
+    - help-text
+- long: exchange
+  single_dash: true
+  group: 'amqp AVOptions:'
+  description: <string> ED......... Exchange to send/read packets (default "amq.direct")
+  provenance:
+    sources:
+    - help-text
+- long: routing_key
+  single_dash: true
+  group: 'amqp AVOptions:'
+  description: <string> ED......... Key to filter streams (default "amqp")
+  provenance:
+    sources:
+    - help-text
+- long: connection_timeout
+  single_dash: true
+  group: 'amqp AVOptions:'
+  description: ED......... Initial connection timeout (default -0.000001)
+  provenance:
+    sources:
+    - help-text
+- long: rist_profile
+  choices:
+  - name: simple
+    description: 0 ED.........
+  - name: main
+    description: 1 ED.........
+  - name: advanced
+    description: 2 ED.........
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <int> ED......... set profile (from 0 to 2) (default main)
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <int> ED......... set buffer_size in ms (from 0 to 30000) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: fifo_size
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <int> ED......... set fifo buffer size, must be a power of 2 (from 32 to 262144) (default 8192)
+  provenance:
+    sources:
+    - help-text
+- long: overrun_nonfatal
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <boolean> .D......... survive in case of receiving fifo buffer overrun (default false)
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <int> ED......... set packet size (from 1 to 9972) (default 1316)
+  provenance:
+    sources:
+    - help-text
+- long: log_level
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <int> ED......... set loglevel (from -1 to INT_MAX) (default 6)
+  provenance:
+    sources:
+    - help-text
+- long: secret
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <string> ED......... set encryption secret
+  provenance:
+    sources:
+    - help-text
+- long: encryption
+  single_dash: true
+  group: 'librist AVOptions:'
+  description: <int> ED......... set encryption type (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... Timeout of socket I/O operations (in microseconds) (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... Connection awaiting timeout (in microseconds) (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: send_buffer_size
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Socket send buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: recv_buffer_size
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Socket receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  choices:
+  - name: ts_size
+    description: 1316 ED.........
+  - name: max_size
+    description: 1456 ED.........
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Maximum SRT packet size (from -1 to 1456) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: payload_size
+  choices:
+  - name: ts_size
+    description: 1316 ED.........
+  - name: max_size
+    description: 1456 ED.........
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Maximum SRT packet size (from -1 to 1456) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: maxbw
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... Maximum bandwidth (bytes per second) that the connection can use (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: pbkeylen
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: '<int> ED......... Crypto key len in bytes {16,24,32} Default: 16 (128-bit) (from -1 to 32) (default -1)'
+  provenance:
+    sources:
+    - help-text
+- long: passphrase
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <string> ED......... Crypto PBKDF2 Passphrase size[0,10..64] 0:disable crypto
+  provenance:
+    sources:
+    - help-text
+- long: enforced_encryption
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: ED......... Enforces that both connection parties have the same passphrase set (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: kmrefreshrate
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... The number of packets to be transmitted after which the encryption key is switched to a new key (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: kmpreannounce
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... The interval between when a new encryption key is sent and when switchover occurs (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: snddropdelay
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... The sender's extra delay(in microseconds) before dropping packets (from -2 to I64_MAX) (default -2)
+  provenance:
+    sources:
+    - help-text
+- long: mss
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... The Maximum Segment Size (from -1 to 1500) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: ffs
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Flight flag size (window size) (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: ipttl
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... IP Time To Live (from -1 to 255) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: iptos
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... IP Type of Service (from -1 to 255) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: inputbw
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... Estimated input stream rate (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: oheadbw
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... MaxBW ceiling based on % over input stream rate (from -1 to 100) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: latency
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... receiver delay (in microseconds) to absorb bursts of missed packet retransmissions (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: tsbpddelay
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... deprecated, same effect as latency option (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: rcvlatency
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... receive latency (in microseconds) (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: peerlatency
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int64> ED......... peer latency (in microseconds) (from -1 to I64_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: tlpktdrop
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <boolean> ED......... Enable too-late pkt drop (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: nakreport
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <boolean> ED......... Enable receiver to send periodic NAK reports (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: connect_timeout
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: '<int64> ED......... Connect timeout(in milliseconds). Caller default: 3000, rendezvous (x 10) (from -1 to I64_MAX) (default -1)'
+  provenance:
+    sources:
+    - help-text
+- long: mode
+  choices:
+  - name: caller
+    description: 0 ED.........
+  - name: listener
+    description: 1 ED.........
+  - name: rendezvous
+    description: 2 ED.........
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Connection mode (caller, listener, rendezvous) (from 0 to 2) (default caller)
+  provenance:
+    sources:
+    - help-text
+- long: sndbuf
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Send buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: rcvbuf
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: lossmaxttl
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Maximum possible packet reorder tolerance (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: minversion
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... The minimum SRT version that is required from the peer (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: streamid
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <string> ED......... A string of up to 512 characters that an Initiator can pass to a Responder
+  provenance:
+    sources:
+    - help-text
+- long: srt_streamid
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <string> ED......... A string of up to 512 characters that an Initiator can pass to a Responder
+  provenance:
+    sources:
+    - help-text
+- long: smoother
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <string> ED......... The type of Smoother used for the transmission for that socket
+  provenance:
+    sources:
+    - help-text
+- long: messageapi
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <boolean> ED......... Enable message API (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: transtype
+  choices:
+  - name: live
+    description: 0 ED.........
+  - name: file
+    description: 1 ED.........
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... The transmission type for the socket (from 0 to 2) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: linger
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <int> ED......... Number of seconds that the socket waits for unsent data when closing (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: tsbpd
+  single_dash: true
+  group: 'libsrt AVOptions:'
+  description: <boolean> ED......... Timestamp-based packet delivery (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'libssh AVOptions:'
+  description: <int> ED......... set timeout of socket I/O operations (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: private_key
+  single_dash: true
+  group: 'libssh AVOptions:'
+  description: <string> ED......... set path to private key
+  provenance:
+    sources:
+    - help-text
+- long: pkt_size
+  single_dash: true
+  group: 'zmq AVOptions:'
+  description: <int> ED......... Maximum send/read packet size (from -1 to INT_MAX) (default 131072)
+  provenance:
+    sources:
+    - help-text
+- long: gateway
+  single_dash: true
+  group: 'IPFS Gateway AVOptions:'
+  description: <string> .D......... The gateway to ask for IPFS data.
+  provenance:
+    sources:
+    - help-text
+- long: gateway
+  single_dash: true
+  group: 'IPFS Gateway AVOptions:'
+  description: <string> .D......... The gateway to ask for IPFS data.
+  provenance:
+    sources:
+    - help-text
+- long: initial_pause
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <boolean> .D......... do not start playing the stream immediately (default false)
+  provenance:
+    sources:
+    - help-text
+- long: rtsp_transport
+  choices:
+  - name: udp
+    description: ED......... UDP
+  - name: tcp
+    description: ED......... TCP
+  - name: udp_multicast
+    description: .D......... UDP multicast
+  - name: http
+    description: .D......... HTTP tunneling
+  - name: https
+    description: .D......... HTTPS tunneling
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <flags> ED......... set RTSP transport protocols (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtsp_flags
+  choices:
+  - name: filter_src
+    description: .D......... only receive packets from the negotiated peer IP
+  - name: listen
+    description: .D......... wait for incoming connections
+  - name: prefer_tcp
+    description: ED......... try RTP via TCP first, if available
+  - name: satip_raw
+    description: .D......... export raw MPEG-TS stream instead of demuxing
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <flags> .D......... set RTSP flags (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: allowed_media_types
+  choices:
+  - name: video
+    description: .D......... Video
+  - name: audio
+    description: .D......... Audio
+  - name: data
+    description: .D......... Data
+  - name: subtitle
+    description: .D......... Subtitle
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: .D......... set media types to accept from the server (default video+audio+data+subtitle)
+  provenance:
+    sources:
+    - help-text
+- long: min_port
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <int> ED......... set minimum local UDP port (from 0 to 65535) (default 5000)
+  provenance:
+    sources:
+    - help-text
+- long: max_port
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <int> ED......... set maximum local UDP port (from 0 to 65535) (default 65000)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <int> .D......... set maximum timeout (in seconds) to wait for incoming connections (-1 is infinite, imply flag listen) (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <int64> .D......... set timeout (in microseconds) of socket I/O operations (from INT_MIN to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: reorder_queue_size
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <int> ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: user_agent
+  single_dash: true
+  group: 'RTSP muxer AVOptions:'
+  description: <string> .D......... override User-Agent header (default "Lavf60.16.100")
+  provenance:
+    sources:
+    - help-text
+- long: aa_fixed_key
+  single_dash: true
+  group: 'aa AVOptions:'
+  description: <binary> .D......... Fixed key used for handling Audible AA files
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: linespeed
+  single_dash: true
+  group: 'Artworx Data Format demuxer AVOptions:'
+  description: <int> .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'Artworx Data Format demuxer AVOptions:'
+  description: <image_size> .D......... set video size, such as 640x480 or hd720.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'Artworx Data Format demuxer AVOptions:'
+  description: <video_rate> .D......... set framerate (frames per second) (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: ignore_loop
+  single_dash: true
+  group: 'APNG demuxer AVOptions:'
+  description: <boolean> .D......... ignore loop setting (default true)
+  provenance:
+    sources:
+    - help-text
+- long: max_fps
+  single_dash: true
+  group: 'APNG demuxer AVOptions:'
+  description: <int> .D......... maximum framerate (0 is no limit) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: default_fps
+  single_dash: true
+  group: 'APNG demuxer AVOptions:'
+  description: <int> .D......... default framerate (0 is as fast as possible) (from 0 to INT_MAX) (default 15)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'aptx (hd) demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'aptx (hd) demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: subfps
+  single_dash: true
+  group: 'aqtdec AVOptions:'
+  description: <rational> .D...S..... set the movie frame rate (from 0 to INT_MAX) (default 25/1)
+  provenance:
+    sources:
+    - help-text
+- long: no_resync_search
+  single_dash: true
+  group: 'asf demuxer AVOptions:'
+  description: <boolean> .D......... Don't try to resynchronize by looking for a certain optional start code (default false)
+  provenance:
+    sources:
+    - help-text
+- long: export_xmp
+  single_dash: true
+  group: 'asf demuxer AVOptions:'
+  description: <boolean> .D......... Export full XMP metadata (default false)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'AV1 Annex B/low overhead OBU demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: use_odml
+  single_dash: true
+  group: 'avi AVOptions:'
+  description: <boolean> .D......... use odml index (default true)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: linespeed
+  single_dash: true
+  group: 'Binary text demuxer AVOptions:'
+  description: <int> .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'Binary text demuxer AVOptions:'
+  description: <image_size> .D......... set video size, such as 640x480 or hd720.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'Binary text demuxer AVOptions:'
+  description: <video_rate> .D......... set framerate (frames per second) (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'bitpacked demuxer AVOptions:'
+  description: <string> .D......... set pixel format (default "yuv420p")
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'bitpacked demuxer AVOptions:'
+  description: <image_size> .D......... set frame size
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'bitpacked demuxer AVOptions:'
+  description: <video_rate> .D......... set frame rate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'CDXL demuxer AVOptions:'
+  description: <int> .D......... (from 8000 to INT_MAX) (default 11025)
+  provenance:
+    sources:
+    - help-text
+- long: frame_rate
+  single_dash: true
+  group: 'CDXL demuxer AVOptions:'
+  description: <video_rate> .D......... (default "15")
+  provenance:
+    sources:
+    - help-text
+- long: frames_per_packet
+  single_dash: true
+  group: 'codec2 demuxer AVOptions:'
+  description: .D......... Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: mode
+  single_dash: true
+  group: 'codec2raw demuxer AVOptions:'
+  description: <int> .D......... codec2 mode [mandatory] (from -1 to 8) (default -1) 3200 0 .D......... 3200 2400 1 .D......... 2400 1600 2 .D......... 1600 1400 3 .D......... 1400 1300 4 .D......... 1300 1200 5 .D......... 1200 700 6 .D......... 700 700B 7 .D......... 700B 700C 8 .D......... 700C
+  provenance:
+    sources:
+    - help-text
+- long: frames_per_packet
+  single_dash: true
+  group: 'codec2raw demuxer AVOptions:'
+  description: .D......... Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: safe
+  single_dash: true
+  group: 'concat demuxer AVOptions:'
+  description: <boolean> .D......... enable safe mode (default true)
+  provenance:
+    sources:
+    - help-text
+- long: auto_convert
+  single_dash: true
+  group: 'concat demuxer AVOptions:'
+  description: <boolean> .D......... automatically convert bitstream format (default true)
+  provenance:
+    sources:
+    - help-text
+- long: segment_time_metadata
+  single_dash: true
+  group: 'concat demuxer AVOptions:'
+  description: .D......... output file segment start time and duration as packet metadata (default false)
+  provenance:
+    sources:
+    - help-text
+- long: allowed_extensions
+  single_dash: true
+  group: 'dash AVOptions:'
+  description: .D......... List of file extensions that dash is allowed to access (default "aac,m4a,m4s,m4v,mov,mp4,webm,ts")
+  provenance:
+    sources:
+    - help-text
+- long: cenc_decryption_key
+  single_dash: true
+  group: 'dash AVOptions:'
+  description: .D......... Media decryption key (hex)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'dfpwm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'dfpwm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'dfpwm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: merge_alpha
+  single_dash: true
+  group: 'ea demuxer AVOptions:'
+  description: <boolean> .D.V....... return VP6 alpha in the main video stream (default false)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'EVC Annex B demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'FITS demuxer AVOptions:'
+  description: <video_rate> .D......... set the framerate (default "1")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: flv_metadata
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: <boolean> .D.V....... Allocate streams according to the onMetaData array (default false)
+  provenance:
+    sources:
+    - help-text
+- long: flv_full_metadata
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: .D.V....... Dump full metadata of the onMetadata (default false)
+  provenance:
+    sources:
+    - help-text
+- long: flv_ignore_prevtag
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: .D.V....... Ignore the Size of previous tag (default false)
+  provenance:
+    sources:
+    - help-text
+- long: missing_streams
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: <int> .D.V..XR... (from 0 to 255) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: flv_metadata
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: <boolean> .D.V....... Allocate streams according to the onMetaData array (default false)
+  provenance:
+    sources:
+    - help-text
+- long: flv_full_metadata
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: .D.V....... Dump full metadata of the onMetadata (default false)
+  provenance:
+    sources:
+    - help-text
+- long: flv_ignore_prevtag
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: .D.V....... Ignore the Size of previous tag (default false)
+  provenance:
+    sources:
+    - help-text
+- long: missing_streams
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: <int> .D.V..XR... (from 0 to 255) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: code_size
+  single_dash: true
+  group: 'G.726 demuxer AVOptions:'
+  description: <int> .D......... Bits per G.726 code (from 2 to 5) (default 4)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'G.726 demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 8000)
+  provenance:
+    sources:
+    - help-text
+- long: code_size
+  single_dash: true
+  group: 'G.726 demuxer AVOptions:'
+  description: <int> .D......... Bits per G.726 code (from 2 to 5) (default 4)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'G.726 demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 8000)
+  provenance:
+    sources:
+    - help-text
+- long: bit_rate
+  single_dash: true
+  group: 'g729 demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 8000)
+  provenance:
+    sources:
+    - help-text
+- long: min_delay
+  single_dash: true
+  group: 'GIF demuxer AVOptions:'
+  description: <int> .D......... minimum valid delay between frames (in hundredths of second) (from 0 to 6000) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: max_gif_delay
+  single_dash: true
+  group: 'GIF demuxer AVOptions:'
+  description: <int> .D......... maximum valid delay between frames (in hundredths of seconds) (from 0 to 65535) (default 65535)
+  provenance:
+    sources:
+    - help-text
+- long: default_delay
+  single_dash: true
+  group: 'GIF demuxer AVOptions:'
+  description: <int> .D......... default delay between frames (in hundredths of second) (from 0 to 6000) (default 10)
+  provenance:
+    sources:
+    - help-text
+- long: ignore_loop
+  single_dash: true
+  group: 'GIF demuxer AVOptions:'
+  description: <boolean> .D......... ignore loop setting (netscape extension) (default true)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'gsm demuxer AVOptions:'
+  description: <int> .D......... (from 1 to 6.50753e+07) (default 8000)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: hca_lowkey
+  single_dash: true
+  group: 'hca AVOptions:'
+  description: <int64> .D......... Low key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: hca_highkey
+  single_dash: true
+  group: 'hca AVOptions:'
+  description: <int64> .D......... High key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: hca_subkey
+  single_dash: true
+  group: 'hca AVOptions:'
+  description: <int> .D......... Subkey used for handling CRI HCA files (from 0 to 65535) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: live_start_index
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: <int> .D......... segment index to start live streams at (negative values are from the end) (from INT_MIN to INT_MAX) (default -3)
+  provenance:
+    sources:
+    - help-text
+- long: prefer_x_start
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: '<boolean> .D......... prefer to use #EXT-X-START if it''s in playlist instead of live_start_index (default false)'
+  provenance:
+    sources:
+    - help-text
+- long: allowed_extensions
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: .D......... List of file extensions that hls is allowed to access (default "3gp,aac,avi,ac3,eac3,flac,mkv,m3u8,m4a,m4s,m4v,mpg,mov,mp2,mp3,mp4,mpeg,mpegts,ogg,ogv,oga,ts,vob,wav")
+  provenance:
+    sources:
+    - help-text
+- long: max_reload
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: <int> .D......... Maximum number of times a insufficient list is attempted to be reloaded (from 0 to INT_MAX) (default 3)
+  provenance:
+    sources:
+    - help-text
+- long: m3u8_hold_counters
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: .D......... The maximum number of times to load m3u8 when it refreshes without new segments (from 0 to INT_MAX) (default 1000)
+  provenance:
+    sources:
+    - help-text
+- long: http_persistent
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: <boolean> .D......... Use persistent HTTP connections (default true)
+  provenance:
+    sources:
+    - help-text
+- long: http_multiple
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: <boolean> .D......... Use multiple HTTP connections for fetching segments (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: http_seekable
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: <boolean> .D......... Use HTTP partial requests, 0 = disable, 1 = enable, -1 = auto (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: seg_format_options
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: .D......... Set options for segment demuxer
+  provenance:
+    sources:
+    - help-text
+- long: seg_max_retry
+  single_dash: true
+  group: 'hls demuxer AVOptions:'
+  description: <int> .D......... Maximum number of times to reload a segment on error. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: linespeed
+  single_dash: true
+  group: 'iCE Draw File demuxer AVOptions:'
+  description: <int> .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'iCE Draw File demuxer AVOptions:'
+  description: <image_size> .D......... set video size, such as 640x480 or hd720.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'iCE Draw File demuxer AVOptions:'
+  description: <video_rate> .D......... set framerate (frames per second) (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pattern_type
+  choices:
+  - name: glob_sequence
+    description: 0 .D......... select glob/sequence pattern type
+  - name: glob
+    description: 1 .D......... select glob pattern type
+  - name: sequence
+    description: 2 .D......... select sequence pattern type
+  - name: none
+    description: 3 .D......... disable pattern matching
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <int> .D......... set pattern type (from 0 to INT_MAX) (default 4)
+  provenance:
+    sources:
+    - help-text
+- long: start_number
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <int> .D......... set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: start_number_range
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: .D......... set range for looking at the first sequence number (from 1 to INT_MAX) (default 5)
+  provenance:
+    sources:
+    - help-text
+- long: ts_from_file
+  choices:
+  - name: none
+    description: 0 .D......... none
+  - name: sec
+    description: 1 .D......... second precision
+  - name: ns
+    description: 2 .D......... nano second precision
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <int> .D......... set frame timestamp from file's one (from 0 to 2) (default none)
+  provenance:
+    sources:
+    - help-text
+- long: export_path_metadata
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: .D......... enable metadata containing input path information (default false)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'image2 demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: pattern_type
+  choices:
+  - name: glob_sequence
+    description: 0 .D......... select glob/sequence pattern type
+  - name: glob
+    description: 1 .D......... select glob pattern type
+  - name: sequence
+    description: 2 .D......... select sequence pattern type
+  - name: none
+    description: 3 .D......... disable pattern matching
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <int> .D......... set pattern type (from 0 to INT_MAX) (default 4)
+  provenance:
+    sources:
+    - help-text
+- long: start_number
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <int> .D......... set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: start_number_range
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: .D......... set range for looking at the first sequence number (from 1 to INT_MAX) (default 5)
+  provenance:
+    sources:
+    - help-text
+- long: ts_from_file
+  choices:
+  - name: none
+    description: 0 .D......... none
+  - name: sec
+    description: 1 .D......... second precision
+  - name: ns
+    description: 2 .D......... nano second precision
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <int> .D......... set frame timestamp from file's one (from 0 to 2) (default none)
+  provenance:
+    sources:
+    - help-text
+- long: export_path_metadata
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: .D......... enable metadata containing input path information (default false)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'alias_pix demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: pattern_type
+  choices:
+  - name: glob_sequence
+    description: 0 .D......... select glob/sequence pattern type
+  - name: glob
+    description: 1 .D......... select glob pattern type
+  - name: sequence
+    description: 2 .D......... select sequence pattern type
+  - name: none
+    description: 3 .D......... disable pattern matching
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <int> .D......... set pattern type (from 0 to INT_MAX) (default 4)
+  provenance:
+    sources:
+    - help-text
+- long: start_number
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <int> .D......... set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: start_number_range
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: .D......... set range for looking at the first sequence number (from 1 to INT_MAX) (default 5)
+  provenance:
+    sources:
+    - help-text
+- long: ts_from_file
+  choices:
+  - name: none
+    description: 0 .D......... none
+  - name: sec
+    description: 1 .D......... second precision
+  - name: ns
+    description: 2 .D......... nano second precision
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <int> .D......... set frame timestamp from file's one (from 0 to 2) (default none)
+  provenance:
+    sources:
+    - help-text
+- long: export_path_metadata
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: .D......... enable metadata containing input path information (default false)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'brender_pix demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: assetmaps
+  single_dash: true
+  group: 'imf AVOptions:'
+  description: <string> .D......... Comma-separated paths to ASSETMAP files.If not specified, the `ASSETMAP.xml` file in the same directory as the CPL is used.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: flv_metadata
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: <boolean> .D.V....... Allocate streams according to the onMetaData array (default false)
+  provenance:
+    sources:
+    - help-text
+- long: flv_full_metadata
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: .D.V....... Dump full metadata of the onMetadata (default false)
+  provenance:
+    sources:
+    - help-text
+- long: flv_ignore_prevtag
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: .D.V....... Ignore the Size of previous tag (default false)
+  provenance:
+    sources:
+    - help-text
+- long: missing_streams
+  single_dash: true
+  group: '(live) flv/kux demuxer AVOptions:'
+  description: <int> .D.V..XR... (from 0 to 255) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: subfps
+  single_dash: true
+  group: 'microdvddec AVOptions:'
+  description: <rational> .D...S..... set the movie frame rate fallback (from 0 to INT_MAX) (default 0/1)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: use_absolute_path
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: .D.V....... allow using absolute path when opening alias, this is a possible security issue (default false)
+  provenance:
+    sources:
+    - help-text
+- long: seek_streams_individually
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: .D.V....... Seek each stream individually to the closest point (default true)
+  provenance:
+    sources:
+    - help-text
+- long: ignore_editlist
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D.V....... Ignore the edit list atom. (default false)
+  provenance:
+    sources:
+    - help-text
+- long: advanced_editlist
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: .D.V....... Modify the AVIndex according to the editlists. Use this option to decode in the order specified by the edits. (default true)
+  provenance:
+    sources:
+    - help-text
+- long: ignore_chapters
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D.V....... (default false)
+  provenance:
+    sources:
+    - help-text
+- long: use_mfra_for
+  choices:
+  - name: auto
+    description: -1 .D.V....... auto
+  - name: dts
+    description: 1 .D.V....... dts
+  - name: pts
+    description: 2 .D.V....... pts
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <int> .D.V....... use mfra for fragment timestamps (from -1 to 2) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: use_tfdt
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D.V....... use tfdt for fragment timestamps (default true)
+  provenance:
+    sources:
+    - help-text
+- long: export_all
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D.V....... Export unrecognized metadata entries (default false)
+  provenance:
+    sources:
+    - help-text
+- long: export_xmp
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D.V....... Export full XMP metadata (default false)
+  provenance:
+    sources:
+    - help-text
+- long: activation_bytes
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <binary> .D......... Secret bytes for Audible AAX files
+  provenance:
+    sources:
+    - help-text
+- long: audible_key
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <binary> .D......... AES-128 Key for Audible AAXC files
+  provenance:
+    sources:
+    - help-text
+- long: audible_iv
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <binary> .D......... AES-128 IV for Audible AAXC files
+  provenance:
+    sources:
+    - help-text
+- long: audible_fixed_key
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: .D......... Fixed key used for handling Audible AAX files
+  provenance:
+    sources:
+    - help-text
+- long: decryption_key
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <binary> .D......... The media decryption key (hex)
+  provenance:
+    sources:
+    - help-text
+- long: enable_drefs
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D.V....... Enable external track support. (default false)
+  provenance:
+    sources:
+    - help-text
+- long: max_stts_delta
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <int> .D......... treat offsets above this value as invalid (from 0 to UINT32_MAX) (default 4294487295)
+  provenance:
+    sources:
+    - help-text
+- long: interleaved_read
+  single_dash: true
+  group: 'mov,mp4,m4a,3gp,3g2,mj2 AVOptions:'
+  description: <boolean> .D......... Interleave packets from multiple tracks at demuxer level (default true)
+  provenance:
+    sources:
+    - help-text
+- long: usetoc
+  single_dash: true
+  group: 'mp3 AVOptions:'
+  description: <boolean> .D......... use table of contents (default false)
+  provenance:
+    sources:
+    - help-text
+- long: resync_size
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: <int> .D......... set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
+  provenance:
+    sources:
+    - help-text
+- long: fix_teletext_pts
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: <boolean> .D......... try to fix pts values of dvb teletext streams (default true)
+  provenance:
+    sources:
+    - help-text
+- long: ts_packetsize
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: <int> .D....XR... output option carrying the raw packet size (from 0 to 0) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: scan_all_pmts
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: <boolean> .D......... scan and combine all PMTs (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: skip_unknown_pmt
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: <boolean> .D......... skip PMTs for programs not advertised in the PAT (default false)
+  provenance:
+    sources:
+    - help-text
+- long: merge_pmt_versions
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: .D......... re-use streams when PMT's version/pids change (default false)
+  provenance:
+    sources:
+    - help-text
+- long: max_packet_size
+  single_dash: true
+  group: 'mpegts demuxer AVOptions:'
+  description: <int> .D......... maximum size of emitted packet (from 1 to 1.07374e+09) (default 204800)
+  provenance:
+    sources:
+    - help-text
+- long: resync_size
+  single_dash: true
+  group: 'mpegtsraw demuxer AVOptions:'
+  description: <int> .D......... set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
+  provenance:
+    sources:
+    - help-text
+- long: compute_pcr
+  single_dash: true
+  group: 'mpegtsraw demuxer AVOptions:'
+  description: <boolean> .D......... compute exact PCR for each transport stream packet (default false)
+  provenance:
+    sources:
+    - help-text
+- long: ts_packetsize
+  single_dash: true
+  group: 'mpegtsraw demuxer AVOptions:'
+  description: <int> .D....XR... output option carrying the raw packet size (from 0 to 0) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: strict_mime_boundary
+  single_dash: true
+  group: 'MPJPEG demuxer AVOptions:'
+  description: .D......... require MIME boundaries match (default false)
+  provenance:
+    sources:
+    - help-text
+- long: eia608_extract
+  single_dash: true
+  group: 'mxf AVOptions:'
+  description: <boolean> .D......... extract eia 608 captions from s436m track (default false)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'AV1 Annex B/low overhead OBU demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'pcm demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'rawvideo demuxer AVOptions:'
+  description: <string> .D......... set pixel format (default "yuv420p")
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'rawvideo demuxer AVOptions:'
+  description: <image_size> .D......... set frame size
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'rawvideo demuxer AVOptions:'
+  description: <video_rate> .D......... set frame rate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: rtp_flags
+  choices:
+  - name: filter_src
+    description: .D......... only receive packets from the negotiated peer IP
+  single_dash: true
+  group: 'RTP demuxer AVOptions:'
+  description: <flags> .D......... set RTP flags (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'RTP demuxer AVOptions:'
+  description: <duration> .D......... set maximum timeout (in seconds) to wait for incoming connections (default 10)
+  provenance:
+    sources:
+    - help-text
+- long: localaddr
+  single_dash: true
+  group: 'RTP demuxer AVOptions:'
+  description: <string> .D......... local address
+  provenance:
+    sources:
+    - help-text
+- long: allowed_media_types
+  choices:
+  - name: video
+    description: .D......... Video
+  - name: audio
+    description: .D......... Audio
+  - name: data
+    description: .D......... Data
+  - name: subtitle
+    description: .D......... Subtitle
+  single_dash: true
+  group: 'RTP demuxer AVOptions:'
+  description: .D......... set media types to accept from the server (default video+audio+data+subtitle)
+  provenance:
+    sources:
+    - help-text
+- long: reorder_queue_size
+  single_dash: true
+  group: 'RTP demuxer AVOptions:'
+  description: .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'RTP demuxer AVOptions:'
+  description: <int> ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: initial_pause
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <boolean> .D......... do not start playing the stream immediately (default false)
+  provenance:
+    sources:
+    - help-text
+- long: rtsp_transport
+  choices:
+  - name: udp
+    description: ED......... UDP
+  - name: tcp
+    description: ED......... TCP
+  - name: udp_multicast
+    description: .D......... UDP multicast
+  - name: http
+    description: .D......... HTTP tunneling
+  - name: https
+    description: .D......... HTTPS tunneling
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <flags> ED......... set RTSP transport protocols (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: rtsp_flags
+  choices:
+  - name: filter_src
+    description: .D......... only receive packets from the negotiated peer IP
+  - name: listen
+    description: .D......... wait for incoming connections
+  - name: prefer_tcp
+    description: ED......... try RTP via TCP first, if available
+  - name: satip_raw
+    description: .D......... export raw MPEG-TS stream instead of demuxing
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <flags> .D......... set RTSP flags (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: allowed_media_types
+  choices:
+  - name: video
+    description: .D......... Video
+  - name: audio
+    description: .D......... Audio
+  - name: data
+    description: .D......... Data
+  - name: subtitle
+    description: .D......... Subtitle
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: .D......... set media types to accept from the server (default video+audio+data+subtitle)
+  provenance:
+    sources:
+    - help-text
+- long: min_port
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <int> ED......... set minimum local UDP port (from 0 to 65535) (default 5000)
+  provenance:
+    sources:
+    - help-text
+- long: max_port
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <int> ED......... set maximum local UDP port (from 0 to 65535) (default 65000)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <int> .D......... set maximum timeout (in seconds) to wait for incoming connections (-1 is infinite, imply flag listen) (from INT_MIN to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: timeout
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <int64> .D......... set timeout (in microseconds) of socket I/O operations (from INT_MIN to I64_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: reorder_queue_size
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <int> ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: user_agent
+  single_dash: true
+  group: 'RTSP demuxer AVOptions:'
+  description: <string> .D......... override User-Agent header (default "Lavf60.16.100")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'sbg_demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'sbg_demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: max_file_size
+  single_dash: true
+  group: 'sbg_demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 5000000)
+  provenance:
+    sources:
+    - help-text
+- long: sdp_flags
+  choices:
+  - name: filter_src
+    description: .D......... only receive packets from the negotiated peer IP
+  - name: custom_io
+    description: .D......... use custom I/O
+  - name: rtcp_to_source
+    description: .D......... send RTCP packets to the source address of received packets
+  single_dash: true
+  group: 'SDP demuxer AVOptions:'
+  description: <flags> .D......... SDP flags (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: listen_timeout
+  single_dash: true
+  group: 'SDP demuxer AVOptions:'
+  description: <duration> .D......... set maximum timeout (in seconds) to wait for incoming connections (default 10)
+  provenance:
+    sources:
+    - help-text
+- long: localaddr
+  single_dash: true
+  group: 'SDP demuxer AVOptions:'
+  description: <string> .D......... local address
+  provenance:
+    sources:
+    - help-text
+- long: allowed_media_types
+  choices:
+  - name: video
+    description: .D......... Video
+  - name: audio
+    description: .D......... Audio
+  - name: data
+    description: .D......... Data
+  - name: subtitle
+    description: .D......... Subtitle
+  single_dash: true
+  group: 'SDP demuxer AVOptions:'
+  description: .D......... set media types to accept from the server (default video+audio+data+subtitle)
+  provenance:
+    sources:
+    - help-text
+- long: reorder_queue_size
+  single_dash: true
+  group: 'SDP demuxer AVOptions:'
+  description: .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: buffer_size
+  single_dash: true
+  group: 'SDP demuxer AVOptions:'
+  description: <int> ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'ser demuxer AVOptions:'
+  description: <video_rate> .D......... set frame rate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'sln demuxer AVOptions:'
+  description: <int> .D......... (from 0 to INT_MAX) (default 8000)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'sln demuxer AVOptions:'
+  description: <int> .D........P (from 0 to INT_MAX) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: ch_layout
+  single_dash: true
+  group: 'sln demuxer AVOptions:'
+  description: <channel_layout> .D.........
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: start_time
+  single_dash: true
+  group: 'tedcaptions_demuxer AVOptions:'
+  description: <int64> .D...S..... set the start time (offset) of the subtitles, in ms (from I64_MIN to I64_MAX) (default 15000)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: chars_per_frame
+  single_dash: true
+  group: 'TTY demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 6000)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'TTY demuxer AVOptions:'
+  description: <image_size> .D......... A string describing frame size, such as 640x480 or hd720.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'TTY demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'v210(x) demuxer AVOptions:'
+  description: <image_size> .D......... set frame size
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'v210(x) demuxer AVOptions:'
+  description: <video_rate> .D......... set frame rate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'v210(x) demuxer AVOptions:'
+  description: <image_size> .D......... set frame size
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'v210(x) demuxer AVOptions:'
+  description: <video_rate> .D......... set frame rate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: sub_name
+  single_dash: true
+  group: 'vobsub AVOptions:'
+  description: <string> .D......... URI for .sub file
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw video demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: max_size
+  single_dash: true
+  group: 'W64 demuxer AVOptions:'
+  description: <int> .D......... max size of single packet (from 1024 to 4.1943e+06) (default 4096)
+  provenance:
+    sources:
+    - help-text
+- long: ignore_length
+  single_dash: true
+  group: 'WAV demuxer AVOptions:'
+  description: <boolean> .D......... Ignore length (default false)
+  provenance:
+    sources:
+    - help-text
+- long: max_size
+  single_dash: true
+  group: 'WAV demuxer AVOptions:'
+  description: <int> .D......... max size of single packet (from 1024 to 4.1943e+06) (default 4096)
+  provenance:
+    sources:
+    - help-text
+- long: live
+  single_dash: true
+  group: 'WebM DASH Manifest demuxer AVOptions:'
+  description: <boolean> .D......... flag indicating that the input is a live file that only has the headers. (default false)
+  provenance:
+    sources:
+    - help-text
+- long: bandwidth
+  single_dash: true
+  group: 'WebM DASH Manifest demuxer AVOptions:'
+  description: <int> .D......... bandwidth of this stream to be specified in the DASH manifest. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: kind
+  choices:
+  - name: subtitles
+    description: 0 .D...S..... WebVTT subtitles kind
+  - name: captions
+    description: 65536 .D...S..... WebVTT captions kind
+  - name: descriptions
+    description: 131072 .D...S..... WebVTT descriptions kind
+  - name: metadata
+    description: 262144 .D...S..... WebVTT metadata kind
+  single_dash: true
+  group: 'WebVTT demuxer AVOptions:'
+  description: <int> .D...S..... Set kind of WebVTT track (from 0 to INT_MAX) (default subtitles)
+  provenance:
+    sources:
+    - help-text
+- long: raw_packet_size
+  single_dash: true
+  group: 'generic raw demuxer AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: linespeed
+  single_dash: true
+  group: 'eXtended BINary text (XBIN) demuxer AVOptions:'
+  description: <int> .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'eXtended BINary text (XBIN) demuxer AVOptions:'
+  description: <image_size> .D......... set video size, such as 640x480 or hd720.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'eXtended BINary text (XBIN) demuxer AVOptions:'
+  description: <video_rate> .D......... set framerate (frames per second) (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <int> .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <video_rate> .D......... set the video framerate (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <string> .D......... set video pixel format
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <image_size> .D......... set video size
+  provenance:
+    sources:
+    - help-text
+- long: loop
+  single_dash: true
+  group: 'imagepipe demuxer AVOptions:'
+  description: <boolean> .D......... force loop over input file sequence (default false)
+  provenance:
+    sources:
+    - help-text
+- long: track_index
+  single_dash: true
+  group: 'Game Music Emu demuxer AVOptions:'
+  description: <int> .D..A...... set track that should be played (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'Game Music Emu demuxer AVOptions:'
+  description: <int> .D..A...... set sample rate (from 1000 to 999999) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: max_size
+  single_dash: true
+  group: 'Game Music Emu demuxer AVOptions:'
+  description: <int64> .D..A...... set max file size supported (in bytes) (from 0 to 1.84467e+19) (default 52428800)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'libopenmpt AVOptions:'
+  description: <int> .D..A...... set sample rate (from 1000 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: layout
+  single_dash: true
+  group: 'libopenmpt AVOptions:'
+  description: <channel_layout> .D..A...... set channel layout (default "stereo")
+  provenance:
+    sources:
+    - help-text
+- long: subsong
+  choices:
+  - name: all
+    description: -1 .D..A...... all
+  - name: auto
+    description: -2 .D..A...... auto
+  single_dash: true
+  group: 'libopenmpt AVOptions:'
+  description: <int> .D..A...... set subsong (from -2 to INT_MAX) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'ALSA indev AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'ALSA indev AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'fbdev indev AVOptions:'
+  description: <video_rate> .D......... (default "25")
+  provenance:
+    sources:
+    - help-text
+- long: dvtype
+  choices:
+  - name: auto
+    description: 0 .D......... auto detect DV/HDV
+  - name: dv
+    description: 1 .D......... force device being treated as DV device
+  - name: hdv
+    description: 2 .D......... force device being treated as HDV device
+  single_dash: true
+  group: 'iec61883 indev AVOptions:'
+  description: <int> .D......... override autodetection of DV/HDV (from 0 to 2) (default auto)
+  provenance:
+    sources:
+    - help-text
+- long: dvbuffer
+  single_dash: true
+  group: 'iec61883 indev AVOptions:'
+  description: <int> .D......... set queue buffer size (in packets) (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: dvguid
+  single_dash: true
+  group: 'iec61883 indev AVOptions:'
+  description: <string> .D......... select one of multiple DV devices by its GUID
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'JACK indev AVOptions:'
+  description: <int> .D......... Number of audio channels. (from 1 to INT_MAX) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: device
+  single_dash: true
+  group: 'kmsgrab indev AVOptions:'
+  description: <string> .D......... DRM device path (default "/dev/dri/card0")
+  provenance:
+    sources:
+    - help-text
+- long: format
+  single_dash: true
+  group: 'kmsgrab indev AVOptions:'
+  description: <pix_fmt> .D......... Pixel format for framebuffer (default none)
+  provenance:
+    sources:
+    - help-text
+- long: format_modifier
+  single_dash: true
+  group: 'kmsgrab indev AVOptions:'
+  description: <int64> .D......... DRM format modifier for framebuffer (from 0 to I64_MAX) (default 72057594037927935)
+  provenance:
+    sources:
+    - help-text
+- long: crtc_id
+  single_dash: true
+  group: 'kmsgrab indev AVOptions:'
+  description: <int64> .D......... CRTC ID to define capture source (from 0 to UINT32_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: plane_id
+  single_dash: true
+  group: 'kmsgrab indev AVOptions:'
+  description: <int64> .D......... Plane ID to define capture source (from 0 to UINT32_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'kmsgrab indev AVOptions:'
+  description: <rational> .D......... Framerate to capture at (from 0 to 1000) (default 30/1)
+  provenance:
+    sources:
+    - help-text
+- long: graph
+  single_dash: true
+  group: 'lavfi indev AVOptions:'
+  description: <string> .D......... set libavfilter graph
+  provenance:
+    sources:
+    - help-text
+- long: graph_file
+  single_dash: true
+  group: 'lavfi indev AVOptions:'
+  description: <string> .D......... set libavfilter graph filename
+  provenance:
+    sources:
+    - help-text
+- long: dumpgraph
+  single_dash: true
+  group: 'lavfi indev AVOptions:'
+  description: <string> .D......... dump graph to stderr
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'openal indev AVOptions:'
+  description: <int> .D......... set number of channels (from 1 to 2) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'openal indev AVOptions:'
+  description: <int> .D......... set sample rate (from 1 to 192000) (default 44100)
+  provenance:
+    sources:
+    - help-text
+- long: sample_size
+  single_dash: true
+  group: 'openal indev AVOptions:'
+  description: <int> .D......... set sample size (from 8 to 16) (default 16)
+  provenance:
+    sources:
+    - help-text
+- long: list_devices
+  choices:
+  - name: 'true'
+    description: 1 .D.........
+  - name: 'false'
+    description: 0 .D.........
+  single_dash: true
+  group: 'openal indev AVOptions:'
+  description: <int> .D......... list available devices (from 0 to 1) (default false)
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'OSS indev AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'OSS indev AVOptions:'
+  description: <int> .D......... (from 1 to INT_MAX) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: server
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <string> .D......... set PulseAudio server
+  provenance:
+    sources:
+    - help-text
+- long: name
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <string> .D......... set application name (default "Lavf60.16.100")
+  provenance:
+    sources:
+    - help-text
+- long: stream_name
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <string> .D......... set stream description (default "record")
+  provenance:
+    sources:
+    - help-text
+- long: sample_rate
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <int> .D......... set sample rate in Hz (from 1 to INT_MAX) (default 48000)
+  provenance:
+    sources:
+    - help-text
+- long: channels
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <int> .D......... set number of audio channels (from 1 to INT_MAX) (default 2)
+  provenance:
+    sources:
+    - help-text
+- long: frame_size
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <int> .D........P set number of bytes per frame (from 1 to INT_MAX) (default 1024)
+  provenance:
+    sources:
+    - help-text
+- long: fragment_size
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <int> .D......... set buffering size, affects latency and cpu usage (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: wallclock
+  single_dash: true
+  group: 'Pulse indev AVOptions:'
+  description: <int> .D......... set the initial pts using the current time (from -1 to 1) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: standard
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <string> .D......... set TV standard, used only by analog frame grabber
+  provenance:
+    sources:
+    - help-text
+- long: channel
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <int> .D......... set TV channel, used only by frame grabber (from -1 to INT_MAX) (default -1)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <image_size> .D......... set frame size
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <string> .D......... set preferred pixel format
+  provenance:
+    sources:
+    - help-text
+- long: input_format
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <string> .D......... set preferred pixel format (for raw video) or codec name
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <string> .D......... set frame rate
+  provenance:
+    sources:
+    - help-text
+- long: list_formats
+  choices:
+  - name: all
+    description: 3 .D......... show all available formats
+  - name: raw
+    description: 1 .D......... show only non-compressed formats
+  - name: compressed
+    description: 2 .D......... show only compressed formats
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <int> .D......... list available formats and exit (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: list_standards
+  choices:
+  - name: all
+    description: 1 .D......... show all supported standards
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <int> .D......... list supported standards and exit (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: timestamps
+  choices:
+  - name: default
+    description: 0 .D......... use timestamps from the kernel
+  - name: abs
+    description: 1 .D......... use absolute timestamps (wall clock)
+  - name: mono2abs
+    description: 2 .D......... force conversion from monotonic to absolute timestamps
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <int> .D......... set type of timestamps for grabbed frames (from 0 to 2) (default default)
+  provenance:
+    sources:
+    - help-text
+- short: 't'
+  value_name: s
+  value_kind: Required
+  choices:
+  - name: default
+    description: 0 .D......... use timestamps from the kernel
+  - name: abs
+    description: 1 .D......... use absolute timestamps (wall clock)
+  - name: mono2abs
+    description: 2 .D......... force conversion from monotonic to absolute timestamps
+  group: 'V4L2 indev AVOptions:'
+  description: <int> .D......... set type of timestamps for grabbed frames (from 0 to 2) (default default)
+  provenance:
+    sources:
+    - help-text
+- long: use_libv4l2
+  single_dash: true
+  group: 'V4L2 indev AVOptions:'
+  description: <boolean> .D......... use libv4l2 (v4l-utils) conversion functions (default false)
+  provenance:
+    sources:
+    - help-text
+- long: window_id
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Window to capture. (from 0 to UINT32_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- short: 'x'
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Initial x coordinate. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- short: 'y'
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Initial y coordinate. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: grab_x
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Initial x coordinate. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: grab_y
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Initial y coordinate. (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <image_size> .D......... A string describing frame size, such as 640x480 or hd720.
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <string> .D......... (default "ntsc")
+  provenance:
+    sources:
+    - help-text
+- long: draw_mouse
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Draw the mouse pointer. (from 0 to 1) (default 1)
+  provenance:
+    sources:
+    - help-text
+- long: follow_mouse
+  choices:
+  - name: centered
+    description: -1 .D......... Keep the mouse pointer at the center of grabbing region when following.
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Move the grabbing region when the mouse pointer reaches within specified amount of pixels to the edge of region. (from -1 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: show_region
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Show the grabbing region. (from 0 to 1) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: region_border
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <int> .D......... Set the region border thickness. (from 1 to 128) (default 3)
+  provenance:
+    sources:
+    - help-text
+- long: select_region
+  single_dash: true
+  group: 'xcbgrab indev AVOptions:'
+  description: <boolean> .D......... Select the grabbing region graphically using the pointer. (default false)
+  provenance:
+    sources:
+    - help-text
+- long: speed
+  single_dash: true
+  group: 'libcdio indev AVOptions:'
+  description: <int> .D......... set drive reading speed (from 0 to INT_MAX) (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: paranoia_mode
+  choices:
+  - name: disable
+    description: .D......... apply no fixups
+  - name: verify
+    description: .D......... verify data integrity in overlap area
+  - name: overlap
+    description: .D......... perform overlapped reads
+  - name: neverskip
+    description: .D......... do not skip failed reads
+  - name: full
+    description: .D......... apply all recovery modes
+  single_dash: true
+  group: 'libcdio indev AVOptions:'
+  description: <flags> .D......... set error recovery mode (default 0)
+  provenance:
+    sources:
+    - help-text
+- long: video_size
+  single_dash: true
+  group: 'libdc1394 indev AVOptions:'
+  description: <string> .D......... A string describing frame size, such as 640x480 or hd720. (default "qvga")
+  provenance:
+    sources:
+    - help-text
+- long: pixel_format
+  single_dash: true
+  group: 'libdc1394 indev AVOptions:'
+  description: <string> .D......... (default "uyvy422")
+  provenance:
+    sources:
+    - help-text
+- long: framerate
+  choices:
+  - name: thread_type
+    description: <flags> ..F........ Allowed thread types (default slice) slice ..F........
+  - name: enable
+    description: <string> ..F......T. set enable expression
+  - name: threads
+    description: <int> ..F........ Allowed number of threads (from 0 to INT_MAX) (default 0)
+  - name: extra_hw_frames
+    description: <int> ..F........ Number of extra hardware frames to allocate for the user (from -1 to INT_MAX) (default -1)
+  - name: action
+    description: <int> ..F.A...... set action (from 0 to 1) (default start) start 0 ..F.A...... start timer stop 1 ..F.A...... stop timer
+  - name: level_in
+    description: <double> ..F.A....T. set input gain (from 0.015625 to 64) (default 1)
+  - name: mode
+    description: <int> ..F.A....T. set mode (from 0 to 1) (default downward) downward 0 ..F.A....T. upward 1 ..F.A....T.
+  - name: threshold
+    description: <double> ..F.A....T. set threshold (from 0.000976563 to 1) (default 0.125)
+  - name: ratio
+    description: <double> ..F.A....T. set ratio (from 1 to 20) (default 2)
+  - name: attack
+    description: <double> ..F.A....T. set attack (from 0.01 to 2000) (default 20)
+  - name: release
+    description: <double> ..F.A....T. set release (from 0.01 to 9000) (default 250)
+  - name: makeup
+    description: <double> ..F.A....T. set make up gain (from 1 to 64) (default 1)
+  - name: knee
+    description: <double> ..F.A....T. set knee (from 1 to 8) (default 2.82843)
+  - name: link
+    description: <int> ..F.A....T. set link type (from 0 to 1) (default average) average 0 ..F.A....T. maximum 1 ..F.A....T.
+  - name: detection
+    description: <int> ..F.A....T. set detection (from 0 to 1) (default rms) peak 0 ..F.A....T. rms 1 ..F.A....T.
+  - name: level_sc
+    description: <double> ..F.A....T. set sidechain gain (from 0.015625 to 64) (default 1)
+  - name: mix
+    description: <double> ..F.A....T. set mix (from 0 to 1) (default 1)
+  - name: contrast
+    description: <float> ..F.A...... set contrast (from 0 to 100) (default 33)
+  - name: cue
+    description: <int64> ..FVA...... cue unix timestamp in microseconds (from 0 to I64_MAX) (default 0)
+  - name: preroll
+    description: <duration> ..FVA...... preroll duration in seconds (default 0)
+  - name: buffer
+    description: <duration> ..FVA...... buffer duration in seconds (default 0)
+  - name: nb_samples
+    description: <int> ..F.A...... set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
+  - name: ns
+    description: <int> ..F.A...... set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
+  - name: duration
+    description: <duration> ..F.A...... set cross fade duration (default 0)
+  - name: d
+    description: <duration> ..F.A...... set cross fade duration (default 0)
+  - name: overlap
+    description: <boolean> ..F.A...... overlap 1st stream end with 2nd stream start (default true)
+  - name: o
+    description: <boolean> ..F.A...... overlap 1st stream end with 2nd stream start (default true)
+  - name: curve1
+    description: <int> ..F.A...... set fade curve type for 1st stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
+  - name: c1
+    description: <int> ..F.A...... set fade curve type for 1st stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
+  - name: curve2
+    description: <int> ..F.A...... set fade curve type for 2nd stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
+  - name: c2
+    description: <int> ..F.A...... set fade curve type for 2nd stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
+  - name: split
+    description: <string> ..F.A...... set split frequencies (default "500")
+  - name: order
+    description: <int> ..F.A...... set filter order (from 0 to 9) (default 4th) 2nd 0 ..F.A...... 2nd order (12 dB/8ve) 4th 1 ..F.A...... 4th order (24 dB/8ve) 6th 2 ..F.A...... 6th order (36 dB/8ve) 8th 3 ..F.A...... 8th order (48 dB/8ve) 10th 4 ..F.A...... 10th order (60 dB/8ve) 12th 5 ..F.A...... 12th order (72 dB/8ve) 14th 6 ..F.A...... 14th order (84 dB/8ve) 16th 7 ..F.A...... 16th order (96 dB/8ve) 18th 8 ..F.A...... 18th order (108 dB/8ve) 20th 9 ..F.A...... 20th order (120 dB/8ve)
+  - name: level
+    description: <float> ..F.A...... set input gain (from 0 to 1) (default 1)
+  - name: gain
+    description: <string> ..F.A...... set output bands gain (default "1.f")
+  - name: precision
+    description: <int> ..F.A...... set processing precision (from 0 to 2) (default auto) auto 0 ..F.A...... set auto processing precision float 1 ..F.A...... set single-floating point processing precision double 2 ..F.A...... set double-floating point processing precision
+  - name: level_out
+    description: <double> ..F.A....T. set level out (from 0.015625 to 64) (default 1)
+  - name: bits
+    description: <double> ..F.A....T. set bit reduction (from 1 to 64) (default 8)
+  - name: dc
+    description: <double> ..F.A....T. set DC (from 0.25 to 4) (default 1)
+  - name: aa
+    description: <double> ..F.A....T. set anti-aliasing (from 0 to 1) (default 0.5)
+  - name: samples
+    description: <double> ..F.A....T. set sample reduction (from 1 to 250) (default 1)
+  - name: lfo
+    description: <boolean> ..F.A....T. enable LFO (default false)
+  - name: lforange
+    description: <double> ..F.A....T. set LFO depth (from 1 to 250) (default 20)
+  - name: lforate
+    description: <double> ..F.A....T. set LFO rate (from 0.01 to 200) (default 0.3)
+  - name: window
+    description: <double> ..F.A...... set window size (from 10 to 100) (default 55)
+  - name: w
+    description: <double> ..F.A...... set window size (from 10 to 100) (default 55)
+  - name: arorder
+    description: <double> ..F.A...... set autoregression order (from 0 to 25) (default 2)
+  - name: a
+    description: <double> ..F.A...... set autoregression order (from 0 to 25) (default 2)
+  - name: t
+    description: <double> ..F.A...... set threshold (from 1 to 100) (default 2)
+  - name: burst
+    description: <double> ..F.A...... set burst fusion (from 0 to 10) (default 2)
+  - name: b
+    description: <double> ..F.A...... set burst fusion (from 0 to 10) (default 2)
+  - name: method
+    description: <int> ..F.A...... set overlap method (from 0 to 1) (default add) add 0 ..F.A...... overlap-add a 0 ..F.A...... overlap-add save 1 ..F.A...... overlap-save s 1 ..F.A...... overlap-save
+  - name: m
+    description: <int> ..F.A...... set overlap method (from 0 to 1) (default add) add 0 ..F.A...... overlap-add a 0 ..F.A...... overlap-add save 1 ..F.A...... overlap-save s 1 ..F.A...... overlap-save
+  - name: hsize
+    description: <int> ..F.A...... set histogram size (from 100 to 9999) (default 1000)
+  - name: n
+    description: <int> ..F.A...... set histogram size (from 100 to 9999) (default 1000)
+  - name: stages
+    description: <int> ..F.A...... set filtering stages (from 1 to 16) (default 6)
+  - name: seed
+    description: <int64> ..F.A...... set random seed (from -1 to UINT32_MAX) (default -1)
+  - name: delays
+    description: <string> ..F.A....T. set list of delays for each channel
+  - name: all
+    description: <boolean> ..F.A...... use last available delay for remained channels (default false)
+  - name: type
+    description: <int> ..F.A....T. set type (from 0 to 3) (default dc) dc 0 ..F.A....T. ac 1 ..F.A....T. square 2 ..F.A....T. pulse 3 ..F.A....T.
+  - name: transfer
+    description: <string> ..F.A....T. set the transfer expression (default "p")
+  - name: channels
+    description: <string> ..F.A....T. set channels to filter (default "all")
+  - name: dfrequency
+    description: <double> ..F.A....T. set detection frequency (from 2 to 1e+06) (default 1000)
+  - name: dqfactor
+    description: <double> ..F.A....T. set detection Q factor (from 0.001 to 1000) (default 1)
+  - name: tfrequency
+    description: <double> ..F.A....T. set target frequency (from 2 to 1e+06) (default 1000)
+  - name: tqfactor
+    description: <double> ..F.A....T. set target Q factor (from 0.001 to 1000) (default 1)
+  - name: range
+    description: <double> ..F.A....T. set max gain (from 1 to 200) (default 50)
+  - name: dftype
+    description: <int> ..F.A....T. set detection filter type (from 0 to 3) (default bandpass) bandpass 0 ..F.A....T. lowpass 1 ..F.A....T. highpass 2 ..F.A....T. peak 3 ..F.A....T.
+  - name: tftype
+    description: <int> ..F.A....T. set target filter type (from 0 to 2) (default bell) bell 0 ..F.A....T. lowshelf 1 ..F.A....T. highshelf 2 ..F.A....T.
+  - name: direction
+    description: <int> ..F.A....T. set direction (from 0 to 1) (default downward) downward 0 ..F.A....T. upward 1 ..F.A....T.
+  - name: auto
+    description: <int> ..F.A....T. set auto threshold (from -1 to 1) (default disabled) disabled -1 ..F.A....T. off 0 ..F.A....T. on 1 ..F.A....T.
+  - name: sensitivity
+    description: <double> ..F.A....T. set smooth sensitivity (from 0 to 1e+06) (default 2)
+  - name: basefreq
+    description: <double> ..F.A....T. set base frequency (from 2 to 1e+06) (default 22050)
+  - name: in_gain
+    description: <float> ..F.A...... set signal input gain (from 0 to 1) (default 0.6)
+  - name: out_gain
+    description: <float> ..F.A...... set signal output gain (from 0 to 1) (default 0.3)
+  - name: decays
+    description: <string> ..F.A...... set list of signal decays (default "0.5")
+  - name: exprs
+    description: <string> ..F.A...... set the '|'-separated list of channels expressions
+  - name: channel_layout
+    description: <string> ..F.A...... set channel layout
+  - name: c
+    description: <string> ..F.A...... set channel layout
+  - name: amount
+    description: <double> ..F.A....T. set amount (from 0 to 64) (default 1)
+  - name: drive
+    description: <double> ..F.A....T. set harmonics (from 0.1 to 10) (default 8.5)
+  - name: blend
+    description: <double> ..F.A....T. set blend harmonics (from -10 to 10) (default 0)
+  - name: freq
+    description: <double> ..F.A....T. set scope (from 2000 to 12000) (default 7500)
+  - name: ceil
+    description: <double> ..F.A....T. set ceiling (from 9999 to 20000) (default 9999)
+  - name: listen
+    description: <boolean> ..F.A....T. enable listen mode (default false)
+  - name: start_sample
+    description: <int64> ..F.A....T. set number of first sample to start fading (from 0 to I64_MAX) (default 0)
+  - name: ss
+    description: <int64> ..F.A....T. set number of first sample to start fading (from 0 to I64_MAX) (default 0)
+  - name: start_time
+    description: <duration> ..F.A....T. set time to start fading (default 0)
+  - name: st
+    description: <duration> ..F.A....T. set time to start fading (default 0)
+  - name: curve
+    description: <int> ..F.A....T. set fade curve type (from -1 to 22) (default tri) nofade -1 ..F.A....T. no fade; keep audio as-is tri 0 ..F.A....T. linear slope qsin 1 ..F.A....T. quarter of sine wave esin 2 ..F.A....T. exponential sine wave hsin 3 ..F.A....T. half of sine wave log 4 ..F.A....T. logarithmic ipar 5 ..F.A....T. inverted parabola qua 6 ..F.A....T. quadratic cub 7 ..F.A....T. cubic squ 8 ..F.A....T. square root cbr 9 ..F.A....T. cubic root par 10 ..F.A....T. parabola exp 11 ..F.A....T. exponential iqsin 12 ..F.A....T. inverted quarter of sine wave ihsin 13 ..F.A....T. inverted half of sine wave dese 14 ..F.A....T. double-exponential seat desi 15 ..F.A....T. double-exponential sigmoid losi 16 ..F.A....T. logistic sigmoid sinc 17 ..F.A....T. sine cardinal function isinc 18 ..F.A....T. inverted sine cardinal function quat 19 ..F.A....T. quartic quatr 20 ..F.A....T. quartic root qsin2 21 ..F.A....T. squared quarter of sine wave hsin2 22 ..F.A....T. squared half of sine wave
+  - name: silence
+    description: <double> ..F.A....T. set the silence gain (from 0 to 1) (default 0)
+  - name: unity
+    description: <double> ..F.A....T. set the unity gain (from 0 to 1) (default 1)
+  - name: noise_reduction
+    description: <float> ..F.A....T. set the noise reduction (from 0.01 to 97) (default 12)
+  - name: nr
+    description: <float> ..F.A....T. set the noise reduction (from 0.01 to 97) (default 12)
+  - name: noise_floor
+    description: <float> ..F.A....T. set the noise floor (from -80 to -20) (default -50)
+  - name: nf
+    description: <float> ..F.A....T. set the noise floor (from -80 to -20) (default -50)
+  - name: noise_type
+    description: <int> ..F.A...... set the noise type (from 0 to 3) (default white) white 0 ..F.A...... white noise w 0 ..F.A...... white noise vinyl 1 ..F.A...... vinyl noise v 1 ..F.A...... vinyl noise shellac 2 ..F.A...... shellac noise s 2 ..F.A...... shellac noise custom 3 ..F.A...... custom noise c 3 ..F.A...... custom noise
+  - name: nt
+    description: <int> ..F.A...... set the noise type (from 0 to 3) (default white) white 0 ..F.A...... white noise w 0 ..F.A...... white noise vinyl 1 ..F.A...... vinyl noise v 1 ..F.A...... vinyl noise shellac 2 ..F.A...... shellac noise s 2 ..F.A...... shellac noise custom 3 ..F.A...... custom noise c 3 ..F.A...... custom noise
+  - name: band_noise
+    description: <string> ..F.A...... set the custom bands noise
+  - name: bn
+    description: <string> ..F.A...... set the custom bands noise
+  - name: residual_floor
+    description: <float> ..F.A....T. set the residual floor (from -80 to -20) (default -38)
+  - name: rf
+    description: <float> ..F.A....T. set the residual floor (from -80 to -20) (default -38)
+  - name: track_noise
+    description: <boolean> ..F.A....T. track noise (default false)
+  - name: tn
+    description: <boolean> ..F.A....T. track noise (default false)
+  - name: track_residual
+    description: <boolean> ..F.A....T. track residual (default false)
+  - name: tr
+    description: <boolean> ..F.A....T. track residual (default false)
+  - name: output_mode
+    description: <int> ..F.A....T. set output mode (from 0 to 2) (default output) input 0 ..F.A....T. input i 0 ..F.A....T. input output 1 ..F.A....T. output o 1 ..F.A....T. output noise 2 ..F.A....T. noise n 2 ..F.A....T. noise
+  - name: om
+    description: <int> ..F.A....T. set output mode (from 0 to 2) (default output) input 0 ..F.A....T. input i 0 ..F.A....T. input output 1 ..F.A....T. output o 1 ..F.A....T. output noise 2 ..F.A....T. noise n 2 ..F.A....T. noise
+  - name: adaptivity
+    description: <float> ..F.A....T. set adaptivity factor (from 0 to 1) (default 0.5)
+  - name: ad
+    description: <float> ..F.A....T. set adaptivity factor (from 0 to 1) (default 0.5)
+  - name: floor_offset
+    description: <float> ..F.A....T. set noise floor offset factor (from -2 to 2) (default 1)
+  - name: fo
+    description: <float> ..F.A....T. set noise floor offset factor (from -2 to 2) (default 1)
+  - name: noise_link
+    description: <int> ..F.A....T. set the noise floor link (from 0 to 3) (default min) none 0 ..F.A....T. none min 1 ..F.A....T. min max 2 ..F.A....T. max average 3 ..F.A....T. average
+  - name: nl
+    description: <int> ..F.A....T. set the noise floor link (from 0 to 3) (default min) none 0 ..F.A....T. none min 1 ..F.A....T. min max 2 ..F.A....T. max average 3 ..F.A....T. average
+  - name: band_multiplier
+    description: <float> ..F.A...... set band multiplier (from 0.2 to 5) (default 1.25)
+  - name: bm
+    description: <float> ..F.A...... set band multiplier (from 0.2 to 5) (default 1.25)
+  - name: sample_noise
+    description: <int> ..F.A....T. set sample noise mode (from 0 to 2) (default none) none 0 ..F.A....T. none start 1 ..F.A....T. start begin 1 ..F.A....T. start stop 2 ..F.A....T. stop end 2 ..F.A....T. stop
+  - name: sn
+    description: <int> ..F.A....T. set sample noise mode (from 0 to 2) (default none) none 0 ..F.A....T. none start 1 ..F.A....T. start begin 1 ..F.A....T. start stop 2 ..F.A....T. stop end 2 ..F.A....T. stop
+  - name: gain_smooth
+    description: <int> ..F.A....T. set gain smooth radius (from 0 to 50) (default 0)
+  - name: gs
+    description: <int> ..F.A....T. set gain smooth radius (from 0 to 50) (default 0)
+  - name: real
+    description: <string> ..F.A...... set channels real expressions (default "re")
+  - name: imag
+    description: <string> ..F.A...... set channels imaginary expressions (default "im")
+  - name: win_size
+    description: <int> ..F.A...... set window size (from 16 to 131072) (default 4096)
+  - name: win_func
+    description: <int> ..F.A...... set window function (from 0 to 20) (default hann) rect 0 ..F.A...... Rectangular bartlett 4 ..F.A...... Bartlett hann 1 ..F.A...... Hann hanning 1 ..F.A...... Hanning hamming 2 ..F.A...... Hamming blackman 3 ..F.A...... Blackman welch 5 ..F.A...... Welch flattop 6 ..F.A...... Flat-top bharris 7 ..F.A...... Blackman-Harris bnuttall 8 ..F.A...... Blackman-Nuttall bhann 11 ..F.A...... Bartlett-Hann sine 9 ..F.A...... Sine nuttall 10 ..F.A...... Nuttall lanczos 12 ..F.A...... Lanczos gauss 13 ..F.A...... Gauss tukey 14 ..F.A...... Tukey dolph 15 ..F.A...... Dolph-Chebyshev cauchy 16 ..F.A...... Cauchy parzen 17 ..F.A...... Parzen poisson 18 ..F.A...... Poisson bohman 19 ..F.A...... Bohman kaiser 20 ..F.A...... Kaiser
+  - name: dry
+    description: <float> ..F.A....T. set dry gain (from 0 to 10) (default 1)
+  - name: wet
+    description: <float> ..F.A....T. set wet gain (from 0 to 10) (default 1)
+  - name: length
+    description: <float> ..F.A...... set IR length (from 0 to 1) (default 1)
+  - name: gtype
+    description: <int> ..F.A...... set IR auto gain type (from -1 to 4) (default peak) none -1 ..F.A...... without auto gain peak 0 ..F.A...... peak gain dc 1 ..F.A...... DC gain gn 2 ..F.A...... gain to noise ac 3 ..F.A...... AC gain rms 4 ..F.A...... RMS gain
+  - name: irgain
+    description: <float> ..F.A...... set IR gain (from 0 to 1) (default 1)
+  - name: irfmt
+    description: <int> ..F.A...... set IR format (from 0 to 1) (default input) mono 0 ..F.A...... single channel input 1 ..F.A...... same as input
+  - name: maxir
+    description: <float> ..F.A...... set max IR length (from 0.1 to 60) (default 30)
+  - name: response
+    description: <boolean> ..FV....... show IR frequency response (default false)
+  - name: channel
+    description: <int> ..FV....... set IR channel to display frequency response (from 0 to 1024) (default 0)
+  - name: size
+    description: <image_size> ..FV....... set video size (default "hd720")
+  - name: rate
+    description: <video_rate> ..FV....... set video rate (default "25")
+  - name: minp
+    description: <int> ..F.A...... set min partition size (from 1 to 65536) (default 8192)
+  - name: maxp
+    description: <int> ..F.A...... set max partition size (from 8 to 65536) (default 8192)
+  - name: nbirs
+    description: <int> ..F.A...... set number of input IRs (from 1 to 32) (default 1)
+  - name: ir
+    description: <int> ..F.A....T. select IR (from 0 to 31) (default 0)
+  - name: irload
+    description: <int> ..F.A...... set IR loading type (from 0 to 1) (default init) init 0 ..F.A...... load all IRs on init access 1 ..F.A...... load IR on access
+  - name: sample_fmts
+    description: <string> ..F.A...... A '|'-separated list of sample formats.
+  - name: f
+    description: <string> ..F.A...... A '|'-separated list of sample formats.
+  - name: sample_rates
+    description: <string> ..F.A...... A '|'-separated list of sample rates.
+  - name: r
+    description: <string> ..F.A...... A '|'-separated list of sample rates.
+  - name: channel_layouts
+    description: <string> ..F.A...... A '|'-separated list of channel layouts.
+  - name: cl
+    description: <string> ..F.A...... A '|'-separated list of channel layouts.
+  - name: shift
+    description: <double> ..F.A....T. set frequency shift (from -2.14748e+09 to INT_MAX) (default 0)
+  - name: sigma
+    description: <double> ..F.A....T. set noise sigma (from 0 to 1) (default 0)
+  - name: levels
+    description: <int> ..F.A...... set number of wavelet levels (from 1 to 12) (default 10)
+  - name: wavet
+    description: <int> ..F.A...... set wavelet type (from 0 to 6) (default sym10) sym2 0 ..F.A...... sym2 sym4 1 ..F.A...... sym4 rbior68 2 ..F.A...... rbior68 deb10 3 ..F.A...... deb10 sym10 4 ..F.A...... sym10 coif5 5 ..F.A...... coif5 bl3 6 ..F.A...... bl3
+  - name: percent
+    description: <double> ..F.A....T. set percent of full denoising (from 0 to 100) (default 85)
+  - name: profile
+    description: <boolean> ..F.A....T. profile noise (default false)
+  - name: adaptive
+    description: <boolean> ..F.A....T. adaptive profiling of noise (default false)
+  - name: softness
+    description: <double> ..F.A....T. set thresholding softness (from 0 to 10) (default 1)
+  - name: zeros
+    description: <string> ..F.A...... set B/numerator/zeros/reflection coefficients (default "1+0i 1-0i")
+  - name: z
+    description: <string> ..F.A...... set B/numerator/zeros/reflection coefficients (default "1+0i 1-0i")
+  - name: poles
+    description: <string> ..F.A...... set A/denominator/poles/ladder coefficients (default "1+0i 1-0i")
+  - name: p
+    description: <string> ..F.A...... set A/denominator/poles/ladder coefficients (default "1+0i 1-0i")
+  - name: gains
+    description: <string> ..F.A...... set channels gains (default "1|1")
+  - name: k
+    description: <string> ..F.A...... set channels gains (default "1|1")
+  - name: format
+    description: <int> ..F.A...... set coefficients format (from -2 to 4) (default zp) ll -2 ..F.A...... lattice-ladder function sf -1 ..F.A...... analog transfer function tf 0 ..F.A...... digital transfer function zp 1 ..F.A...... Z-plane zeros/poles pr 2 ..F.A...... Z-plane zeros/poles (polar radians) pd 3 ..F.A...... Z-plane zeros/poles (polar degrees) sp 4 ..F.A...... S-plane zeros/poles
+  - name: process
+    description: <int> ..F.A...... set kind of processing (from 0 to 2) (default s) d 0 ..F.A...... direct s 1 ..F.A...... serial p 2 ..F.A...... parallel
+  - name: e
+    description: <int> ..F.A...... set precision (from 0 to 3) (default dbl) dbl 0 ..F.A...... double-precision floating-point flt 1 ..F.A...... single-precision floating-point i32 2 ..F.A...... 32-bit integers i16 3 ..F.A...... 16-bit integers
+  - name: normalize
+    description: <boolean> ..F.A...... normalize coefficients (default true)
+  - name: nb_inputs
+    description: <int> ..F.A...... set number of inputs (from 1 to INT_MAX) (default 2)
+  - name: limit
+    description: <double> ..F.A....T. set limit (from 0.0625 to 1) (default 1)
+  - name: asc
+    description: <boolean> ..F.A....T. enable asc (default false)
+  - name: asc_level
+    description: <double> ..F.A....T. set asc level (from 0 to 1) (default 0.5)
+  - name: latency
+    description: <boolean> ..F.A....T. compensate delay (default false)
+  - name: frequency
+    description: <double> ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+  - name: width_type
+    description: <int> ..F.A....T. set filter-width type (from 1 to 5) (default q) h 1 ..F.A....T. Hz q 3 ..F.A....T. Q-Factor o 2 ..F.A....T. octave s 4 ..F.A....T. slope k 5 ..F.A....T. kHz
+  - name: width
+    description: <double> ..F.A....T. set width (from 0 to 99999) (default 0.707)
+  - name: transform
+    description: <int> ..F.A...... set transform type (from 0 to 6) (default di) di 0 ..F.A...... direct form I dii 1 ..F.A...... direct form II tdi 2 ..F.A...... transposed direct form I tdii 3 ..F.A...... transposed direct form II latt 4 ..F.A...... lattice-ladder form svf 5 ..F.A...... state variable filter form zdf 6 ..F.A...... zero-delay filter form
+  - name: loop
+    description: <int> ..F.A...... number of loops (from -1 to INT_MAX) (default 0)
+  - name: start
+    description: <int64> ..F.A...... set the loop start sample (from -1 to I64_MAX) (default 0)
+  - name: time
+    description: <duration> ..F.A...... set the loop start time (default INT64_MAX)
+  - name: inputs
+    description: <int> ..F.A...... specify the number of inputs (from 1 to 64) (default 2)
+  - name: key
+    description: <string> ..F.A...... set metadata key
+  - name: value
+    description: <string> ..F.A...... set metadata value
+  - name: function
+    description: <int> ..F.A...... function for comparing values (from 0 to 6) (default same_str) same_str 0 ..F.A...... starts_with 1 ..F.A...... less 2 ..F.A...... equal 3 ..F.A...... greater 4 ..F.A...... expr 5 ..F.A...... ends_with 6 ..F.A......
+  - name: expr
+    description: <string> ..F.A...... set expression for expr function
+  - name: file
+    description: <string> ..F.A...... set file where to print metadata information
+  - name: direct
+    description: <boolean> ..F.A...... reduce buffering when printing to user-set file or pipe (default false)
+  - name: weights
+    description: <string> ..F.A....T. Set weight for each input. (default "1 1")
+  - name: params
+    description: <string> ..F.A...... (default "")
+  - name: curves
+    description: <boolean> ..FV....... draw frequency response curves (default false)
+  - name: mgain
+    description: <double> ..FV....... set max gain (from -900 to 900) (default 60)
+  - name: fscale
+    description: <int> ..FV....... set frequency scale (from 0 to 1) (default log) lin 0 ..FV....... linear log 1 ..FV....... logarithmic
+  - name: colors
+    description: <string> ..FV....... set channels curves colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+  - name: strength
+    description: <float> ..F.A....T. set denoising strength (from 1e-05 to 10000) (default 1e-05)
+  - name: s
+    description: <float> ..F.A....T. set denoising strength (from 1e-05 to 10000) (default 1e-05)
+  - name: patch
+    description: <duration> ..F.A....T. set patch duration (default 0.002)
+  - name: research
+    description: <duration> ..F.A....T. set research duration (default 0.006)
+  - name: output
+    description: <int> ..F.A....T. set output mode (from 0 to 2) (default o) i 0 ..F.A....T. input o 1 ..F.A....T. output n 2 ..F.A....T. noise
+  - name: smooth
+    description: <float> ..F.A....T. set smooth factor (from 1 to 1000) (default 11)
+  - name: mu
+    description: <float> ..F.A....T. set the filter mu (from 0 to 2) (default 0.75)
+  - name: eps
+    description: <float> ..F.A....T. set the filter eps (from 0 to 1) (default 1)
+  - name: leakage
+    description: <float> ..F.A....T. set the filter leakage (from 0 to 1) (default 0)
+  - name: out_mode
+    description: <int> ..F.A....T. set output mode (from 0 to 4) (default o) i 0 ..F.A....T. input d 1 ..F.A....T. desired o 2 ..F.A....T. output n 3 ..F.A....T. noise e 4 ..F.A....T. error
+  - name: packet_size
+    description: <int> ..F.A...... set silence packet size (from 0 to INT_MAX) (default 4096)
+  - name: pad_len
+    description: <int64> ..F.A...... set number of samples of silence to add (from -1 to I64_MAX) (default -1)
+  - name: whole_len
+    description: <int64> ..F.A...... set minimum target number of samples in the audio stream (from -1 to I64_MAX) (default -1)
+  - name: pad_dur
+    description: <duration> ..F.A...... set duration of silence to add (default -0.000001)
+  - name: whole_dur
+    description: <duration> ..F.A...... set minimum target duration in the audio stream (default -0.000001)
+  - name: delay
+    description: <double> ..F.A...... set delay in milliseconds (from 0 to 5) (default 3)
+  - name: decay
+    description: <double> ..F.A...... set decay (from 0 to 0.99) (default 0.4)
+  - name: speed
+    description: <double> ..F.A...... set modulation speed (from 0.1 to 2) (default 0.5)
+  - name: clip
+    description: <double> ..F.A....T. set clip level (from 0.015625 to 1) (default 1)
+  - name: diff
+    description: <boolean> ..F.A....T. enable difference (default false)
+  - name: iterations
+    description: <int> ..F.A....T. set iterations (from 1 to 20) (default 10)
+  - name: offset_l
+    description: <double> ..F.A...... set offset L (from 0 to 1) (default 0)
+  - name: offset_r
+    description: <double> ..F.A...... set offset R (from 0 to 1) (default 0.5)
+  - name: timing
+    description: <int> ..F.A...... set timing (from 0 to 2) (default hz) bpm 0 ..F.A...... ms 1 ..F.A...... hz 2 ..F.A......
+  - name: bpm
+    description: <double> ..F.A...... set BPM (from 30 to 300) (default 120)
+  - name: ms
+    description: <int> ..F.A...... set ms (from 10 to 2000) (default 500)
+  - name: hz
+    description: <double> ..F.A...... set frequency (from 0.01 to 100) (default 2)
+  - name: sample_rate
+    description: <int> ..F.A...... (from 0 to INT_MAX) (default 0)
+  - name: lambda
+    description: <float> ..F.A....T. set the filter lambda (from 0 to 1) (default 1)
+  - name: delta
+    description: <float> ..F.A...... set the filter delta (from 0 to 32767) (default 2)
+  - name: model
+    description: <string> ..F.A....T. set model name
+  - name: timestamps
+    description: <string> ..F.A...... timestamps of input at which to split input
+  - name: outputs
+    description: <int> ..F.A...... set the number of outputs (from 1 to INT_MAX) (default 1)
+  - name: commands
+    description: <string> ..FVA...... set commands
+  - name: filename
+    description: <string> ..FVA...... set commands file
+  - name: nb_out_samples
+    description: <int> ..F.A....T. set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)
+  - name: pad
+    description: <boolean> ..F.A....T. pad last frame with zeros (default true)
+  - name: tb
+    description: <string> ..F.A...... set expression determining the output timebase (default "intb")
+  - name: param
+    description: <double> ..F.A....T. set softclip parameter (from 0.01 to 3) (default 1)
+  - name: oversample
+    description: <int> ..F.A....T. set oversample factor (from 1 to 64) (default 1)
+  - name: measure
+    description: <flags> ..F.A...... select the parameters which are measured (default all+mean+variance+centroid+spread+skewness+kurtosis+entropy+flatness+crest+flux+slope+decrease+rolloff) none ..F.A...... all ..F.A...... mean ..F.A...... variance ..F.A...... centroid ..F.A...... spread ..F.A...... skewness ..F.A...... kurtosis ..F.A...... entropy ..F.A...... flatness ..F.A...... crest ..F.A...... flux ..F.A...... slope ..F.A...... decrease ..F.A...... rolloff ..F.A......
+  - name: hmm
+    description: <string> ..F.A...... set directory containing acoustic model files
+  - name: dict
+    description: <string> ..F.A...... set pronunciation dictionary
+  - name: lm
+    description: <string> ..F.A...... set language model file
+  - name: lmctl
+    description: <string> ..F.A...... set language model set
+  - name: lmname
+    description: <string> ..F.A...... set which language model to use
+  - name: logfn
+    description: <string> ..F.A...... set output for log messages (default "/dev/null")
+  - name: metadata
+    description: <boolean> ..F.A...... inject metadata in the filtergraph (default false)
+  - name: reset
+    description: <int> ..F.A...... Set the number of frames over which cumulative stats are calculated before being reset (from 0 to INT_MAX) (default 0)
+  - name: measure_overall
+    description: <flags> ..F.A...... Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count) none ..F.A...... all ..F.A...... Bit_depth ..F.A...... Crest_factor ..F.A...... DC_offset ..F.A...... Dynamic_range ..F.A...... Entropy ..F.A...... Flat_factor ..F.A...... Max_difference ..F.A...... Max_level ..F.A...... Mean_difference ..F.A...... Min_difference ..F.A...... Min_level ..F.A...... Noise_floor ..F.A...... Noise_floor_count ..F.A...... Number_of_Infs ..F.A...... Number_of_NaNs ..F.A...... Number_of_denormals ..F.A...... Number_of_samples ..F.A...... Peak_count ..F.A...... Peak_level ..F.A...... RMS_difference ..F.A...... RMS_level ..F.A...... RMS_peak ..F.A...... RMS_trough ..F.A...... Zero_crossings ..F.A...... Zero_crossings_rate ..F.A...... Abs_Peak_count ..F.A......
+  - name: map
+    description: <string> ..FVA....T. input indexes to remap to outputs
+  - name: boost
+    description: <double> ..F.A....T. set max boost (from 1 to 12) (default 2)
+  - name: feedback
+    description: <double> ..F.A....T. set feedback (from 0 to 1) (default 0.9)
+  - name: cutoff
+    description: <double> ..F.A....T. set cutoff (from 50 to 900) (default 100)
+  - name: slope
+    description: <double> ..F.A....T. set slope (from 0.0001 to 1) (default 0.5)
+  - name: centerf
+    description: <double> ..F.A....T. set center frequency (from 2 to 999999) (default 1000)
+  - name: qfactor
+    description: <double> ..F.A....T. set Q-factor (from 0.01 to 100) (default 1)
+  - name: tempo
+    description: <double> ..F.A....T. set tempo scale factor (from 0.5 to 100) (default 1)
+  - name: starti
+    description: <duration> ..F.A...... Timestamp of the first frame that should be passed (default INT64_MAX)
+  - name: end
+    description: <duration> ..F.A...... Timestamp of the first frame that should be dropped again (default INT64_MAX)
+  - name: endi
+    description: <duration> ..F.A...... Timestamp of the first frame that should be dropped again (default INT64_MAX)
+  - name: start_pts
+    description: <int64> ..F.A...... Timestamp of the first frame that should be passed (from I64_MIN to I64_MAX) (default I64_MIN)
+  - name: end_pts
+    description: <int64> ..F.A...... Timestamp of the first frame that should be dropped again (from I64_MIN to I64_MAX) (default I64_MIN)
+  - name: durationi
+    description: <duration> ..F.A...... Maximum duration of the output (default 0)
+  - name: end_sample
+    description: <int64> ..F.A...... Number of the first audio sample that should be dropped again (from 0 to I64_MAX) (default I64_MAX)
+  - name: algo
+    description: <int> ..F.A...... set the algorithm (from 0 to 2) (default best) slow 0 ..F.A...... slow algorithm fast 1 ..F.A...... fast algorithm best 2 ..F.A...... best algorithm
+  - name: bind_address
+    description: <string> ..FVA...... set bind address (default "tcp://*:5555")
+  - name: csg
+    description: <boolean> ..F.A....T. use constant skirt gain (default false)
+  - name: blocksize
+    description: <int> ..F.A...... set the block size (from 0 to 32768) (default 0)
+  - name: g
+    description: <double> ..F.A....T. set gain (from -900 to 900) (default 0)
+  - name: a0
+    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 1)
+  - name: a1
+    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+  - name: a2
+    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+  - name: b0
+    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+  - name: b1
+    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+  - name: b2
+    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+  - name: fcut
+    description: <int> ..F.A...... Set cut frequency (in Hz) (from 0 to 2000) (default 0)
+  - name: feed
+    description: <int> ..F.A...... Set feed level (in Hz) (from 0 to 150) (default 0)
+  - name: speeds
+    description: <string> ..F.A...... set speeds
+  - name: depths
+    description: <string> ..F.A...... set depths
+  - name: attacks
+    description: <string> ..F.A...... set time over which increase of volume is determined (default "0")
+  - name: points
+    description: <string> ..F.A...... set points of transfer function (default "-70/-70|-60/-20|1/0")
+  - name: soft-knee
+    description: <double> ..F.A...... set soft-knee (from 0.01 to 900) (default 0.01)
+  - name: volume
+    description: <double> ..F.A...... set initial volume (from -900 to 0) (default 0)
+  - name: mm
+    description: <int> ..F.A....T. set mm distance (from 0 to 10) (default 0)
+  - name: cm
+    description: <int> ..F.A....T. set cm distance (from 0 to 100) (default 0)
+  - name: temp
+    description: <int> ..F.A....T. set temperature °C (from -50 to 50) (default 20)
+  - name: block_size
+    description: <int> ..F.A...... set the block size (from 0 to 32768) (default 0)
+  - name: i
+    description: <float> ..F.A....T. set intensity (from -10 to 10) (default 2)
+  - name: limitergain
+    description: <double> ..F.A...... set limiter gain (from 0 to 1) (default 0)
+  - name: original
+    description: <double> ..F.A....T. set original center factor (from 0 to 1) (default 1)
+  - name: enhance
+    description: <double> ..F.A....T. set dialogue enhance factor (from 0 to 3) (default 1)
+  - name: voice
+    description: <double> ..F.A....T. set voice detection factor (from 2 to 32) (default 2)
+  - name: framelen
+    description: <int> ..F.A....T. set the frame length in msec (from 10 to 8000) (default 500)
+  - name: gausssize
+    description: <int> ..F.A....T. set the filter size (from 3 to 301) (default 31)
+  - name: peak
+    description: <double> ..F.A....T. set the peak value (from 0 to 1) (default 0.95)
+  - name: maxgain
+    description: <double> ..F.A....T. set the max amplification (from 1 to 100) (default 10)
+  - name: targetrms
+    description: <double> ..F.A....T. set the target RMS (from 0 to 1) (default 0)
+  - name: coupling
+    description: <boolean> ..F.A....T. set channel coupling (default true)
+  - name: correctdc
+    description: <boolean> ..F.A....T. set DC correction (default false)
+  - name: altboundary
+    description: <boolean> ..F.A....T. set alternative boundary mode (default false)
+  - name: compress
+    description: <double> ..F.A....T. set the compress factor (from 0 to 30) (default 0)
+  - name: h
+    description: <string> ..F.A....T. set channels to filter (default "all")
+  - name: v
+    description: <string> ..F.A....T. set the custom peak mapping curve
+  - name: video
+    description: <boolean> ..FV....... set video output (default false)
+  - name: meter
+    description: <int> ..FV....... set scale meter (+9 to +18) (from 9 to 18) (default 9)
+  - name: framelog
+    description: <int> ..FVA...... force frame logging level (from INT_MIN to INT_MAX) (default -1) quiet -8 ..FVA...... logging disabled info 32 ..FVA...... information logging level verbose 40 ..FVA...... verbose logging level
+  - name: dualmono
+    description: <boolean> ..F.A...... treat mono input files as dual-mono (default false)
+  - name: panlaw
+    description: <double> ..F.A...... set a specific pan law for dual-mono files (from -10 to 0) (default -3.0103)
+  - name: target
+    description: <int> ..FV....... set a specific target level in LUFS (-23 to 0) (from -23 to 0) (default -23)
+  - name: gauge
+    description: <int> ..FV....... set gauge display type (from 0 to 1) (default momentary) momentary 0 ..FV....... display momentary value m 0 ..FV....... display momentary value shortterm 1 ..FV....... display short-term value s 1 ..FV....... display short-term value
+  - name: scale
+    description: <int> ..FV....... sets display method for the stats (from 0 to 1) (default absolute) absolute 0 ..FV....... display absolute values (LUFS) LUFS 0 ..FV....... display absolute values (LUFS) relative 1 ..FV....... display values relative to target (LU) LU 1 ..FV....... display values relative to target (LU)
+  - name: integrated
+    description: <double> ..F.A.XR... integrated loudness (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
+  - name: lra_low
+    description: <double> ..F.A.XR... LRA low (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
+  - name: lra_high
+    description: <double> ..F.A.XR... LRA high (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
+  - name: sample_peak
+    description: <double> ..F.A.XR... sample peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
+  - name: true_peak
+    description: <double> ..F.A.XR... true peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
+  - name: gain_entry
+    description: <string> ..F.A....T. set gain entry
+  - name: accuracy
+    description: <double> ..F.A...... set accuracy (from 0 to 1e+10) (default 5)
+  - name: wfunc
+    description: <int> ..F.A...... set window function (from 0 to 9) (default hann) rectangular 0 ..F.A...... rectangular window hann 1 ..F.A...... hann window hamming 2 ..F.A...... hamming window blackman 3 ..F.A...... blackman window nuttall3 4 ..F.A...... 3-term nuttall window mnuttall3 5 ..F.A...... minimum 3-term nuttall window nuttall 6 ..F.A...... nuttall window bnuttall 7 ..F.A...... blackman-nuttall window bharris 8 ..F.A...... blackman-harris window tukey 9 ..F.A...... tukey window
+  - name: fixed
+    description: <boolean> ..F.A...... set fixed frame samples (default false)
+  - name: multi
+    description: <boolean> ..F.A...... set multi channels mode (default false)
+  - name: zero_phase
+    description: <boolean> ..F.A...... set zero phase mode (default false)
+  - name: dumpfile
+    description: <string> ..F.A...... set dump file
+  - name: dumpscale
+    description: <int> ..F.A...... set dump scale (from 0 to 3) (default linlog) linlin 0 ..F.A...... linear-freq linear-gain linlog 1 ..F.A...... linear-freq logarithmic-gain loglin 2 ..F.A...... logarithmic-freq linear-gain loglog 3 ..F.A...... logarithmic-freq logarithmic-gain
+  - name: fft2
+    description: <boolean> ..F.A...... set 2-channels fft (default false)
+  - name: min_phase
+    description: <boolean> ..F.A...... set minimum phase mode (default false)
+  - name: depth
+    description: <double> ..F.A...... added swept delay in milliseconds (from 0 to 10) (default 2)
+  - name: regen
+    description: <double> ..F.A...... percentage regeneration (delayed signal feedback) (from -95 to 95) (default 0)
+  - name: shape
+    description: <int> ..F.A...... swept wave shape (from 0 to 1) (default sinusoidal) triangular 1 ..F.A...... t 1 ..F.A...... sinusoidal 0 ..F.A...... s 0 ..F.A......
+  - name: phase
+    description: <double> ..F.A...... swept wave percentage phase-shift for multi-channel (from 0 to 100) (default 25)
+  - name: interp
+    description: <int> ..F.A...... delay-line interpolation (from 0 to 1) (default linear) linear 0 ..F.A...... quadratic 1 ..F.A......
+  - name: side_gain
+    description: <double> ..F.A...... set side gain (from 0.015625 to 64) (default 1)
+  - name: middle_source
+    description: <int> ..F.A...... set middle source (from 0 to 3) (default mid) left 0 ..F.A...... right 1 ..F.A...... mid 2 ..F.A...... L+R side 3 ..F.A...... L-R
+  - name: middle_phase
+    description: <boolean> ..F.A...... set middle phase (default false)
+  - name: left_delay
+    description: <double> ..F.A...... set left delay (from 0 to 40) (default 2.05)
+  - name: left_balance
+    description: <double> ..F.A...... set left balance (from -1 to 1) (default -1)
+  - name: left_gain
+    description: <double> ..F.A...... set left gain (from 0.015625 to 64) (default 1)
+  - name: left_phase
+    description: <boolean> ..F.A...... set left phase (default false)
+  - name: right_delay
+    description: <double> ..F.A...... set right delay (from 0 to 40) (default 2.12)
+  - name: right_balance
+    description: <double> ..F.A...... set right balance (from -1 to 1) (default 1)
+  - name: right_gain
+    description: <double> ..F.A...... set right gain (from 0.015625 to 64) (default 1)
+  - name: right_phase
+    description: <boolean> ..F.A...... set right phase (default true)
+  - name: process_stereo
+    description: <boolean> ..F.A...... Process stereo channels together. Only apply target_gain when both channels match. (default true)
+  - name: cdt_ms
+    description: <int> ..F.A...... Code detect timer period in ms. (from 100 to 60000) (default 2000)
+  - name: force_pe
+    description: <boolean> ..F.A...... Always extend peaks above -3dBFS even when PE is not signaled. (default false)
+  - name: analyze_mode
+    description: <int> ..F.A...... Replace audio with solid tone and signal some processing aspect in the amplitude. (from 0 to 4) (default off) off 0 ..F.A...... disabled lle 1 ..F.A...... gain adjustment level at each sample pe 2 ..F.A...... samples where peak extend occurs cdt 3 ..F.A...... samples where the code detect timer is active tgm 4 ..F.A...... samples where the target gain does not match between channels
+  - name: bits_per_sample
+    description: <int> ..F.A...... Valid bits per sample (location of the true LSB). (from 16 to 24) (default 16) 16 16 ..F.A...... 16-bit (in s32 or s16) 20 20 ..F.A...... 20-bit (in s32) 24 24 ..F.A...... 24-bit (in s32)
+  - name: lfe
+    description: <float> ..F.A...... set lfe gain in dB (from -20 to 40) (default 0)
+  - name: hrir
+    description: <int> ..F.A...... set hrir format (from 0 to 1) (default stereo) stereo 0 ..F.A...... hrir files have exactly 2 channels multich 1 ..F.A...... single multichannel hrir file
+  - name: plugin
+    description: <string> ..F.A...... set plugin name
+  - name: controls
+    description: <string> ..F.A...... set plugin options
+  - name: l
+    description: <boolean> ..F.A...... enable latency compensation (default false)
+  - name: lra
+    description: <double> ..F.A...... set loudness range target (from 1 to 50) (default 7)
+  - name: tp
+    description: <double> ..F.A...... set maximum true peak (from -9 to 0) (default -2)
+  - name: measured_i
+    description: <double> ..F.A...... measured IL of input file (from -99 to 0) (default 0)
+  - name: measured_lra
+    description: <double> ..F.A...... measured LRA of input file (from 0 to 99) (default 0)
+  - name: measured_tp
+    description: <double> ..F.A...... measured true peak of input file (from -99 to 99) (default 99)
+  - name: measured_thresh
+    description: <double> ..F.A...... measured threshold of input file (from -99 to 0) (default -70)
+  - name: offset
+    description: <double> ..F.A...... set offset gain (from -99 to 99) (default 0)
+  - name: linear
+    description: <boolean> ..F.A...... normalize linearly if possible (default true)
+  - name: dual_mono
+    description: <boolean> ..F.A...... treat mono input as dual-mono (default false)
+  - name: print_format
+    description: <int> ..F.A...... set print format for stats (from 0 to 2) (default none) none 0 ..F.A...... json 1 ..F.A...... summary 2 ..F.A......
+  - name: args
+    description: <string> ..F.A...... set parameters for each band (default "0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000")
+  - name: track_gain
+    description: <float> ..F.A.XR... track gain (dB) (from -FLT_MAX to FLT_MAX) (default 0)
+  - name: track_peak
+    description: <float> ..F.A.XR... track peak (from -FLT_MAX to FLT_MAX) (default 0)
+  - name: pitch
+    description: <double> ..F.A....T. set pitch scale factor (from 0.01 to 100) (default 1)
+  - name: transients
+    description: <int> ..F.A...... set transients (from 0 to INT_MAX) (default crisp) crisp 0 ..F.A...... mixed 256 ..F.A...... smooth 512 ..F.A......
+  - name: detector
+    description: <int> ..F.A...... set detector (from 0 to INT_MAX) (default compound) compound 0 ..F.A...... percussive 1024 ..F.A...... soft 2048 ..F.A......
+  - name: smoothing
+    description: <int> ..F.A...... set smoothing (from 0 to INT_MAX) (default off) off 0 ..F.A...... on 8388608 ..F.A......
+  - name: formant
+    description: <int> ..F.A...... set formant (from 0 to INT_MAX) (default shifted) shifted 0 ..F.A...... preserved 16777216 ..F.A......
+  - name: pitchq
+    description: <int> ..F.A...... set pitch quality (from 0 to INT_MAX) (default speed) quality 33554432 ..F.A...... speed 0 ..F.A...... consistency 67108864 ..F.A......
+  - name: noise
+    description: <double> ..F.A...... set noise tolerance (from 0 to DBL_MAX) (default 0.001)
+  - name: mono
+    description: <boolean> ..F.A...... check each channel separately (default false)
+  - name: start_periods
+    description: <int> ..F.A...... set periods of silence parts to skip from start (from 0 to 9000) (default 0)
+  - name: start_duration
+    description: <duration> ..F.A...... set start duration of non-silence part (default 0)
+  - name: start_threshold
+    description: <double> ..F.A....T. set threshold for start silence detection (from 0 to DBL_MAX) (default 0)
+  - name: start_silence
+    description: <duration> ..F.A...... set start duration of silence part to keep (default 0)
+  - name: start_mode
+    description: <int> ..F.A....T. set which channel will trigger trimming from start (from 0 to 1) (default any) any 0 ..F.A....T. all 1 ..F.A....T.
+  - name: stop_periods
+    description: <int> ..F.A...... set periods of silence parts to skip from end (from -9000 to 9000) (default 0)
+  - name: stop_duration
+    description: <duration> ..F.A...... set stop duration of silence part (default 0)
+  - name: stop_threshold
+    description: <double> ..F.A....T. set threshold for stop silence detection (from 0 to DBL_MAX) (default 0)
+  - name: stop_silence
+    description: <duration> ..F.A...... set stop duration of silence part to keep (default 0)
+  - name: stop_mode
+    description: <int> ..F.A....T. set which channel will trigger trimming from end (from 0 to 1) (default all) any 0 ..F.A....T. all 1 ..F.A....T.
+  - name: timestamp
+    description: <int> ..F.A...... set how every output frame timestamp is processed (from 0 to 1) (default write) write 0 ..F.A...... full timestamps rewrite, keep only the start time copy 1 ..F.A...... non-dropped frames are left with same timestamp
+  - name: sofa
+    description: <string> ..F.A...... sofa filename
+  - name: rotation
+    description: <float> ..F.A...... set rotation (from -360 to 360) (default 0)
+  - name: elevation
+    description: <float> ..F.A...... set elevation (from -90 to 90) (default 0)
+  - name: radius
+    description: <float> ..F.A...... set radius (from 0 to 5) (default 1)
+  - name: speakers
+    description: <string> ..F.A...... set speaker custom positions
+  - name: lfegain
+    description: <float> ..F.A...... set lfe gain (from -20 to 40) (default 0)
+  - name: framesize
+    description: <int> ..F.A...... set frame size (from 1024 to 96000) (default 1024)
+  - name: interpolate
+    description: <boolean> ..F.A...... interpolate IRs from neighbors (default false)
+  - name: minphase
+    description: <boolean> ..F.A...... minphase IRs (default false)
+  - name: anglestep
+    description: <float> ..F.A...... set neighbor search angle step (from 0.01 to 10) (default 0.5)
+  - name: radstep
+    description: <float> ..F.A...... set neighbor search radius step (from 0.01 to 1) (default 0.01)
+  - name: expansion
+    description: <double> ..F.A....T. set the max expansion factor (from 1 to 50) (default 2)
+  - name: compression
+    description: <double> ..F.A....T. set the max compression factor (from 1 to 50) (default 2)
+  - name: raise
+    description: <double> ..F.A....T. set the expansion raising amount (from 0 to 1) (default 0.001)
+  - name: fall
+    description: <double> ..F.A....T. set the compression raising amount (from 0 to 1) (default 0.001)
+  - name: invert
+    description: <boolean> ..F.A....T. set inverted filtering (default false)
+  - name: rms
+    description: <double> ..F.A....T. set the RMS value (from 0 to 1) (default 0)
+  - name: balance_in
+    description: <double> ..F.A....T. set balance in (from -1 to 1) (default 0)
+  - name: balance_out
+    description: <double> ..F.A....T. set balance out (from -1 to 1) (default 0)
+  - name: softclip
+    description: <boolean> ..F.A....T. enable softclip (default false)
+  - name: mutel
+    description: <boolean> ..F.A....T. mute L (default false)
+  - name: muter
+    description: <boolean> ..F.A....T. mute R (default false)
+  - name: phasel
+    description: <boolean> ..F.A....T. phase L (default false)
+  - name: phaser
+    description: <boolean> ..F.A....T. phase R (default false)
+  - name: slev
+    description: <double> ..F.A....T. set side level (from 0.015625 to 64) (default 1)
+  - name: sbal
+    description: <double> ..F.A....T. set side balance (from -1 to 1) (default 0)
+  - name: mlev
+    description: <double> ..F.A....T. set middle level (from 0.015625 to 64) (default 1)
+  - name: mpan
+    description: <double> ..F.A....T. set middle pan (from -1 to 1) (default 0)
+  - name: base
+    description: <double> ..F.A....T. set stereo base (from -1 to 1) (default 0)
+  - name: sclevel
+    description: <double> ..F.A....T. set S/C level (from 1 to 100) (default 1)
+  - name: bmode_in
+    description: <int> ..F.A....T. set balance in mode (from 0 to 2) (default balance) balance 0 ..F.A....T. amplitude 1 ..F.A....T. power 2 ..F.A....T.
+  - name: bmode_out
+    description: <int> ..F.A....T. set balance out mode (from 0 to 2) (default balance) balance 0 ..F.A....T. amplitude 1 ..F.A....T. power 2 ..F.A....T.
+  - name: crossfeed
+    description: <float> ..F.A....T. set cross feed (from 0 to 0.8) (default 0.3)
+  - name: drymix
+    description: <float> ..F.A....T. set dry-mix (from 0 to 1) (default 0.8)
+  - name: chl_out
+    description: <string> ..F.A...... set output channel layout (default "5.1")
+  - name: chl_in
+    description: <string> ..F.A...... set input channel layout (default "stereo")
+  - name: lfe_low
+    description: <int> ..F.A...... LFE low cut off (from 0 to 256) (default 128)
+  - name: lfe_high
+    description: <int> ..F.A...... LFE high cut off (from 0 to 512) (default 256)
+  - name: lfe_mode
+    description: <int> ..F.A....T. set LFE channel mode (from 0 to 1) (default add) add 0 ..F.A....T. just add LFE channel sub 1 ..F.A....T. substract LFE channel with others
+  - name: angle
+    description: <float> ..F.A....T. set soundfield transform angle (from 0 to 360) (default 90)
+  - name: focus
+    description: <float> ..F.A....T. set soundfield transform focus (from -1 to 1) (default 0)
+  - name: fc_in
+    description: <float> ..F.A....T. set front center channel input level (from 0 to 10) (default 1)
+  - name: fc_out
+    description: <float> ..F.A....T. set front center channel output level (from 0 to 10) (default 1)
+  - name: fl_in
+    description: <float> ..F.A....T. set front left channel input level (from 0 to 10) (default 1)
+  - name: fl_out
+    description: <float> ..F.A....T. set front left channel output level (from 0 to 10) (default 1)
+  - name: fr_in
+    description: <float> ..F.A....T. set front right channel input level (from 0 to 10) (default 1)
+  - name: fr_out
+    description: <float> ..F.A....T. set front right channel output level (from 0 to 10) (default 1)
+  - name: sl_in
+    description: <float> ..F.A....T. set side left channel input level (from 0 to 10) (default 1)
+  - name: sl_out
+    description: <float> ..F.A....T. set side left channel output level (from 0 to 10) (default 1)
+  - name: sr_in
+    description: <float> ..F.A....T. set side right channel input level (from 0 to 10) (default 1)
+  - name: sr_out
+    description: <float> ..F.A....T. set side right channel output level (from 0 to 10) (default 1)
+  - name: bl_in
+    description: <float> ..F.A....T. set back left channel input level (from 0 to 10) (default 1)
+  - name: bl_out
+    description: <float> ..F.A....T. set back left channel output level (from 0 to 10) (default 1)
+  - name: br_in
+    description: <float> ..F.A....T. set back right channel input level (from 0 to 10) (default 1)
+  - name: br_out
+    description: <float> ..F.A....T. set back right channel output level (from 0 to 10) (default 1)
+  - name: bc_in
+    description: <float> ..F.A....T. set back center channel input level (from 0 to 10) (default 1)
+  - name: bc_out
+    description: <float> ..F.A....T. set back center channel output level (from 0 to 10) (default 1)
+  - name: lfe_in
+    description: <float> ..F.A....T. set lfe channel input level (from 0 to 10) (default 1)
+  - name: lfe_out
+    description: <float> ..F.A....T. set lfe channel output level (from 0 to 10) (default 1)
+  - name: allx
+    description: <float> ..F.A....T. set all channel's x spread (from -1 to 15) (default -1)
+  - name: ally
+    description: <float> ..F.A....T. set all channel's y spread (from -1 to 15) (default -1)
+  - name: fcx
+    description: <float> ..F.A....T. set front center channel x spread (from 0.06 to 15) (default 0.5)
+  - name: flx
+    description: <float> ..F.A....T. set front left channel x spread (from 0.06 to 15) (default 0.5)
+  - name: frx
+    description: <float> ..F.A....T. set front right channel x spread (from 0.06 to 15) (default 0.5)
+  - name: blx
+    description: <float> ..F.A....T. set back left channel x spread (from 0.06 to 15) (default 0.5)
+  - name: brx
+    description: <float> ..F.A....T. set back right channel x spread (from 0.06 to 15) (default 0.5)
+  - name: slx
+    description: <float> ..F.A....T. set side left channel x spread (from 0.06 to 15) (default 0.5)
+  - name: srx
+    description: <float> ..F.A....T. set side right channel x spread (from 0.06 to 15) (default 0.5)
+  - name: bcx
+    description: <float> ..F.A....T. set back center channel x spread (from 0.06 to 15) (default 0.5)
+  - name: fcy
+    description: <float> ..F.A....T. set front center channel y spread (from 0.06 to 15) (default 0.5)
+  - name: fly
+    description: <float> ..F.A....T. set front left channel y spread (from 0.06 to 15) (default 0.5)
+  - name: fry
+    description: <float> ..F.A....T. set front right channel y spread (from 0.06 to 15) (default 0.5)
+  - name: bly
+    description: <float> ..F.A....T. set back left channel y spread (from 0.06 to 15) (default 0.5)
+  - name: bry
+    description: <float> ..F.A....T. set back right channel y spread (from 0.06 to 15) (default 0.5)
+  - name: sly
+    description: <float> ..F.A....T. set side left channel y spread (from 0.06 to 15) (default 0.5)
+  - name: sry
+    description: <float> ..F.A....T. set side right channel y spread (from 0.06 to 15) (default 0.5)
+  - name: bcy
+    description: <float> ..F.A....T. set back center channel y spread (from 0.06 to 15) (default 0.5)
+  - name: eval
+    description: <int> ..F.A...... specify when to evaluate expressions (from 0 to 1) (default once) once 0 ..F.A...... eval volume expression once frame 1 ..F.A...... eval volume expression per-frame
+  - name: replaygain
+    description: <int> ..F.A...... Apply replaygain side data when present (from 0 to 3) (default drop) drop 0 ..F.A...... replaygain side data is dropped ignore 1 ..F.A...... replaygain side data is ignored track 2 ..F.A...... track gain is preferred album 3 ..F.A...... album gain is preferred
+  - name: taps
+    description: <int> ..F.A...... set number of taps for delay filter (from 0 to 32768) (default 0)
+  - name: preset
+    description: <int> ..F.A...... set equalizer preset (from -1 to 17) (default flat) custom -1 ..F.A...... flat 0 ..F.A...... acoustic 1 ..F.A...... bass 2 ..F.A...... beats 3 ..F.A...... classic 4 ..F.A...... clear 5 ..F.A...... deep bass 6 ..F.A...... dubstep 7 ..F.A...... electronic 8 ..F.A...... hardstyle 9 ..F.A...... hip-hop 10 ..F.A...... jazz 11 ..F.A...... metal 12 ..F.A...... movie 13 ..F.A...... pop 14 ..F.A...... r&b 15 ..F.A...... rock 16 ..F.A...... vocal booster 17 ..F.A......
+  - name: bands
+    description: <string> ..F.A...... set central frequency values per band (default "25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000")
+  - name: magnitude
+    description: <string> ..F.A...... set magnitude values (default "1 1")
+  - name: amplitude
+    description: <double> ..F.A...... set amplitude (from 0 to 1) (default 1)
+  - name: color
+    description: <int> ..F.A...... set noise color (from 0 to 5) (default white) white 0 ..F.A...... pink 1 ..F.A...... brown 2 ..F.A...... blue 3 ..F.A...... violet 4 ..F.A...... velvet 5 ..F.A......
+  - name: colour
+    description: <int> ..F.A...... set noise color (from 0 to 5) (default white) white 0 ..F.A...... pink 1 ..F.A...... brown 2 ..F.A...... blue 3 ..F.A...... violet 4 ..F.A...... velvet 5 ..F.A......
+  - name: density
+    description: <double> ..F.A...... set density (from 0 to 1) (default 0.05)
+  - name: list_voices
+    description: <boolean> ..F.A...... list voices and exit (default false)
+  - name: text
+    description: <string> ..F.A...... set text to speak
+  - name: textfile
+    description: <string> ..F.A...... set filename of the text to speak
+  - name: hp
+    description: <float> ..F.A...... set high-pass filter frequency (from 0 to INT_MAX) (default 0)
+  - name: lp
+    description: <float> ..F.A...... set low-pass filter frequency (from 0 to INT_MAX) (default 0)
+  - name: beta
+    description: <float> ..F.A...... set kaiser window beta (from -1 to 256) (default -1)
+  - name: att
+    description: <float> ..F.A...... set stop-band attenuation (from 40 to 180) (default 120)
+  - name: round
+    description: <boolean> ..F.A...... enable rounding (default false)
+  - name: hptaps
+    description: <int> ..F.A...... set number of taps for high-pass filter (from 0 to 32768) (default 0)
+  - name: lptaps
+    description: <int> ..F.A...... set number of taps for low-pass filter (from 0 to 32768) (default 0)
+  - name: beep_factor
+    description: <double> ..F.A...... set the beep frequency factor (from 0 to DBL_MAX) (default 0)
+  - name: x
+    description: <string> ..FV....... Region distance from left edge of frame. (default "0")
+  - name: y
+    description: <string> ..FV....... Region distance from top edge of frame. (default "0")
+  - name: qoffset
+    description: <rational> ..FV....... Quantisation offset to apply in the region. (from -1 to 1) (default -1/10)
+  - name: clear
+    description: <boolean> ..FV....... Remove any existing regions of interest before adding the new one. (default false)
+  - name: eof_action
+    description: <int> ..FV....... Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat) repeat 0 ..FV....... Repeat the previous frame. endall 1 ..FV....... End both streams. pass 2 ..FV....... Pass through the main input.
+  - name: shortest
+    description: <boolean> ..FV....... force termination when the shortest input terminates (default false)
+  - name: repeatlast
+    description: <boolean> ..FV....... extend last frame of secondary streams beyond EOF (default true)
+  - name: ts_sync_mode
+    description: <int> ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default) default 0 ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame nearest 1 ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+  - name: factor
+    description: <float> ..FV.....T. set factor (from 0 to 65535) (default 2)
+  - name: tolerance
+    description: <float> ..FV.....T. set tolerance (from 0 to 65535) (default 0)
+  - name: low
+    description: <float> ..FV.....T. set low limit for amplification (from 0 to 65535) (default 65535)
+  - name: high
+    description: <float> ..FV.....T. set high limit for amplification (from 0 to 65535) (default 65535)
+  - name: planes
+    description: <flags> ..FV.....T. set what planes to filter (default 7)
+  - name: original_size
+    description: <image_size> ..FV....... set the size of the original video (used to scale fonts)
+  - name: fontsdir
+    description: <string> ..FV....... set the directory containing the fonts to read
+  - name: alpha
+    description: <boolean> ..FV....... enable processing of alpha channel (default false)
+  - name: shaping
+    description: <int> ..FV....... set shaping engine (from -1 to 1) (default auto) auto -1 ..FV....... simple 0 ..FV....... simple shaping complex 1 ..FV....... complex shaping
+  - name: similarity
+    description: <float> ..FV.....T. set the similarity (from 0 to 1) (default 0.1)
+  - name: min_val
+    description: <int> ..FV.....T. set minimum luminance value for bounding box (from 0 to 65535) (default 16)
+  - name: window_size
+    description: <int> ..FV....... set neighbours window_size (from 1 to 255) (default 1)
+  - name: bitplane
+    description: <int> ..FV....... set bit plane to use for measuring noise (from 1 to 16) (default 1)
+  - name: filter
+    description: <boolean> ..FV....... show noisy pixels (default false)
+  - name: pic_th
+    description: <double> ..FV....... set the picture black ratio threshold (from 0 to 1) (default 0.98)
+  - name: pixel_black_th
+    description: <double> ..FV....... set the pixel black threshold (from 0 to 1) (default 0.1)
+  - name: pix_th
+    description: <double> ..FV....... set the pixel black threshold (from 0 to 1) (default 0.1)
+  - name: thresh
+    description: <int> ..FV....... threshold below which a pixel value is considered black (from 0 to 255) (default 32)
+  - name: c0_mode
+    description: '<int> ..FV.....T. set component #0 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
+  - name: c1_mode
+    description: '<int> ..FV.....T. set component #1 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
+  - name: c2_mode
+    description: '<int> ..FV.....T. set component #2 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
+  - name: c3_mode
+    description: '<int> ..FV.....T. set component #3 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
+  - name: all_mode
+    description: <int> ..FV.....T. set blend mode for all components (from -1 to 39) (default -1) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.
+  - name: c0_expr
+    description: '<string> ..FV.....T. set color component #0 expression'
+  - name: c1_expr
+    description: '<string> ..FV.....T. set color component #1 expression'
+  - name: c2_expr
+    description: '<string> ..FV.....T. set color component #2 expression'
+  - name: c3_expr
+    description: '<string> ..FV.....T. set color component #3 expression'
+  - name: all_expr
+    description: <string> ..FV.....T. set expression for all color components
+  - name: c0_opacity
+    description: '<double> ..FV.....T. set color component #0 opacity (from 0 to 1) (default 1)'
+  - name: c1_opacity
+    description: '<double> ..FV.....T. set color component #1 opacity (from 0 to 1) (default 1)'
+  - name: c2_opacity
+    description: '<double> ..FV.....T. set color component #2 opacity (from 0 to 1) (default 1)'
+  - name: c3_opacity
+    description: '<double> ..FV.....T. set color component #3 opacity (from 0 to 1) (default 1)'
+  - name: all_opacity
+    description: <double> ..FV.....T. set opacity for all color components (from 0 to 1) (default 1)
+  - name: period_min
+    description: <int> ..FV....... Minimum period to search for (from 2 to 32) (default 3)
+  - name: period_max
+    description: <int> ..FV....... Maximum period to search for (from 2 to 64) (default 24)
+  - name: block_pct
+    description: <int> ..FV....... block pooling threshold when calculating blurriness (from 1 to 100) (default 80)
+  - name: block_width
+    description: <int> ..FV....... block size for block-based abbreviation of blurriness (from -1 to INT_MAX) (default -1)
+  - name: block_height
+    description: <int> ..FV....... block size for block-based abbreviation of blurriness (from -1 to INT_MAX) (default -1)
+  - name: block
+    description: <int> ..FV....... set size of local patch (from 8 to 64) (default 16)
+  - name: bstep
+    description: <int> ..FV....... set sliding step for processing blocks (from 1 to 64) (default 4)
+  - name: group
+    description: <int> ..FV....... set maximal number of similar blocks (from 1 to 256) (default 1)
+  - name: mstep
+    description: <int> ..FV....... set step for block matching (from 1 to 64) (default 1)
+  - name: thmse
+    description: <float> ..FV....... set threshold of mean square error for block matching (from 0 to INT_MAX) (default 0)
+  - name: hdthr
+    description: <float> ..FV....... set hard threshold for 3D transfer domain (from 0 to INT_MAX) (default 2.7)
+  - name: estim
+    description: <int> ..FV....... set filtering estimation mode (from 0 to 1) (default basic) basic 0 ..FV....... basic estimate final 1 ..FV....... final estimate
+  - name: ref
+    description: <boolean> ..FV....... have reference stream (default false)
+  - name: luma_radius
+    description: <string> ..FV....... Radius of the luma blurring box (default "2")
+  - name: lr
+    description: <string> ..FV....... Radius of the luma blurring box (default "2")
+  - name: luma_power
+    description: <int> ..FV....... How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
+  - name: chroma_radius
+    description: <string> ..FV....... Radius of the chroma blurring box
+  - name: cr
+    description: <string> ..FV....... Radius of the chroma blurring box
+  - name: chroma_power
+    description: <int> ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+  - name: cp
+    description: <int> ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+  - name: alpha_radius
+    description: <string> ..FV....... Radius of the alpha blurring box
+  - name: ar
+    description: <string> ..FV....... Radius of the alpha blurring box
+  - name: alpha_power
+    description: <int> ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+  - name: ap
+    description: <int> ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+  - name: parity
+    description: <int> ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto) tff 0 ..FV....... assume top field first bff 1 ..FV....... assume bottom field first auto -1 ..FV....... auto detect parity
+  - name: deint
+    description: <int> ..FV....... specify which frames to deinterlace (from 0 to 1) (default all) all 0 ..FV....... deinterlace all frames interlaced 1 ..FV....... only deinterlace frames marked as interlaced
+  - name: dist_x
+    description: <float> ..FV....... Set horizontal distortion amount (from -10 to 10) (default 0)
+  - name: dist_y
+    description: <float> ..FV....... Set vertical distortion amount (from -10 to 10) (default 0)
+  - name: yuv
+    description: <boolean> ..FV.....T. color parameter is in yuv instead of rgb (default false)
+  - name: thres
+    description: <float> ..FV.....T. set y+u+v threshold (from 1 to 200) (default 30)
+  - name: sizew
+    description: <int> ..FV.....T. set horizontal patch size (from 1 to 100) (default 5)
+  - name: sizeh
+    description: <int> ..FV.....T. set vertical patch size (from 1 to 100) (default 5)
+  - name: stepw
+    description: <int> ..FV.....T. set horizontal step (from 1 to 50) (default 1)
+  - name: steph
+    description: <int> ..FV.....T. set vertical step (from 1 to 50) (default 1)
+  - name: threy
+    description: <float> ..FV.....T. set y threshold (from 1 to 200) (default 200)
+  - name: threu
+    description: <float> ..FV.....T. set u threshold (from 1 to 200) (default 200)
+  - name: threv
+    description: <float> ..FV.....T. set v threshold (from 1 to 200) (default 200)
+  - name: distance
+    description: <int> ..FV.....T. set distance type (from 0 to 1) (default manhattan) manhattan 0 ..FV.....T. euclidean 1 ..FV.....T.
+  - name: cbh
+    description: <int> ..FV.....T. shift chroma-blue horizontally (from -255 to 255) (default 0)
+  - name: cbv
+    description: <int> ..FV.....T. shift chroma-blue vertically (from -255 to 255) (default 0)
+  - name: crh
+    description: <int> ..FV.....T. shift chroma-red horizontally (from -255 to 255) (default 0)
+  - name: crv
+    description: <int> ..FV.....T. shift chroma-red vertically (from -255 to 255) (default 0)
+  - name: edge
+    description: <int> ..FV.....T. set edge operation (from 0 to 1) (default smear) smear 0 ..FV.....T. wrap 1 ..FV.....T.
+  - name: system
+    description: <int> ..FV....... set color system (from 0 to 9) (default hdtv) ntsc 0 ..FV....... NTSC 1953 Y'I'O' (ITU-R BT.470 System M) 470m 0 ..FV....... NTSC 1953 Y'I'O' (ITU-R BT.470 System M) ebu 1 ..FV....... EBU Y'U'V' (PAL/SECAM) (ITU-R BT.470 System B, G) 470bg 1 ..FV....... EBU Y'U'V' (PAL/SECAM) (ITU-R BT.470 System B, G) smpte 2 ..FV....... SMPTE-C RGB 240m 3 ..FV....... SMPTE-240M Y'PbPr apple 4 ..FV....... Apple RGB widergb 5 ..FV....... Adobe Wide Gamut RGB cie1931 6 ..FV....... CIE 1931 RGB hdtv 7 ..FV....... ITU.BT-709 Y'CbCr rec709 7 ..FV....... ITU.BT-709 Y'CbCr uhdtv 8 ..FV....... ITU-R.BT-2020 rec2020 8 ..FV....... ITU-R.BT-2020 dcip3 9 ..FV....... DCI-P3
+  - name: cie
+    description: <int> ..FV....... set cie system (from 0 to 2) (default xyy) xyy 0 ..FV....... CIE 1931 xyY ucs 1 ..FV....... CIE 1960 UCS luv 2 ..FV....... CIE 1976 Luv
+  - name: gamuts
+    description: <flags> ..FV....... set what gamuts to draw (default 0) ntsc ..FV....... 470m ..FV....... ebu ..FV....... 470bg ..FV....... smpte ..FV....... 240m ..FV....... apple ..FV....... widergb ..FV....... cie1931 ..FV....... hdtv ..FV....... rec709 ..FV....... uhdtv ..FV....... rec2020 ..FV....... dcip3 ..FV.......
+  - name: intensity
+    description: <float> ..FV....... set ciescope intensity (from 0 to 1) (default 0.001)
+  - name: corrgamma
+    description: <boolean> ..FV....... (default true)
+  - name: showwhite
+    description: <boolean> ..FV....... (default false)
+  - name: gamma
+    description: <double> ..FV....... (from 0.1 to 6) (default 2.6)
+  - name: fill
+    description: <boolean> ..FV....... fill with CIE colors (default true)
+  - name: mv
+    description: <flags> ..FV....... set motion vectors to visualize (default 0) pf ..FV....... forward predicted MVs of P-frames bf ..FV....... forward predicted MVs of B-frames bb ..FV....... backward predicted MVs of B-frames
+  - name: qp
+    description: <boolean> ..FV....... (default false)
+  - name: mv_type
+    description: <flags> ..FV....... set motion vectors type (default 0) fp ..FV....... forward predicted MVs bp ..FV....... backward predicted MVs
+  - name: mvt
+    description: <flags> ..FV....... set motion vectors type (default 0) fp ..FV....... forward predicted MVs bp ..FV....... backward predicted MVs
+  - name: frame_type
+    description: <flags> ..FV....... set frame types to visualize motion vectors of (default 0) if ..FV....... I-frames pf ..FV....... P-frames bf ..FV....... B-frames
+  - name: ft
+    description: <flags> ..FV....... set frame types to visualize motion vectors of (default 0) if ..FV....... I-frames pf ..FV....... P-frames bf ..FV....... B-frames
+  - name: rs
+    description: <float> ..FV.....T. set red shadows (from -1 to 1) (default 0)
+  - name: bs
+    description: <float> ..FV.....T. set blue shadows (from -1 to 1) (default 0)
+  - name: rm
+    description: <float> ..FV.....T. set red midtones (from -1 to 1) (default 0)
+  - name: gm
+    description: <float> ..FV.....T. set green midtones (from -1 to 1) (default 0)
+  - name: rh
+    description: <float> ..FV.....T. set red highlights (from -1 to 1) (default 0)
+  - name: gh
+    description: <float> ..FV.....T. set green highlights (from -1 to 1) (default 0)
+  - name: bh
+    description: <float> ..FV.....T. set blue highlights (from -1 to 1) (default 0)
+  - name: pl
+    description: <boolean> ..FV.....T. preserve lightness (default false)
+  - name: rr
+    description: <double> ..FV.....T. set the red gain for the red channel (from -2 to 2) (default 1)
+  - name: rg
+    description: <double> ..FV.....T. set the green gain for the red channel (from -2 to 2) (default 0)
+  - name: rb
+    description: <double> ..FV.....T. set the blue gain for the red channel (from -2 to 2) (default 0)
+  - name: ra
+    description: <double> ..FV.....T. set the alpha gain for the red channel (from -2 to 2) (default 0)
+  - name: gr
+    description: <double> ..FV.....T. set the red gain for the green channel (from -2 to 2) (default 0)
+  - name: gg
+    description: <double> ..FV.....T. set the green gain for the green channel (from -2 to 2) (default 1)
+  - name: gb
+    description: <double> ..FV.....T. set the blue gain for the green channel (from -2 to 2) (default 0)
+  - name: ga
+    description: <double> ..FV.....T. set the alpha gain for the green channel (from -2 to 2) (default 0)
+  - name: br
+    description: <double> ..FV.....T. set the red gain for the blue channel (from -2 to 2) (default 0)
+  - name: bg
+    description: <double> ..FV.....T. set the green gain for the blue channel (from -2 to 2) (default 0)
+  - name: bb
+    description: <double> ..FV.....T. set the blue gain for the blue channel (from -2 to 2) (default 1)
+  - name: ba
+    description: <double> ..FV.....T. set the alpha gain for the blue channel (from -2 to 2) (default 0)
+  - name: ag
+    description: <double> ..FV.....T. set the green gain for the alpha channel (from -2 to 2) (default 0)
+  - name: ab
+    description: <double> ..FV.....T. set the blue gain for the alpha channel (from -2 to 2) (default 0)
+  - name: pc
+    description: <int> ..FV.....T. set the preserve color mode (from 0 to 6) (default none) none 0 ..FV.....T. disabled lum 1 ..FV.....T. luminance max 2 ..FV.....T. max avg 3 ..FV.....T. average sum 4 ..FV.....T. sum nrm 5 ..FV.....T. norm pwr 6 ..FV.....T. power
+  - name: pa
+    description: <double> ..FV.....T. set the preserve color amount (from 0 to 1) (default 0)
+  - name: rc
+    description: <float> ..FV.....T. set the red-cyan contrast (from -1 to 1) (default 0)
+  - name: by
+    description: <float> ..FV.....T. set the blue-yellow contrast (from -1 to 1) (default 0)
+  - name: rcw
+    description: <float> ..FV.....T. set the red-cyan weight (from 0 to 1) (default 0)
+  - name: gmw
+    description: <float> ..FV.....T. set the green-magenta weight (from 0 to 1) (default 0)
+  - name: byw
+    description: <float> ..FV.....T. set the blue-yellow weight (from 0 to 1) (default 0)
+  - name: rl
+    description: <float> ..FV.....T. set the red shadow spot (from -1 to 1) (default 0)
+  - name: bl
+    description: <float> ..FV.....T. set the blue shadow spot (from -1 to 1) (default 0)
+  - name: saturation
+    description: <float> ..FV.....T. set the amount of saturation (from -3 to 3) (default 1)
+  - name: analyze
+    description: <int> ..FV.....T. set the analyze mode (from 0 to 3) (default manual) manual 0 ..FV.....T. manually set options average 1 ..FV.....T. use average pixels minmax 2 ..FV.....T. use minmax pixels median 3 ..FV.....T. use median pixels
+  - name: hue
+    description: <float> ..FV.....T. set the hue (from 0 to 360) (default 0)
+  - name: lightness
+    description: <float> ..FV.....T. set the lightness (from 0 to 1) (default 0.5)
+  - name: rimin
+    description: <double> ..FV.....T. set input red black point (from -1 to 1) (default 0)
+  - name: gimin
+    description: <double> ..FV.....T. set input green black point (from -1 to 1) (default 0)
+  - name: bimin
+    description: <double> ..FV.....T. set input blue black point (from -1 to 1) (default 0)
+  - name: aimin
+    description: <double> ..FV.....T. set input alpha black point (from -1 to 1) (default 0)
+  - name: rimax
+    description: <double> ..FV.....T. set input red white point (from -1 to 1) (default 1)
+  - name: gimax
+    description: <double> ..FV.....T. set input green white point (from -1 to 1) (default 1)
+  - name: bimax
+    description: <double> ..FV.....T. set input blue white point (from -1 to 1) (default 1)
+  - name: aimax
+    description: <double> ..FV.....T. set input alpha white point (from -1 to 1) (default 1)
+  - name: romin
+    description: <double> ..FV.....T. set output red black point (from 0 to 1) (default 0)
+  - name: gomin
+    description: <double> ..FV.....T. set output green black point (from 0 to 1) (default 0)
+  - name: bomin
+    description: <double> ..FV.....T. set output blue black point (from 0 to 1) (default 0)
+  - name: aomin
+    description: <double> ..FV.....T. set output alpha black point (from 0 to 1) (default 0)
+  - name: romax
+    description: <double> ..FV.....T. set output red white point (from 0 to 1) (default 1)
+  - name: gomax
+    description: <double> ..FV.....T. set output green white point (from 0 to 1) (default 1)
+  - name: bomax
+    description: <double> ..FV.....T. set output blue white point (from 0 to 1) (default 1)
+  - name: aomax
+    description: <double> ..FV.....T. set output alpha white point (from 0 to 1) (default 1)
+  - name: preserve
+    description: <int> ..FV.....T. set preserve color mode (from 0 to 6) (default none) none 0 ..FV.....T. disabled lum 1 ..FV.....T. luminance max 2 ..FV.....T. max avg 3 ..FV.....T. average sum 4 ..FV.....T. sum nrm 5 ..FV.....T. norm pwr 6 ..FV.....T. power
+  - name: patch_size
+    description: <image_size> ..FV.....T. set patch size (default "64x64")
+  - name: nb_patches
+    description: <int> ..FV.....T. set number of patches (from 0 to 64) (default 0)
+  - name: kernel
+    description: <int> ..FV.....T. set the kernel used for measuring color difference (from 0 to 1) (default euclidean) euclidean 0 ..FV.....T. square root of sum of squared differences weuclidean 1 ..FV.....T. weighted square root of sum of squared differences
+  - name: src
+    description: <int> ..FV....... set source color matrix (from -1 to 4) (default -1) bt709 0 ..FV....... set BT.709 colorspace fcc 1 ..FV....... set FCC colorspace bt601 2 ..FV....... set BT.601 colorspace bt470 2 ..FV....... set BT.470 colorspace bt470bg 2 ..FV....... set BT.470 colorspace smpte170m 2 ..FV....... set SMTPE-170M colorspace smpte240m 3 ..FV....... set SMPTE-240M colorspace bt2020 4 ..FV....... set BT.2020 colorspace
+  - name: dst
+    description: <int> ..FV....... set destination color matrix (from -1 to 4) (default -1) bt709 0 ..FV....... set BT.709 colorspace fcc 1 ..FV....... set FCC colorspace bt601 2 ..FV....... set BT.601 colorspace bt470 2 ..FV....... set BT.470 colorspace bt470bg 2 ..FV....... set BT.470 colorspace smpte170m 2 ..FV....... set SMTPE-170M colorspace smpte240m 3 ..FV....... set SMPTE-240M colorspace bt2020 4 ..FV....... set BT.2020 colorspace
+  - name: space
+    description: <int> ..FV....... Output colorspace (from 0 to 14) (default 2) bt709 1 ..FV....... fcc 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... gbr 0 ..FV....... bt2020nc 9 ..FV....... bt2020ncl 9 ..FV.......
+  - name: primaries
+    description: <int> ..FV....... Output color primaries (from 0 to 22) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... smpte428 10 ..FV....... film 8 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... bt2020 9 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
+  - name: trc
+    description: <int> ..FV....... Output transfer characteristics (from 0 to 18) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... gamma22 4 ..FV....... bt470bg 5 ..FV....... gamma28 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... linear 8 ..FV....... srgb 13 ..FV....... iec61966-2-1 13 ..FV....... xvycc 11 ..FV....... iec61966-2-4 11 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV.......
+  - name: fast
+    description: <boolean> ..FV....... Ignore primary chromaticity and gamma correction (default false)
+  - name: dither
+    description: <int> ..FV....... Dithering mode (from 0 to 1) (default none) none 0 ..FV....... fsb 1 ..FV.......
+  - name: wpadapt
+    description: <int> ..FV....... Whitepoint adaptation method (from 0 to 2) (default bradford) bradford 0 ..FV....... vonkries 1 ..FV....... identity 2 ..FV.......
+  - name: iall
+    description: <int> ..FV....... Set all input color properties together (from 0 to 8) (default 0) bt470m 1 ..FV....... bt470bg 2 ..FV....... bt601-6-525 3 ..FV....... bt601-6-625 4 ..FV....... bt709 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... bt2020 8 ..FV.......
+  - name: ispace
+    description: <int> ..FV....... Input colorspace (from 0 to 22) (default 2) bt709 1 ..FV....... fcc 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... gbr 0 ..FV....... bt2020nc 9 ..FV....... bt2020ncl 9 ..FV.......
+  - name: irange
+    description: <int> ..FV....... Input color range (from 0 to 2) (default 0) tv 1 ..FV....... mpeg 1 ..FV....... pc 2 ..FV....... jpeg 2 ..FV.......
+  - name: iprimaries
+    description: <int> ..FV....... Input color primaries (from 0 to 22) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... smpte428 10 ..FV....... film 8 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... bt2020 9 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
+  - name: itrc
+    description: <int> ..FV....... Input transfer characteristics (from 0 to 18) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... gamma22 4 ..FV....... bt470bg 5 ..FV....... gamma28 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... linear 8 ..FV....... srgb 13 ..FV....... iec61966-2-1 13 ..FV....... xvycc 11 ..FV....... iec61966-2-4 11 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV.......
+  - name: temperature
+    description: <float> ..FV.....T. set the temperature in Kelvin (from 1000 to 40000) (default 6500)
+  - name: impulse
+    description: <int> ..FV....... when to process impulses (from 0 to 1) (default all) first 0 ..FV....... process only first impulse, ignore rest all 1 ..FV....... process all impulses
+  - name: cover
+    description: <string> ..FV....... cover bitmap filename
+  - name: out_w
+    description: <string> ..FV.....T. set the width crop area expression (default "iw")
+  - name: out_h
+    description: <string> ..FV.....T. set the height crop area expression (default "ih")
+  - name: keep_aspect
+    description: <boolean> ..FV....... keep aspect ratio (default false)
+  - name: exact
+    description: <boolean> ..FV....... do exact cropping (default false)
+  - name: skip
+    description: <int> ..FV....... Number of initial frames to skip (from 0 to INT_MAX) (default 2)
+  - name: reset_count
+    description: <int> ..FV....... Recalculate the crop area after this many frames (from 0 to INT_MAX) (default 0)
+  - name: max_outliers
+    description: <int> ..FV....... Threshold count of outliers (from 0 to INT_MAX) (default 0)
+  - name: mv_threshold
+    description: <int> ..FV....... motion vector threshold when estimating video window size (from 0 to 100) (default 8)
+  - name: master
+    description: <string> ..FV.....T. set master points coordinates
+  - name: red
+    description: <string> ..FV.....T. set red points coordinates
+  - name: green
+    description: <string> ..FV.....T. set green points coordinates
+  - name: blue
+    description: <string> ..FV.....T. set blue points coordinates
+  - name: psfile
+    description: <string> ..FV.....T. set Photoshop curves file name
+  - name: plot
+    description: <string> ..FV.....T. save Gnuplot script of the curves in specified file
+  - name: axis
+    description: <boolean> ..FV.....T. draw column/row numbers (default false)
+  - name: opacity
+    description: <float> ..FV.....T. set background opacity (from 0 to 1) (default 0.75)
+  - name: components
+    description: <int> ..FV.....T. set components to display (from 1 to 15) (default 15)
+  - name: blur
+    description: <boolean> ..FV.....T. set blur (default true)
+  - name: cycle
+    description: <int> ..FV....... set the number of frame from which one will be dropped (from 2 to 25) (default 5)
+  - name: dupthresh
+    description: <double> ..FV....... set duplicate threshold (from 0 to 100) (default 1.1)
+  - name: scthresh
+    description: <double> ..FV....... set scene change threshold (from 0 to 100) (default 15)
+  - name: blockx
+    description: <int> ..FV....... set the size of the x-axis blocks used during metric calculations (from 4 to 512) (default 32)
+  - name: blocky
+    description: <int> ..FV....... set the size of the y-axis blocks used during metric calculations (from 4 to 512) (default 32)
+  - name: ppsrc
+    description: <boolean> ..FV....... mark main input as a pre-processed input and activate clean source input stream (default false)
+  - name: chroma
+    description: <boolean> ..FV....... set whether or not chroma is considered in the metric calculations (default true)
+  - name: mixed
+    description: <boolean> ..FV....... set whether or not the input only partially contains content to be decimated (default false)
+  - name: lt
+    description: <float> ..FV....... set spatial luma threshold (from 0 to 1) (default 0.079)
+  - name: tl
+    description: <float> ..FV....... set tolerance for temporal luma (from 0 to 1) (default 0.079)
+  - name: tc
+    description: <float> ..FV....... set tolerance for chroma temporal variation (from 0 to 1) (default 0.058)
+  - name: ct
+    description: <float> ..FV....... set temporal chroma threshold (from 0 to 1) (default 0.019)
+  - name: threshold0
+    description: <int> ..FV.....T. set threshold for 1st plane (from 0 to 65535) (default 65535)
+  - name: threshold1
+    description: <int> ..FV.....T. set threshold for 2nd plane (from 0 to 65535) (default 65535)
+  - name: threshold2
+    description: <int> ..FV.....T. set threshold for 3rd plane (from 0 to 65535) (default 65535)
+  - name: threshold3
+    description: <int> ..FV.....T. set threshold for 4th plane (from 0 to 65535) (default 65535)
+  - name: bypass
+    description: <boolean> ..FV....... leave frames unchanged (default false)
+  - name: show
+    description: <boolean> ..FV....... show delogo area (default false)
+  - name: denoise
+    description: <int> ..FV....... denoise level (from 0 to 64) (default 0)
+  - name: filter_type
+    description: <int> ..FV....... filter type(derain/dehaze) (from 0 to 1) (default derain) derain 0 ..FV....... derain filter flag dehaze 1 ..FV....... dehaze filter flag
+  - name: dnn_backend
+    description: <int> ..FV....... DNN backend (from 0 to 1) (default 1)
+  - name: input
+    description: <string> ..FV....... input name of the model (default "x")
+  - name: rx
+    description: <int> ..FV....... set x for the rectangular search area (from 0 to 64) (default 16)
+  - name: ry
+    description: <int> ..FV....... set y for the rectangular search area (from 0 to 64) (default 16)
+  - name: search
+    description: <int> ..FV....... set search strategy (from 0 to 1) (default exhaustive) exhaustive 0 ..FV....... exhaustive search less 1 ..FV....... less exhaustive search
+  - name: opencl
+    description: <boolean> ..FV....... ignored (default false)
+  - name: tripod
+    description: <boolean> ..FV....... simulates a tripod by preventing any camera movement whatsoever from the original frame (default false)
+  - name: debug
+    description: <boolean> ..FV....... turn on additional debugging information (default false)
+  - name: adaptive_crop
+    description: <boolean> ..FV....... attempt to subtly crop borders to reduce mirrored content (default true)
+  - name: refine_features
+    description: <boolean> ..FV....... refine feature point locations at a sub-pixel level (default true)
+  - name: smooth_strength
+    description: <float> ..FV....... smoothing strength (0 attempts to adaptively determine optimal strength) (from 0 to 1) (default 0)
+  - name: expand
+    description: <float> ..FV.....T. set the spillmap expand (from 0 to 1) (default 0)
+  - name: brightness
+    description: <float> ..FV.....T. set brightness (from -10 to 10) (default 0)
+  - name: first_field
+    description: <int> ..FV....... select first field (from 0 to 1) (default top) top 0 ..FV....... select top field first t 0 ..FV....... select top field first bottom 1 ..FV....... select bottom field first b 1 ..FV....... select bottom field first
+  - name: pattern
+    description: <string> ..FV....... pattern that describe for how many fields a frame is to be displayed (default "23")
+  - name: start_frame
+    description: <int> ..FV....... position of first frame with respect to the pattern if stream is cut (from 0 to 13) (default 0)
+  - name: coordinates
+    description: <int> ..FV.....T. set coordinates (from 0 to 255) (default 255)
+  - name: backend_configs
+    description: <string> ..FV....... backend configs
+  - name: options
+    description: <string> ..FV......P backend configs (deprecated, use backend_configs)
+  - name: async
+    description: <boolean> ..FV....... use DNN async inference (ignored, use backend_configs='async=1') (default true)
+  - name: confidence
+    description: <float> ..FV....... threshold of confidence (from 0 to 1) (default 0.5)
+  - name: labels
+    description: <string> ..FV....... path to labels file
+  - name: height
+    description: <string> ..FV.....T. set height of the box (default "0")
+  - name: thickness
+    description: <string> ..FV.....T. set the box thickness (default "3")
+  - name: replace
+    description: <boolean> ..FV.....T. replace color & alpha (default false)
+  - name: box_source
+    description: <string> ..FV.....T. use datas from bounding box in side data
+  - name: m1
+    description: <string> ..FV....... set 1st metadata key (default "")
+  - name: fg1
+    description: <string> ..FV....... set 1st foreground color expression (default "0xffff0000")
+  - name: m2
+    description: <string> ..FV....... set 2nd metadata key (default "")
+  - name: fg2
+    description: <string> ..FV....... set 2nd foreground color expression (default "0xff00ff00")
+  - name: m3
+    description: <string> ..FV....... set 3rd metadata key (default "")
+  - name: fg3
+    description: <string> ..FV....... set 3rd foreground color expression (default "0xffff00ff")
+  - name: m4
+    description: <string> ..FV....... set 4th metadata key (default "")
+  - name: fg4
+    description: <string> ..FV....... set 4th foreground color expression (default "0xffffff00")
+  - name: min
+    description: <float> ..FV....... set minimal value (from INT_MIN to INT_MAX) (default -1)
+  - name: max
+    description: <float> ..FV....... set maximal value (from INT_MIN to INT_MAX) (default 1)
+  - name: slide
+    description: <int> ..FV....... set slide mode (from 0 to 4) (default frame) frame 0 ..FV....... draw new frames replace 1 ..FV....... replace old columns with new scroll 2 ..FV....... scroll from right to left rscroll 3 ..FV....... scroll from left to right picture 4 ..FV....... display graph in single frame
+  - name: fontfile
+    description: <string> ..FV....... set font file
+  - name: fontcolor
+    description: <color> ..FV.....T. set foreground color (default "black")
+  - name: fontcolor_expr
+    description: <string> ..FV....... set foreground color expression (default "")
+  - name: boxcolor
+    description: <color> ..FV.....T. set box color (default "white")
+  - name: bordercolor
+    description: <color> ..FV.....T. set border color (default "black")
+  - name: shadowcolor
+    description: <color> ..FV.....T. set shadow color (default "black")
+  - name: box
+    description: <boolean> ..FV.....T. set box (default false)
+  - name: boxborderw
+    description: <string> ..FV.....T. set box borders width (default "0")
+  - name: line_spacing
+    description: <int> ..FV.....T. set line spacing in pixels (from INT_MIN to INT_MAX) (default 0)
+  - name: fontsize
+    description: <string> ..FV.....T. set font size
+  - name: text_align
+    description: <flags> ..FV.....T. set text alignment (default 0) left ..FV.....T. L ..FV.....T. right ..FV.....T. R ..FV.....T. center ..FV.....T. C ..FV.....T. top ..FV.....T. T ..FV.....T. bottom ..FV.....T. B ..FV.....T. middle ..FV.....T. M ..FV.....T.
+  - name: boxw
+    description: <int> ..FV.....T. set box width (from 0 to INT_MAX) (default 0)
+  - name: boxh
+    description: <int> ..FV.....T. set box height (from 0 to INT_MAX) (default 0)
+  - name: shadowx
+    description: <int> ..FV.....T. set shadow x offset (from INT_MIN to INT_MAX) (default 0)
+  - name: shadowy
+    description: <int> ..FV.....T. set shadow y offset (from INT_MIN to INT_MAX) (default 0)
+  - name: borderw
+    description: <int> ..FV.....T. set border width (from INT_MIN to INT_MAX) (default 0)
+  - name: tabsize
+    description: <int> ..FV.....T. set tab size (from 0 to INT_MAX) (default 4)
+  - name: basetime
+    description: <int64> ..FV....... set base time (from I64_MIN to I64_MAX) (default I64_MIN)
+  - name: font
+    description: <string> ..FV....... Font name (default "Sans")
+  - name: y_align
+    description: <int> ..FV.....T. set the y alignment (from 0 to 2) (default text) text 0 ..FV....... y is referred to the top of the first text line baseline 1 ..FV....... y is referred to the baseline of the first line font 2 ..FV....... y is referred to the font defined line metrics
+  - name: timecode
+    description: <string> ..FV....... set initial timecode
+  - name: tc24hmax
+    description: <boolean> ..FV....... set 24 hours max (timecode only) (default false)
+  - name: timecode_rate
+    description: <rational> ..FV....... set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
+  - name: reload
+    description: <int> ..FV....... reload text file at specified frame interval (from 0 to INT_MAX) (default 0)
+  - name: fix_bounds
+    description: <boolean> ..FV....... check and fix text coords to avoid clipping (default false)
+  - name: start_number
+    description: <int> ..FV....... start frame number for n/frame_num variable (from 0 to INT_MAX) (default 0)
+  - name: text_source
+    description: <string> ..FV....... the source of text
+  - name: text_shaping
+    description: <boolean> ..FV....... attempt to shape text before drawing (default true)
+  - name: ft_load_flags
+    description: <flags> ..FV....... set font loading flags for libfreetype (default 0) default ..FV....... no_scale ..FV....... no_hinting ..FV....... render ..FV....... no_bitmap ..FV....... vertical_layout ..FV....... force_autohint ..FV....... crop_bitmap ..FV....... pedantic ..FV....... ignore_global_advance_width ..FV....... no_recurse ..FV....... ignore_transform ..FV....... monochrome ..FV....... linear_design ..FV....... no_autohint ..FV.......
+  - name: codebook_length
+    description: <int> ..FV....... set codebook length (from 1 to INT_MAX) (default 256)
+  - name: nb_steps
+    description: <int> ..FV....... set max number of steps used to compute the mapping (from 1 to INT_MAX) (default 1)
+  - name: pal8
+    description: <boolean> ..FV....... set the pal8 output (default false)
+  - name: use_alpha
+    description: <boolean> ..FV....... use alpha channel for mapping (default false)
+  - name: gamma_r
+    description: <string> ..FV.....T. gamma value for red (default "1.0")
+  - name: gamma_g
+    description: <string> ..FV.....T. gamma value for green (default "1.0")
+  - name: gamma_b
+    description: <string> ..FV.....T. gamma value for blue (default "1.0")
+  - name: gamma_weight
+    description: <string> ..FV.....T. set the gamma weight which reduces the effect of gamma on bright areas (default "1.0")
+  - name: rslope
+    description: <int> ..FV.....T. specify the search radius for edge slope tracing (from 1 to 15) (default 1)
+  - name: redge
+    description: <int> ..FV.....T. specify the search radius for best edge matching (from 0 to 15) (default 2)
+  - name: ecost
+    description: <int> ..FV.....T. specify the edge cost for edge matching (from 0 to 50) (default 2)
+  - name: mcost
+    description: <int> ..FV.....T. specify the middle cost for edge matching (from 0 to 50) (default 1)
+  - name: dcost
+    description: <int> ..FV.....T. specify the distance cost for edge matching (from 0 to 50) (default 1)
+  - name: exposure
+    description: <float> ..FV.....T. set the exposure correction (from -3 to 3) (default 0)
+  - name: black
+    description: <float> ..FV.....T. set the black level correction (from -1 to 1) (default 0)
+  - name: nb_frames
+    description: <int> ..FV....... Number of frames to which the effect should be applied. (from 1 to INT_MAX) (default 25)
+  - name: prev
+    description: <int> ..FV....... set number of previous frames for temporal denoising (from 0 to 1) (default 0)
+  - name: next
+    description: <int> ..FV....... set number of next frames for temporal denoising (from 0 to 1) (default 0)
+  - name: hint
+    description: <string> ..FV....... set hint file
+  - name: field
+    description: <int> ..FV....... set the field to match from (from -1 to 1) (default auto) auto -1 ..FV....... automatic (same value as 'order') bottom 0 ..FV....... bottom field top 1 ..FV....... top field
+  - name: mchroma
+    description: <boolean> ..FV....... set whether or not chroma is included during the match comparisons (default true)
+  - name: y0
+    description: <int> ..FV....... define an exclusion band which excludes the lines between y0 and y1 from the field matching decision (from 0 to INT_MAX) (default 0)
+  - name: y1
+    description: <int> ..FV....... define an exclusion band which excludes the lines between y0 and y1 from the field matching decision (from 0 to INT_MAX) (default 0)
+  - name: combmatch
+    description: <int> ..FV....... set combmatching mode (from 0 to 2) (default sc) none 0 ..FV....... disable combmatching sc 1 ..FV....... enable combmatching only on scene change full 2 ..FV....... enable combmatching all the time
+  - name: combdbg
+    description: <int> ..FV....... enable comb debug (from 0 to 2) (default none) none 0 ..FV....... no forced calculation pcn 1 ..FV....... calculate p/c/n pcnub 2 ..FV....... calculate p/c/n/u/b
+  - name: cthresh
+    description: <int> ..FV....... set the area combing threshold used for combed frame detection (from -1 to 255) (default 9)
+  - name: combpel
+    description: <int> ..FV....... set the number of combed pixels inside any of the blocky by blockx size blocks on the frame for the frame to be detected as combed (from 0 to INT_MAX) (default 80)
+  - name: left
+    description: <int> ..FV.....T. set the left fill border (from 0 to INT_MAX) (default 0)
+  - name: right
+    description: <int> ..FV.....T. set the right fill border (from 0 to INT_MAX) (default 0)
+  - name: top
+    description: <int> ..FV.....T. set the top fill border (from 0 to INT_MAX) (default 0)
+  - name: bottom
+    description: <int> ..FV.....T. set the bottom fill border (from 0 to INT_MAX) (default 0)
+  - name: object
+    description: <string> ..FV....... object bitmap filename
+  - name: mipmaps
+    description: <int> ..FV....... set mipmaps (from 1 to 5) (default 3)
+  - name: xmin
+    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
+  - name: ymin
+    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
+  - name: xmax
+    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
+  - name: ymax
+    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
+  - name: discard
+    description: <boolean> ..FV....... (default false)
+  - name: s0
+    description: '<int> ..FV....... set source #0 component value (from -1 to 65535) (default 0)'
+  - name: s1
+    description: '<int> ..FV....... set source #1 component value (from -1 to 65535) (default 0)'
+  - name: s2
+    description: '<int> ..FV....... set source #2 component value (from -1 to 65535) (default 0)'
+  - name: s3
+    description: '<int> ..FV....... set source #3 component value (from -1 to 65535) (default 0)'
+  - name: d0
+    description: '<int> ..FV....... set destination #0 component value (from 0 to 65535) (default 0)'
+  - name: d1
+    description: '<int> ..FV....... set destination #1 component value (from 0 to 65535) (default 0)'
+  - name: d2
+    description: '<int> ..FV....... set destination #2 component value (from 0 to 65535) (default 0)'
+  - name: d3
+    description: '<int> ..FV....... set destination #3 component value (from 0 to 65535) (default 0)'
+  - name: pix_fmts
+    description: <string> ..FV....... A '|'-separated list of pixel formats
+  - name: fps
+    description: <string> ..FV....... A string describing desired output framerate (default "25")
+  - name: interp_start
+    description: <int> ..FV....... point to start linear interpolation (from 0 to 255) (default 15)
+  - name: interp_end
+    description: <int> ..FV....... point to end linear interpolation (from 0 to 255) (default 240)
+  - name: scene
+    description: <double> ..FV....... scene change level (from 0 to 100) (default 8.2)
+  - name: flags
+    description: <flags> ..FV....... set flags (default scene_change_detect+scd) scene_change_detect ..FV....... enable scene change detection scd ..FV....... enable scene change detection
+  - name: step
+    description: <int> ..FV....... set frame step (from 1 to INT_MAX) (default 1)
+  - name: first
+    description: <int64> ..FV....... set first frame to freeze (from 0 to I64_MAX) (default 0)
+  - name: last
+    description: <int64> ..FV....... set last frame to freeze (from 0 to I64_MAX) (default 0)
+  - name: filter_name
+    description: <string> ..FV.......
+  - name: filter_params
+    description: <string> ..FV.....T.
+  - name: quality
+    description: <int> ..FV....... set quality (from 4 to 5) (default 4)
+  - name: use_bframe_qp
+    description: <boolean> ..FV....... use B-frames' QP (default false)
+  - name: steps
+    description: <int> ..FV.....T. set number of steps (from 1 to 6) (default 1)
+  - name: lum_expr
+    description: <string> ..FV....... set luminance expression
+  - name: lum
+    description: <string> ..FV....... set luminance expression
+  - name: cb_expr
+    description: <string> ..FV....... set chroma blue expression
+  - name: cb
+    description: <string> ..FV....... set chroma blue expression
+  - name: cr_expr
+    description: <string> ..FV....... set chroma red expression
+  - name: alpha_expr
+    description: <string> ..FV....... set alpha expression
+  - name: red_expr
+    description: <string> ..FV....... set red expression
+  - name: green_expr
+    description: <string> ..FV....... set green expression
+  - name: blue_expr
+    description: <string> ..FV....... set blue expression
+  - name: interpolation
+    description: <int> ..FV....... set interpolation method (from 0 to 1) (default bilinear) nearest 0 ..FV....... nearest interpolation n 0 ..FV....... nearest interpolation bilinear 1 ..FV....... bilinear interpolation b 1 ..FV....... bilinear interpolation
+  - name: difford
+    description: <int> ..FV....... set differentiation order (from 0 to 2) (default 1)
+  - name: minknorm
+    description: <int> ..FV....... set Minkowski norm (from 0 to 20) (default 1)
+  - name: sub
+    description: <int> ..FV.....T. subsampling ratio for fast mode (from 2 to 64) (default 4)
+  - name: guidance
+    description: '<int> ..FV....... set guidance mode (0: off mode; 1: on mode) (from 0 to 1) (default off) off 0 ..FV....... only one input is enabled on 1 ..FV....... two inputs are required'
+  - name: clut
+    description: <int> ..FV.....T. when to process CLUT (from 0 to 1) (default all) first 0 ..FV.....T. process only first CLUT, ignore rest all 1 ..FV.....T. process all CLUTs
+  - name: antibanding
+    description: <int> ..FV....... set the antibanding level (from 0 to 2) (default none) none 0 ..FV....... apply no antibanding weak 1 ..FV....... apply weak antibanding strong 2 ..FV....... apply strong antibanding
+  - name: level_height
+    description: <int> ..FV....... set level height (from 50 to 2048) (default 200)
+  - name: scale_height
+    description: <int> ..FV....... set scale height (from 0 to 40) (default 12)
+  - name: display_mode
+    description: <int> ..FV....... set display mode (from 0 to 2) (default stack) overlay 0 ..FV....... parade 1 ..FV....... stack 2 ..FV.......
+  - name: levels_mode
+    description: <int> ..FV....... set levels mode (from 0 to 1) (default linear) linear 0 ..FV....... logarithmic 1 ..FV.......
+  - name: fgopacity
+    description: <float> ..FV....... set foreground opacity (from 0 to 1) (default 0.7)
+  - name: bgopacity
+    description: <float> ..FV....... set background opacity (from 0 to 1) (default 0.5)
+  - name: colors_mode
+    description: <int> ..FV....... set colors mode (from 0 to 9) (default whiteonblack) whiteonblack 0 ..FV....... blackonwhite 1 ..FV....... whiteongray 2 ..FV....... blackongray 3 ..FV....... coloronblack 4 ..FV....... coloronwhite 5 ..FV....... colorongray 6 ..FV....... blackoncolor 7 ..FV....... whiteoncolor 8 ..FV....... grayoncolor 9 ..FV.......
+  - name: luma_spatial
+    description: <double> ..FV.....T. spatial luma strength (from 0 to DBL_MAX) (default 0)
+  - name: chroma_spatial
+    description: <double> ..FV.....T. spatial chroma strength (from 0 to DBL_MAX) (default 0)
+  - name: luma_tmp
+    description: <double> ..FV.....T. temporal luma strength (from 0 to DBL_MAX) (default 0)
+  - name: chroma_tmp
+    description: <double> ..FV.....T. temporal chroma strength (from 0 to DBL_MAX) (default 0)
+  - name: sat
+    description: <float> ..FV.....T. set the saturation value (from -1 to 1) (default 0)
+  - name: val
+    description: <float> ..FV.....T. set the value value (from -1 to 1) (default 0)
+  - name: rw
+    description: <float> ..FV.....T. set the red weight (from 0 to 1) (default 0.333)
+  - name: gw
+    description: <float> ..FV.....T. set the green weight (from 0 to 1) (default 0.334)
+  - name: bw
+    description: <float> ..FV.....T. set the blue weight (from 0 to 1) (default 0.333)
+  - name: derive_device
+    description: <string> ..FV....... Derive a new device of this type
+  - name: reverse
+    description: <int> ..FV....... Map in reverse (create and allocate in the sink) (from 0 to 1) (default 0)
+  - name: device
+    description: <int> ..FV....... Number of the device to use (from 0 to INT_MAX) (default 0)
+  - name: intl_thres
+    description: <float> ..FV....... set interlacing threshold (from -1 to FLT_MAX) (default 1.04)
+  - name: prog_thres
+    description: <float> ..FV....... set progressive threshold (from -1 to FLT_MAX) (default 1.5)
+  - name: rep_thres
+    description: <float> ..FV....... set repeat threshold (from -1 to FLT_MAX) (default 3)
+  - name: half_life
+    description: <float> ..FV....... half life of cumulative statistics (from -1 to INT_MAX) (default 0)
+  - name: luma_mode
+    description: <int> ..FV.....T. select luma mode (from 0 to 2) (default none) none 0 ..FV.....T. interleave 1 ..FV.....T. i 1 ..FV.....T. deinterleave 2 ..FV.....T. d 2 ..FV.....T.
+  - name: chroma_mode
+    description: <int> ..FV.....T. select chroma mode (from 0 to 2) (default none) none 0 ..FV.....T. interleave 1 ..FV.....T. i 1 ..FV.....T. deinterleave 2 ..FV.....T. d 2 ..FV.....T.
+  - name: alpha_mode
+    description: <int> ..FV.....T. select alpha mode (from 0 to 2) (default none) none 0 ..FV.....T. interleave 1 ..FV.....T. i 1 ..FV.....T. deinterleave 2 ..FV.....T. d 2 ..FV.....T.
+  - name: luma_swap
+    description: <boolean> ..FV.....T. swap luma fields (default false)
+  - name: ls
+    description: <boolean> ..FV.....T. swap luma fields (default false)
+  - name: chroma_swap
+    description: <boolean> ..FV.....T. swap chroma fields (default false)
+  - name: cs
+    description: <boolean> ..FV.....T. swap chroma fields (default false)
+  - name: alpha_swap
+    description: <boolean> ..FV.....T. swap alpha fields (default false)
+  - name: as
+    description: <boolean> ..FV.....T. swap alpha fields (default false)
+  - name: scan
+    description: <int> ..FV....... scanning mode (from 0 to 1) (default tff) tff 0 ..FV....... top field first bff 1 ..FV....... bottom field first
+  - name: lowpass
+    description: <int> ..FV....... set vertical low-pass filter (from 0 to 2) (default linear) off 0 ..FV....... disable vertical low-pass filter linear 1 ..FV....... linear vertical low-pass filter complex 2 ..FV....... complex vertical low-pass filter
+  - name: sharp
+    description: <boolean> ..FV....... set sharpening (default false)
+  - name: twoway
+    description: <boolean> ..FV....... set twoway (default false)
+  - name: cx
+    description: <double> ..FV.....T. set relative center x (from 0 to 1) (default 0.5)
+  - name: cy
+    description: <double> ..FV.....T. set relative center y (from 0 to 1) (default 0.5)
+  - name: k1
+    description: <double> ..FV.....T. set quadratic distortion factor (from -1 to 1) (default 0)
+  - name: k2
+    description: <double> ..FV.....T. set double quadratic distortion factor (from -1 to 1) (default 0)
+  - name: fc
+    description: <color> ..FV.....T. set the color of the unmapped pixels (default "black@0")
+  - name: crop_x
+    description: <string> ..FV.....T. Input video crop x (default "(iw-cw)/2")
+  - name: crop_y
+    description: <string> ..FV.....T. Input video crop y (default "(ih-ch)/2")
+  - name: crop_w
+    description: <string> ..FV.....T. Input video crop w (default "iw")
+  - name: crop_h
+    description: <string> ..FV.....T. Input video crop h (default "ih")
+  - name: pos_x
+    description: <string> ..FV.....T. Output video placement x (default "(ow-pw)/2")
+  - name: pos_y
+    description: <string> ..FV.....T. Output video placement y (default "(oh-ph)/2")
+  - name: pos_w
+    description: <string> ..FV.....T. Output video placement w (default "ow")
+  - name: pos_h
+    description: <string> ..FV.....T. Output video placement h (default "oh")
+  - name: normalize_sar
+    description: <boolean> ..FV....... force SAR normalization to 1:1 by adjusting pos_x/y/w/h (default false)
+  - name: pad_crop_ratio
+    description: <float> ..FV.....T. ratio between padding and cropping when normalizing SAR (0=pad, 1=crop) (from 0 to 1) (default 0)
+  - name: fillcolor
+    description: <string> ..FV.....T. Background fill color (default "black")
+  - name: corner_rounding
+    description: <float> ..FV.....T. Corner rounding radius (from 0 to 1) (default 0)
+  - name: extra_opts
+    description: <dictionary> ..FV.....T. Pass extra libplacebo-specific options using a :-separated list of key=value pairs
+  - name: colorspace
+    description: <int> ..FV.....T. select colorspace (from -1 to 14) (default auto) auto -1 ..FV....... keep the same colorspace gbr 0 ..FV....... bt709 1 ..FV....... unknown 2 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... bt2020nc 9 ..FV....... bt2020c 10 ..FV....... ictcp 14 ..FV.......
+  - name: color_primaries
+    description: <int> ..FV.....T. select color primaries (from -1 to 22) (default auto) auto -1 ..FV....... keep the same color primaries bt709 1 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... film 8 ..FV....... bt2020 9 ..FV....... smpte428 10 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
+  - name: color_trc
+    description: <int> ..FV.....T. select color transfer (from -1 to 18) (default auto) auto -1 ..FV....... keep the same color transfer bt709 1 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... linear 8 ..FV....... iec61966-2-4 11 ..FV....... bt1361e 12 ..FV....... iec61966-2-1 13 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV....... smpte2084 16 ..FV....... arib-std-b67 18 ..FV.......
+  - name: upscaler
+    description: <string> ..FV.....T. Upscaler function (default "spline36")
+  - name: downscaler
+    description: <string> ..FV.....T. Downscaler function (default "mitchell")
+  - name: frame_mixer
+    description: <string> ..FV.....T. Frame mixing function (default "none")
+  - name: lut_entries
+    description: <int> ..FV.....T. Number of scaler LUT entries (from 0 to 256) (default 0)
+  - name: antiringing
+    description: <float> ..FV.....T. Antiringing strength (for non-EWA filters) (from 0 to 1) (default 0)
+  - name: sigmoid
+    description: <boolean> ..FV.....T. Enable sigmoid upscaling (default true)
+  - name: apply_filmgrain
+    description: <boolean> ..FV.....T. Apply film grain metadata (default true)
+  - name: deband
+    description: <boolean> ..FV.....T. Enable debanding (default false)
+  - name: deband_threshold
+    description: <float> ..FV.....T. Deband threshold (from 0 to 1024) (default 4)
+  - name: deband_radius
+    description: <float> ..FV.....T. Deband radius (from 0 to 1024) (default 16)
+  - name: deband_grain
+    description: <float> ..FV.....T. Deband grain (from 0 to 1024) (default 6)
+  - name: peak_detect
+    description: <boolean> ..FV.....T. Enable dynamic peak detection for HDR tone-mapping (default true)
+  - name: smoothing_period
+    description: <float> ..FV.....T. Peak detection smoothing period (from 0 to 1000) (default 100)
+  - name: minimum_peak
+    description: <float> ..FV.....T. Peak detection minimum peak (from 0 to 100) (default 1)
+  - name: percentile
+    description: <float> ..FV.....T. Peak detection percentile (from 0 to 100) (default 99.995)
+  - name: gamut_mode
+    description: <int> ..FV.....T. Gamut-mapping mode (from 0 to 8) (default perceptual) clip 0 ..FV....... Hard-clip (RGB per-channel) perceptual 1 ..FV....... Colorimetric soft clipping relative 2 ..FV....... Relative colorimetric clipping saturation 3 ..FV....... Saturation mapping (RGB -> RGB) absolute 4 ..FV....... Absolute colorimetric clipping desaturate 5 ..FV....... Colorimetrically desaturate colors towards white darken 6 ..FV....... Colorimetric clip with bias towards darkening image to fit gamut warn 7 ..FV....... Highlight out-of-gamut colors linear 8 ..FV....... Linearly reduce chromaticity to fit gamut
+  - name: tonemapping
+    description: <int> ..FV.....T. Tone-mapping algorithm (from 0 to 11) (default auto) auto 0 ..FV....... Automatic selection clip 1 ..FV....... No tone mapping (clip st2094-40 2 ..FV....... SMPTE ST 2094-40 st2094-10 3 ..FV....... SMPTE ST 2094-10 bt.2390 4 ..FV....... ITU-R BT.2390 EETF bt.2446a 5 ..FV....... ITU-R BT.2446 Method A spline 6 ..FV....... Single-pivot polynomial spline reinhard 7 ..FV....... Reinhard mobius 8 ..FV....... Mobius hable 9 ..FV....... Filmic tone-mapping (Hable) gamma 10 ..FV....... Gamma function with knee linear 11 ..FV....... Perceptually linear stretch
+  - name: gamut_warning
+    description: <boolean> ..FV.....TP Highlight out-of-gamut colors (default false)
+  - name: gamut_clipping
+    description: <boolean> ..FV.....TP Enable desaturating colorimetric gamut clipping (default false)
+  - name: intent
+    description: <int> ..FV.....TP Rendering intent (from 0 to 3) (default perceptual) perceptual 0 ..FV....... Perceptual relative 1 ..FV....... Relative colorimetric absolute 3 ..FV....... Absolute colorimetric saturation 2 ..FV....... Saturation mapping
+  - name: tonemapping_mode
+    description: <int> ..FV.....TP Tone-mapping mode (from 0 to 4) (default auto) auto 0 ..FV....... Automatic selection rgb 1 ..FV....... Per-channel (RGB) max 2 ..FV....... Maximum component hybrid 3 ..FV....... Hybrid of Luma/RGB luma 4 ..FV....... Luminance
+  - name: overshoot
+    description: <float> ..FV.....TP Tone-mapping overshoot margin (from 0 to 1) (default 0.05)
+  - name: hybrid_mix
+    description: <float> ..FV.....T. Tone-mapping hybrid LMS mixing coefficient (from 0 to 1) (default 0.2)
+  - name: dithering
+    description: <int> ..FV.....T. Dither method to use (from -1 to 3) (default blue) none -1 ..FV....... Disable dithering blue 0 ..FV....... Blue noise ordered 1 ..FV....... Ordered LUT ordered_fixed 2 ..FV....... Fixed function ordered white 3 ..FV....... White noise
+  - name: dither_lut_size
+    description: <int> ..FV....... Dithering LUT size (from 1 to 8) (default 6)
+  - name: dither_temporal
+    description: <boolean> ..FV.....T. Enable temporal dithering (default false)
+  - name: cones
+    description: <flags> ..FV.....T. Colorblindness adaptation model (default 0) l ..FV....... L cone m ..FV....... M cone s ..FV....... S cone
+  - name: cone-strength
+    description: <float> ..FV.....T. Colorblindness adaptation strength (from 0 to 10) (default 0)
+  - name: skip_aa
+    description: <boolean> ..FV.....T. Skip anti-aliasing (default false)
+  - name: polar_cutoff
+    description: <float> ..FV.....T. Polar LUT cutoff (from 0 to 1) (default 0)
+  - name: disable_linear
+    description: <boolean> ..FV.....T. Disable linear scaling (default false)
+  - name: disable_builtin
+    description: <boolean> ..FV.....T. Disable built-in scalers (default false)
+  - name: force_icc_lut
+    description: <boolean> ..FV.....TP Deprecated, does nothing (default false)
+  - name: force_dither
+    description: <boolean> ..FV.....T. Force dithering (default false)
+  - name: disable_fbos
+    description: <boolean> ..FV.....T. Force-disable FBOs (default false)
+  - name: elasticity
+    description: <float> ..FV.....T. set the elasticity (from 0 to 10) (default 2)
+  - name: reference
+    description: <boolean> ..FV....... enable reference stream (default false)
+  - name: c0
+    description: '<string> ..FV.....T. set component #0 expression (default "clipval")'
+  - name: c3
+    description: '<string> ..FV.....T. set component #3 expression (default "clipval")'
+  - name: u
+    description: <string> ..FV.....T. set U expression (default "clipval")
+  - name: undershoot
+    description: <int> ..FV.....T. set undershoot (from 0 to 65535) (default 0)
+  - name: sum
+    description: <int> ..FV.....T. set sum value (from 0 to 65535) (default 10)
+  - name: mapping
+    description: <int> ..FV......P set input to output plane mapping (from -1 to 8.58993e+08) (default -1)
+  - name: map0s
+    description: <int> ..FV....... set 1st input to output stream mapping (from 0 to 3) (default 0)
+  - name: map0p
+    description: <int> ..FV....... set 1st input to output plane mapping (from 0 to 3) (default 0)
+  - name: map1s
+    description: <int> ..FV....... set 2nd input to output stream mapping (from 0 to 3) (default 0)
+  - name: map1p
+    description: <int> ..FV....... set 2nd input to output plane mapping (from 0 to 3) (default 0)
+  - name: map2s
+    description: <int> ..FV....... set 3rd input to output stream mapping (from 0 to 3) (default 0)
+  - name: map2p
+    description: <int> ..FV....... set 3rd input to output plane mapping (from 0 to 3) (default 0)
+  - name: map3s
+    description: <int> ..FV....... set 4th input to output stream mapping (from 0 to 3) (default 0)
+  - name: map3p
+    description: <int> ..FV....... set 4th input to output plane mapping (from 0 to 3) (default 0)
+  - name: mb_size
+    description: <int> ..FV....... macroblock size (from 8 to INT_MAX) (default 16)
+  - name: search_param
+    description: <int> ..FV....... search parameter (from 4 to INT_MAX) (default 7)
+  - name: mi_mode
+    description: <int> ..FV....... motion interpolation mode (from 0 to 2) (default mci) dup 0 ..FV....... duplicate frames blend 1 ..FV....... blend frames mci 2 ..FV....... motion compensated interpolation
+  - name: mc_mode
+    description: <int> ..FV....... motion compensation mode (from 0 to 1) (default obmc) obmc 0 ..FV....... overlapped block motion compensation aobmc 1 ..FV....... adaptive overlapped block motion compensation
+  - name: me_mode
+    description: <int> ..FV....... motion estimation mode (from 0 to 1) (default bilat) bidir 0 ..FV....... bidirectional motion estimation bilat 1 ..FV....... bilateral motion estimation
+  - name: me
+    description: <int> ..FV....... motion estimation method (from 1 to 9) (default epzs) esa 1 ..FV....... exhaustive search tss 2 ..FV....... three step search tdls 3 ..FV....... two dimensional logarithmic search ntss 4 ..FV....... new three step search fss 5 ..FV....... four step search ds 6 ..FV....... diamond search hexbs 7 ..FV....... hexagon-based search epzs 8 ..FV....... enhanced predictive zonal search umh 9 ..FV....... uneven multi-hexagon search
+  - name: vsbmc
+    description: <int> ..FV....... variable-size block motion compensation (from 0 to 1) (default 0)
+  - name: scd
+    description: <int> ..FV....... scene change detection method (from 0 to 1) (default fdiff) none 0 ..FV....... disable detection fdiff 1 ..FV....... frame difference
+  - name: scd_threshold
+    description: <double> ..FV....... scene change threshold (from 0 to 100) (default 10)
+  - name: structure
+    description: <int> ..FV.....T. when to process structures (from 0 to 1) (default all) first 0 ..FV.....T. process only first structure, ignore rest all 1 ..FV.....T. process all structure
+  - name: keep
+    description: <int> ..FV....... set the number of similar consecutive frames to be kept before starting to drop similar frames (from 0 to INT_MAX) (default 0)
+  - name: hi
+    description: <int> ..FV....... set high dropping threshold (from INT_MIN to INT_MAX) (default 768)
+  - name: lo
+    description: <int> ..FV....... set low dropping threshold (from INT_MIN to INT_MAX) (default 320)
+  - name: frac
+    description: <float> ..FV....... set fraction dropping threshold (from 0 to 1) (default 0.33)
+  - name: negate_alpha
+    description: <boolean> ..FV.....T. (default false)
+  - name: s4
+    description: <double> ..FV....... denoising strength for component 4 (from 1 to 100) (default 1)
+  - name: p1
+    description: <int> ..FV....... patch size for component 1 (from 0 to 99) (default 0)
+  - name: p2
+    description: <int> ..FV....... patch size for component 2 (from 0 to 99) (default 0)
+  - name: p3
+    description: <int> ..FV....... patch size for component 3 (from 0 to 99) (default 0)
+  - name: p4
+    description: <int> ..FV....... patch size for component 4 (from 0 to 99) (default 0)
+  - name: nsize
+    description: <int> ..FV.....T. set size of local neighborhood around each pixel, used by the predictor neural network (from 0 to 6) (default s32x4) s8x6 0 ..FV.....T. s16x6 1 ..FV.....T. s32x6 2 ..FV.....T. s48x6 3 ..FV.....T. s8x4 4 ..FV.....T. s16x4 5 ..FV.....T. s32x4 6 ..FV.....T.
+  - name: nns
+    description: <int> ..FV.....T. set number of neurons in predictor neural network (from 0 to 4) (default n32) n16 0 ..FV.....T. n32 1 ..FV.....T. n64 2 ..FV.....T. n128 3 ..FV.....T. n256 4 ..FV.....T.
+  - name: qual
+    description: <int> ..FV.....T. set quality (from 1 to 2) (default fast) fast 1 ..FV.....T. slow 2 ..FV.....T.
+  - name: etype
+    description: <int> ..FV.....T. set which set of weights to use in the predictor (from 0 to 1) (default a) a 0 ..FV.....T. weights trained to minimize absolute error abs 0 ..FV.....T. weights trained to minimize absolute error s 1 ..FV.....T. weights trained to minimize squared error mse 1 ..FV.....T. weights trained to minimize squared error
+  - name: pscrn
+    description: <int> ..FV.....T. set prescreening (from 0 to 4) (default new) none 0 ..FV.....T. original 1 ..FV.....T. new 2 ..FV.....T. new2 3 ..FV.....T. new3 4 ..FV.....T.
+  - name: all_seed
+    description: '<int> ..FV....... set component #0 noise seed (from -1 to INT_MAX) (default -1)'
+  - name: all_strength
+    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
+  - name: alls
+    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
+  - name: all_flags
+    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: allf
+    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c0_seed
+    description: '<int> ..FV....... set component #0 noise seed (from -1 to INT_MAX) (default -1)'
+  - name: c0_strength
+    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
+  - name: c0s
+    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
+  - name: c0_flags
+    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c0f
+    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c1_seed
+    description: '<int> ..FV....... set component #1 noise seed (from -1 to INT_MAX) (default -1)'
+  - name: c1_strength
+    description: '<int> ..FV....... set component #1 strength (from 0 to 100) (default 0)'
+  - name: c1s
+    description: '<int> ..FV....... set component #1 strength (from 0 to 100) (default 0)'
+  - name: c1_flags
+    description: '<flags> ..FV....... set component #1 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c1f
+    description: '<flags> ..FV....... set component #1 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c2_seed
+    description: '<int> ..FV....... set component #2 noise seed (from -1 to INT_MAX) (default -1)'
+  - name: c2_strength
+    description: '<int> ..FV....... set component #2 strength (from 0 to 100) (default 0)'
+  - name: c2s
+    description: '<int> ..FV....... set component #2 strength (from 0 to 100) (default 0)'
+  - name: c2_flags
+    description: '<flags> ..FV....... set component #2 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c2f
+    description: '<flags> ..FV....... set component #2 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c3_seed
+    description: '<int> ..FV....... set component #3 noise seed (from -1 to INT_MAX) (default -1)'
+  - name: c3_strength
+    description: '<int> ..FV....... set component #3 strength (from 0 to 100) (default 0)'
+  - name: c3s
+    description: '<int> ..FV....... set component #3 strength (from 0 to 100) (default 0)'
+  - name: c3_flags
+    description: '<flags> ..FV....... set component #3 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: c3f
+    description: '<flags> ..FV....... set component #3 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
+  - name: blackpt
+    description: <color> ..FV.....T. output color to which darkest input color is mapped (default "black")
+  - name: whitept
+    description: <color> ..FV.....T. output color to which brightest input color is mapped (default "white")
+  - name: independence
+    description: <float> ..FV.....T. proportion of independent to linked channel normalization (from 0 to 1) (default 1)
+  - name: tx
+    description: <float> ..FV.....T. set trace x position (from 0 to 1) (default 0.5)
+  - name: ty
+    description: <float> ..FV.....T. set trace y position (from 0 to 1) (default 0.9)
+  - name: tw
+    description: <float> ..FV.....T. set trace width (from 0.1 to 1) (default 0.8)
+  - name: th
+    description: <float> ..FV.....T. set trace height (from 0.1 to 1) (default 0.3)
+  - name: sc
+    description: <boolean> ..FV.....T. draw scope (default true)
+  - name: luma_strength
+    description: <double> ..FV....... set luma strength (from 0 to 1000) (default 1)
+  - name: chroma_strength
+    description: <double> ..FV....... set chroma strength (from 0 to 1000) (default 1)
+  - name: aspect
+    description: <rational> ..FV....... pad to fit an aspect instead of a resolution (from 0 to DBL_MAX) (default 0/1)
+  - name: max_colors
+    description: <int> ..FV....... set the maximum number of colors to use in the palette (from 2 to 256) (default 256)
+  - name: stats_mode
+    description: <int> ..FV....... set statistics mode (from 0 to 2) (default full) full 0 ..FV....... compute full frame histograms diff 1 ..FV....... compute histograms only for the part that differs from previous frame single 2 ..FV....... compute new histogram for each frame
+  - name: bayer_scale
+    description: <int> ..FV....... set scale for bayer dithering (from 0 to 5) (default 2)
+  - name: diff_mode
+    description: <int> ..FV....... set frame difference mode (from 0 to 1) (default 0) rectangle 1 ..FV....... process smallest different rectangle
+  - name: new
+    description: <boolean> ..FV....... take new palette for each output frame (default false)
+  - name: alpha_threshold
+    description: <int> ..FV....... set the alpha threshold for transparency (from 0 to 255) (default 128)
+  - name: debug_kdtree
+    description: <string> ..FV....... save Graphviz graph of the kdtree in specified file
+  - name: x0
+    description: <string> ..FV....... set top left x coordinate (default "0")
+  - name: x1
+    description: <string> ..FV....... set top right x coordinate (default "W")
+  - name: x2
+    description: <string> ..FV....... set bottom left x coordinate (default "0")
+  - name: y2
+    description: <string> ..FV....... set bottom left y coordinate (default "H")
+  - name: x3
+    description: <string> ..FV....... set bottom right x coordinate (default "W")
+  - name: y3
+    description: <string> ..FV....... set bottom right y coordinate (default "H")
+  - name: sense
+    description: <int> ..FV....... specify the sense of the coordinates (from 0 to 1) (default source) source 0 ..FV....... specify locations in source to send to corners in destination destination 1 ..FV....... specify locations in destination to send corners of source
+  - name: frames
+    description: <int> ..FV....... set how many frames to use (from 2 to 240) (default 30)
+  - name: wx
+    description: <float> ..FV.....T. set window x offset (from -1 to 1) (default -1)
+  - name: wy
+    description: <float> ..FV.....T. set window y offset (from -1 to 1) (default -1)
+  - name: subfilters
+    description: <string> ..FV....... set postprocess subfilters (default "de")
+  - name: inplace
+    description: <boolean> ..FV....... enable inplace mode (default false)
+  - name: saturatio
+    description: <float> ..FV....... Output video saturation (from 0 to 10) (default 1)
+  - name: source
+    description: <string> ..FV....... OpenCL program source file
+  - name: index
+    description: <int> ..FV.....T. set component as base (from 0 to 3) (default 0)
+  - name: stats_file
+    description: <string> ..FV....... Set file where to store per-frame difference information
+  - name: stats_version
+    description: <int> ..FV....... Set the format version for the stats file. (from 1 to 2) (default 1)
+  - name: output_max
+    description: <boolean> ..FV....... Add raw stats (max values) to the output log. (default false)
+  - name: jl
+    description: <int> ..FV....... set left junk size (from 0 to INT_MAX) (default 1)
+  - name: jr
+    description: <int> ..FV....... set right junk size (from 0 to INT_MAX) (default 1)
+  - name: jt
+    description: <int> ..FV....... set top junk size (from 1 to INT_MAX) (default 4)
+  - name: jb
+    description: <int> ..FV....... set bottom junk size (from 1 to INT_MAX) (default 4)
+  - name: sb
+    description: <boolean> ..FV....... set strict breaks (default false)
+  - name: mp
+    description: <int> ..FV....... set metric plane (from 0 to 2) (default y) y 0 ..FV....... luma u 1 ..FV....... chroma blue v 2 ..FV....... chroma red
+  - name: scan_min
+    description: <int> ..FV.....T. set from which line to scan for codes (from 0 to INT_MAX) (default 0)
+  - name: scan_max
+    description: <int> ..FV.....T. set to which line to scan for codes (from 0 to INT_MAX) (default 29)
+  - name: spw
+    description: <float> ..FV.....T. set ratio of width reserved for sync code detection (from 0.1 to 0.7) (default 0.27)
+  - name: chp
+    description: <boolean> ..FV.....T. check and apply parity bit (default false)
+  - name: thr_b
+    description: <double> ..FV....... black color threshold (from 0 to 1) (default 0.2)
+  - name: thr_w
+    description: <double> ..FV....... white color threshold (from 0 to 1) (default 0.6)
+  - name: m0
+    description: <int> ..FV....... set mode for 1st plane (from 0 to 24) (default 0)
+  - name: rv
+    description: <int> ..FV.....T. shift red vertically (from -255 to 255) (default 0)
+  - name: gv
+    description: <int> ..FV.....T. shift green vertically (from -255 to 255) (default 0)
+  - name: bv
+    description: <int> ..FV.....T. shift blue vertically (from -255 to 255) (default 0)
+  - name: ah
+    description: <int> ..FV.....T. shift alpha horizontally (from -255 to 255) (default 0)
+  - name: av
+    description: <int> ..FV.....T. shift alpha vertically (from -255 to 255) (default 0)
+  - name: ow
+    description: <string> ..FV....... set output width expression (default "iw")
+  - name: oh
+    description: <string> ..FV....... set output height expression (default "ih")
+  - name: bilinear
+    description: <boolean> ..FV....... use bilinear interpolation (default true)
+  - name: lpfr
+    description: <float> ..FV....... set luma pre-filter radius (from 0.1 to 2) (default 1)
+  - name: cpfr
+    description: <float> ..FV....... set chroma pre-filter radius (from -0.9 to 2) (default -0.9)
+  - name: interl
+    description: <boolean> ..FV....... set interlacing (default false)
+  - name: in_color_matrix
+    description: <string> ..FV....... set input YCbCr type (default "auto") auto ..FV....... bt601 ..FV....... bt470 ..FV....... smpte170m ..FV....... bt709 ..FV....... fcc ..FV....... smpte240m ..FV....... bt2020 ..FV.......
+  - name: out_color_matrix
+    description: <string> ..FV....... set output YCbCr type auto ..FV....... bt601 ..FV....... bt470 ..FV....... smpte170m ..FV....... bt709 ..FV....... fcc ..FV....... smpte240m ..FV....... bt2020 ..FV.......
+  - name: in_range
+    description: <int> ..FV....... set input color range (from 0 to 2) (default auto) auto 0 ..FV....... unknown 0 ..FV....... full 2 ..FV....... limited 1 ..FV....... jpeg 2 ..FV....... mpeg 1 ..FV....... tv 1 ..FV....... pc 2 ..FV.......
+  - name: out_range
+    description: <int> ..FV....... set output color range (from 0 to 2) (default auto) auto 0 ..FV....... unknown 0 ..FV....... full 2 ..FV....... limited 1 ..FV....... jpeg 2 ..FV....... mpeg 1 ..FV....... tv 1 ..FV....... pc 2 ..FV.......
+  - name: in_v_chr_pos
+    description: <int> ..FV....... input vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
+  - name: in_h_chr_pos
+    description: <int> ..FV....... input horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
+  - name: out_v_chr_pos
+    description: <int> ..FV....... output vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
+  - name: out_h_chr_pos
+    description: <int> ..FV....... output horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
+  - name: param0
+    description: <double> ..FV....... Scaler param 0 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+  - name: param1
+    description: <double> ..FV....... Scaler param 1 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+  - name: interp_algo
+    description: <int> ..FV....... Interpolation algorithm used for resizing (from 0 to 4) (default 0) nearest 1 ..FV....... nearest neighbour bilinear 2 ..FV....... bilinear bicubic 3 ..FV....... bicubic lanczos 4 ..FV....... lanczos
+  - name: passthrough
+    description: <boolean> ..FV....... Do not process frames at all if parameters match (default true)
+  - name: scaler
+    description: <int> ..FV....... Scaler function (from 0 to 2) (default bilinear) bilinear 0 ..FV....... Bilinear interpolation (fastest) nearest 1 ..FV....... Nearest (useful for pixel art)
+  - name: sc_pass
+    description: <boolean> ..FV....... Set the flag to pass scene change frames (default false)
+  - name: horizontal
+    description: <float> ..FV.....T. set the horizontal scrolling speed (from -1 to 1) (default 0)
+  - name: vertical
+    description: <float> ..FV.....T. set the vertical scrolling speed (from -1 to 1) (default 0)
+  - name: hpos
+    description: <float> ..FV....... set initial horizontal position (from 0 to 1) (default 0)
+  - name: vpos
+    description: <float> ..FV....... set initial vertical position (from 0 to 1) (default 0)
+  - name: reds
+    description: <string> ..FV....... adjust red regions
+  - name: yellows
+    description: <string> ..FV....... adjust yellow regions
+  - name: greens
+    description: <string> ..FV....... adjust green regions
+  - name: cyans
+    description: <string> ..FV....... adjust cyan regions
+  - name: blues
+    description: <string> ..FV....... adjust blue regions
+  - name: magentas
+    description: <string> ..FV....... adjust magenta regions
+  - name: whites
+    description: <string> ..FV....... adjust white regions
+  - name: neutrals
+    description: <string> ..FV....... adjust neutral regions
+  - name: blacks
+    description: <string> ..FV....... adjust black regions
+  - name: dar
+    description: <string> ..FV....... set display aspect ratio (default "0")
+  - name: field_mode
+    description: <int> ..FV....... select interlace mode (from -1 to 2) (default auto) auto -1 ..FV....... keep the same input field bff 0 ..FV....... mark as bottom-field-first tff 1 ..FV....... mark as top-field-first prog 2 ..FV....... mark as progressive
+  - name: sar
+    description: <string> ..FV....... set sample (pixel) aspect ratio (default "0")
+  - name: sharpness
+    description: <int> ..FV....... sharpness level (from 0 to 64) (default 44)
+  - name: shx
+    description: <float> ..FV.....T. set x shear factor (from -2 to 2) (default 0)
+  - name: shy
+    description: <float> ..FV.....T. set y shear factor (from -2 to 2) (default 0)
+  - name: checksum
+    description: <boolean> ..FV....... calculate checksums (default true)
+  - name: map0
+    description: <int> ..FV....... Index of the input plane to be used as the first output plane (from 0 to 3) (default 0)
+  - name: map1
+    description: <int> ..FV....... Index of the input plane to be used as the second output plane (from 0 to 3) (default 1)
+  - name: map2
+    description: <int> ..FV....... Index of the input plane to be used as the third output plane (from 0 to 3) (default 2)
+  - name: map3
+    description: <int> ..FV....... Index of the input plane to be used as the fourth output plane (from 0 to 3) (default 3)
+  - name: stat
+    description: <flags> ..FV....... set statistics filters (default 0) tout ..FV....... analyze pixels for temporal outliers vrep ..FV....... analyze video lines for vertical line repetition brng ..FV....... analyze for pixels outside of broadcast range
+  - name: out
+    description: <int> ..FV....... set video filter (from -1 to 2) (default -1) tout 0 ..FV....... highlight pixels that depict temporal outliers vrep 1 ..FV....... highlight video lines that depict vertical line repetition brng 2 ..FV....... highlight pixels that are outside of broadcast range
+  - name: detectmode
+    description: <int> ..FV....... set the detectmode (from 0 to 2) (default off) off 0 ..FV....... full 1 ..FV....... fast 2 ..FV.......
+  - name: th_d
+    description: <int> ..FV....... threshold to detect one word as similar (from 1 to INT_MAX) (default 9000)
+  - name: th_dc
+    description: <int> ..FV....... threshold to detect all words as similar (from 1 to INT_MAX) (default 60000)
+  - name: th_xh
+    description: <int> ..FV....... threshold to detect frames as similar (from 1 to INT_MAX) (default 116)
+  - name: th_di
+    description: <int> ..FV....... minimum length of matching sequence in frames (from 0 to INT_MAX) (default 0)
+  - name: th_it
+    description: <double> ..FV....... threshold for relation of good to all frames (from 0 to 1) (default 0.5)
+  - name: print_summary
+    description: <boolean> ..FV....... Print summary showing average values (default false)
+  - name: luma_threshold
+    description: <int> ..FV....... set luma threshold (from -30 to 30) (default 0)
+  - name: chroma_threshold
+    description: <int> ..FV....... set chroma threshold (from -31 to 30) (default -31)
+  - name: scale_factor
+    description: <int> ..FV....... scale factor for SRCNN model (from 2 to 4) (default 2)
+  - name: compute_chroma
+    description: <int> ..FV....... Specifies if non-luma channels must be computed (from 0 to 1) (default 1)
+  - name: frame_skip_ratio
+    description: <int> ..FV....... Specifies the number of frames to be skipped from evaluation, for every evaluated frame (from 0 to 1e+06) (default 0)
+  - name: ref_projection
+    description: <int> ..FV....... projection of the reference video (from 0 to 4) (default e) e 4 ..FV....... equirectangular equirect 4 ..FV....... equirectangular c3x2 0 ..FV....... cubemap 3x2 c2x3 1 ..FV....... cubemap 2x3 barrel 2 ..FV....... barrel facebook's 360 format barrelsplit 3 ..FV....... barrel split facebook's 360 format
+  - name: main_projection
+    description: <int> ..FV....... projection of the main video (from 0 to 5) (default 5) e 4 ..FV....... equirectangular equirect 4 ..FV....... equirectangular c3x2 0 ..FV....... cubemap 3x2 c2x3 1 ..FV....... cubemap 2x3 barrel 2 ..FV....... barrel facebook's 360 format barrelsplit 3 ..FV....... barrel split facebook's 360 format
+  - name: ref_stereo
+    description: <int> ..FV....... stereo format of the reference video (from 0 to 2) (default mono) mono 2 ..FV....... tb 0 ..FV....... lr 1 ..FV.......
+  - name: main_stereo
+    description: <int> ..FV....... stereo format of main video (from 0 to 3) (default 3) mono 2 ..FV....... tb 0 ..FV....... lr 1 ..FV.......
+  - name: ref_pad
+    description: <float> ..FV....... Expansion (padding) coefficient for each cube face of the reference video (from 0 to 10) (default 0)
+  - name: main_pad
+    description: <float> ..FV....... Expansion (padding) coeffiecient for each cube face of the main video (from 0 to 10) (default 0)
+  - name: use_tape
+    description: <int> ..FV....... Specifies if the tape based SSIM 360 algorithm must be used independent of the input video types (from 0 to 1) (default 0)
+  - name: heatmap_str
+    description: <string> ..FV....... Heatmap data for view-based evaluation. For heatmap file format, please refer to EntSphericalVideoHeatmapData.
+  - name: in
+    description: <int> ..FV....... set input format (from 16 to 32) (default sbsl) ab2l 24 ..FV....... above below half height left first tb2l 24 ..FV....... above below half height left first ab2r 25 ..FV....... above below half height right first tb2r 25 ..FV....... above below half height right first abl 22 ..FV....... above below left first tbl 22 ..FV....... above below left first abr 23 ..FV....... above below right first tbr 23 ..FV....... above below right first al 26 ..FV....... alternating frames left first ar 27 ..FV....... alternating frames right first sbs2l 20 ..FV....... side by side half width left first sbs2r 21 ..FV....... side by side half width right first sbsl 18 ..FV....... side by side left first sbsr 19 ..FV....... side by side right first irl 16 ..FV....... interleave rows left first irr 17 ..FV....... interleave rows right first icl 30 ..FV....... interleave columns left first icr 31 ..FV....... interleave columns right first
+  - name: charenc
+    description: <string> ..FV....... set input character encoding
+  - name: stream_index
+    description: <int> ..FV....... set stream index (from -1 to INT_MAX) (default -1)
+  - name: si
+    description: <int> ..FV....... set stream index (from -1 to INT_MAX) (default -1)
+  - name: force_style
+    description: <string> ..FV....... force subtitle style
+  - name: wrap_unicode
+    description: <boolean> ..FV....... break lines according to the Unicode Line Breaking Algorithm (default auto)
+  - name: envelope
+    description: <boolean> ..FV....... display envelope (default false)
+  - name: ecolor
+    description: <color> ..FV....... set envelope color (default "gold")
+  - name: ec
+    description: <color> ..FV....... set envelope color (default "gold")
+  - name: log
+    description: <int> ..FV....... force stats logging level (from INT_MIN to INT_MAX) (default info) quiet -8 ..FV....... logging disabled info 32 ..FV....... information logging level verbose 40 ..FV....... verbose logging level
+  - name: layout
+    description: <image_size> ..FV....... set grid size (default "6x5")
+  - name: margin
+    description: <int> ..FV....... set outer border margin in pixels (from 0 to 1024) (default 0)
+  - name: padding
+    description: <int> ..FV....... set inner border thickness in pixels (from 0 to 1024) (default 0)
+  - name: init_padding
+    description: <int> ..FV....... set how many frames to initially pad (from 0 to INT_MAX) (default 0)
+  - name: tonemap
+    description: <int> ..FV....... tonemap algorithm selection (from 0 to 6) (default none) none 0 ..FV....... linear 1 ..FV....... gamma 2 ..FV....... clip 3 ..FV....... reinhard 4 ..FV....... hable 5 ..FV....... mobius 6 ..FV.......
+  - name: desat
+    description: <double> ..FV....... desaturation strength (from 0 to DBL_MAX) (default 2)
+  - name: matrix
+    description: <int> ..FV....... set colorspace matrix (from -1 to INT_MAX) (default -1) bt709 1 ..FV....... bt2020 9 ..FV.......
+  - name: stop
+    description: <int> ..FV....... set the number of frames to add after input finished (from -1 to INT_MAX) (default 0)
+  - name: dir
+    description: <int> ..FV....... set transpose direction (from 0 to 7) (default cclock_flip) cclock_flip 0 ..FV....... rotate counter-clockwise with vertical flip clock 1 ..FV....... rotate clockwise cclock 2 ..FV....... rotate counter-clockwise clock_flip 3 ..FV....... rotate clockwise with vertical flip
+  - name: end_frame
+    description: <int64> ..FV....... Number of the first frame that should be dropped again (from 0 to I64_MAX) (default I64_MAX)
+  - name: luma_msize_x
+    description: <int> ..FV....... set luma matrix horizontal size (from 3 to 23) (default 5)
+  - name: lx
+    description: <int> ..FV....... set luma matrix horizontal size (from 3 to 23) (default 5)
+  - name: luma_msize_y
+    description: <int> ..FV....... set luma matrix vertical size (from 3 to 23) (default 5)
+  - name: ly
+    description: <int> ..FV....... set luma matrix vertical size (from 3 to 23) (default 5)
+  - name: luma_amount
+    description: <float> ..FV....... set luma effect strength (from -2 to 5) (default 1)
+  - name: la
+    description: <float> ..FV....... set luma effect strength (from -2 to 5) (default 1)
+  - name: chroma_msize_x
+    description: <int> ..FV....... set chroma matrix horizontal size (from 3 to 23) (default 5)
+  - name: chroma_msize_y
+    description: <int> ..FV....... set chroma matrix vertical size (from 3 to 23) (default 5)
+  - name: chroma_amount
+    description: <float> ..FV....... set chroma effect strength (from -2 to 5) (default 0)
+  - name: ca
+    description: <float> ..FV....... set chroma effect strength (from -2 to 5) (default 0)
+  - name: alpha_msize_x
+    description: <int> ..FV....... set alpha matrix horizontal size (from 3 to 23) (default 5)
+  - name: ax
+    description: <int> ..FV....... set alpha matrix horizontal size (from 3 to 23) (default 5)
+  - name: alpha_msize_y
+    description: <int> ..FV....... set alpha matrix vertical size (from 3 to 23) (default 5)
+  - name: ay
+    description: <int> ..FV....... set alpha matrix vertical size (from 3 to 23) (default 5)
+  - name: alpha_amount
+    description: <float> ..FV....... set alpha effect strength (from -2 to 5) (default 0)
+  - name: codec
+    description: <string> ..FV....... Codec name (default "snow")
+  - name: in_stereo
+    description: <int> ..FV....... input stereo format (from 0 to 2) (default 2d) 2d 0 ..FV....... 2d mono sbs 1 ..FV....... side by side tb 2 ..FV....... top bottom
+  - name: out_stereo
+    description: <int> ..FV....... output stereo format (from 0 to 2) (default 2d) 2d 0 ..FV....... 2d mono sbs 1 ..FV....... side by side tb 2 ..FV....... top bottom
+  - name: in_forder
+    description: <string> ..FV....... input cubemap face order (default "rludfb")
+  - name: out_forder
+    description: <string> ..FV....... output cubemap face order (default "rludfb")
+  - name: in_frot
+    description: <string> ..FV....... input cubemap face rotation (default "000000")
+  - name: out_frot
+    description: <string> ..FV....... output cubemap face rotation (default "000000")
+  - name: in_pad
+    description: <float> ..FV.....T. percent input cubemap pads (from 0 to 0.1) (default 0)
+  - name: out_pad
+    description: <float> ..FV.....T. percent output cubemap pads (from 0 to 0.1) (default 0)
+  - name: fin_pad
+    description: <int> ..FV.....T. fixed input cubemap pads (from 0 to 100) (default 0)
+  - name: fout_pad
+    description: <int> ..FV.....T. fixed output cubemap pads (from 0 to 100) (default 0)
+  - name: yaw
+    description: <float> ..FV.....T. yaw rotation (from -180 to 180) (default 0)
+  - name: roll
+    description: <float> ..FV.....T. roll rotation (from -180 to 180) (default 0)
+  - name: rorder
+    description: <string> ..FV.....T. rotation order (default "ypr")
+  - name: h_fov
+    description: <float> ..FV.....T. output horizontal field of view (from 0 to 360) (default 0)
+  - name: v_fov
+    description: <float> ..FV.....T. output vertical field of view (from 0 to 360) (default 0)
+  - name: d_fov
+    description: <float> ..FV.....T. output diagonal field of view (from 0 to 360) (default 0)
+  - name: h_flip
+    description: <boolean> ..FV.....T. flip out video horizontally (default false)
+  - name: v_flip
+    description: <boolean> ..FV.....T. flip out video vertically (default false)
+  - name: d_flip
+    description: <boolean> ..FV.....T. flip out video indepth (default false)
+  - name: ih_flip
+    description: <boolean> ..FV.....T. flip in video horizontally (default false)
+  - name: iv_flip
+    description: <boolean> ..FV.....T. flip in video vertically (default false)
+  - name: in_trans
+    description: <boolean> ..FV....... transpose video input (default false)
+  - name: out_trans
+    description: <boolean> ..FV....... transpose video output (default false)
+  - name: ih_fov
+    description: <float> ..FV.....T. input horizontal field of view (from 0 to 360) (default 0)
+  - name: iv_fov
+    description: <float> ..FV.....T. input vertical field of view (from 0 to 360) (default 0)
+  - name: id_fov
+    description: <float> ..FV.....T. input diagonal field of view (from 0 to 360) (default 0)
+  - name: h_offset
+    description: <float> ..FV.....T. output horizontal off-axis offset (from -1 to 1) (default 0)
+  - name: v_offset
+    description: <float> ..FV.....T. output vertical off-axis offset (from -1 to 1) (default 0)
+  - name: alpha_mask
+    description: <boolean> ..FV....... build mask in alpha plane (default false)
+  - name: reset_rot
+    description: <boolean> ..FV.....T. reset rotation (default false)
+  - name: nsteps
+    description: <int> ..FV....... set number of steps (from 1 to 32) (default 6)
+  - name: min_r
+    description: <int> ..FV.....T. set min blur radius (from 0 to 254) (default 0)
+  - name: max_r
+    description: <int> ..FV.....T. set max blur radius (from 1 to 255) (default 8)
+  - name: graticule
+    description: <int> ..FV....... set graticule (from 0 to 3) (default none) none 0 ..FV....... green 1 ..FV....... color 2 ..FV....... invert 3 ..FV.......
+  - name: lthreshold
+    description: <float> ..FV....... set low threshold (from 0 to 1) (default 0)
+  - name: hthreshold
+    description: <float> ..FV....... set high threshold (from 0 to 1) (default 1)
+  - name: tint0
+    description: <float> ..FV.....T. set 1st tint (from -1 to 1) (default 0)
+  - name: t0
+    description: <float> ..FV.....T. set 1st tint (from -1 to 1) (default 0)
+  - name: tint1
+    description: <float> ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
+  - name: t1
+    description: <float> ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
+  - name: rbal
+    description: <float> ..FV.....T. set the red balance value (from -10 to 10) (default 1)
+  - name: gbal
+    description: <float> ..FV.....T. set the green balance value (from -10 to 10) (default 1)
+  - name: bbal
+    description: <float> ..FV.....T. set the blue balance value (from -10 to 10) (default 1)
+  - name: rlum
+    description: <float> ..FV.....T. set the red luma coefficient (from 0 to 1) (default 0.072186)
+  - name: glum
+    description: <float> ..FV.....T. set the green luma coefficient (from 0 to 1) (default 0.715158)
+  - name: blum
+    description: <float> ..FV.....T. set the blue luma coefficient (from 0 to 1) (default 0.212656)
+  - name: alternate
+    description: <boolean> ..FV.....T. use alternate colors (default false)
+  - name: result
+    description: <string> ..FV....... path to the file used to write the transforms (default "transforms.trf")
+  - name: shakiness
+    description: '<int> ..FV....... how shaky is the video and how quick is the camera? 1: little (fast) 10: very strong/quick (slow) (from 1 to 10) (default 5)'
+  - name: stepsize
+    description: <int> ..FV....... region around minimum is scanned with 1 pixel resolution (from 1 to 32) (default 6)
+  - name: mincontrast
+    description: <double> ..FV....... below this contrast a field is discarded (0-1) (from 0 to 1) (default 0.25)
+  - name: optalgo
+    description: <int> ..FV....... set camera path optimization algo (from 0 to 2) (default opt) opt 0 ..FV....... global optimization gauss 1 ..FV....... gaussian kernel avg 2 ..FV....... simple averaging on motion
+  - name: maxshift
+    description: <int> ..FV....... set maximal number of pixels to translate image (from -1 to 500) (default -1)
+  - name: maxangle
+    description: <double> ..FV....... set maximal angle in rad to rotate image (from -1 to 3.14) (default -1)
+  - name: crop
+    description: <int> ..FV....... set cropping mode (from 0 to 1) (default keep) keep 0 ..FV....... keep border black 1 ..FV....... black border
+  - name: relative
+    description: <int> ..FV....... consider transforms as relative (from 0 to 1) (default 1)
+  - name: zoom
+    description: '<double> ..FV....... set percentage to zoom (>0: zoom in, <0: zoom out (from -100 to 100) (default 0)'
+  - name: optzoom
+    description: '<int> ..FV....... set optimal zoom (0: nothing, 1: optimal static zoom, 2: optimal dynamic zoom) (from 0 to 2) (default 1)'
+  - name: zoomspeed
+    description: '<double> ..FV....... for adative zoom: percent to zoom maximally each frame (from 0 to 5) (default 0.25)'
+  - name: interpol
+    description: <int> ..FV....... set type of interpolation (from 0 to 3) (default bilinear) no 0 ..FV....... no interpolation linear 1 ..FV....... linear (horizontal) bilinear 2 ..FV....... bi-linear bicubic 3 ..FV....... bi-cubic
+  - name: mirror
+    description: <boolean> ..FV....... set mirroring (default true)
+  - name: display
+    description: <int> ..FV....... set display mode (from 0 to 2) (default stack) overlay 0 ..FV....... stack 1 ..FV....... parade 2 ..FV.......
+  - name: fl
+    description: <flags> ..FV.....T. set graticule flags (default numbers) numbers ..FV.....T. draw numbers dots ..FV.....T. draw dots instead of lines
+  - name: fitmode
+    description: <int> ..FV....... set fit mode (from 0 to 1) (default none) none 0 ..FV....... size 1 ..FV.......
+  - name: fm
+    description: <int> ..FV....... set fit mode (from 0 to 1) (default none) none 0 ..FV....... size 1 ..FV.......
+  - name: secondary
+    description: <int> ..FV....... when to process secondary frame (from 0 to 1) (default all) first 0 ..FV....... process only first secondary frame, ignore rest all 1 ..FV....... process all secondary frames
+  - name: transition
+    description: <int> ..FV....... set cross fade transition (from -1 to 57) (default fade) custom -1 ..FV....... custom transition fade 0 ..FV....... fade transition wipeleft 1 ..FV....... wipe left transition wiperight 2 ..FV....... wipe right transition wipeup 3 ..FV....... wipe up transition wipedown 4 ..FV....... wipe down transition slideleft 5 ..FV....... slide left transition slideright 6 ..FV....... slide right transition slideup 7 ..FV....... slide up transition slidedown 8 ..FV....... slide down transition circlecrop 9 ..FV....... circle crop transition rectcrop 10 ..FV....... rect crop transition distance 11 ..FV....... distance transition fadeblack 12 ..FV....... fadeblack transition fadewhite 13 ..FV....... fadewhite transition radial 14 ..FV....... radial transition smoothleft 15 ..FV....... smoothleft transition smoothright 16 ..FV....... smoothright transition smoothup 17 ..FV....... smoothup transition smoothdown 18 ..FV....... smoothdown transition circleopen 19 ..FV....... circleopen transition circleclose 20 ..FV....... circleclose transition vertopen 21 ..FV....... vert open transition vertclose 22 ..FV....... vert close transition horzopen 23 ..FV....... horz open transition horzclose 24 ..FV....... horz close transition dissolve 25 ..FV....... dissolve transition pixelize 26 ..FV....... pixelize transition diagtl 27 ..FV....... diag tl transition diagtr 28 ..FV....... diag tr transition diagbl 29 ..FV....... diag bl transition diagbr 30 ..FV....... diag br transition hlslice 31 ..FV....... hl slice transition hrslice 32 ..FV....... hr slice transition vuslice 33 ..FV....... vu slice transition vdslice 34 ..FV....... vd slice transition hblur 35 ..FV....... hblur transition fadegrays 36 ..FV....... fadegrays transition wipetl 37 ..FV....... wipe tl transition wipetr 38 ..FV....... wipe tr transition wipebl 39 ..FV....... wipe bl transition wipebr 40 ..FV....... wipe br transition squeezeh 41 ..FV....... squeeze h transition squeezev 42 ..FV....... squeeze v transition zoomin 43 ..FV....... zoom in transition fadefast 44 ..FV....... fast fade transition fadeslow 45 ..FV....... slow fade transition hlwind 46 ..FV....... hl wind transition hrwind 47 ..FV....... hr wind transition vuwind 48 ..FV....... vu wind transition vdwind 49 ..FV....... vd wind transition coverleft 50 ..FV....... cover left transition coverright 51 ..FV....... cover right transition coverup 52 ..FV....... cover up transition coverdown 53 ..FV....... cover down transition revealleft 54 ..FV....... reveal left transition revealright 55 ..FV....... reveal right transition revealup 56 ..FV....... reveal up transition revealdown 57 ..FV....... reveal down transition
+  - name: grid
+    description: <image_size> ..FV....... set fixed size grid layout
+  - name: rangein
+    description: <int> ..FV....... set input color range (from -1 to 1) (default input) input -1 ..FV....... limited 0 ..FV....... full 1 ..FV....... unknown -1 ..FV....... tv 0 ..FV....... pc 1 ..FV.......
+  - name: rin
+    description: <int> ..FV....... set input color range (from -1 to 1) (default input) input -1 ..FV....... limited 0 ..FV....... full 1 ..FV....... unknown -1 ..FV....... tv 0 ..FV....... pc 1 ..FV.......
+  - name: primariesin
+    description: <int> ..FV....... set input color primaries (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 170m 6 ..FV....... 240m 7 ..FV....... 2020 9 ..FV....... unknown 2 ..FV....... bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... film 8 ..FV....... bt2020 9 ..FV....... smpte428 10 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
+  - name: pin
+    description: <int> ..FV....... set input color primaries (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 170m 6 ..FV....... 240m 7 ..FV....... 2020 9 ..FV....... unknown 2 ..FV....... bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... film 8 ..FV....... bt2020 9 ..FV....... smpte428 10 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
+  - name: transferin
+    description: <int> ..FV....... set input transfer characteristic (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 601 6 ..FV....... linear 8 ..FV....... 2020_10 14 ..FV....... 2020_12 15 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... bt709 1 ..FV....... linear 8 ..FV....... log100 9 ..FV....... log316 10 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV....... smpte2084 16 ..FV....... iec61966-2-4 11 ..FV....... iec61966-2-1 13 ..FV....... arib-std-b67 18 ..FV.......
+  - name: tin
+    description: <int> ..FV....... set input transfer characteristic (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 601 6 ..FV....... linear 8 ..FV....... 2020_10 14 ..FV....... 2020_12 15 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... bt709 1 ..FV....... linear 8 ..FV....... log100 9 ..FV....... log316 10 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV....... smpte2084 16 ..FV....... iec61966-2-4 11 ..FV....... iec61966-2-1 13 ..FV....... arib-std-b67 18 ..FV.......
+  - name: matrixin
+    description: <int> ..FV....... set input colorspace matrix (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 470bg 5 ..FV....... 170m 6 ..FV....... 2020_ncl 9 ..FV....... 2020_cl 10 ..FV....... unknown 2 ..FV....... gbr 0 ..FV....... bt709 1 ..FV....... fcc 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... bt2020nc 9 ..FV....... bt2020c 10 ..FV....... chroma-derived-nc 12 ..FV....... chroma-derived-c 13 ..FV....... ictcp 14 ..FV.......
+  - name: chromal
+    description: <int> ..FV....... set output chroma location (from -1 to 5) (default input) input -1 ..FV....... left 0 ..FV....... center 1 ..FV....... topleft 2 ..FV....... top 3 ..FV....... bottomleft 4 ..FV....... bottom 5 ..FV.......
+  - name: chromalin
+    description: <int> ..FV....... set input chroma location (from -1 to 5) (default input) input -1 ..FV....... left 0 ..FV....... center 1 ..FV....... topleft 2 ..FV....... top 3 ..FV....... bottomleft 4 ..FV....... bottom 5 ..FV.......
+  - name: cin
+    description: <int> ..FV....... set input chroma location (from -1 to 5) (default input) input -1 ..FV....... left 0 ..FV....... center 1 ..FV....... topleft 2 ..FV....... top 3 ..FV....... bottomleft 4 ..FV....... bottom 5 ..FV.......
+  - name: npl
+    description: <double> ..FV....... set nominal peak luminance (from 0 to DBL_MAX) (default nan)
+  - name: agamma
+    description: <boolean> ..FV....... allow approximate gamma (default true)
+  - name: param_a
+    description: <double> ..FV....... parameter A, which is parameter "b" for bicubic, and the number of filter taps for lanczos (from -DBL_MAX to DBL_MAX) (default nan)
+  - name: param_b
+    description: <double> ..FV....... parameter B, which is parameter "c" for bicubic (from -DBL_MAX to DBL_MAX) (default nan)
+  - name: grid_tile_size
+    description: <image_size> ..FV....... set tile size in grid layout
+  - name: rule
+    description: <int> ..FV....... set rule (from 0 to 255) (default 110)
+  - name: random_seed
+    description: <int64> ..FV....... set the seed for filling the initial grid randomly (from -1 to UINT32_MAX) (default -1)
+  - name: scroll
+    description: <boolean> ..FV....... scroll pattern downward (default true)
+  - name: start_full
+    description: <boolean> ..FV....... start filling the whole video (default false)
+  - name: full
+    description: <boolean> ..FV....... start filling the whole video (default true)
+  - name: stitch
+    description: <boolean> ..FV....... stitch boundaries (default true)
+  - name: framerate
+    description: <video_rate> ..FV....... (default "25")
+  - name: c4
+    description: <color> ..FV....... set 5th color (default "random")
+  - name: c5
+    description: <color> ..FV....... set 6th color (default "random")
+  - name: c6
+    description: <color> ..FV....... set 7th color (default "random")
+  - name: c7
+    description: <color> ..FV....... set 8th color (default "random")
+  - name: nb_colors
+    description: <int> ..FV....... set the number of colors (from 2 to 8) (default 2)
+  - name: mold
+    description: <int> ..FV....... set mold speed for dead cells (from 0 to 255) (default 0)
+  - name: life_color
+    description: <color> ..FV....... set life color (default "white")
+  - name: death_color
+    description: <color> ..FV....... set death color (default "black")
+  - name: mold_color
+    description: <color> ..FV....... set mold color (default "black")
+  - name: maxiter
+    description: <int> ..FV....... set max iterations number (from 1 to INT_MAX) (default 7189)
+  - name: start_x
+    description: <double> ..FV....... set the initial x position (from -100 to 100) (default -0.743644)
+  - name: start_y
+    description: <double> ..FV....... set the initial y position (from -100 to 100) (default -0.131826)
+  - name: start_scale
+    description: <double> ..FV....... set the initial scale value (from 0 to FLT_MAX) (default 3)
+  - name: end_scale
+    description: <double> ..FV....... set the terminal scale value (from 0 to FLT_MAX) (default 0.3)
+  - name: bailout
+    description: <double> ..FV....... set the bailout value (from 0 to FLT_MAX) (default 10)
+  - name: morphxf
+    description: <double> ..FV....... set morph x frequency (from -FLT_MAX to FLT_MAX) (default 0.01)
+  - name: morphyf
+    description: <double> ..FV....... set morph y frequency (from -FLT_MAX to FLT_MAX) (default 0.0123)
+  - name: morphamp
+    description: <double> ..FV....... set morph amplitude (from -FLT_MAX to FLT_MAX) (default 0)
+  - name: outer
+    description: <int> ..FV....... set outer coloring mode (from 0 to INT_MAX) (default normalized_iteration_count) iteration_count 0 ..FV....... set iteration count mode normalized_iteration_count 1 ..FV....... set normalized iteration count mode white 2 ..FV....... set white mode outz 3 ..FV....... set outz mode
+  - name: inner
+    description: <int> ..FV....... set inner coloring mode (from 0 to INT_MAX) (default mincol) black 0 ..FV....... set black mode period 1 ..FV....... set period mode convergence 2 ..FV....... show time until convergence mincol 3 ..FV....... color based on point closest to the origin of the iterations
+  - name: test
+    description: <int> ..FV....... set test to perform (from 0 to INT_MAX) (default all) dc_luma 0 ..FV....... dc_chroma 1 ..FV....... freq_luma 2 ..FV....... freq_chroma 3 ..FV....... amp_luma 4 ..FV....... amp_chroma 5 ..FV....... cbp 6 ..FV....... mv 7 ..FV....... ring1 8 ..FV....... ring2 9 ..FV....... all 10 ..FV.......
+  - name: max_frames
+    description: <int64> ..FV....... Set the maximum number of frames generated for each test (from 1 to I64_MAX) (default 30)
+  - name: complement
+    description: <boolean> ..FV....... set complement colors (default false)
+  - name: co
+    description: <boolean> ..FV....... set complement colors (default false)
+  - name: jump
+    description: <int> ..FV....... set the jump (from 1 to 10000) (default 100)
+  - name: decimals
+    description: <int> ..FV....... set number of decimals to show (from 0 to 17) (default 0)
+  - name: xo
+    description: <int> ..FV.....T. set X-axis offset (from INT_MIN to INT_MAX) (default 0)
+  - name: yo
+    description: <int> ..FV.....T. set Y-axis offset (from INT_MIN to INT_MAX) (default 0)
+  - name: to
+    description: <int> ..FV.....T. set T-axis offset (from INT_MIN to INT_MAX) (default 0)
+  - name: k0
+    description: <int> ..FV.....T. set 0-order phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kx
+    description: <int> ..FV.....T. set 1-order X-axis phase (from INT_MIN to INT_MAX) (default 0)
+  - name: ky
+    description: <int> ..FV.....T. set 1-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kt
+    description: <int> ..FV.....T. set 1-order T-axis phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kxt
+    description: <int> ..FV.....T. set X-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kyt
+    description: <int> ..FV.....T. set Y-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kxy
+    description: <int> ..FV.....T. set X-axis*Y-axis product phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kx2
+    description: <int> ..FV.....T. set 2-order X-axis phase (from INT_MIN to INT_MAX) (default 0)
+  - name: ky2
+    description: <int> ..FV.....T. set 2-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kt2
+    description: <int> ..FV.....T. set 2-order T-axis phase (from INT_MIN to INT_MAX) (default 0)
+  - name: ku
+    description: <int> ..FV.....T. set 0-order U-color phase (from INT_MIN to INT_MAX) (default 0)
+  - name: kv
+    description: <int> ..FV.....T. set 0-order V-color phase (from INT_MIN to INT_MAX) (default 0)
+  - name: fov
+    description: <float> ..FV.....T. set camera FoV (from 40 to 150) (default 90)
+  - name: xzoom
+    description: <float> ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
+  - name: yzoom
+    description: <float> ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
+  - name: zzoom
+    description: <float> ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
+  - name: xpos
+    description: <float> ..FV.....T. set camera position (from -60 to 60) (default 0)
+  - name: ypos
+    description: <float> ..FV.....T. set camera position (from -60 to 60) (default 0)
+  - name: zpos
+    description: <float> ..FV.....T. set camera position (from -60 to 60) (default 0)
+  - name: dmode
+    description: <int> ..FV....... set method to display channels (from 0 to 1) (default single) single 0 ..FV....... all channels use single histogram separate 1 ..FV....... each channel have own histogram
+  - name: ascale
+    description: <int> ..FV....... set amplitude scale (from 0 to 1) (default log) log 1 ..FV....... logarithmic lin 0 ..FV....... linear
+  - name: acount
+    description: <int> ..FV....... how much frames to accumulate (from -1 to 100) (default 1)
+  - name: rheight
+    description: <float> ..FV....... set histogram ratio of window height (from 0 to 1) (default 0.1)
+  - name: hmode
+    description: <int> ..FV....... set histograms mode (from 0 to 1) (default abs) abs 0 ..FV....... use absolute samples sign 1 ..FV....... use unchanged samples
+  - name: gc
+    description: <int> ..FV....... set green contrast (from 0 to 255) (default 7)
+  - name: bc
+    description: <int> ..FV....... set blue contrast (from 0 to 255) (default 1)
+  - name: mpc
+    description: <string> ..FV....... set median phase color (default "none")
+  - name: phasing
+    description: <boolean> ..FV....... set mono and out-of-phase detection output (default false)
+  - name: ac
+    description: <int> ..FV.....T. set alpha contrast (from 0 to 255) (default 255)
+  - name: gf
+    description: <int> ..FV.....T. set green fade (from 0 to 255) (default 10)
+  - name: bf
+    description: <int> ..FV.....T. set blue fade (from 0 to 255) (default 5)
+  - name: af
+    description: <int> ..FV.....T. set alpha fade (from 0 to 255) (default 5)
+  - name: draw
+    description: <int> ..FV.....T. set draw mode (from 0 to 2) (default dot) dot 0 ..FV.....T. draw dots line 1 ..FV.....T. draw lines aaline 2 ..FV.....T. draw anti-aliased lines
+  - name: swap
+    description: <boolean> ..FV.....T. swap x axis with y axis (default true)
+  - name: unsafe
+    description: <boolean> ..FVA...... enable unsafe mode (default false)
+  - name: bar_h
+    description: <int> ..FV....... set bargraph height (from -1 to INT_MAX) (default -1)
+  - name: axis_h
+    description: <int> ..FV....... set axis height (from -1 to INT_MAX) (default -1)
+  - name: sono_h
+    description: <int> ..FV....... set sonogram height (from -1 to INT_MAX) (default -1)
+  - name: fullhd
+    description: <boolean> ..FV....... set fullhd size (default true)
+  - name: sono_v
+    description: <string> ..FV....... set sonogram volume (default "16")
+  - name: bar_v
+    description: <string> ..FV....... set bargraph volume (default "sono_v")
+  - name: volume2
+    description: <string> ..FV....... set bargraph volume (default "sono_v")
+  - name: sono_g
+    description: <float> ..FV....... set sonogram gamma (from 1 to 7) (default 3)
+  - name: bar_g
+    description: <float> ..FV....... set bargraph gamma (from 1 to 7) (default 1)
+  - name: gamma2
+    description: <float> ..FV....... set bargraph gamma (from 1 to 7) (default 1)
+  - name: bar_t
+    description: <float> ..FV....... set bar transparency (from 0 to 1) (default 1)
+  - name: timeclamp
+    description: <double> ..FV....... set timeclamp (from 0.002 to 1) (default 0.17)
+  - name: endfreq
+    description: <double> ..FV....... set end frequency (from 10 to 100000) (default 20495.6)
+  - name: coeffclamp
+    description: <float> ..FV....... set coeffclamp (from 0.1 to 10) (default 1)
+  - name: tlength
+    description: <string> ..FV....... set tlength (default "384*tc/(384+tc*f)")
+  - name: count
+    description: <int> ..FV....... set transform count (from 1 to 30) (default 6)
+  - name: fcount
+    description: <int> ..FV....... set frequency count (from 0 to 10) (default 0)
+  - name: axisfile
+    description: <string> ..FV....... set axis image
+  - name: csp
+    description: <int> ..FV....... set color space (from 0 to INT_MAX) (default unspecified) unspecified 2 ..FV....... unspecified bt709 1 ..FV....... bt709 fcc 4 ..FV....... fcc bt470bg 5 ..FV....... bt470bg smpte170m 6 ..FV....... smpte170m smpte240m 7 ..FV....... smpte240m bt2020ncl 9 ..FV....... bt2020ncl
+  - name: cscheme
+    description: <string> ..FV....... set color scheme (default "1|0.5|0|0|0.5|1")
+  - name: iscale
+    description: <int> ..FV....... set intensity scale (from 0 to 4) (default log) linear 1 ..FV....... linear log 0 ..FV....... logarithmic sqrt 2 ..FV....... sqrt cbrt 3 ..FV....... cbrt qdrt 4 ..FV....... qdrt
+  - name: imin
+    description: <float> ..FV....... set minimum intensity (from 0 to 1) (default 0)
+  - name: imax
+    description: <float> ..FV....... set maximum intensity (from 0 to 1) (default 1)
+  - name: logb
+    description: <float> ..FV....... set logarithmic basis (from 0 to 1) (default 0.0001)
+  - name: deviation
+    description: <float> ..FV....... set frequency deviation (from 0 to 100) (default 1)
+  - name: pps
+    description: <int> ..FV....... set pixels per second (from 1 to 1024) (default 64)
+  - name: bar
+    description: <float> ..FV....... set bar ratio (from 0 to 1) (default 0)
+  - name: averaging
+    description: <int> ..FV....... set time averaging (from 0 to INT_MAX) (default 1)
+  - name: cmode
+    description: <int> ..FV....... set channel mode (from 0 to 1) (default combined) combined 0 ..FV....... show all channels in same window separate 1 ..FV....... show each channel in own window
+  - name: minamp
+    description: <float> ..FV....... set minimum amplitude (from FLT_MIN to 1e-06) (default 1e-06)
+  - name: data
+    description: <int> ..FV....... set data mode (from 0 to 2) (default magnitude) magnitude 0 ..FV....... show magnitude phase 1 ..FV....... show phase delay 2 ..FV....... show group delay
+  - name: orientation
+    description: <int> ..FV....... set orientation (from 0 to 1) (default vertical) vertical 0 ..FV....... horizontal 1 ..FV.......
+  - name: legend
+    description: <boolean> ..FV....... draw legend (default false)
+  - name: drange
+    description: <float> ..FV....... set dynamic range in dBFS (from 10 to 200) (default 120)
+  - name: dm
+    description: <double> ..FV....... duration for max value display (from 0 to 9000) (default 0)
+  - name: dmc
+    description: <color> ..FV....... set color of the max value line (default "orange")
+  - name: ds
+    description: <int> ..FV....... set display scale (from 0 to 1) (default lin) lin 0 ..FV....... linear log 1 ..FV....... log
+  - name: split_channels
+    description: <boolean> ..FV....... draw channels separately (default false)
+  - name: fr
+    description: <video_rate> ..FV....... set frame rate (default "30")
+  - name: samplerate
+    description: <int> ..F.A...... set sample rate (from 8000 to 384000) (default 44100)
+  - name: sr
+    description: <int> ..F.A...... set sample rate (from 8000 to 384000) (default 44100)
+  - name: period
+    description: <int> ..F.A...... set beep period (from 1 to 99) (default 3)
+  - name: dl
+    description: <int> ..FV.....T. set flash delay (from -30 to 30) (default 0)
+  - name: fg
+    description: <color> ..FV....... set foreground color (default "white")
+  - name: format_name
+    description: <string> ..FVA...... set format name
+  - name: seek_point
+    description: <double> ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
+  - name: sp
+    description: <double> ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
+  - name: streams
+    description: <string> ..FVA...... set streams
+  - name: discontinuity
+    description: <duration> ..FVA...... set discontinuity threshold (default 0)
+  - name: dec_threads
+    description: <int> ..FVA...... set the number of threads for decoding (from 0 to INT_MAX) (default 0)
+  - name: format_opts
+    description: <dictionary> ..FVA...... set format options for the opened file
+  - name: time_base
+    description: <rational> ..F.A...... (from 0 to INT_MAX) (default 0/1)
+  - name: sample_fmt
+    description: <sample_fmt> ..F.A...... (default none)
+  - name: video_size
+    description: <image_size> ..FV.......
+  - name: pix_fmt
+    description: <pix_fmt> ..FV....... (default none)
+  - name: pixel_aspect
+    description: <rational> ..FV....... sample aspect ratio (from 0 to DBL_MAX) (default 0/1)
+  - name: frame_rate
+    description: <rational> ..FV....... (from 0 to DBL_MAX) (default 0/1)
+  - name: channel_counts
+    description: <binary> ..F.A.....P set the supported channel counts (deprecated, use ch_layouts)
+  - name: ch_layouts
+    description: <string> ..F.A...... set a '|'-separated list of supported channel layouts
+  single_dash: true
+  group: 'libdc1394 indev AVOptions:'
+  description: <string> .D......... (default "ntsc")
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/ffplay/6.1.1-3ubuntu5/expected.snap
+++ b/corpus/ffplay/6.1.1-3ubuntu5/expected.snap
@@ -8811,2702 +8811,1354 @@ flags:
     - help-text
 - long: framerate
   choices:
-  - name: thread_type
-    description: <flags> ..F........ Allowed thread types (default slice) slice ..F........
-  - name: enable
-    description: <string> ..F......T. set enable expression
-  - name: threads
-    description: <int> ..F........ Allowed number of threads (from 0 to INT_MAX) (default 0)
-  - name: extra_hw_frames
-    description: <int> ..F........ Number of extra hardware frames to allocate for the user (from -1 to INT_MAX) (default -1)
-  - name: action
-    description: <int> ..F.A...... set action (from 0 to 1) (default start) start 0 ..F.A...... start timer stop 1 ..F.A...... stop timer
-  - name: level_in
-    description: <double> ..F.A....T. set input gain (from 0.015625 to 64) (default 1)
-  - name: mode
-    description: <int> ..F.A....T. set mode (from 0 to 1) (default downward) downward 0 ..F.A....T. upward 1 ..F.A....T.
-  - name: threshold
-    description: <double> ..F.A....T. set threshold (from 0.000976563 to 1) (default 0.125)
-  - name: ratio
-    description: <double> ..F.A....T. set ratio (from 1 to 20) (default 2)
-  - name: attack
-    description: <double> ..F.A....T. set attack (from 0.01 to 2000) (default 20)
-  - name: release
-    description: <double> ..F.A....T. set release (from 0.01 to 9000) (default 250)
-  - name: makeup
-    description: <double> ..F.A....T. set make up gain (from 1 to 64) (default 1)
-  - name: knee
-    description: <double> ..F.A....T. set knee (from 1 to 8) (default 2.82843)
-  - name: link
-    description: <int> ..F.A....T. set link type (from 0 to 1) (default average) average 0 ..F.A....T. maximum 1 ..F.A....T.
-  - name: detection
-    description: <int> ..F.A....T. set detection (from 0 to 1) (default rms) peak 0 ..F.A....T. rms 1 ..F.A....T.
-  - name: level_sc
-    description: <double> ..F.A....T. set sidechain gain (from 0.015625 to 64) (default 1)
-  - name: mix
-    description: <double> ..F.A....T. set mix (from 0 to 1) (default 1)
-  - name: contrast
-    description: <float> ..F.A...... set contrast (from 0 to 100) (default 33)
-  - name: cue
-    description: <int64> ..FVA...... cue unix timestamp in microseconds (from 0 to I64_MAX) (default 0)
-  - name: preroll
-    description: <duration> ..FVA...... preroll duration in seconds (default 0)
-  - name: buffer
-    description: <duration> ..FVA...... buffer duration in seconds (default 0)
-  - name: nb_samples
-    description: <int> ..F.A...... set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
-  - name: ns
-    description: <int> ..F.A...... set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
-  - name: duration
-    description: <duration> ..F.A...... set cross fade duration (default 0)
-  - name: d
-    description: <duration> ..F.A...... set cross fade duration (default 0)
-  - name: overlap
-    description: <boolean> ..F.A...... overlap 1st stream end with 2nd stream start (default true)
-  - name: o
-    description: <boolean> ..F.A...... overlap 1st stream end with 2nd stream start (default true)
-  - name: curve1
-    description: <int> ..F.A...... set fade curve type for 1st stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
-  - name: c1
-    description: <int> ..F.A...... set fade curve type for 1st stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
-  - name: curve2
-    description: <int> ..F.A...... set fade curve type for 2nd stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
-  - name: c2
-    description: <int> ..F.A...... set fade curve type for 2nd stream (from -1 to 22) (default tri) nofade -1 ..F.A...... no fade; keep audio as-is tri 0 ..F.A...... linear slope qsin 1 ..F.A...... quarter of sine wave esin 2 ..F.A...... exponential sine wave hsin 3 ..F.A...... half of sine wave log 4 ..F.A...... logarithmic ipar 5 ..F.A...... inverted parabola qua 6 ..F.A...... quadratic cub 7 ..F.A...... cubic squ 8 ..F.A...... square root cbr 9 ..F.A...... cubic root par 10 ..F.A...... parabola exp 11 ..F.A...... exponential iqsin 12 ..F.A...... inverted quarter of sine wave ihsin 13 ..F.A...... inverted half of sine wave dese 14 ..F.A...... double-exponential seat desi 15 ..F.A...... double-exponential sigmoid losi 16 ..F.A...... logistic sigmoid sinc 17 ..F.A...... sine cardinal function isinc 18 ..F.A...... inverted sine cardinal function quat 19 ..F.A...... quartic quatr 20 ..F.A...... quartic root qsin2 21 ..F.A...... squared quarter of sine wave hsin2 22 ..F.A...... squared half of sine wave
-  - name: split
-    description: <string> ..F.A...... set split frequencies (default "500")
-  - name: order
-    description: <int> ..F.A...... set filter order (from 0 to 9) (default 4th) 2nd 0 ..F.A...... 2nd order (12 dB/8ve) 4th 1 ..F.A...... 4th order (24 dB/8ve) 6th 2 ..F.A...... 6th order (36 dB/8ve) 8th 3 ..F.A...... 8th order (48 dB/8ve) 10th 4 ..F.A...... 10th order (60 dB/8ve) 12th 5 ..F.A...... 12th order (72 dB/8ve) 14th 6 ..F.A...... 14th order (84 dB/8ve) 16th 7 ..F.A...... 16th order (96 dB/8ve) 18th 8 ..F.A...... 18th order (108 dB/8ve) 20th 9 ..F.A...... 20th order (120 dB/8ve)
-  - name: level
-    description: <float> ..F.A...... set input gain (from 0 to 1) (default 1)
-  - name: gain
-    description: <string> ..F.A...... set output bands gain (default "1.f")
-  - name: precision
-    description: <int> ..F.A...... set processing precision (from 0 to 2) (default auto) auto 0 ..F.A...... set auto processing precision float 1 ..F.A...... set single-floating point processing precision double 2 ..F.A...... set double-floating point processing precision
-  - name: level_out
-    description: <double> ..F.A....T. set level out (from 0.015625 to 64) (default 1)
-  - name: bits
-    description: <double> ..F.A....T. set bit reduction (from 1 to 64) (default 8)
-  - name: dc
-    description: <double> ..F.A....T. set DC (from 0.25 to 4) (default 1)
-  - name: aa
-    description: <double> ..F.A....T. set anti-aliasing (from 0 to 1) (default 0.5)
-  - name: samples
-    description: <double> ..F.A....T. set sample reduction (from 1 to 250) (default 1)
-  - name: lfo
-    description: <boolean> ..F.A....T. enable LFO (default false)
-  - name: lforange
-    description: <double> ..F.A....T. set LFO depth (from 1 to 250) (default 20)
-  - name: lforate
-    description: <double> ..F.A....T. set LFO rate (from 0.01 to 200) (default 0.3)
-  - name: window
-    description: <double> ..F.A...... set window size (from 10 to 100) (default 55)
-  - name: w
-    description: <double> ..F.A...... set window size (from 10 to 100) (default 55)
-  - name: arorder
-    description: <double> ..F.A...... set autoregression order (from 0 to 25) (default 2)
-  - name: a
-    description: <double> ..F.A...... set autoregression order (from 0 to 25) (default 2)
-  - name: t
-    description: <double> ..F.A...... set threshold (from 1 to 100) (default 2)
-  - name: burst
-    description: <double> ..F.A...... set burst fusion (from 0 to 10) (default 2)
-  - name: b
-    description: <double> ..F.A...... set burst fusion (from 0 to 10) (default 2)
-  - name: method
-    description: <int> ..F.A...... set overlap method (from 0 to 1) (default add) add 0 ..F.A...... overlap-add a 0 ..F.A...... overlap-add save 1 ..F.A...... overlap-save s 1 ..F.A...... overlap-save
-  - name: m
-    description: <int> ..F.A...... set overlap method (from 0 to 1) (default add) add 0 ..F.A...... overlap-add a 0 ..F.A...... overlap-add save 1 ..F.A...... overlap-save s 1 ..F.A...... overlap-save
-  - name: hsize
-    description: <int> ..F.A...... set histogram size (from 100 to 9999) (default 1000)
-  - name: n
-    description: <int> ..F.A...... set histogram size (from 100 to 9999) (default 1000)
-  - name: stages
-    description: <int> ..F.A...... set filtering stages (from 1 to 16) (default 6)
-  - name: seed
-    description: <int64> ..F.A...... set random seed (from -1 to UINT32_MAX) (default -1)
-  - name: delays
-    description: <string> ..F.A....T. set list of delays for each channel
-  - name: all
-    description: <boolean> ..F.A...... use last available delay for remained channels (default false)
-  - name: type
-    description: <int> ..F.A....T. set type (from 0 to 3) (default dc) dc 0 ..F.A....T. ac 1 ..F.A....T. square 2 ..F.A....T. pulse 3 ..F.A....T.
-  - name: transfer
-    description: <string> ..F.A....T. set the transfer expression (default "p")
-  - name: channels
-    description: <string> ..F.A....T. set channels to filter (default "all")
-  - name: dfrequency
-    description: <double> ..F.A....T. set detection frequency (from 2 to 1e+06) (default 1000)
-  - name: dqfactor
-    description: <double> ..F.A....T. set detection Q factor (from 0.001 to 1000) (default 1)
-  - name: tfrequency
-    description: <double> ..F.A....T. set target frequency (from 2 to 1e+06) (default 1000)
-  - name: tqfactor
-    description: <double> ..F.A....T. set target Q factor (from 0.001 to 1000) (default 1)
-  - name: range
-    description: <double> ..F.A....T. set max gain (from 1 to 200) (default 50)
-  - name: dftype
-    description: <int> ..F.A....T. set detection filter type (from 0 to 3) (default bandpass) bandpass 0 ..F.A....T. lowpass 1 ..F.A....T. highpass 2 ..F.A....T. peak 3 ..F.A....T.
-  - name: tftype
-    description: <int> ..F.A....T. set target filter type (from 0 to 2) (default bell) bell 0 ..F.A....T. lowshelf 1 ..F.A....T. highshelf 2 ..F.A....T.
-  - name: direction
-    description: <int> ..F.A....T. set direction (from 0 to 1) (default downward) downward 0 ..F.A....T. upward 1 ..F.A....T.
-  - name: auto
-    description: <int> ..F.A....T. set auto threshold (from -1 to 1) (default disabled) disabled -1 ..F.A....T. off 0 ..F.A....T. on 1 ..F.A....T.
-  - name: sensitivity
-    description: <double> ..F.A....T. set smooth sensitivity (from 0 to 1e+06) (default 2)
-  - name: basefreq
-    description: <double> ..F.A....T. set base frequency (from 2 to 1e+06) (default 22050)
-  - name: in_gain
-    description: <float> ..F.A...... set signal input gain (from 0 to 1) (default 0.6)
-  - name: out_gain
-    description: <float> ..F.A...... set signal output gain (from 0 to 1) (default 0.3)
-  - name: decays
-    description: <string> ..F.A...... set list of signal decays (default "0.5")
-  - name: exprs
-    description: <string> ..F.A...... set the '|'-separated list of channels expressions
-  - name: channel_layout
-    description: <string> ..F.A...... set channel layout
-  - name: c
-    description: <string> ..F.A...... set channel layout
-  - name: amount
-    description: <double> ..F.A....T. set amount (from 0 to 64) (default 1)
-  - name: drive
-    description: <double> ..F.A....T. set harmonics (from 0.1 to 10) (default 8.5)
-  - name: blend
-    description: <double> ..F.A....T. set blend harmonics (from -10 to 10) (default 0)
-  - name: freq
-    description: <double> ..F.A....T. set scope (from 2000 to 12000) (default 7500)
-  - name: ceil
-    description: <double> ..F.A....T. set ceiling (from 9999 to 20000) (default 9999)
-  - name: listen
-    description: <boolean> ..F.A....T. enable listen mode (default false)
-  - name: start_sample
-    description: <int64> ..F.A....T. set number of first sample to start fading (from 0 to I64_MAX) (default 0)
-  - name: ss
-    description: <int64> ..F.A....T. set number of first sample to start fading (from 0 to I64_MAX) (default 0)
-  - name: start_time
-    description: <duration> ..F.A....T. set time to start fading (default 0)
-  - name: st
-    description: <duration> ..F.A....T. set time to start fading (default 0)
-  - name: curve
-    description: <int> ..F.A....T. set fade curve type (from -1 to 22) (default tri) nofade -1 ..F.A....T. no fade; keep audio as-is tri 0 ..F.A....T. linear slope qsin 1 ..F.A....T. quarter of sine wave esin 2 ..F.A....T. exponential sine wave hsin 3 ..F.A....T. half of sine wave log 4 ..F.A....T. logarithmic ipar 5 ..F.A....T. inverted parabola qua 6 ..F.A....T. quadratic cub 7 ..F.A....T. cubic squ 8 ..F.A....T. square root cbr 9 ..F.A....T. cubic root par 10 ..F.A....T. parabola exp 11 ..F.A....T. exponential iqsin 12 ..F.A....T. inverted quarter of sine wave ihsin 13 ..F.A....T. inverted half of sine wave dese 14 ..F.A....T. double-exponential seat desi 15 ..F.A....T. double-exponential sigmoid losi 16 ..F.A....T. logistic sigmoid sinc 17 ..F.A....T. sine cardinal function isinc 18 ..F.A....T. inverted sine cardinal function quat 19 ..F.A....T. quartic quatr 20 ..F.A....T. quartic root qsin2 21 ..F.A....T. squared quarter of sine wave hsin2 22 ..F.A....T. squared half of sine wave
-  - name: silence
-    description: <double> ..F.A....T. set the silence gain (from 0 to 1) (default 0)
-  - name: unity
-    description: <double> ..F.A....T. set the unity gain (from 0 to 1) (default 1)
-  - name: noise_reduction
-    description: <float> ..F.A....T. set the noise reduction (from 0.01 to 97) (default 12)
-  - name: nr
-    description: <float> ..F.A....T. set the noise reduction (from 0.01 to 97) (default 12)
-  - name: noise_floor
-    description: <float> ..F.A....T. set the noise floor (from -80 to -20) (default -50)
-  - name: nf
-    description: <float> ..F.A....T. set the noise floor (from -80 to -20) (default -50)
-  - name: noise_type
-    description: <int> ..F.A...... set the noise type (from 0 to 3) (default white) white 0 ..F.A...... white noise w 0 ..F.A...... white noise vinyl 1 ..F.A...... vinyl noise v 1 ..F.A...... vinyl noise shellac 2 ..F.A...... shellac noise s 2 ..F.A...... shellac noise custom 3 ..F.A...... custom noise c 3 ..F.A...... custom noise
-  - name: nt
-    description: <int> ..F.A...... set the noise type (from 0 to 3) (default white) white 0 ..F.A...... white noise w 0 ..F.A...... white noise vinyl 1 ..F.A...... vinyl noise v 1 ..F.A...... vinyl noise shellac 2 ..F.A...... shellac noise s 2 ..F.A...... shellac noise custom 3 ..F.A...... custom noise c 3 ..F.A...... custom noise
-  - name: band_noise
-    description: <string> ..F.A...... set the custom bands noise
-  - name: bn
-    description: <string> ..F.A...... set the custom bands noise
-  - name: residual_floor
-    description: <float> ..F.A....T. set the residual floor (from -80 to -20) (default -38)
-  - name: rf
-    description: <float> ..F.A....T. set the residual floor (from -80 to -20) (default -38)
-  - name: track_noise
-    description: <boolean> ..F.A....T. track noise (default false)
-  - name: tn
-    description: <boolean> ..F.A....T. track noise (default false)
-  - name: track_residual
-    description: <boolean> ..F.A....T. track residual (default false)
-  - name: tr
-    description: <boolean> ..F.A....T. track residual (default false)
-  - name: output_mode
-    description: <int> ..F.A....T. set output mode (from 0 to 2) (default output) input 0 ..F.A....T. input i 0 ..F.A....T. input output 1 ..F.A....T. output o 1 ..F.A....T. output noise 2 ..F.A....T. noise n 2 ..F.A....T. noise
-  - name: om
-    description: <int> ..F.A....T. set output mode (from 0 to 2) (default output) input 0 ..F.A....T. input i 0 ..F.A....T. input output 1 ..F.A....T. output o 1 ..F.A....T. output noise 2 ..F.A....T. noise n 2 ..F.A....T. noise
-  - name: adaptivity
-    description: <float> ..F.A....T. set adaptivity factor (from 0 to 1) (default 0.5)
-  - name: ad
-    description: <float> ..F.A....T. set adaptivity factor (from 0 to 1) (default 0.5)
-  - name: floor_offset
-    description: <float> ..F.A....T. set noise floor offset factor (from -2 to 2) (default 1)
-  - name: fo
-    description: <float> ..F.A....T. set noise floor offset factor (from -2 to 2) (default 1)
-  - name: noise_link
-    description: <int> ..F.A....T. set the noise floor link (from 0 to 3) (default min) none 0 ..F.A....T. none min 1 ..F.A....T. min max 2 ..F.A....T. max average 3 ..F.A....T. average
-  - name: nl
-    description: <int> ..F.A....T. set the noise floor link (from 0 to 3) (default min) none 0 ..F.A....T. none min 1 ..F.A....T. min max 2 ..F.A....T. max average 3 ..F.A....T. average
-  - name: band_multiplier
-    description: <float> ..F.A...... set band multiplier (from 0.2 to 5) (default 1.25)
-  - name: bm
-    description: <float> ..F.A...... set band multiplier (from 0.2 to 5) (default 1.25)
-  - name: sample_noise
-    description: <int> ..F.A....T. set sample noise mode (from 0 to 2) (default none) none 0 ..F.A....T. none start 1 ..F.A....T. start begin 1 ..F.A....T. start stop 2 ..F.A....T. stop end 2 ..F.A....T. stop
-  - name: sn
-    description: <int> ..F.A....T. set sample noise mode (from 0 to 2) (default none) none 0 ..F.A....T. none start 1 ..F.A....T. start begin 1 ..F.A....T. start stop 2 ..F.A....T. stop end 2 ..F.A....T. stop
-  - name: gain_smooth
-    description: <int> ..F.A....T. set gain smooth radius (from 0 to 50) (default 0)
-  - name: gs
-    description: <int> ..F.A....T. set gain smooth radius (from 0 to 50) (default 0)
-  - name: real
-    description: <string> ..F.A...... set channels real expressions (default "re")
-  - name: imag
-    description: <string> ..F.A...... set channels imaginary expressions (default "im")
-  - name: win_size
-    description: <int> ..F.A...... set window size (from 16 to 131072) (default 4096)
-  - name: win_func
-    description: <int> ..F.A...... set window function (from 0 to 20) (default hann) rect 0 ..F.A...... Rectangular bartlett 4 ..F.A...... Bartlett hann 1 ..F.A...... Hann hanning 1 ..F.A...... Hanning hamming 2 ..F.A...... Hamming blackman 3 ..F.A...... Blackman welch 5 ..F.A...... Welch flattop 6 ..F.A...... Flat-top bharris 7 ..F.A...... Blackman-Harris bnuttall 8 ..F.A...... Blackman-Nuttall bhann 11 ..F.A...... Bartlett-Hann sine 9 ..F.A...... Sine nuttall 10 ..F.A...... Nuttall lanczos 12 ..F.A...... Lanczos gauss 13 ..F.A...... Gauss tukey 14 ..F.A...... Tukey dolph 15 ..F.A...... Dolph-Chebyshev cauchy 16 ..F.A...... Cauchy parzen 17 ..F.A...... Parzen poisson 18 ..F.A...... Poisson bohman 19 ..F.A...... Bohman kaiser 20 ..F.A...... Kaiser
-  - name: dry
-    description: <float> ..F.A....T. set dry gain (from 0 to 10) (default 1)
-  - name: wet
-    description: <float> ..F.A....T. set wet gain (from 0 to 10) (default 1)
-  - name: length
-    description: <float> ..F.A...... set IR length (from 0 to 1) (default 1)
-  - name: gtype
-    description: <int> ..F.A...... set IR auto gain type (from -1 to 4) (default peak) none -1 ..F.A...... without auto gain peak 0 ..F.A...... peak gain dc 1 ..F.A...... DC gain gn 2 ..F.A...... gain to noise ac 3 ..F.A...... AC gain rms 4 ..F.A...... RMS gain
-  - name: irgain
-    description: <float> ..F.A...... set IR gain (from 0 to 1) (default 1)
-  - name: irfmt
-    description: <int> ..F.A...... set IR format (from 0 to 1) (default input) mono 0 ..F.A...... single channel input 1 ..F.A...... same as input
-  - name: maxir
-    description: <float> ..F.A...... set max IR length (from 0.1 to 60) (default 30)
-  - name: response
-    description: <boolean> ..FV....... show IR frequency response (default false)
-  - name: channel
-    description: <int> ..FV....... set IR channel to display frequency response (from 0 to 1024) (default 0)
-  - name: size
-    description: <image_size> ..FV....... set video size (default "hd720")
-  - name: rate
-    description: <video_rate> ..FV....... set video rate (default "25")
-  - name: minp
-    description: <int> ..F.A...... set min partition size (from 1 to 65536) (default 8192)
-  - name: maxp
-    description: <int> ..F.A...... set max partition size (from 8 to 65536) (default 8192)
-  - name: nbirs
-    description: <int> ..F.A...... set number of input IRs (from 1 to 32) (default 1)
-  - name: ir
-    description: <int> ..F.A....T. select IR (from 0 to 31) (default 0)
-  - name: irload
-    description: <int> ..F.A...... set IR loading type (from 0 to 1) (default init) init 0 ..F.A...... load all IRs on init access 1 ..F.A...... load IR on access
-  - name: sample_fmts
-    description: <string> ..F.A...... A '|'-separated list of sample formats.
-  - name: f
-    description: <string> ..F.A...... A '|'-separated list of sample formats.
-  - name: sample_rates
-    description: <string> ..F.A...... A '|'-separated list of sample rates.
-  - name: r
-    description: <string> ..F.A...... A '|'-separated list of sample rates.
-  - name: channel_layouts
-    description: <string> ..F.A...... A '|'-separated list of channel layouts.
-  - name: cl
-    description: <string> ..F.A...... A '|'-separated list of channel layouts.
-  - name: shift
-    description: <double> ..F.A....T. set frequency shift (from -2.14748e+09 to INT_MAX) (default 0)
-  - name: sigma
-    description: <double> ..F.A....T. set noise sigma (from 0 to 1) (default 0)
-  - name: levels
-    description: <int> ..F.A...... set number of wavelet levels (from 1 to 12) (default 10)
-  - name: wavet
-    description: <int> ..F.A...... set wavelet type (from 0 to 6) (default sym10) sym2 0 ..F.A...... sym2 sym4 1 ..F.A...... sym4 rbior68 2 ..F.A...... rbior68 deb10 3 ..F.A...... deb10 sym10 4 ..F.A...... sym10 coif5 5 ..F.A...... coif5 bl3 6 ..F.A...... bl3
-  - name: percent
-    description: <double> ..F.A....T. set percent of full denoising (from 0 to 100) (default 85)
-  - name: profile
-    description: <boolean> ..F.A....T. profile noise (default false)
-  - name: adaptive
-    description: <boolean> ..F.A....T. adaptive profiling of noise (default false)
-  - name: softness
-    description: <double> ..F.A....T. set thresholding softness (from 0 to 10) (default 1)
-  - name: zeros
-    description: <string> ..F.A...... set B/numerator/zeros/reflection coefficients (default "1+0i 1-0i")
-  - name: z
-    description: <string> ..F.A...... set B/numerator/zeros/reflection coefficients (default "1+0i 1-0i")
-  - name: poles
-    description: <string> ..F.A...... set A/denominator/poles/ladder coefficients (default "1+0i 1-0i")
-  - name: p
-    description: <string> ..F.A...... set A/denominator/poles/ladder coefficients (default "1+0i 1-0i")
-  - name: gains
-    description: <string> ..F.A...... set channels gains (default "1|1")
-  - name: k
-    description: <string> ..F.A...... set channels gains (default "1|1")
-  - name: format
-    description: <int> ..F.A...... set coefficients format (from -2 to 4) (default zp) ll -2 ..F.A...... lattice-ladder function sf -1 ..F.A...... analog transfer function tf 0 ..F.A...... digital transfer function zp 1 ..F.A...... Z-plane zeros/poles pr 2 ..F.A...... Z-plane zeros/poles (polar radians) pd 3 ..F.A...... Z-plane zeros/poles (polar degrees) sp 4 ..F.A...... S-plane zeros/poles
-  - name: process
-    description: <int> ..F.A...... set kind of processing (from 0 to 2) (default s) d 0 ..F.A...... direct s 1 ..F.A...... serial p 2 ..F.A...... parallel
-  - name: e
-    description: <int> ..F.A...... set precision (from 0 to 3) (default dbl) dbl 0 ..F.A...... double-precision floating-point flt 1 ..F.A...... single-precision floating-point i32 2 ..F.A...... 32-bit integers i16 3 ..F.A...... 16-bit integers
-  - name: normalize
-    description: <boolean> ..F.A...... normalize coefficients (default true)
-  - name: nb_inputs
-    description: <int> ..F.A...... set number of inputs (from 1 to INT_MAX) (default 2)
-  - name: limit
-    description: <double> ..F.A....T. set limit (from 0.0625 to 1) (default 1)
-  - name: asc
-    description: <boolean> ..F.A....T. enable asc (default false)
-  - name: asc_level
-    description: <double> ..F.A....T. set asc level (from 0 to 1) (default 0.5)
-  - name: latency
-    description: <boolean> ..F.A....T. compensate delay (default false)
-  - name: frequency
-    description: <double> ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
-  - name: width_type
-    description: <int> ..F.A....T. set filter-width type (from 1 to 5) (default q) h 1 ..F.A....T. Hz q 3 ..F.A....T. Q-Factor o 2 ..F.A....T. octave s 4 ..F.A....T. slope k 5 ..F.A....T. kHz
-  - name: width
-    description: <double> ..F.A....T. set width (from 0 to 99999) (default 0.707)
-  - name: transform
-    description: <int> ..F.A...... set transform type (from 0 to 6) (default di) di 0 ..F.A...... direct form I dii 1 ..F.A...... direct form II tdi 2 ..F.A...... transposed direct form I tdii 3 ..F.A...... transposed direct form II latt 4 ..F.A...... lattice-ladder form svf 5 ..F.A...... state variable filter form zdf 6 ..F.A...... zero-delay filter form
-  - name: loop
-    description: <int> ..F.A...... number of loops (from -1 to INT_MAX) (default 0)
-  - name: start
-    description: <int64> ..F.A...... set the loop start sample (from -1 to I64_MAX) (default 0)
-  - name: time
-    description: <duration> ..F.A...... set the loop start time (default INT64_MAX)
-  - name: inputs
-    description: <int> ..F.A...... specify the number of inputs (from 1 to 64) (default 2)
-  - name: key
-    description: <string> ..F.A...... set metadata key
-  - name: value
-    description: <string> ..F.A...... set metadata value
-  - name: function
-    description: <int> ..F.A...... function for comparing values (from 0 to 6) (default same_str) same_str 0 ..F.A...... starts_with 1 ..F.A...... less 2 ..F.A...... equal 3 ..F.A...... greater 4 ..F.A...... expr 5 ..F.A...... ends_with 6 ..F.A......
-  - name: expr
-    description: <string> ..F.A...... set expression for expr function
-  - name: file
-    description: <string> ..F.A...... set file where to print metadata information
-  - name: direct
-    description: <boolean> ..F.A...... reduce buffering when printing to user-set file or pipe (default false)
-  - name: weights
-    description: <string> ..F.A....T. Set weight for each input. (default "1 1")
-  - name: params
-    description: <string> ..F.A...... (default "")
-  - name: curves
-    description: <boolean> ..FV....... draw frequency response curves (default false)
-  - name: mgain
-    description: <double> ..FV....... set max gain (from -900 to 900) (default 60)
-  - name: fscale
-    description: <int> ..FV....... set frequency scale (from 0 to 1) (default log) lin 0 ..FV....... linear log 1 ..FV....... logarithmic
-  - name: colors
-    description: <string> ..FV....... set channels curves colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
-  - name: strength
-    description: <float> ..F.A....T. set denoising strength (from 1e-05 to 10000) (default 1e-05)
-  - name: s
-    description: <float> ..F.A....T. set denoising strength (from 1e-05 to 10000) (default 1e-05)
-  - name: patch
-    description: <duration> ..F.A....T. set patch duration (default 0.002)
-  - name: research
-    description: <duration> ..F.A....T. set research duration (default 0.006)
-  - name: output
-    description: <int> ..F.A....T. set output mode (from 0 to 2) (default o) i 0 ..F.A....T. input o 1 ..F.A....T. output n 2 ..F.A....T. noise
-  - name: smooth
-    description: <float> ..F.A....T. set smooth factor (from 1 to 1000) (default 11)
-  - name: mu
-    description: <float> ..F.A....T. set the filter mu (from 0 to 2) (default 0.75)
-  - name: eps
-    description: <float> ..F.A....T. set the filter eps (from 0 to 1) (default 1)
-  - name: leakage
-    description: <float> ..F.A....T. set the filter leakage (from 0 to 1) (default 0)
-  - name: out_mode
-    description: <int> ..F.A....T. set output mode (from 0 to 4) (default o) i 0 ..F.A....T. input d 1 ..F.A....T. desired o 2 ..F.A....T. output n 3 ..F.A....T. noise e 4 ..F.A....T. error
-  - name: packet_size
-    description: <int> ..F.A...... set silence packet size (from 0 to INT_MAX) (default 4096)
-  - name: pad_len
-    description: <int64> ..F.A...... set number of samples of silence to add (from -1 to I64_MAX) (default -1)
-  - name: whole_len
-    description: <int64> ..F.A...... set minimum target number of samples in the audio stream (from -1 to I64_MAX) (default -1)
-  - name: pad_dur
-    description: <duration> ..F.A...... set duration of silence to add (default -0.000001)
-  - name: whole_dur
-    description: <duration> ..F.A...... set minimum target duration in the audio stream (default -0.000001)
-  - name: delay
-    description: <double> ..F.A...... set delay in milliseconds (from 0 to 5) (default 3)
-  - name: decay
-    description: <double> ..F.A...... set decay (from 0 to 0.99) (default 0.4)
-  - name: speed
-    description: <double> ..F.A...... set modulation speed (from 0.1 to 2) (default 0.5)
-  - name: clip
-    description: <double> ..F.A....T. set clip level (from 0.015625 to 1) (default 1)
-  - name: diff
-    description: <boolean> ..F.A....T. enable difference (default false)
-  - name: iterations
-    description: <int> ..F.A....T. set iterations (from 1 to 20) (default 10)
-  - name: offset_l
-    description: <double> ..F.A...... set offset L (from 0 to 1) (default 0)
-  - name: offset_r
-    description: <double> ..F.A...... set offset R (from 0 to 1) (default 0.5)
-  - name: timing
-    description: <int> ..F.A...... set timing (from 0 to 2) (default hz) bpm 0 ..F.A...... ms 1 ..F.A...... hz 2 ..F.A......
-  - name: bpm
-    description: <double> ..F.A...... set BPM (from 30 to 300) (default 120)
-  - name: ms
-    description: <int> ..F.A...... set ms (from 10 to 2000) (default 500)
-  - name: hz
-    description: <double> ..F.A...... set frequency (from 0.01 to 100) (default 2)
-  - name: sample_rate
-    description: <int> ..F.A...... (from 0 to INT_MAX) (default 0)
-  - name: lambda
-    description: <float> ..F.A....T. set the filter lambda (from 0 to 1) (default 1)
-  - name: delta
-    description: <float> ..F.A...... set the filter delta (from 0 to 32767) (default 2)
-  - name: model
-    description: <string> ..F.A....T. set model name
-  - name: timestamps
-    description: <string> ..F.A...... timestamps of input at which to split input
-  - name: outputs
-    description: <int> ..F.A...... set the number of outputs (from 1 to INT_MAX) (default 1)
-  - name: commands
-    description: <string> ..FVA...... set commands
-  - name: filename
-    description: <string> ..FVA...... set commands file
-  - name: nb_out_samples
-    description: <int> ..F.A....T. set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)
-  - name: pad
-    description: <boolean> ..F.A....T. pad last frame with zeros (default true)
-  - name: tb
-    description: <string> ..F.A...... set expression determining the output timebase (default "intb")
-  - name: param
-    description: <double> ..F.A....T. set softclip parameter (from 0.01 to 3) (default 1)
-  - name: oversample
-    description: <int> ..F.A....T. set oversample factor (from 1 to 64) (default 1)
-  - name: measure
-    description: <flags> ..F.A...... select the parameters which are measured (default all+mean+variance+centroid+spread+skewness+kurtosis+entropy+flatness+crest+flux+slope+decrease+rolloff) none ..F.A...... all ..F.A...... mean ..F.A...... variance ..F.A...... centroid ..F.A...... spread ..F.A...... skewness ..F.A...... kurtosis ..F.A...... entropy ..F.A...... flatness ..F.A...... crest ..F.A...... flux ..F.A...... slope ..F.A...... decrease ..F.A...... rolloff ..F.A......
-  - name: hmm
-    description: <string> ..F.A...... set directory containing acoustic model files
-  - name: dict
-    description: <string> ..F.A...... set pronunciation dictionary
-  - name: lm
-    description: <string> ..F.A...... set language model file
-  - name: lmctl
-    description: <string> ..F.A...... set language model set
-  - name: lmname
-    description: <string> ..F.A...... set which language model to use
-  - name: logfn
-    description: <string> ..F.A...... set output for log messages (default "/dev/null")
-  - name: metadata
-    description: <boolean> ..F.A...... inject metadata in the filtergraph (default false)
-  - name: reset
-    description: <int> ..F.A...... Set the number of frames over which cumulative stats are calculated before being reset (from 0 to INT_MAX) (default 0)
-  - name: measure_overall
-    description: <flags> ..F.A...... Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count) none ..F.A...... all ..F.A...... Bit_depth ..F.A...... Crest_factor ..F.A...... DC_offset ..F.A...... Dynamic_range ..F.A...... Entropy ..F.A...... Flat_factor ..F.A...... Max_difference ..F.A...... Max_level ..F.A...... Mean_difference ..F.A...... Min_difference ..F.A...... Min_level ..F.A...... Noise_floor ..F.A...... Noise_floor_count ..F.A...... Number_of_Infs ..F.A...... Number_of_NaNs ..F.A...... Number_of_denormals ..F.A...... Number_of_samples ..F.A...... Peak_count ..F.A...... Peak_level ..F.A...... RMS_difference ..F.A...... RMS_level ..F.A...... RMS_peak ..F.A...... RMS_trough ..F.A...... Zero_crossings ..F.A...... Zero_crossings_rate ..F.A...... Abs_Peak_count ..F.A......
-  - name: map
-    description: <string> ..FVA....T. input indexes to remap to outputs
-  - name: boost
-    description: <double> ..F.A....T. set max boost (from 1 to 12) (default 2)
-  - name: feedback
-    description: <double> ..F.A....T. set feedback (from 0 to 1) (default 0.9)
-  - name: cutoff
-    description: <double> ..F.A....T. set cutoff (from 50 to 900) (default 100)
-  - name: slope
-    description: <double> ..F.A....T. set slope (from 0.0001 to 1) (default 0.5)
-  - name: centerf
-    description: <double> ..F.A....T. set center frequency (from 2 to 999999) (default 1000)
-  - name: qfactor
-    description: <double> ..F.A....T. set Q-factor (from 0.01 to 100) (default 1)
-  - name: tempo
-    description: <double> ..F.A....T. set tempo scale factor (from 0.5 to 100) (default 1)
-  - name: starti
-    description: <duration> ..F.A...... Timestamp of the first frame that should be passed (default INT64_MAX)
-  - name: end
-    description: <duration> ..F.A...... Timestamp of the first frame that should be dropped again (default INT64_MAX)
-  - name: endi
-    description: <duration> ..F.A...... Timestamp of the first frame that should be dropped again (default INT64_MAX)
-  - name: start_pts
-    description: <int64> ..F.A...... Timestamp of the first frame that should be passed (from I64_MIN to I64_MAX) (default I64_MIN)
-  - name: end_pts
-    description: <int64> ..F.A...... Timestamp of the first frame that should be dropped again (from I64_MIN to I64_MAX) (default I64_MIN)
-  - name: durationi
-    description: <duration> ..F.A...... Maximum duration of the output (default 0)
-  - name: end_sample
-    description: <int64> ..F.A...... Number of the first audio sample that should be dropped again (from 0 to I64_MAX) (default I64_MAX)
-  - name: algo
-    description: <int> ..F.A...... set the algorithm (from 0 to 2) (default best) slow 0 ..F.A...... slow algorithm fast 1 ..F.A...... fast algorithm best 2 ..F.A...... best algorithm
-  - name: bind_address
-    description: <string> ..FVA...... set bind address (default "tcp://*:5555")
-  - name: csg
-    description: <boolean> ..F.A....T. use constant skirt gain (default false)
-  - name: blocksize
-    description: <int> ..F.A...... set the block size (from 0 to 32768) (default 0)
-  - name: g
-    description: <double> ..F.A....T. set gain (from -900 to 900) (default 0)
-  - name: a0
-    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 1)
-  - name: a1
-    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
-  - name: a2
-    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
-  - name: b0
-    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
-  - name: b1
-    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
-  - name: b2
-    description: <double> ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
-  - name: fcut
-    description: <int> ..F.A...... Set cut frequency (in Hz) (from 0 to 2000) (default 0)
-  - name: feed
-    description: <int> ..F.A...... Set feed level (in Hz) (from 0 to 150) (default 0)
-  - name: speeds
-    description: <string> ..F.A...... set speeds
-  - name: depths
-    description: <string> ..F.A...... set depths
-  - name: attacks
-    description: <string> ..F.A...... set time over which increase of volume is determined (default "0")
-  - name: points
-    description: <string> ..F.A...... set points of transfer function (default "-70/-70|-60/-20|1/0")
-  - name: soft-knee
-    description: <double> ..F.A...... set soft-knee (from 0.01 to 900) (default 0.01)
-  - name: volume
-    description: <double> ..F.A...... set initial volume (from -900 to 0) (default 0)
-  - name: mm
-    description: <int> ..F.A....T. set mm distance (from 0 to 10) (default 0)
-  - name: cm
-    description: <int> ..F.A....T. set cm distance (from 0 to 100) (default 0)
-  - name: temp
-    description: <int> ..F.A....T. set temperature °C (from -50 to 50) (default 20)
-  - name: block_size
-    description: <int> ..F.A...... set the block size (from 0 to 32768) (default 0)
-  - name: i
-    description: <float> ..F.A....T. set intensity (from -10 to 10) (default 2)
-  - name: limitergain
-    description: <double> ..F.A...... set limiter gain (from 0 to 1) (default 0)
-  - name: original
-    description: <double> ..F.A....T. set original center factor (from 0 to 1) (default 1)
-  - name: enhance
-    description: <double> ..F.A....T. set dialogue enhance factor (from 0 to 3) (default 1)
-  - name: voice
-    description: <double> ..F.A....T. set voice detection factor (from 2 to 32) (default 2)
-  - name: framelen
-    description: <int> ..F.A....T. set the frame length in msec (from 10 to 8000) (default 500)
-  - name: gausssize
-    description: <int> ..F.A....T. set the filter size (from 3 to 301) (default 31)
-  - name: peak
-    description: <double> ..F.A....T. set the peak value (from 0 to 1) (default 0.95)
-  - name: maxgain
-    description: <double> ..F.A....T. set the max amplification (from 1 to 100) (default 10)
-  - name: targetrms
-    description: <double> ..F.A....T. set the target RMS (from 0 to 1) (default 0)
-  - name: coupling
-    description: <boolean> ..F.A....T. set channel coupling (default true)
-  - name: correctdc
-    description: <boolean> ..F.A....T. set DC correction (default false)
-  - name: altboundary
-    description: <boolean> ..F.A....T. set alternative boundary mode (default false)
-  - name: compress
-    description: <double> ..F.A....T. set the compress factor (from 0 to 30) (default 0)
-  - name: h
-    description: <string> ..F.A....T. set channels to filter (default "all")
-  - name: v
-    description: <string> ..F.A....T. set the custom peak mapping curve
-  - name: video
-    description: <boolean> ..FV....... set video output (default false)
-  - name: meter
-    description: <int> ..FV....... set scale meter (+9 to +18) (from 9 to 18) (default 9)
-  - name: framelog
-    description: <int> ..FVA...... force frame logging level (from INT_MIN to INT_MAX) (default -1) quiet -8 ..FVA...... logging disabled info 32 ..FVA...... information logging level verbose 40 ..FVA...... verbose logging level
-  - name: dualmono
-    description: <boolean> ..F.A...... treat mono input files as dual-mono (default false)
-  - name: panlaw
-    description: <double> ..F.A...... set a specific pan law for dual-mono files (from -10 to 0) (default -3.0103)
-  - name: target
-    description: <int> ..FV....... set a specific target level in LUFS (-23 to 0) (from -23 to 0) (default -23)
-  - name: gauge
-    description: <int> ..FV....... set gauge display type (from 0 to 1) (default momentary) momentary 0 ..FV....... display momentary value m 0 ..FV....... display momentary value shortterm 1 ..FV....... display short-term value s 1 ..FV....... display short-term value
-  - name: scale
-    description: <int> ..FV....... sets display method for the stats (from 0 to 1) (default absolute) absolute 0 ..FV....... display absolute values (LUFS) LUFS 0 ..FV....... display absolute values (LUFS) relative 1 ..FV....... display values relative to target (LU) LU 1 ..FV....... display values relative to target (LU)
-  - name: integrated
-    description: <double> ..F.A.XR... integrated loudness (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
-  - name: lra_low
-    description: <double> ..F.A.XR... LRA low (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
-  - name: lra_high
-    description: <double> ..F.A.XR... LRA high (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
-  - name: sample_peak
-    description: <double> ..F.A.XR... sample peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
-  - name: true_peak
-    description: <double> ..F.A.XR... true peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
-  - name: gain_entry
-    description: <string> ..F.A....T. set gain entry
-  - name: accuracy
-    description: <double> ..F.A...... set accuracy (from 0 to 1e+10) (default 5)
-  - name: wfunc
-    description: <int> ..F.A...... set window function (from 0 to 9) (default hann) rectangular 0 ..F.A...... rectangular window hann 1 ..F.A...... hann window hamming 2 ..F.A...... hamming window blackman 3 ..F.A...... blackman window nuttall3 4 ..F.A...... 3-term nuttall window mnuttall3 5 ..F.A...... minimum 3-term nuttall window nuttall 6 ..F.A...... nuttall window bnuttall 7 ..F.A...... blackman-nuttall window bharris 8 ..F.A...... blackman-harris window tukey 9 ..F.A...... tukey window
-  - name: fixed
-    description: <boolean> ..F.A...... set fixed frame samples (default false)
-  - name: multi
-    description: <boolean> ..F.A...... set multi channels mode (default false)
-  - name: zero_phase
-    description: <boolean> ..F.A...... set zero phase mode (default false)
-  - name: dumpfile
-    description: <string> ..F.A...... set dump file
-  - name: dumpscale
-    description: <int> ..F.A...... set dump scale (from 0 to 3) (default linlog) linlin 0 ..F.A...... linear-freq linear-gain linlog 1 ..F.A...... linear-freq logarithmic-gain loglin 2 ..F.A...... logarithmic-freq linear-gain loglog 3 ..F.A...... logarithmic-freq logarithmic-gain
-  - name: fft2
-    description: <boolean> ..F.A...... set 2-channels fft (default false)
-  - name: min_phase
-    description: <boolean> ..F.A...... set minimum phase mode (default false)
-  - name: depth
-    description: <double> ..F.A...... added swept delay in milliseconds (from 0 to 10) (default 2)
-  - name: regen
-    description: <double> ..F.A...... percentage regeneration (delayed signal feedback) (from -95 to 95) (default 0)
-  - name: shape
-    description: <int> ..F.A...... swept wave shape (from 0 to 1) (default sinusoidal) triangular 1 ..F.A...... t 1 ..F.A...... sinusoidal 0 ..F.A...... s 0 ..F.A......
-  - name: phase
-    description: <double> ..F.A...... swept wave percentage phase-shift for multi-channel (from 0 to 100) (default 25)
-  - name: interp
-    description: <int> ..F.A...... delay-line interpolation (from 0 to 1) (default linear) linear 0 ..F.A...... quadratic 1 ..F.A......
-  - name: side_gain
-    description: <double> ..F.A...... set side gain (from 0.015625 to 64) (default 1)
-  - name: middle_source
-    description: <int> ..F.A...... set middle source (from 0 to 3) (default mid) left 0 ..F.A...... right 1 ..F.A...... mid 2 ..F.A...... L+R side 3 ..F.A...... L-R
-  - name: middle_phase
-    description: <boolean> ..F.A...... set middle phase (default false)
-  - name: left_delay
-    description: <double> ..F.A...... set left delay (from 0 to 40) (default 2.05)
-  - name: left_balance
-    description: <double> ..F.A...... set left balance (from -1 to 1) (default -1)
-  - name: left_gain
-    description: <double> ..F.A...... set left gain (from 0.015625 to 64) (default 1)
-  - name: left_phase
-    description: <boolean> ..F.A...... set left phase (default false)
-  - name: right_delay
-    description: <double> ..F.A...... set right delay (from 0 to 40) (default 2.12)
-  - name: right_balance
-    description: <double> ..F.A...... set right balance (from -1 to 1) (default 1)
-  - name: right_gain
-    description: <double> ..F.A...... set right gain (from 0.015625 to 64) (default 1)
-  - name: right_phase
-    description: <boolean> ..F.A...... set right phase (default true)
-  - name: process_stereo
-    description: <boolean> ..F.A...... Process stereo channels together. Only apply target_gain when both channels match. (default true)
-  - name: cdt_ms
-    description: <int> ..F.A...... Code detect timer period in ms. (from 100 to 60000) (default 2000)
-  - name: force_pe
-    description: <boolean> ..F.A...... Always extend peaks above -3dBFS even when PE is not signaled. (default false)
-  - name: analyze_mode
-    description: <int> ..F.A...... Replace audio with solid tone and signal some processing aspect in the amplitude. (from 0 to 4) (default off) off 0 ..F.A...... disabled lle 1 ..F.A...... gain adjustment level at each sample pe 2 ..F.A...... samples where peak extend occurs cdt 3 ..F.A...... samples where the code detect timer is active tgm 4 ..F.A...... samples where the target gain does not match between channels
-  - name: bits_per_sample
-    description: <int> ..F.A...... Valid bits per sample (location of the true LSB). (from 16 to 24) (default 16) 16 16 ..F.A...... 16-bit (in s32 or s16) 20 20 ..F.A...... 20-bit (in s32) 24 24 ..F.A...... 24-bit (in s32)
-  - name: lfe
-    description: <float> ..F.A...... set lfe gain in dB (from -20 to 40) (default 0)
-  - name: hrir
-    description: <int> ..F.A...... set hrir format (from 0 to 1) (default stereo) stereo 0 ..F.A...... hrir files have exactly 2 channels multich 1 ..F.A...... single multichannel hrir file
-  - name: plugin
-    description: <string> ..F.A...... set plugin name
-  - name: controls
-    description: <string> ..F.A...... set plugin options
-  - name: l
-    description: <boolean> ..F.A...... enable latency compensation (default false)
-  - name: lra
-    description: <double> ..F.A...... set loudness range target (from 1 to 50) (default 7)
-  - name: tp
-    description: <double> ..F.A...... set maximum true peak (from -9 to 0) (default -2)
-  - name: measured_i
-    description: <double> ..F.A...... measured IL of input file (from -99 to 0) (default 0)
-  - name: measured_lra
-    description: <double> ..F.A...... measured LRA of input file (from 0 to 99) (default 0)
-  - name: measured_tp
-    description: <double> ..F.A...... measured true peak of input file (from -99 to 99) (default 99)
-  - name: measured_thresh
-    description: <double> ..F.A...... measured threshold of input file (from -99 to 0) (default -70)
-  - name: offset
-    description: <double> ..F.A...... set offset gain (from -99 to 99) (default 0)
-  - name: linear
-    description: <boolean> ..F.A...... normalize linearly if possible (default true)
-  - name: dual_mono
-    description: <boolean> ..F.A...... treat mono input as dual-mono (default false)
-  - name: print_format
-    description: <int> ..F.A...... set print format for stats (from 0 to 2) (default none) none 0 ..F.A...... json 1 ..F.A...... summary 2 ..F.A......
-  - name: args
-    description: <string> ..F.A...... set parameters for each band (default "0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000")
-  - name: track_gain
-    description: <float> ..F.A.XR... track gain (dB) (from -FLT_MAX to FLT_MAX) (default 0)
-  - name: track_peak
-    description: <float> ..F.A.XR... track peak (from -FLT_MAX to FLT_MAX) (default 0)
-  - name: pitch
-    description: <double> ..F.A....T. set pitch scale factor (from 0.01 to 100) (default 1)
-  - name: transients
-    description: <int> ..F.A...... set transients (from 0 to INT_MAX) (default crisp) crisp 0 ..F.A...... mixed 256 ..F.A...... smooth 512 ..F.A......
-  - name: detector
-    description: <int> ..F.A...... set detector (from 0 to INT_MAX) (default compound) compound 0 ..F.A...... percussive 1024 ..F.A...... soft 2048 ..F.A......
-  - name: smoothing
-    description: <int> ..F.A...... set smoothing (from 0 to INT_MAX) (default off) off 0 ..F.A...... on 8388608 ..F.A......
-  - name: formant
-    description: <int> ..F.A...... set formant (from 0 to INT_MAX) (default shifted) shifted 0 ..F.A...... preserved 16777216 ..F.A......
-  - name: pitchq
-    description: <int> ..F.A...... set pitch quality (from 0 to INT_MAX) (default speed) quality 33554432 ..F.A...... speed 0 ..F.A...... consistency 67108864 ..F.A......
-  - name: noise
-    description: <double> ..F.A...... set noise tolerance (from 0 to DBL_MAX) (default 0.001)
-  - name: mono
-    description: <boolean> ..F.A...... check each channel separately (default false)
-  - name: start_periods
-    description: <int> ..F.A...... set periods of silence parts to skip from start (from 0 to 9000) (default 0)
-  - name: start_duration
-    description: <duration> ..F.A...... set start duration of non-silence part (default 0)
-  - name: start_threshold
-    description: <double> ..F.A....T. set threshold for start silence detection (from 0 to DBL_MAX) (default 0)
-  - name: start_silence
-    description: <duration> ..F.A...... set start duration of silence part to keep (default 0)
-  - name: start_mode
-    description: <int> ..F.A....T. set which channel will trigger trimming from start (from 0 to 1) (default any) any 0 ..F.A....T. all 1 ..F.A....T.
-  - name: stop_periods
-    description: <int> ..F.A...... set periods of silence parts to skip from end (from -9000 to 9000) (default 0)
-  - name: stop_duration
-    description: <duration> ..F.A...... set stop duration of silence part (default 0)
-  - name: stop_threshold
-    description: <double> ..F.A....T. set threshold for stop silence detection (from 0 to DBL_MAX) (default 0)
-  - name: stop_silence
-    description: <duration> ..F.A...... set stop duration of silence part to keep (default 0)
-  - name: stop_mode
-    description: <int> ..F.A....T. set which channel will trigger trimming from end (from 0 to 1) (default all) any 0 ..F.A....T. all 1 ..F.A....T.
-  - name: timestamp
-    description: <int> ..F.A...... set how every output frame timestamp is processed (from 0 to 1) (default write) write 0 ..F.A...... full timestamps rewrite, keep only the start time copy 1 ..F.A...... non-dropped frames are left with same timestamp
-  - name: sofa
-    description: <string> ..F.A...... sofa filename
-  - name: rotation
-    description: <float> ..F.A...... set rotation (from -360 to 360) (default 0)
-  - name: elevation
-    description: <float> ..F.A...... set elevation (from -90 to 90) (default 0)
-  - name: radius
-    description: <float> ..F.A...... set radius (from 0 to 5) (default 1)
-  - name: speakers
-    description: <string> ..F.A...... set speaker custom positions
-  - name: lfegain
-    description: <float> ..F.A...... set lfe gain (from -20 to 40) (default 0)
-  - name: framesize
-    description: <int> ..F.A...... set frame size (from 1024 to 96000) (default 1024)
-  - name: interpolate
-    description: <boolean> ..F.A...... interpolate IRs from neighbors (default false)
-  - name: minphase
-    description: <boolean> ..F.A...... minphase IRs (default false)
-  - name: anglestep
-    description: <float> ..F.A...... set neighbor search angle step (from 0.01 to 10) (default 0.5)
-  - name: radstep
-    description: <float> ..F.A...... set neighbor search radius step (from 0.01 to 1) (default 0.01)
-  - name: expansion
-    description: <double> ..F.A....T. set the max expansion factor (from 1 to 50) (default 2)
-  - name: compression
-    description: <double> ..F.A....T. set the max compression factor (from 1 to 50) (default 2)
-  - name: raise
-    description: <double> ..F.A....T. set the expansion raising amount (from 0 to 1) (default 0.001)
-  - name: fall
-    description: <double> ..F.A....T. set the compression raising amount (from 0 to 1) (default 0.001)
-  - name: invert
-    description: <boolean> ..F.A....T. set inverted filtering (default false)
-  - name: rms
-    description: <double> ..F.A....T. set the RMS value (from 0 to 1) (default 0)
-  - name: balance_in
-    description: <double> ..F.A....T. set balance in (from -1 to 1) (default 0)
-  - name: balance_out
-    description: <double> ..F.A....T. set balance out (from -1 to 1) (default 0)
-  - name: softclip
-    description: <boolean> ..F.A....T. enable softclip (default false)
-  - name: mutel
-    description: <boolean> ..F.A....T. mute L (default false)
-  - name: muter
-    description: <boolean> ..F.A....T. mute R (default false)
-  - name: phasel
-    description: <boolean> ..F.A....T. phase L (default false)
-  - name: phaser
-    description: <boolean> ..F.A....T. phase R (default false)
-  - name: slev
-    description: <double> ..F.A....T. set side level (from 0.015625 to 64) (default 1)
-  - name: sbal
-    description: <double> ..F.A....T. set side balance (from -1 to 1) (default 0)
-  - name: mlev
-    description: <double> ..F.A....T. set middle level (from 0.015625 to 64) (default 1)
-  - name: mpan
-    description: <double> ..F.A....T. set middle pan (from -1 to 1) (default 0)
-  - name: base
-    description: <double> ..F.A....T. set stereo base (from -1 to 1) (default 0)
-  - name: sclevel
-    description: <double> ..F.A....T. set S/C level (from 1 to 100) (default 1)
-  - name: bmode_in
-    description: <int> ..F.A....T. set balance in mode (from 0 to 2) (default balance) balance 0 ..F.A....T. amplitude 1 ..F.A....T. power 2 ..F.A....T.
-  - name: bmode_out
-    description: <int> ..F.A....T. set balance out mode (from 0 to 2) (default balance) balance 0 ..F.A....T. amplitude 1 ..F.A....T. power 2 ..F.A....T.
-  - name: crossfeed
-    description: <float> ..F.A....T. set cross feed (from 0 to 0.8) (default 0.3)
-  - name: drymix
-    description: <float> ..F.A....T. set dry-mix (from 0 to 1) (default 0.8)
-  - name: chl_out
-    description: <string> ..F.A...... set output channel layout (default "5.1")
-  - name: chl_in
-    description: <string> ..F.A...... set input channel layout (default "stereo")
-  - name: lfe_low
-    description: <int> ..F.A...... LFE low cut off (from 0 to 256) (default 128)
-  - name: lfe_high
-    description: <int> ..F.A...... LFE high cut off (from 0 to 512) (default 256)
-  - name: lfe_mode
-    description: <int> ..F.A....T. set LFE channel mode (from 0 to 1) (default add) add 0 ..F.A....T. just add LFE channel sub 1 ..F.A....T. substract LFE channel with others
-  - name: angle
-    description: <float> ..F.A....T. set soundfield transform angle (from 0 to 360) (default 90)
-  - name: focus
-    description: <float> ..F.A....T. set soundfield transform focus (from -1 to 1) (default 0)
-  - name: fc_in
-    description: <float> ..F.A....T. set front center channel input level (from 0 to 10) (default 1)
-  - name: fc_out
-    description: <float> ..F.A....T. set front center channel output level (from 0 to 10) (default 1)
-  - name: fl_in
-    description: <float> ..F.A....T. set front left channel input level (from 0 to 10) (default 1)
-  - name: fl_out
-    description: <float> ..F.A....T. set front left channel output level (from 0 to 10) (default 1)
-  - name: fr_in
-    description: <float> ..F.A....T. set front right channel input level (from 0 to 10) (default 1)
-  - name: fr_out
-    description: <float> ..F.A....T. set front right channel output level (from 0 to 10) (default 1)
-  - name: sl_in
-    description: <float> ..F.A....T. set side left channel input level (from 0 to 10) (default 1)
-  - name: sl_out
-    description: <float> ..F.A....T. set side left channel output level (from 0 to 10) (default 1)
-  - name: sr_in
-    description: <float> ..F.A....T. set side right channel input level (from 0 to 10) (default 1)
-  - name: sr_out
-    description: <float> ..F.A....T. set side right channel output level (from 0 to 10) (default 1)
-  - name: bl_in
-    description: <float> ..F.A....T. set back left channel input level (from 0 to 10) (default 1)
-  - name: bl_out
-    description: <float> ..F.A....T. set back left channel output level (from 0 to 10) (default 1)
-  - name: br_in
-    description: <float> ..F.A....T. set back right channel input level (from 0 to 10) (default 1)
-  - name: br_out
-    description: <float> ..F.A....T. set back right channel output level (from 0 to 10) (default 1)
-  - name: bc_in
-    description: <float> ..F.A....T. set back center channel input level (from 0 to 10) (default 1)
-  - name: bc_out
-    description: <float> ..F.A....T. set back center channel output level (from 0 to 10) (default 1)
-  - name: lfe_in
-    description: <float> ..F.A....T. set lfe channel input level (from 0 to 10) (default 1)
-  - name: lfe_out
-    description: <float> ..F.A....T. set lfe channel output level (from 0 to 10) (default 1)
-  - name: allx
-    description: <float> ..F.A....T. set all channel's x spread (from -1 to 15) (default -1)
-  - name: ally
-    description: <float> ..F.A....T. set all channel's y spread (from -1 to 15) (default -1)
-  - name: fcx
-    description: <float> ..F.A....T. set front center channel x spread (from 0.06 to 15) (default 0.5)
-  - name: flx
-    description: <float> ..F.A....T. set front left channel x spread (from 0.06 to 15) (default 0.5)
-  - name: frx
-    description: <float> ..F.A....T. set front right channel x spread (from 0.06 to 15) (default 0.5)
-  - name: blx
-    description: <float> ..F.A....T. set back left channel x spread (from 0.06 to 15) (default 0.5)
-  - name: brx
-    description: <float> ..F.A....T. set back right channel x spread (from 0.06 to 15) (default 0.5)
-  - name: slx
-    description: <float> ..F.A....T. set side left channel x spread (from 0.06 to 15) (default 0.5)
-  - name: srx
-    description: <float> ..F.A....T. set side right channel x spread (from 0.06 to 15) (default 0.5)
-  - name: bcx
-    description: <float> ..F.A....T. set back center channel x spread (from 0.06 to 15) (default 0.5)
-  - name: fcy
-    description: <float> ..F.A....T. set front center channel y spread (from 0.06 to 15) (default 0.5)
-  - name: fly
-    description: <float> ..F.A....T. set front left channel y spread (from 0.06 to 15) (default 0.5)
-  - name: fry
-    description: <float> ..F.A....T. set front right channel y spread (from 0.06 to 15) (default 0.5)
-  - name: bly
-    description: <float> ..F.A....T. set back left channel y spread (from 0.06 to 15) (default 0.5)
-  - name: bry
-    description: <float> ..F.A....T. set back right channel y spread (from 0.06 to 15) (default 0.5)
-  - name: sly
-    description: <float> ..F.A....T. set side left channel y spread (from 0.06 to 15) (default 0.5)
-  - name: sry
-    description: <float> ..F.A....T. set side right channel y spread (from 0.06 to 15) (default 0.5)
-  - name: bcy
-    description: <float> ..F.A....T. set back center channel y spread (from 0.06 to 15) (default 0.5)
-  - name: eval
-    description: <int> ..F.A...... specify when to evaluate expressions (from 0 to 1) (default once) once 0 ..F.A...... eval volume expression once frame 1 ..F.A...... eval volume expression per-frame
-  - name: replaygain
-    description: <int> ..F.A...... Apply replaygain side data when present (from 0 to 3) (default drop) drop 0 ..F.A...... replaygain side data is dropped ignore 1 ..F.A...... replaygain side data is ignored track 2 ..F.A...... track gain is preferred album 3 ..F.A...... album gain is preferred
-  - name: taps
-    description: <int> ..F.A...... set number of taps for delay filter (from 0 to 32768) (default 0)
-  - name: preset
-    description: <int> ..F.A...... set equalizer preset (from -1 to 17) (default flat) custom -1 ..F.A...... flat 0 ..F.A...... acoustic 1 ..F.A...... bass 2 ..F.A...... beats 3 ..F.A...... classic 4 ..F.A...... clear 5 ..F.A...... deep bass 6 ..F.A...... dubstep 7 ..F.A...... electronic 8 ..F.A...... hardstyle 9 ..F.A...... hip-hop 10 ..F.A...... jazz 11 ..F.A...... metal 12 ..F.A...... movie 13 ..F.A...... pop 14 ..F.A...... r&b 15 ..F.A...... rock 16 ..F.A...... vocal booster 17 ..F.A......
-  - name: bands
-    description: <string> ..F.A...... set central frequency values per band (default "25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000")
-  - name: magnitude
-    description: <string> ..F.A...... set magnitude values (default "1 1")
-  - name: amplitude
-    description: <double> ..F.A...... set amplitude (from 0 to 1) (default 1)
-  - name: color
-    description: <int> ..F.A...... set noise color (from 0 to 5) (default white) white 0 ..F.A...... pink 1 ..F.A...... brown 2 ..F.A...... blue 3 ..F.A...... violet 4 ..F.A...... velvet 5 ..F.A......
-  - name: colour
-    description: <int> ..F.A...... set noise color (from 0 to 5) (default white) white 0 ..F.A...... pink 1 ..F.A...... brown 2 ..F.A...... blue 3 ..F.A...... violet 4 ..F.A...... velvet 5 ..F.A......
-  - name: density
-    description: <double> ..F.A...... set density (from 0 to 1) (default 0.05)
-  - name: list_voices
-    description: <boolean> ..F.A...... list voices and exit (default false)
-  - name: text
-    description: <string> ..F.A...... set text to speak
-  - name: textfile
-    description: <string> ..F.A...... set filename of the text to speak
-  - name: hp
-    description: <float> ..F.A...... set high-pass filter frequency (from 0 to INT_MAX) (default 0)
-  - name: lp
-    description: <float> ..F.A...... set low-pass filter frequency (from 0 to INT_MAX) (default 0)
-  - name: beta
-    description: <float> ..F.A...... set kaiser window beta (from -1 to 256) (default -1)
-  - name: att
-    description: <float> ..F.A...... set stop-band attenuation (from 40 to 180) (default 120)
-  - name: round
-    description: <boolean> ..F.A...... enable rounding (default false)
-  - name: hptaps
-    description: <int> ..F.A...... set number of taps for high-pass filter (from 0 to 32768) (default 0)
-  - name: lptaps
-    description: <int> ..F.A...... set number of taps for low-pass filter (from 0 to 32768) (default 0)
-  - name: beep_factor
-    description: <double> ..F.A...... set the beep frequency factor (from 0 to DBL_MAX) (default 0)
-  - name: x
-    description: <string> ..FV....... Region distance from left edge of frame. (default "0")
-  - name: y
-    description: <string> ..FV....... Region distance from top edge of frame. (default "0")
-  - name: qoffset
-    description: <rational> ..FV....... Quantisation offset to apply in the region. (from -1 to 1) (default -1/10)
-  - name: clear
-    description: <boolean> ..FV....... Remove any existing regions of interest before adding the new one. (default false)
-  - name: eof_action
-    description: <int> ..FV....... Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat) repeat 0 ..FV....... Repeat the previous frame. endall 1 ..FV....... End both streams. pass 2 ..FV....... Pass through the main input.
-  - name: shortest
-    description: <boolean> ..FV....... force termination when the shortest input terminates (default false)
-  - name: repeatlast
-    description: <boolean> ..FV....... extend last frame of secondary streams beyond EOF (default true)
-  - name: ts_sync_mode
-    description: <int> ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default) default 0 ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame nearest 1 ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
-  - name: factor
-    description: <float> ..FV.....T. set factor (from 0 to 65535) (default 2)
-  - name: tolerance
-    description: <float> ..FV.....T. set tolerance (from 0 to 65535) (default 0)
-  - name: low
-    description: <float> ..FV.....T. set low limit for amplification (from 0 to 65535) (default 65535)
-  - name: high
-    description: <float> ..FV.....T. set high limit for amplification (from 0 to 65535) (default 65535)
-  - name: planes
-    description: <flags> ..FV.....T. set what planes to filter (default 7)
-  - name: original_size
-    description: <image_size> ..FV....... set the size of the original video (used to scale fonts)
-  - name: fontsdir
-    description: <string> ..FV....... set the directory containing the fonts to read
-  - name: alpha
-    description: <boolean> ..FV....... enable processing of alpha channel (default false)
-  - name: shaping
-    description: <int> ..FV....... set shaping engine (from -1 to 1) (default auto) auto -1 ..FV....... simple 0 ..FV....... simple shaping complex 1 ..FV....... complex shaping
-  - name: similarity
-    description: <float> ..FV.....T. set the similarity (from 0 to 1) (default 0.1)
-  - name: min_val
-    description: <int> ..FV.....T. set minimum luminance value for bounding box (from 0 to 65535) (default 16)
-  - name: window_size
-    description: <int> ..FV....... set neighbours window_size (from 1 to 255) (default 1)
-  - name: bitplane
-    description: <int> ..FV....... set bit plane to use for measuring noise (from 1 to 16) (default 1)
-  - name: filter
-    description: <boolean> ..FV....... show noisy pixels (default false)
-  - name: pic_th
-    description: <double> ..FV....... set the picture black ratio threshold (from 0 to 1) (default 0.98)
-  - name: pixel_black_th
-    description: <double> ..FV....... set the pixel black threshold (from 0 to 1) (default 0.1)
-  - name: pix_th
-    description: <double> ..FV....... set the pixel black threshold (from 0 to 1) (default 0.1)
-  - name: thresh
-    description: <int> ..FV....... threshold below which a pixel value is considered black (from 0 to 255) (default 32)
-  - name: c0_mode
-    description: '<int> ..FV.....T. set component #0 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
-  - name: c1_mode
-    description: '<int> ..FV.....T. set component #1 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
-  - name: c2_mode
-    description: '<int> ..FV.....T. set component #2 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
-  - name: c3_mode
-    description: '<int> ..FV.....T. set component #3 blend mode (from 0 to 39) (default normal) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.'
-  - name: all_mode
-    description: <int> ..FV.....T. set blend mode for all components (from -1 to 39) (default -1) addition 1 ..FV.....T. addition128 28 ..FV.....T. grainmerge 28 ..FV.....T. and 2 ..FV.....T. average 3 ..FV.....T. burn 4 ..FV.....T. darken 5 ..FV.....T. difference 6 ..FV.....T. difference128 7 ..FV.....T. grainextract 7 ..FV.....T. divide 8 ..FV.....T. dodge 9 ..FV.....T. exclusion 10 ..FV.....T. extremity 32 ..FV.....T. freeze 31 ..FV.....T. glow 27 ..FV.....T. hardlight 11 ..FV.....T. hardmix 25 ..FV.....T. heat 30 ..FV.....T. lighten 12 ..FV.....T. linearlight 26 ..FV.....T. multiply 13 ..FV.....T. multiply128 29 ..FV.....T. negation 14 ..FV.....T. normal 0 ..FV.....T. or 15 ..FV.....T. overlay 16 ..FV.....T. phoenix 17 ..FV.....T. pinlight 18 ..FV.....T. reflect 19 ..FV.....T. screen 20 ..FV.....T. softlight 21 ..FV.....T. subtract 22 ..FV.....T. vividlight 23 ..FV.....T. xor 24 ..FV.....T. softdifference 33 ..FV.....T. geometric 34 ..FV.....T. harmonic 35 ..FV.....T. bleach 36 ..FV.....T. stain 37 ..FV.....T. interpolate 38 ..FV.....T. hardoverlay 39 ..FV.....T.
-  - name: c0_expr
-    description: '<string> ..FV.....T. set color component #0 expression'
-  - name: c1_expr
-    description: '<string> ..FV.....T. set color component #1 expression'
-  - name: c2_expr
-    description: '<string> ..FV.....T. set color component #2 expression'
-  - name: c3_expr
-    description: '<string> ..FV.....T. set color component #3 expression'
-  - name: all_expr
-    description: <string> ..FV.....T. set expression for all color components
-  - name: c0_opacity
-    description: '<double> ..FV.....T. set color component #0 opacity (from 0 to 1) (default 1)'
-  - name: c1_opacity
-    description: '<double> ..FV.....T. set color component #1 opacity (from 0 to 1) (default 1)'
-  - name: c2_opacity
-    description: '<double> ..FV.....T. set color component #2 opacity (from 0 to 1) (default 1)'
-  - name: c3_opacity
-    description: '<double> ..FV.....T. set color component #3 opacity (from 0 to 1) (default 1)'
-  - name: all_opacity
-    description: <double> ..FV.....T. set opacity for all color components (from 0 to 1) (default 1)
-  - name: period_min
-    description: <int> ..FV....... Minimum period to search for (from 2 to 32) (default 3)
-  - name: period_max
-    description: <int> ..FV....... Maximum period to search for (from 2 to 64) (default 24)
-  - name: block_pct
-    description: <int> ..FV....... block pooling threshold when calculating blurriness (from 1 to 100) (default 80)
-  - name: block_width
-    description: <int> ..FV....... block size for block-based abbreviation of blurriness (from -1 to INT_MAX) (default -1)
-  - name: block_height
-    description: <int> ..FV....... block size for block-based abbreviation of blurriness (from -1 to INT_MAX) (default -1)
-  - name: block
-    description: <int> ..FV....... set size of local patch (from 8 to 64) (default 16)
-  - name: bstep
-    description: <int> ..FV....... set sliding step for processing blocks (from 1 to 64) (default 4)
-  - name: group
-    description: <int> ..FV....... set maximal number of similar blocks (from 1 to 256) (default 1)
-  - name: mstep
-    description: <int> ..FV....... set step for block matching (from 1 to 64) (default 1)
-  - name: thmse
-    description: <float> ..FV....... set threshold of mean square error for block matching (from 0 to INT_MAX) (default 0)
-  - name: hdthr
-    description: <float> ..FV....... set hard threshold for 3D transfer domain (from 0 to INT_MAX) (default 2.7)
-  - name: estim
-    description: <int> ..FV....... set filtering estimation mode (from 0 to 1) (default basic) basic 0 ..FV....... basic estimate final 1 ..FV....... final estimate
-  - name: ref
-    description: <boolean> ..FV....... have reference stream (default false)
-  - name: luma_radius
-    description: <string> ..FV....... Radius of the luma blurring box (default "2")
-  - name: lr
-    description: <string> ..FV....... Radius of the luma blurring box (default "2")
-  - name: luma_power
-    description: <int> ..FV....... How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
-  - name: chroma_radius
-    description: <string> ..FV....... Radius of the chroma blurring box
-  - name: cr
-    description: <string> ..FV....... Radius of the chroma blurring box
-  - name: chroma_power
-    description: <int> ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
-  - name: cp
-    description: <int> ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
-  - name: alpha_radius
-    description: <string> ..FV....... Radius of the alpha blurring box
-  - name: ar
-    description: <string> ..FV....... Radius of the alpha blurring box
-  - name: alpha_power
-    description: <int> ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
-  - name: ap
-    description: <int> ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
-  - name: parity
-    description: <int> ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto) tff 0 ..FV....... assume top field first bff 1 ..FV....... assume bottom field first auto -1 ..FV....... auto detect parity
-  - name: deint
-    description: <int> ..FV....... specify which frames to deinterlace (from 0 to 1) (default all) all 0 ..FV....... deinterlace all frames interlaced 1 ..FV....... only deinterlace frames marked as interlaced
-  - name: dist_x
-    description: <float> ..FV....... Set horizontal distortion amount (from -10 to 10) (default 0)
-  - name: dist_y
-    description: <float> ..FV....... Set vertical distortion amount (from -10 to 10) (default 0)
-  - name: yuv
-    description: <boolean> ..FV.....T. color parameter is in yuv instead of rgb (default false)
-  - name: thres
-    description: <float> ..FV.....T. set y+u+v threshold (from 1 to 200) (default 30)
-  - name: sizew
-    description: <int> ..FV.....T. set horizontal patch size (from 1 to 100) (default 5)
-  - name: sizeh
-    description: <int> ..FV.....T. set vertical patch size (from 1 to 100) (default 5)
-  - name: stepw
-    description: <int> ..FV.....T. set horizontal step (from 1 to 50) (default 1)
-  - name: steph
-    description: <int> ..FV.....T. set vertical step (from 1 to 50) (default 1)
-  - name: threy
-    description: <float> ..FV.....T. set y threshold (from 1 to 200) (default 200)
-  - name: threu
-    description: <float> ..FV.....T. set u threshold (from 1 to 200) (default 200)
-  - name: threv
-    description: <float> ..FV.....T. set v threshold (from 1 to 200) (default 200)
-  - name: distance
-    description: <int> ..FV.....T. set distance type (from 0 to 1) (default manhattan) manhattan 0 ..FV.....T. euclidean 1 ..FV.....T.
-  - name: cbh
-    description: <int> ..FV.....T. shift chroma-blue horizontally (from -255 to 255) (default 0)
-  - name: cbv
-    description: <int> ..FV.....T. shift chroma-blue vertically (from -255 to 255) (default 0)
-  - name: crh
-    description: <int> ..FV.....T. shift chroma-red horizontally (from -255 to 255) (default 0)
-  - name: crv
-    description: <int> ..FV.....T. shift chroma-red vertically (from -255 to 255) (default 0)
-  - name: edge
-    description: <int> ..FV.....T. set edge operation (from 0 to 1) (default smear) smear 0 ..FV.....T. wrap 1 ..FV.....T.
-  - name: system
-    description: <int> ..FV....... set color system (from 0 to 9) (default hdtv) ntsc 0 ..FV....... NTSC 1953 Y'I'O' (ITU-R BT.470 System M) 470m 0 ..FV....... NTSC 1953 Y'I'O' (ITU-R BT.470 System M) ebu 1 ..FV....... EBU Y'U'V' (PAL/SECAM) (ITU-R BT.470 System B, G) 470bg 1 ..FV....... EBU Y'U'V' (PAL/SECAM) (ITU-R BT.470 System B, G) smpte 2 ..FV....... SMPTE-C RGB 240m 3 ..FV....... SMPTE-240M Y'PbPr apple 4 ..FV....... Apple RGB widergb 5 ..FV....... Adobe Wide Gamut RGB cie1931 6 ..FV....... CIE 1931 RGB hdtv 7 ..FV....... ITU.BT-709 Y'CbCr rec709 7 ..FV....... ITU.BT-709 Y'CbCr uhdtv 8 ..FV....... ITU-R.BT-2020 rec2020 8 ..FV....... ITU-R.BT-2020 dcip3 9 ..FV....... DCI-P3
-  - name: cie
-    description: <int> ..FV....... set cie system (from 0 to 2) (default xyy) xyy 0 ..FV....... CIE 1931 xyY ucs 1 ..FV....... CIE 1960 UCS luv 2 ..FV....... CIE 1976 Luv
-  - name: gamuts
-    description: <flags> ..FV....... set what gamuts to draw (default 0) ntsc ..FV....... 470m ..FV....... ebu ..FV....... 470bg ..FV....... smpte ..FV....... 240m ..FV....... apple ..FV....... widergb ..FV....... cie1931 ..FV....... hdtv ..FV....... rec709 ..FV....... uhdtv ..FV....... rec2020 ..FV....... dcip3 ..FV.......
-  - name: intensity
-    description: <float> ..FV....... set ciescope intensity (from 0 to 1) (default 0.001)
-  - name: corrgamma
-    description: <boolean> ..FV....... (default true)
-  - name: showwhite
-    description: <boolean> ..FV....... (default false)
-  - name: gamma
-    description: <double> ..FV....... (from 0.1 to 6) (default 2.6)
-  - name: fill
-    description: <boolean> ..FV....... fill with CIE colors (default true)
-  - name: mv
-    description: <flags> ..FV....... set motion vectors to visualize (default 0) pf ..FV....... forward predicted MVs of P-frames bf ..FV....... forward predicted MVs of B-frames bb ..FV....... backward predicted MVs of B-frames
-  - name: qp
-    description: <boolean> ..FV....... (default false)
-  - name: mv_type
-    description: <flags> ..FV....... set motion vectors type (default 0) fp ..FV....... forward predicted MVs bp ..FV....... backward predicted MVs
-  - name: mvt
-    description: <flags> ..FV....... set motion vectors type (default 0) fp ..FV....... forward predicted MVs bp ..FV....... backward predicted MVs
-  - name: frame_type
-    description: <flags> ..FV....... set frame types to visualize motion vectors of (default 0) if ..FV....... I-frames pf ..FV....... P-frames bf ..FV....... B-frames
-  - name: ft
-    description: <flags> ..FV....... set frame types to visualize motion vectors of (default 0) if ..FV....... I-frames pf ..FV....... P-frames bf ..FV....... B-frames
-  - name: rs
-    description: <float> ..FV.....T. set red shadows (from -1 to 1) (default 0)
-  - name: bs
-    description: <float> ..FV.....T. set blue shadows (from -1 to 1) (default 0)
-  - name: rm
-    description: <float> ..FV.....T. set red midtones (from -1 to 1) (default 0)
-  - name: gm
-    description: <float> ..FV.....T. set green midtones (from -1 to 1) (default 0)
-  - name: rh
-    description: <float> ..FV.....T. set red highlights (from -1 to 1) (default 0)
-  - name: gh
-    description: <float> ..FV.....T. set green highlights (from -1 to 1) (default 0)
-  - name: bh
-    description: <float> ..FV.....T. set blue highlights (from -1 to 1) (default 0)
-  - name: pl
-    description: <boolean> ..FV.....T. preserve lightness (default false)
-  - name: rr
-    description: <double> ..FV.....T. set the red gain for the red channel (from -2 to 2) (default 1)
-  - name: rg
-    description: <double> ..FV.....T. set the green gain for the red channel (from -2 to 2) (default 0)
-  - name: rb
-    description: <double> ..FV.....T. set the blue gain for the red channel (from -2 to 2) (default 0)
-  - name: ra
-    description: <double> ..FV.....T. set the alpha gain for the red channel (from -2 to 2) (default 0)
-  - name: gr
-    description: <double> ..FV.....T. set the red gain for the green channel (from -2 to 2) (default 0)
-  - name: gg
-    description: <double> ..FV.....T. set the green gain for the green channel (from -2 to 2) (default 1)
-  - name: gb
-    description: <double> ..FV.....T. set the blue gain for the green channel (from -2 to 2) (default 0)
-  - name: ga
-    description: <double> ..FV.....T. set the alpha gain for the green channel (from -2 to 2) (default 0)
-  - name: br
-    description: <double> ..FV.....T. set the red gain for the blue channel (from -2 to 2) (default 0)
-  - name: bg
-    description: <double> ..FV.....T. set the green gain for the blue channel (from -2 to 2) (default 0)
-  - name: bb
-    description: <double> ..FV.....T. set the blue gain for the blue channel (from -2 to 2) (default 1)
-  - name: ba
-    description: <double> ..FV.....T. set the alpha gain for the blue channel (from -2 to 2) (default 0)
-  - name: ag
-    description: <double> ..FV.....T. set the green gain for the alpha channel (from -2 to 2) (default 0)
-  - name: ab
-    description: <double> ..FV.....T. set the blue gain for the alpha channel (from -2 to 2) (default 0)
-  - name: pc
-    description: <int> ..FV.....T. set the preserve color mode (from 0 to 6) (default none) none 0 ..FV.....T. disabled lum 1 ..FV.....T. luminance max 2 ..FV.....T. max avg 3 ..FV.....T. average sum 4 ..FV.....T. sum nrm 5 ..FV.....T. norm pwr 6 ..FV.....T. power
-  - name: pa
-    description: <double> ..FV.....T. set the preserve color amount (from 0 to 1) (default 0)
-  - name: rc
-    description: <float> ..FV.....T. set the red-cyan contrast (from -1 to 1) (default 0)
-  - name: by
-    description: <float> ..FV.....T. set the blue-yellow contrast (from -1 to 1) (default 0)
-  - name: rcw
-    description: <float> ..FV.....T. set the red-cyan weight (from 0 to 1) (default 0)
-  - name: gmw
-    description: <float> ..FV.....T. set the green-magenta weight (from 0 to 1) (default 0)
-  - name: byw
-    description: <float> ..FV.....T. set the blue-yellow weight (from 0 to 1) (default 0)
-  - name: rl
-    description: <float> ..FV.....T. set the red shadow spot (from -1 to 1) (default 0)
-  - name: bl
-    description: <float> ..FV.....T. set the blue shadow spot (from -1 to 1) (default 0)
-  - name: saturation
-    description: <float> ..FV.....T. set the amount of saturation (from -3 to 3) (default 1)
-  - name: analyze
-    description: <int> ..FV.....T. set the analyze mode (from 0 to 3) (default manual) manual 0 ..FV.....T. manually set options average 1 ..FV.....T. use average pixels minmax 2 ..FV.....T. use minmax pixels median 3 ..FV.....T. use median pixels
-  - name: hue
-    description: <float> ..FV.....T. set the hue (from 0 to 360) (default 0)
-  - name: lightness
-    description: <float> ..FV.....T. set the lightness (from 0 to 1) (default 0.5)
-  - name: rimin
-    description: <double> ..FV.....T. set input red black point (from -1 to 1) (default 0)
-  - name: gimin
-    description: <double> ..FV.....T. set input green black point (from -1 to 1) (default 0)
-  - name: bimin
-    description: <double> ..FV.....T. set input blue black point (from -1 to 1) (default 0)
-  - name: aimin
-    description: <double> ..FV.....T. set input alpha black point (from -1 to 1) (default 0)
-  - name: rimax
-    description: <double> ..FV.....T. set input red white point (from -1 to 1) (default 1)
-  - name: gimax
-    description: <double> ..FV.....T. set input green white point (from -1 to 1) (default 1)
-  - name: bimax
-    description: <double> ..FV.....T. set input blue white point (from -1 to 1) (default 1)
-  - name: aimax
-    description: <double> ..FV.....T. set input alpha white point (from -1 to 1) (default 1)
-  - name: romin
-    description: <double> ..FV.....T. set output red black point (from 0 to 1) (default 0)
-  - name: gomin
-    description: <double> ..FV.....T. set output green black point (from 0 to 1) (default 0)
-  - name: bomin
-    description: <double> ..FV.....T. set output blue black point (from 0 to 1) (default 0)
-  - name: aomin
-    description: <double> ..FV.....T. set output alpha black point (from 0 to 1) (default 0)
-  - name: romax
-    description: <double> ..FV.....T. set output red white point (from 0 to 1) (default 1)
-  - name: gomax
-    description: <double> ..FV.....T. set output green white point (from 0 to 1) (default 1)
-  - name: bomax
-    description: <double> ..FV.....T. set output blue white point (from 0 to 1) (default 1)
-  - name: aomax
-    description: <double> ..FV.....T. set output alpha white point (from 0 to 1) (default 1)
-  - name: preserve
-    description: <int> ..FV.....T. set preserve color mode (from 0 to 6) (default none) none 0 ..FV.....T. disabled lum 1 ..FV.....T. luminance max 2 ..FV.....T. max avg 3 ..FV.....T. average sum 4 ..FV.....T. sum nrm 5 ..FV.....T. norm pwr 6 ..FV.....T. power
-  - name: patch_size
-    description: <image_size> ..FV.....T. set patch size (default "64x64")
-  - name: nb_patches
-    description: <int> ..FV.....T. set number of patches (from 0 to 64) (default 0)
-  - name: kernel
-    description: <int> ..FV.....T. set the kernel used for measuring color difference (from 0 to 1) (default euclidean) euclidean 0 ..FV.....T. square root of sum of squared differences weuclidean 1 ..FV.....T. weighted square root of sum of squared differences
-  - name: src
-    description: <int> ..FV....... set source color matrix (from -1 to 4) (default -1) bt709 0 ..FV....... set BT.709 colorspace fcc 1 ..FV....... set FCC colorspace bt601 2 ..FV....... set BT.601 colorspace bt470 2 ..FV....... set BT.470 colorspace bt470bg 2 ..FV....... set BT.470 colorspace smpte170m 2 ..FV....... set SMTPE-170M colorspace smpte240m 3 ..FV....... set SMPTE-240M colorspace bt2020 4 ..FV....... set BT.2020 colorspace
-  - name: dst
-    description: <int> ..FV....... set destination color matrix (from -1 to 4) (default -1) bt709 0 ..FV....... set BT.709 colorspace fcc 1 ..FV....... set FCC colorspace bt601 2 ..FV....... set BT.601 colorspace bt470 2 ..FV....... set BT.470 colorspace bt470bg 2 ..FV....... set BT.470 colorspace smpte170m 2 ..FV....... set SMTPE-170M colorspace smpte240m 3 ..FV....... set SMPTE-240M colorspace bt2020 4 ..FV....... set BT.2020 colorspace
-  - name: space
-    description: <int> ..FV....... Output colorspace (from 0 to 14) (default 2) bt709 1 ..FV....... fcc 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... gbr 0 ..FV....... bt2020nc 9 ..FV....... bt2020ncl 9 ..FV.......
-  - name: primaries
-    description: <int> ..FV....... Output color primaries (from 0 to 22) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... smpte428 10 ..FV....... film 8 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... bt2020 9 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
-  - name: trc
-    description: <int> ..FV....... Output transfer characteristics (from 0 to 18) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... gamma22 4 ..FV....... bt470bg 5 ..FV....... gamma28 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... linear 8 ..FV....... srgb 13 ..FV....... iec61966-2-1 13 ..FV....... xvycc 11 ..FV....... iec61966-2-4 11 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV.......
-  - name: fast
-    description: <boolean> ..FV....... Ignore primary chromaticity and gamma correction (default false)
-  - name: dither
-    description: <int> ..FV....... Dithering mode (from 0 to 1) (default none) none 0 ..FV....... fsb 1 ..FV.......
-  - name: wpadapt
-    description: <int> ..FV....... Whitepoint adaptation method (from 0 to 2) (default bradford) bradford 0 ..FV....... vonkries 1 ..FV....... identity 2 ..FV.......
-  - name: iall
-    description: <int> ..FV....... Set all input color properties together (from 0 to 8) (default 0) bt470m 1 ..FV....... bt470bg 2 ..FV....... bt601-6-525 3 ..FV....... bt601-6-625 4 ..FV....... bt709 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... bt2020 8 ..FV.......
-  - name: ispace
-    description: <int> ..FV....... Input colorspace (from 0 to 22) (default 2) bt709 1 ..FV....... fcc 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... gbr 0 ..FV....... bt2020nc 9 ..FV....... bt2020ncl 9 ..FV.......
-  - name: irange
-    description: <int> ..FV....... Input color range (from 0 to 2) (default 0) tv 1 ..FV....... mpeg 1 ..FV....... pc 2 ..FV....... jpeg 2 ..FV.......
-  - name: iprimaries
-    description: <int> ..FV....... Input color primaries (from 0 to 22) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... smpte428 10 ..FV....... film 8 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... bt2020 9 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
-  - name: itrc
-    description: <int> ..FV....... Input transfer characteristics (from 0 to 18) (default 2) bt709 1 ..FV....... bt470m 4 ..FV....... gamma22 4 ..FV....... bt470bg 5 ..FV....... gamma28 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... linear 8 ..FV....... srgb 13 ..FV....... iec61966-2-1 13 ..FV....... xvycc 11 ..FV....... iec61966-2-4 11 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV.......
-  - name: temperature
-    description: <float> ..FV.....T. set the temperature in Kelvin (from 1000 to 40000) (default 6500)
-  - name: impulse
-    description: <int> ..FV....... when to process impulses (from 0 to 1) (default all) first 0 ..FV....... process only first impulse, ignore rest all 1 ..FV....... process all impulses
-  - name: cover
-    description: <string> ..FV....... cover bitmap filename
-  - name: out_w
-    description: <string> ..FV.....T. set the width crop area expression (default "iw")
-  - name: out_h
-    description: <string> ..FV.....T. set the height crop area expression (default "ih")
-  - name: keep_aspect
-    description: <boolean> ..FV....... keep aspect ratio (default false)
-  - name: exact
-    description: <boolean> ..FV....... do exact cropping (default false)
-  - name: skip
-    description: <int> ..FV....... Number of initial frames to skip (from 0 to INT_MAX) (default 2)
-  - name: reset_count
-    description: <int> ..FV....... Recalculate the crop area after this many frames (from 0 to INT_MAX) (default 0)
-  - name: max_outliers
-    description: <int> ..FV....... Threshold count of outliers (from 0 to INT_MAX) (default 0)
-  - name: mv_threshold
-    description: <int> ..FV....... motion vector threshold when estimating video window size (from 0 to 100) (default 8)
-  - name: master
-    description: <string> ..FV.....T. set master points coordinates
-  - name: red
-    description: <string> ..FV.....T. set red points coordinates
-  - name: green
-    description: <string> ..FV.....T. set green points coordinates
-  - name: blue
-    description: <string> ..FV.....T. set blue points coordinates
-  - name: psfile
-    description: <string> ..FV.....T. set Photoshop curves file name
-  - name: plot
-    description: <string> ..FV.....T. save Gnuplot script of the curves in specified file
-  - name: axis
-    description: <boolean> ..FV.....T. draw column/row numbers (default false)
-  - name: opacity
-    description: <float> ..FV.....T. set background opacity (from 0 to 1) (default 0.75)
-  - name: components
-    description: <int> ..FV.....T. set components to display (from 1 to 15) (default 15)
-  - name: blur
-    description: <boolean> ..FV.....T. set blur (default true)
-  - name: cycle
-    description: <int> ..FV....... set the number of frame from which one will be dropped (from 2 to 25) (default 5)
-  - name: dupthresh
-    description: <double> ..FV....... set duplicate threshold (from 0 to 100) (default 1.1)
-  - name: scthresh
-    description: <double> ..FV....... set scene change threshold (from 0 to 100) (default 15)
-  - name: blockx
-    description: <int> ..FV....... set the size of the x-axis blocks used during metric calculations (from 4 to 512) (default 32)
-  - name: blocky
-    description: <int> ..FV....... set the size of the y-axis blocks used during metric calculations (from 4 to 512) (default 32)
-  - name: ppsrc
-    description: <boolean> ..FV....... mark main input as a pre-processed input and activate clean source input stream (default false)
-  - name: chroma
-    description: <boolean> ..FV....... set whether or not chroma is considered in the metric calculations (default true)
-  - name: mixed
-    description: <boolean> ..FV....... set whether or not the input only partially contains content to be decimated (default false)
-  - name: lt
-    description: <float> ..FV....... set spatial luma threshold (from 0 to 1) (default 0.079)
-  - name: tl
-    description: <float> ..FV....... set tolerance for temporal luma (from 0 to 1) (default 0.079)
-  - name: tc
-    description: <float> ..FV....... set tolerance for chroma temporal variation (from 0 to 1) (default 0.058)
-  - name: ct
-    description: <float> ..FV....... set temporal chroma threshold (from 0 to 1) (default 0.019)
-  - name: threshold0
-    description: <int> ..FV.....T. set threshold for 1st plane (from 0 to 65535) (default 65535)
-  - name: threshold1
-    description: <int> ..FV.....T. set threshold for 2nd plane (from 0 to 65535) (default 65535)
-  - name: threshold2
-    description: <int> ..FV.....T. set threshold for 3rd plane (from 0 to 65535) (default 65535)
-  - name: threshold3
-    description: <int> ..FV.....T. set threshold for 4th plane (from 0 to 65535) (default 65535)
-  - name: bypass
-    description: <boolean> ..FV....... leave frames unchanged (default false)
-  - name: show
-    description: <boolean> ..FV....... show delogo area (default false)
-  - name: denoise
-    description: <int> ..FV....... denoise level (from 0 to 64) (default 0)
-  - name: filter_type
-    description: <int> ..FV....... filter type(derain/dehaze) (from 0 to 1) (default derain) derain 0 ..FV....... derain filter flag dehaze 1 ..FV....... dehaze filter flag
-  - name: dnn_backend
-    description: <int> ..FV....... DNN backend (from 0 to 1) (default 1)
-  - name: input
-    description: <string> ..FV....... input name of the model (default "x")
-  - name: rx
-    description: <int> ..FV....... set x for the rectangular search area (from 0 to 64) (default 16)
-  - name: ry
-    description: <int> ..FV....... set y for the rectangular search area (from 0 to 64) (default 16)
-  - name: search
-    description: <int> ..FV....... set search strategy (from 0 to 1) (default exhaustive) exhaustive 0 ..FV....... exhaustive search less 1 ..FV....... less exhaustive search
-  - name: opencl
-    description: <boolean> ..FV....... ignored (default false)
-  - name: tripod
-    description: <boolean> ..FV....... simulates a tripod by preventing any camera movement whatsoever from the original frame (default false)
-  - name: debug
-    description: <boolean> ..FV....... turn on additional debugging information (default false)
-  - name: adaptive_crop
-    description: <boolean> ..FV....... attempt to subtly crop borders to reduce mirrored content (default true)
-  - name: refine_features
-    description: <boolean> ..FV....... refine feature point locations at a sub-pixel level (default true)
-  - name: smooth_strength
-    description: <float> ..FV....... smoothing strength (0 attempts to adaptively determine optimal strength) (from 0 to 1) (default 0)
-  - name: expand
-    description: <float> ..FV.....T. set the spillmap expand (from 0 to 1) (default 0)
-  - name: brightness
-    description: <float> ..FV.....T. set brightness (from -10 to 10) (default 0)
-  - name: first_field
-    description: <int> ..FV....... select first field (from 0 to 1) (default top) top 0 ..FV....... select top field first t 0 ..FV....... select top field first bottom 1 ..FV....... select bottom field first b 1 ..FV....... select bottom field first
-  - name: pattern
-    description: <string> ..FV....... pattern that describe for how many fields a frame is to be displayed (default "23")
-  - name: start_frame
-    description: <int> ..FV....... position of first frame with respect to the pattern if stream is cut (from 0 to 13) (default 0)
-  - name: coordinates
-    description: <int> ..FV.....T. set coordinates (from 0 to 255) (default 255)
-  - name: backend_configs
-    description: <string> ..FV....... backend configs
-  - name: options
-    description: <string> ..FV......P backend configs (deprecated, use backend_configs)
-  - name: async
-    description: <boolean> ..FV....... use DNN async inference (ignored, use backend_configs='async=1') (default true)
-  - name: confidence
-    description: <float> ..FV....... threshold of confidence (from 0 to 1) (default 0.5)
-  - name: labels
-    description: <string> ..FV....... path to labels file
-  - name: height
-    description: <string> ..FV.....T. set height of the box (default "0")
-  - name: thickness
-    description: <string> ..FV.....T. set the box thickness (default "3")
-  - name: replace
-    description: <boolean> ..FV.....T. replace color & alpha (default false)
-  - name: box_source
-    description: <string> ..FV.....T. use datas from bounding box in side data
-  - name: m1
-    description: <string> ..FV....... set 1st metadata key (default "")
-  - name: fg1
-    description: <string> ..FV....... set 1st foreground color expression (default "0xffff0000")
-  - name: m2
-    description: <string> ..FV....... set 2nd metadata key (default "")
-  - name: fg2
-    description: <string> ..FV....... set 2nd foreground color expression (default "0xff00ff00")
-  - name: m3
-    description: <string> ..FV....... set 3rd metadata key (default "")
-  - name: fg3
-    description: <string> ..FV....... set 3rd foreground color expression (default "0xffff00ff")
-  - name: m4
-    description: <string> ..FV....... set 4th metadata key (default "")
-  - name: fg4
-    description: <string> ..FV....... set 4th foreground color expression (default "0xffffff00")
-  - name: min
-    description: <float> ..FV....... set minimal value (from INT_MIN to INT_MAX) (default -1)
-  - name: max
-    description: <float> ..FV....... set maximal value (from INT_MIN to INT_MAX) (default 1)
-  - name: slide
-    description: <int> ..FV....... set slide mode (from 0 to 4) (default frame) frame 0 ..FV....... draw new frames replace 1 ..FV....... replace old columns with new scroll 2 ..FV....... scroll from right to left rscroll 3 ..FV....... scroll from left to right picture 4 ..FV....... display graph in single frame
-  - name: fontfile
-    description: <string> ..FV....... set font file
-  - name: fontcolor
-    description: <color> ..FV.....T. set foreground color (default "black")
-  - name: fontcolor_expr
-    description: <string> ..FV....... set foreground color expression (default "")
-  - name: boxcolor
-    description: <color> ..FV.....T. set box color (default "white")
-  - name: bordercolor
-    description: <color> ..FV.....T. set border color (default "black")
-  - name: shadowcolor
-    description: <color> ..FV.....T. set shadow color (default "black")
-  - name: box
-    description: <boolean> ..FV.....T. set box (default false)
-  - name: boxborderw
-    description: <string> ..FV.....T. set box borders width (default "0")
-  - name: line_spacing
-    description: <int> ..FV.....T. set line spacing in pixels (from INT_MIN to INT_MAX) (default 0)
-  - name: fontsize
-    description: <string> ..FV.....T. set font size
-  - name: text_align
-    description: <flags> ..FV.....T. set text alignment (default 0) left ..FV.....T. L ..FV.....T. right ..FV.....T. R ..FV.....T. center ..FV.....T. C ..FV.....T. top ..FV.....T. T ..FV.....T. bottom ..FV.....T. B ..FV.....T. middle ..FV.....T. M ..FV.....T.
-  - name: boxw
-    description: <int> ..FV.....T. set box width (from 0 to INT_MAX) (default 0)
-  - name: boxh
-    description: <int> ..FV.....T. set box height (from 0 to INT_MAX) (default 0)
-  - name: shadowx
-    description: <int> ..FV.....T. set shadow x offset (from INT_MIN to INT_MAX) (default 0)
-  - name: shadowy
-    description: <int> ..FV.....T. set shadow y offset (from INT_MIN to INT_MAX) (default 0)
-  - name: borderw
-    description: <int> ..FV.....T. set border width (from INT_MIN to INT_MAX) (default 0)
-  - name: tabsize
-    description: <int> ..FV.....T. set tab size (from 0 to INT_MAX) (default 4)
-  - name: basetime
-    description: <int64> ..FV....... set base time (from I64_MIN to I64_MAX) (default I64_MIN)
-  - name: font
-    description: <string> ..FV....... Font name (default "Sans")
-  - name: y_align
-    description: <int> ..FV.....T. set the y alignment (from 0 to 2) (default text) text 0 ..FV....... y is referred to the top of the first text line baseline 1 ..FV....... y is referred to the baseline of the first line font 2 ..FV....... y is referred to the font defined line metrics
-  - name: timecode
-    description: <string> ..FV....... set initial timecode
-  - name: tc24hmax
-    description: <boolean> ..FV....... set 24 hours max (timecode only) (default false)
-  - name: timecode_rate
-    description: <rational> ..FV....... set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
-  - name: reload
-    description: <int> ..FV....... reload text file at specified frame interval (from 0 to INT_MAX) (default 0)
-  - name: fix_bounds
-    description: <boolean> ..FV....... check and fix text coords to avoid clipping (default false)
-  - name: start_number
-    description: <int> ..FV....... start frame number for n/frame_num variable (from 0 to INT_MAX) (default 0)
-  - name: text_source
-    description: <string> ..FV....... the source of text
-  - name: text_shaping
-    description: <boolean> ..FV....... attempt to shape text before drawing (default true)
-  - name: ft_load_flags
-    description: <flags> ..FV....... set font loading flags for libfreetype (default 0) default ..FV....... no_scale ..FV....... no_hinting ..FV....... render ..FV....... no_bitmap ..FV....... vertical_layout ..FV....... force_autohint ..FV....... crop_bitmap ..FV....... pedantic ..FV....... ignore_global_advance_width ..FV....... no_recurse ..FV....... ignore_transform ..FV....... monochrome ..FV....... linear_design ..FV....... no_autohint ..FV.......
-  - name: codebook_length
-    description: <int> ..FV....... set codebook length (from 1 to INT_MAX) (default 256)
-  - name: nb_steps
-    description: <int> ..FV....... set max number of steps used to compute the mapping (from 1 to INT_MAX) (default 1)
-  - name: pal8
-    description: <boolean> ..FV....... set the pal8 output (default false)
-  - name: use_alpha
-    description: <boolean> ..FV....... use alpha channel for mapping (default false)
-  - name: gamma_r
-    description: <string> ..FV.....T. gamma value for red (default "1.0")
-  - name: gamma_g
-    description: <string> ..FV.....T. gamma value for green (default "1.0")
-  - name: gamma_b
-    description: <string> ..FV.....T. gamma value for blue (default "1.0")
-  - name: gamma_weight
-    description: <string> ..FV.....T. set the gamma weight which reduces the effect of gamma on bright areas (default "1.0")
-  - name: rslope
-    description: <int> ..FV.....T. specify the search radius for edge slope tracing (from 1 to 15) (default 1)
-  - name: redge
-    description: <int> ..FV.....T. specify the search radius for best edge matching (from 0 to 15) (default 2)
-  - name: ecost
-    description: <int> ..FV.....T. specify the edge cost for edge matching (from 0 to 50) (default 2)
-  - name: mcost
-    description: <int> ..FV.....T. specify the middle cost for edge matching (from 0 to 50) (default 1)
-  - name: dcost
-    description: <int> ..FV.....T. specify the distance cost for edge matching (from 0 to 50) (default 1)
-  - name: exposure
-    description: <float> ..FV.....T. set the exposure correction (from -3 to 3) (default 0)
-  - name: black
-    description: <float> ..FV.....T. set the black level correction (from -1 to 1) (default 0)
-  - name: nb_frames
-    description: <int> ..FV....... Number of frames to which the effect should be applied. (from 1 to INT_MAX) (default 25)
-  - name: prev
-    description: <int> ..FV....... set number of previous frames for temporal denoising (from 0 to 1) (default 0)
-  - name: next
-    description: <int> ..FV....... set number of next frames for temporal denoising (from 0 to 1) (default 0)
-  - name: hint
-    description: <string> ..FV....... set hint file
-  - name: field
-    description: <int> ..FV....... set the field to match from (from -1 to 1) (default auto) auto -1 ..FV....... automatic (same value as 'order') bottom 0 ..FV....... bottom field top 1 ..FV....... top field
-  - name: mchroma
-    description: <boolean> ..FV....... set whether or not chroma is included during the match comparisons (default true)
-  - name: y0
-    description: <int> ..FV....... define an exclusion band which excludes the lines between y0 and y1 from the field matching decision (from 0 to INT_MAX) (default 0)
-  - name: y1
-    description: <int> ..FV....... define an exclusion band which excludes the lines between y0 and y1 from the field matching decision (from 0 to INT_MAX) (default 0)
-  - name: combmatch
-    description: <int> ..FV....... set combmatching mode (from 0 to 2) (default sc) none 0 ..FV....... disable combmatching sc 1 ..FV....... enable combmatching only on scene change full 2 ..FV....... enable combmatching all the time
-  - name: combdbg
-    description: <int> ..FV....... enable comb debug (from 0 to 2) (default none) none 0 ..FV....... no forced calculation pcn 1 ..FV....... calculate p/c/n pcnub 2 ..FV....... calculate p/c/n/u/b
-  - name: cthresh
-    description: <int> ..FV....... set the area combing threshold used for combed frame detection (from -1 to 255) (default 9)
-  - name: combpel
-    description: <int> ..FV....... set the number of combed pixels inside any of the blocky by blockx size blocks on the frame for the frame to be detected as combed (from 0 to INT_MAX) (default 80)
-  - name: left
-    description: <int> ..FV.....T. set the left fill border (from 0 to INT_MAX) (default 0)
-  - name: right
-    description: <int> ..FV.....T. set the right fill border (from 0 to INT_MAX) (default 0)
-  - name: top
-    description: <int> ..FV.....T. set the top fill border (from 0 to INT_MAX) (default 0)
-  - name: bottom
-    description: <int> ..FV.....T. set the bottom fill border (from 0 to INT_MAX) (default 0)
-  - name: object
-    description: <string> ..FV....... object bitmap filename
-  - name: mipmaps
-    description: <int> ..FV....... set mipmaps (from 1 to 5) (default 3)
-  - name: xmin
-    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
-  - name: ymin
-    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
-  - name: xmax
-    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
-  - name: ymax
-    description: <int> ..FV....... (from 0 to INT_MAX) (default 0)
-  - name: discard
-    description: <boolean> ..FV....... (default false)
-  - name: s0
-    description: '<int> ..FV....... set source #0 component value (from -1 to 65535) (default 0)'
-  - name: s1
-    description: '<int> ..FV....... set source #1 component value (from -1 to 65535) (default 0)'
-  - name: s2
-    description: '<int> ..FV....... set source #2 component value (from -1 to 65535) (default 0)'
-  - name: s3
-    description: '<int> ..FV....... set source #3 component value (from -1 to 65535) (default 0)'
-  - name: d0
-    description: '<int> ..FV....... set destination #0 component value (from 0 to 65535) (default 0)'
-  - name: d1
-    description: '<int> ..FV....... set destination #1 component value (from 0 to 65535) (default 0)'
-  - name: d2
-    description: '<int> ..FV....... set destination #2 component value (from 0 to 65535) (default 0)'
-  - name: d3
-    description: '<int> ..FV....... set destination #3 component value (from 0 to 65535) (default 0)'
-  - name: pix_fmts
-    description: <string> ..FV....... A '|'-separated list of pixel formats
-  - name: fps
-    description: <string> ..FV....... A string describing desired output framerate (default "25")
-  - name: interp_start
-    description: <int> ..FV....... point to start linear interpolation (from 0 to 255) (default 15)
-  - name: interp_end
-    description: <int> ..FV....... point to end linear interpolation (from 0 to 255) (default 240)
-  - name: scene
-    description: <double> ..FV....... scene change level (from 0 to 100) (default 8.2)
-  - name: flags
-    description: <flags> ..FV....... set flags (default scene_change_detect+scd) scene_change_detect ..FV....... enable scene change detection scd ..FV....... enable scene change detection
-  - name: step
-    description: <int> ..FV....... set frame step (from 1 to INT_MAX) (default 1)
-  - name: first
-    description: <int64> ..FV....... set first frame to freeze (from 0 to I64_MAX) (default 0)
-  - name: last
-    description: <int64> ..FV....... set last frame to freeze (from 0 to I64_MAX) (default 0)
-  - name: filter_name
-    description: <string> ..FV.......
-  - name: filter_params
-    description: <string> ..FV.....T.
-  - name: quality
-    description: <int> ..FV....... set quality (from 4 to 5) (default 4)
-  - name: use_bframe_qp
-    description: <boolean> ..FV....... use B-frames' QP (default false)
-  - name: steps
-    description: <int> ..FV.....T. set number of steps (from 1 to 6) (default 1)
-  - name: lum_expr
-    description: <string> ..FV....... set luminance expression
-  - name: lum
-    description: <string> ..FV....... set luminance expression
-  - name: cb_expr
-    description: <string> ..FV....... set chroma blue expression
-  - name: cb
-    description: <string> ..FV....... set chroma blue expression
-  - name: cr_expr
-    description: <string> ..FV....... set chroma red expression
-  - name: alpha_expr
-    description: <string> ..FV....... set alpha expression
-  - name: red_expr
-    description: <string> ..FV....... set red expression
-  - name: green_expr
-    description: <string> ..FV....... set green expression
-  - name: blue_expr
-    description: <string> ..FV....... set blue expression
-  - name: interpolation
-    description: <int> ..FV....... set interpolation method (from 0 to 1) (default bilinear) nearest 0 ..FV....... nearest interpolation n 0 ..FV....... nearest interpolation bilinear 1 ..FV....... bilinear interpolation b 1 ..FV....... bilinear interpolation
-  - name: difford
-    description: <int> ..FV....... set differentiation order (from 0 to 2) (default 1)
-  - name: minknorm
-    description: <int> ..FV....... set Minkowski norm (from 0 to 20) (default 1)
-  - name: sub
-    description: <int> ..FV.....T. subsampling ratio for fast mode (from 2 to 64) (default 4)
-  - name: guidance
-    description: '<int> ..FV....... set guidance mode (0: off mode; 1: on mode) (from 0 to 1) (default off) off 0 ..FV....... only one input is enabled on 1 ..FV....... two inputs are required'
-  - name: clut
-    description: <int> ..FV.....T. when to process CLUT (from 0 to 1) (default all) first 0 ..FV.....T. process only first CLUT, ignore rest all 1 ..FV.....T. process all CLUTs
-  - name: antibanding
-    description: <int> ..FV....... set the antibanding level (from 0 to 2) (default none) none 0 ..FV....... apply no antibanding weak 1 ..FV....... apply weak antibanding strong 2 ..FV....... apply strong antibanding
-  - name: level_height
-    description: <int> ..FV....... set level height (from 50 to 2048) (default 200)
-  - name: scale_height
-    description: <int> ..FV....... set scale height (from 0 to 40) (default 12)
-  - name: display_mode
-    description: <int> ..FV....... set display mode (from 0 to 2) (default stack) overlay 0 ..FV....... parade 1 ..FV....... stack 2 ..FV.......
-  - name: levels_mode
-    description: <int> ..FV....... set levels mode (from 0 to 1) (default linear) linear 0 ..FV....... logarithmic 1 ..FV.......
-  - name: fgopacity
-    description: <float> ..FV....... set foreground opacity (from 0 to 1) (default 0.7)
-  - name: bgopacity
-    description: <float> ..FV....... set background opacity (from 0 to 1) (default 0.5)
-  - name: colors_mode
-    description: <int> ..FV....... set colors mode (from 0 to 9) (default whiteonblack) whiteonblack 0 ..FV....... blackonwhite 1 ..FV....... whiteongray 2 ..FV....... blackongray 3 ..FV....... coloronblack 4 ..FV....... coloronwhite 5 ..FV....... colorongray 6 ..FV....... blackoncolor 7 ..FV....... whiteoncolor 8 ..FV....... grayoncolor 9 ..FV.......
-  - name: luma_spatial
-    description: <double> ..FV.....T. spatial luma strength (from 0 to DBL_MAX) (default 0)
-  - name: chroma_spatial
-    description: <double> ..FV.....T. spatial chroma strength (from 0 to DBL_MAX) (default 0)
-  - name: luma_tmp
-    description: <double> ..FV.....T. temporal luma strength (from 0 to DBL_MAX) (default 0)
-  - name: chroma_tmp
-    description: <double> ..FV.....T. temporal chroma strength (from 0 to DBL_MAX) (default 0)
-  - name: sat
-    description: <float> ..FV.....T. set the saturation value (from -1 to 1) (default 0)
-  - name: val
-    description: <float> ..FV.....T. set the value value (from -1 to 1) (default 0)
-  - name: rw
-    description: <float> ..FV.....T. set the red weight (from 0 to 1) (default 0.333)
-  - name: gw
-    description: <float> ..FV.....T. set the green weight (from 0 to 1) (default 0.334)
-  - name: bw
-    description: <float> ..FV.....T. set the blue weight (from 0 to 1) (default 0.333)
-  - name: derive_device
-    description: <string> ..FV....... Derive a new device of this type
-  - name: reverse
-    description: <int> ..FV....... Map in reverse (create and allocate in the sink) (from 0 to 1) (default 0)
-  - name: device
-    description: <int> ..FV....... Number of the device to use (from 0 to INT_MAX) (default 0)
-  - name: intl_thres
-    description: <float> ..FV....... set interlacing threshold (from -1 to FLT_MAX) (default 1.04)
-  - name: prog_thres
-    description: <float> ..FV....... set progressive threshold (from -1 to FLT_MAX) (default 1.5)
-  - name: rep_thres
-    description: <float> ..FV....... set repeat threshold (from -1 to FLT_MAX) (default 3)
-  - name: half_life
-    description: <float> ..FV....... half life of cumulative statistics (from -1 to INT_MAX) (default 0)
-  - name: luma_mode
-    description: <int> ..FV.....T. select luma mode (from 0 to 2) (default none) none 0 ..FV.....T. interleave 1 ..FV.....T. i 1 ..FV.....T. deinterleave 2 ..FV.....T. d 2 ..FV.....T.
-  - name: chroma_mode
-    description: <int> ..FV.....T. select chroma mode (from 0 to 2) (default none) none 0 ..FV.....T. interleave 1 ..FV.....T. i 1 ..FV.....T. deinterleave 2 ..FV.....T. d 2 ..FV.....T.
-  - name: alpha_mode
-    description: <int> ..FV.....T. select alpha mode (from 0 to 2) (default none) none 0 ..FV.....T. interleave 1 ..FV.....T. i 1 ..FV.....T. deinterleave 2 ..FV.....T. d 2 ..FV.....T.
-  - name: luma_swap
-    description: <boolean> ..FV.....T. swap luma fields (default false)
-  - name: ls
-    description: <boolean> ..FV.....T. swap luma fields (default false)
-  - name: chroma_swap
-    description: <boolean> ..FV.....T. swap chroma fields (default false)
-  - name: cs
-    description: <boolean> ..FV.....T. swap chroma fields (default false)
-  - name: alpha_swap
-    description: <boolean> ..FV.....T. swap alpha fields (default false)
-  - name: as
-    description: <boolean> ..FV.....T. swap alpha fields (default false)
-  - name: scan
-    description: <int> ..FV....... scanning mode (from 0 to 1) (default tff) tff 0 ..FV....... top field first bff 1 ..FV....... bottom field first
-  - name: lowpass
-    description: <int> ..FV....... set vertical low-pass filter (from 0 to 2) (default linear) off 0 ..FV....... disable vertical low-pass filter linear 1 ..FV....... linear vertical low-pass filter complex 2 ..FV....... complex vertical low-pass filter
-  - name: sharp
-    description: <boolean> ..FV....... set sharpening (default false)
-  - name: twoway
-    description: <boolean> ..FV....... set twoway (default false)
-  - name: cx
-    description: <double> ..FV.....T. set relative center x (from 0 to 1) (default 0.5)
-  - name: cy
-    description: <double> ..FV.....T. set relative center y (from 0 to 1) (default 0.5)
-  - name: k1
-    description: <double> ..FV.....T. set quadratic distortion factor (from -1 to 1) (default 0)
-  - name: k2
-    description: <double> ..FV.....T. set double quadratic distortion factor (from -1 to 1) (default 0)
-  - name: fc
-    description: <color> ..FV.....T. set the color of the unmapped pixels (default "black@0")
-  - name: crop_x
-    description: <string> ..FV.....T. Input video crop x (default "(iw-cw)/2")
-  - name: crop_y
-    description: <string> ..FV.....T. Input video crop y (default "(ih-ch)/2")
-  - name: crop_w
-    description: <string> ..FV.....T. Input video crop w (default "iw")
-  - name: crop_h
-    description: <string> ..FV.....T. Input video crop h (default "ih")
-  - name: pos_x
-    description: <string> ..FV.....T. Output video placement x (default "(ow-pw)/2")
-  - name: pos_y
-    description: <string> ..FV.....T. Output video placement y (default "(oh-ph)/2")
-  - name: pos_w
-    description: <string> ..FV.....T. Output video placement w (default "ow")
-  - name: pos_h
-    description: <string> ..FV.....T. Output video placement h (default "oh")
-  - name: normalize_sar
-    description: <boolean> ..FV....... force SAR normalization to 1:1 by adjusting pos_x/y/w/h (default false)
-  - name: pad_crop_ratio
-    description: <float> ..FV.....T. ratio between padding and cropping when normalizing SAR (0=pad, 1=crop) (from 0 to 1) (default 0)
-  - name: fillcolor
-    description: <string> ..FV.....T. Background fill color (default "black")
-  - name: corner_rounding
-    description: <float> ..FV.....T. Corner rounding radius (from 0 to 1) (default 0)
-  - name: extra_opts
-    description: <dictionary> ..FV.....T. Pass extra libplacebo-specific options using a :-separated list of key=value pairs
-  - name: colorspace
-    description: <int> ..FV.....T. select colorspace (from -1 to 14) (default auto) auto -1 ..FV....... keep the same colorspace gbr 0 ..FV....... bt709 1 ..FV....... unknown 2 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... bt2020nc 9 ..FV....... bt2020c 10 ..FV....... ictcp 14 ..FV.......
-  - name: color_primaries
-    description: <int> ..FV.....T. select color primaries (from -1 to 22) (default auto) auto -1 ..FV....... keep the same color primaries bt709 1 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... film 8 ..FV....... bt2020 9 ..FV....... smpte428 10 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
-  - name: color_trc
-    description: <int> ..FV.....T. select color transfer (from -1 to 18) (default auto) auto -1 ..FV....... keep the same color transfer bt709 1 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... linear 8 ..FV....... iec61966-2-4 11 ..FV....... bt1361e 12 ..FV....... iec61966-2-1 13 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV....... smpte2084 16 ..FV....... arib-std-b67 18 ..FV.......
-  - name: upscaler
-    description: <string> ..FV.....T. Upscaler function (default "spline36")
-  - name: downscaler
-    description: <string> ..FV.....T. Downscaler function (default "mitchell")
-  - name: frame_mixer
-    description: <string> ..FV.....T. Frame mixing function (default "none")
-  - name: lut_entries
-    description: <int> ..FV.....T. Number of scaler LUT entries (from 0 to 256) (default 0)
-  - name: antiringing
-    description: <float> ..FV.....T. Antiringing strength (for non-EWA filters) (from 0 to 1) (default 0)
-  - name: sigmoid
-    description: <boolean> ..FV.....T. Enable sigmoid upscaling (default true)
-  - name: apply_filmgrain
-    description: <boolean> ..FV.....T. Apply film grain metadata (default true)
-  - name: deband
-    description: <boolean> ..FV.....T. Enable debanding (default false)
-  - name: deband_threshold
-    description: <float> ..FV.....T. Deband threshold (from 0 to 1024) (default 4)
-  - name: deband_radius
-    description: <float> ..FV.....T. Deband radius (from 0 to 1024) (default 16)
-  - name: deband_grain
-    description: <float> ..FV.....T. Deband grain (from 0 to 1024) (default 6)
-  - name: peak_detect
-    description: <boolean> ..FV.....T. Enable dynamic peak detection for HDR tone-mapping (default true)
-  - name: smoothing_period
-    description: <float> ..FV.....T. Peak detection smoothing period (from 0 to 1000) (default 100)
-  - name: minimum_peak
-    description: <float> ..FV.....T. Peak detection minimum peak (from 0 to 100) (default 1)
-  - name: percentile
-    description: <float> ..FV.....T. Peak detection percentile (from 0 to 100) (default 99.995)
-  - name: gamut_mode
-    description: <int> ..FV.....T. Gamut-mapping mode (from 0 to 8) (default perceptual) clip 0 ..FV....... Hard-clip (RGB per-channel) perceptual 1 ..FV....... Colorimetric soft clipping relative 2 ..FV....... Relative colorimetric clipping saturation 3 ..FV....... Saturation mapping (RGB -> RGB) absolute 4 ..FV....... Absolute colorimetric clipping desaturate 5 ..FV....... Colorimetrically desaturate colors towards white darken 6 ..FV....... Colorimetric clip with bias towards darkening image to fit gamut warn 7 ..FV....... Highlight out-of-gamut colors linear 8 ..FV....... Linearly reduce chromaticity to fit gamut
-  - name: tonemapping
-    description: <int> ..FV.....T. Tone-mapping algorithm (from 0 to 11) (default auto) auto 0 ..FV....... Automatic selection clip 1 ..FV....... No tone mapping (clip st2094-40 2 ..FV....... SMPTE ST 2094-40 st2094-10 3 ..FV....... SMPTE ST 2094-10 bt.2390 4 ..FV....... ITU-R BT.2390 EETF bt.2446a 5 ..FV....... ITU-R BT.2446 Method A spline 6 ..FV....... Single-pivot polynomial spline reinhard 7 ..FV....... Reinhard mobius 8 ..FV....... Mobius hable 9 ..FV....... Filmic tone-mapping (Hable) gamma 10 ..FV....... Gamma function with knee linear 11 ..FV....... Perceptually linear stretch
-  - name: gamut_warning
-    description: <boolean> ..FV.....TP Highlight out-of-gamut colors (default false)
-  - name: gamut_clipping
-    description: <boolean> ..FV.....TP Enable desaturating colorimetric gamut clipping (default false)
-  - name: intent
-    description: <int> ..FV.....TP Rendering intent (from 0 to 3) (default perceptual) perceptual 0 ..FV....... Perceptual relative 1 ..FV....... Relative colorimetric absolute 3 ..FV....... Absolute colorimetric saturation 2 ..FV....... Saturation mapping
-  - name: tonemapping_mode
-    description: <int> ..FV.....TP Tone-mapping mode (from 0 to 4) (default auto) auto 0 ..FV....... Automatic selection rgb 1 ..FV....... Per-channel (RGB) max 2 ..FV....... Maximum component hybrid 3 ..FV....... Hybrid of Luma/RGB luma 4 ..FV....... Luminance
-  - name: overshoot
-    description: <float> ..FV.....TP Tone-mapping overshoot margin (from 0 to 1) (default 0.05)
-  - name: hybrid_mix
-    description: <float> ..FV.....T. Tone-mapping hybrid LMS mixing coefficient (from 0 to 1) (default 0.2)
-  - name: dithering
-    description: <int> ..FV.....T. Dither method to use (from -1 to 3) (default blue) none -1 ..FV....... Disable dithering blue 0 ..FV....... Blue noise ordered 1 ..FV....... Ordered LUT ordered_fixed 2 ..FV....... Fixed function ordered white 3 ..FV....... White noise
-  - name: dither_lut_size
-    description: <int> ..FV....... Dithering LUT size (from 1 to 8) (default 6)
-  - name: dither_temporal
-    description: <boolean> ..FV.....T. Enable temporal dithering (default false)
-  - name: cones
-    description: <flags> ..FV.....T. Colorblindness adaptation model (default 0) l ..FV....... L cone m ..FV....... M cone s ..FV....... S cone
-  - name: cone-strength
-    description: <float> ..FV.....T. Colorblindness adaptation strength (from 0 to 10) (default 0)
-  - name: skip_aa
-    description: <boolean> ..FV.....T. Skip anti-aliasing (default false)
-  - name: polar_cutoff
-    description: <float> ..FV.....T. Polar LUT cutoff (from 0 to 1) (default 0)
-  - name: disable_linear
-    description: <boolean> ..FV.....T. Disable linear scaling (default false)
-  - name: disable_builtin
-    description: <boolean> ..FV.....T. Disable built-in scalers (default false)
-  - name: force_icc_lut
-    description: <boolean> ..FV.....TP Deprecated, does nothing (default false)
-  - name: force_dither
-    description: <boolean> ..FV.....T. Force dithering (default false)
-  - name: disable_fbos
-    description: <boolean> ..FV.....T. Force-disable FBOs (default false)
-  - name: elasticity
-    description: <float> ..FV.....T. set the elasticity (from 0 to 10) (default 2)
-  - name: reference
-    description: <boolean> ..FV....... enable reference stream (default false)
-  - name: c0
-    description: '<string> ..FV.....T. set component #0 expression (default "clipval")'
-  - name: c3
-    description: '<string> ..FV.....T. set component #3 expression (default "clipval")'
-  - name: u
-    description: <string> ..FV.....T. set U expression (default "clipval")
-  - name: undershoot
-    description: <int> ..FV.....T. set undershoot (from 0 to 65535) (default 0)
-  - name: sum
-    description: <int> ..FV.....T. set sum value (from 0 to 65535) (default 10)
-  - name: mapping
-    description: <int> ..FV......P set input to output plane mapping (from -1 to 8.58993e+08) (default -1)
-  - name: map0s
-    description: <int> ..FV....... set 1st input to output stream mapping (from 0 to 3) (default 0)
-  - name: map0p
-    description: <int> ..FV....... set 1st input to output plane mapping (from 0 to 3) (default 0)
-  - name: map1s
-    description: <int> ..FV....... set 2nd input to output stream mapping (from 0 to 3) (default 0)
-  - name: map1p
-    description: <int> ..FV....... set 2nd input to output plane mapping (from 0 to 3) (default 0)
-  - name: map2s
-    description: <int> ..FV....... set 3rd input to output stream mapping (from 0 to 3) (default 0)
-  - name: map2p
-    description: <int> ..FV....... set 3rd input to output plane mapping (from 0 to 3) (default 0)
-  - name: map3s
-    description: <int> ..FV....... set 4th input to output stream mapping (from 0 to 3) (default 0)
-  - name: map3p
-    description: <int> ..FV....... set 4th input to output plane mapping (from 0 to 3) (default 0)
-  - name: mb_size
-    description: <int> ..FV....... macroblock size (from 8 to INT_MAX) (default 16)
-  - name: search_param
-    description: <int> ..FV....... search parameter (from 4 to INT_MAX) (default 7)
-  - name: mi_mode
-    description: <int> ..FV....... motion interpolation mode (from 0 to 2) (default mci) dup 0 ..FV....... duplicate frames blend 1 ..FV....... blend frames mci 2 ..FV....... motion compensated interpolation
-  - name: mc_mode
-    description: <int> ..FV....... motion compensation mode (from 0 to 1) (default obmc) obmc 0 ..FV....... overlapped block motion compensation aobmc 1 ..FV....... adaptive overlapped block motion compensation
-  - name: me_mode
-    description: <int> ..FV....... motion estimation mode (from 0 to 1) (default bilat) bidir 0 ..FV....... bidirectional motion estimation bilat 1 ..FV....... bilateral motion estimation
-  - name: me
-    description: <int> ..FV....... motion estimation method (from 1 to 9) (default epzs) esa 1 ..FV....... exhaustive search tss 2 ..FV....... three step search tdls 3 ..FV....... two dimensional logarithmic search ntss 4 ..FV....... new three step search fss 5 ..FV....... four step search ds 6 ..FV....... diamond search hexbs 7 ..FV....... hexagon-based search epzs 8 ..FV....... enhanced predictive zonal search umh 9 ..FV....... uneven multi-hexagon search
-  - name: vsbmc
-    description: <int> ..FV....... variable-size block motion compensation (from 0 to 1) (default 0)
-  - name: scd
-    description: <int> ..FV....... scene change detection method (from 0 to 1) (default fdiff) none 0 ..FV....... disable detection fdiff 1 ..FV....... frame difference
-  - name: scd_threshold
-    description: <double> ..FV....... scene change threshold (from 0 to 100) (default 10)
-  - name: structure
-    description: <int> ..FV.....T. when to process structures (from 0 to 1) (default all) first 0 ..FV.....T. process only first structure, ignore rest all 1 ..FV.....T. process all structure
-  - name: keep
-    description: <int> ..FV....... set the number of similar consecutive frames to be kept before starting to drop similar frames (from 0 to INT_MAX) (default 0)
-  - name: hi
-    description: <int> ..FV....... set high dropping threshold (from INT_MIN to INT_MAX) (default 768)
-  - name: lo
-    description: <int> ..FV....... set low dropping threshold (from INT_MIN to INT_MAX) (default 320)
-  - name: frac
-    description: <float> ..FV....... set fraction dropping threshold (from 0 to 1) (default 0.33)
-  - name: negate_alpha
-    description: <boolean> ..FV.....T. (default false)
-  - name: s4
-    description: <double> ..FV....... denoising strength for component 4 (from 1 to 100) (default 1)
-  - name: p1
-    description: <int> ..FV....... patch size for component 1 (from 0 to 99) (default 0)
-  - name: p2
-    description: <int> ..FV....... patch size for component 2 (from 0 to 99) (default 0)
-  - name: p3
-    description: <int> ..FV....... patch size for component 3 (from 0 to 99) (default 0)
-  - name: p4
-    description: <int> ..FV....... patch size for component 4 (from 0 to 99) (default 0)
-  - name: nsize
-    description: <int> ..FV.....T. set size of local neighborhood around each pixel, used by the predictor neural network (from 0 to 6) (default s32x4) s8x6 0 ..FV.....T. s16x6 1 ..FV.....T. s32x6 2 ..FV.....T. s48x6 3 ..FV.....T. s8x4 4 ..FV.....T. s16x4 5 ..FV.....T. s32x4 6 ..FV.....T.
-  - name: nns
-    description: <int> ..FV.....T. set number of neurons in predictor neural network (from 0 to 4) (default n32) n16 0 ..FV.....T. n32 1 ..FV.....T. n64 2 ..FV.....T. n128 3 ..FV.....T. n256 4 ..FV.....T.
-  - name: qual
-    description: <int> ..FV.....T. set quality (from 1 to 2) (default fast) fast 1 ..FV.....T. slow 2 ..FV.....T.
-  - name: etype
-    description: <int> ..FV.....T. set which set of weights to use in the predictor (from 0 to 1) (default a) a 0 ..FV.....T. weights trained to minimize absolute error abs 0 ..FV.....T. weights trained to minimize absolute error s 1 ..FV.....T. weights trained to minimize squared error mse 1 ..FV.....T. weights trained to minimize squared error
-  - name: pscrn
-    description: <int> ..FV.....T. set prescreening (from 0 to 4) (default new) none 0 ..FV.....T. original 1 ..FV.....T. new 2 ..FV.....T. new2 3 ..FV.....T. new3 4 ..FV.....T.
-  - name: all_seed
-    description: '<int> ..FV....... set component #0 noise seed (from -1 to INT_MAX) (default -1)'
-  - name: all_strength
-    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
-  - name: alls
-    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
-  - name: all_flags
-    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: allf
-    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c0_seed
-    description: '<int> ..FV....... set component #0 noise seed (from -1 to INT_MAX) (default -1)'
-  - name: c0_strength
-    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
-  - name: c0s
-    description: '<int> ..FV....... set component #0 strength (from 0 to 100) (default 0)'
-  - name: c0_flags
-    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c0f
-    description: '<flags> ..FV....... set component #0 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c1_seed
-    description: '<int> ..FV....... set component #1 noise seed (from -1 to INT_MAX) (default -1)'
-  - name: c1_strength
-    description: '<int> ..FV....... set component #1 strength (from 0 to 100) (default 0)'
-  - name: c1s
-    description: '<int> ..FV....... set component #1 strength (from 0 to 100) (default 0)'
-  - name: c1_flags
-    description: '<flags> ..FV....... set component #1 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c1f
-    description: '<flags> ..FV....... set component #1 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c2_seed
-    description: '<int> ..FV....... set component #2 noise seed (from -1 to INT_MAX) (default -1)'
-  - name: c2_strength
-    description: '<int> ..FV....... set component #2 strength (from 0 to 100) (default 0)'
-  - name: c2s
-    description: '<int> ..FV....... set component #2 strength (from 0 to 100) (default 0)'
-  - name: c2_flags
-    description: '<flags> ..FV....... set component #2 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c2f
-    description: '<flags> ..FV....... set component #2 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c3_seed
-    description: '<int> ..FV....... set component #3 noise seed (from -1 to INT_MAX) (default -1)'
-  - name: c3_strength
-    description: '<int> ..FV....... set component #3 strength (from 0 to 100) (default 0)'
-  - name: c3s
-    description: '<int> ..FV....... set component #3 strength (from 0 to 100) (default 0)'
-  - name: c3_flags
-    description: '<flags> ..FV....... set component #3 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: c3f
-    description: '<flags> ..FV....... set component #3 flags (default 0) a ..FV....... averaged noise p ..FV....... (semi)regular pattern t ..FV....... temporal noise u ..FV....... uniform noise'
-  - name: blackpt
-    description: <color> ..FV.....T. output color to which darkest input color is mapped (default "black")
-  - name: whitept
-    description: <color> ..FV.....T. output color to which brightest input color is mapped (default "white")
-  - name: independence
-    description: <float> ..FV.....T. proportion of independent to linked channel normalization (from 0 to 1) (default 1)
-  - name: tx
-    description: <float> ..FV.....T. set trace x position (from 0 to 1) (default 0.5)
-  - name: ty
-    description: <float> ..FV.....T. set trace y position (from 0 to 1) (default 0.9)
-  - name: tw
-    description: <float> ..FV.....T. set trace width (from 0.1 to 1) (default 0.8)
-  - name: th
-    description: <float> ..FV.....T. set trace height (from 0.1 to 1) (default 0.3)
-  - name: sc
-    description: <boolean> ..FV.....T. draw scope (default true)
-  - name: luma_strength
-    description: <double> ..FV....... set luma strength (from 0 to 1000) (default 1)
-  - name: chroma_strength
-    description: <double> ..FV....... set chroma strength (from 0 to 1000) (default 1)
-  - name: aspect
-    description: <rational> ..FV....... pad to fit an aspect instead of a resolution (from 0 to DBL_MAX) (default 0/1)
-  - name: max_colors
-    description: <int> ..FV....... set the maximum number of colors to use in the palette (from 2 to 256) (default 256)
-  - name: stats_mode
-    description: <int> ..FV....... set statistics mode (from 0 to 2) (default full) full 0 ..FV....... compute full frame histograms diff 1 ..FV....... compute histograms only for the part that differs from previous frame single 2 ..FV....... compute new histogram for each frame
-  - name: bayer_scale
-    description: <int> ..FV....... set scale for bayer dithering (from 0 to 5) (default 2)
-  - name: diff_mode
-    description: <int> ..FV....... set frame difference mode (from 0 to 1) (default 0) rectangle 1 ..FV....... process smallest different rectangle
-  - name: new
-    description: <boolean> ..FV....... take new palette for each output frame (default false)
-  - name: alpha_threshold
-    description: <int> ..FV....... set the alpha threshold for transparency (from 0 to 255) (default 128)
-  - name: debug_kdtree
-    description: <string> ..FV....... save Graphviz graph of the kdtree in specified file
-  - name: x0
-    description: <string> ..FV....... set top left x coordinate (default "0")
-  - name: x1
-    description: <string> ..FV....... set top right x coordinate (default "W")
-  - name: x2
-    description: <string> ..FV....... set bottom left x coordinate (default "0")
-  - name: y2
-    description: <string> ..FV....... set bottom left y coordinate (default "H")
-  - name: x3
-    description: <string> ..FV....... set bottom right x coordinate (default "W")
-  - name: y3
-    description: <string> ..FV....... set bottom right y coordinate (default "H")
-  - name: sense
-    description: <int> ..FV....... specify the sense of the coordinates (from 0 to 1) (default source) source 0 ..FV....... specify locations in source to send to corners in destination destination 1 ..FV....... specify locations in destination to send corners of source
-  - name: frames
-    description: <int> ..FV....... set how many frames to use (from 2 to 240) (default 30)
-  - name: wx
-    description: <float> ..FV.....T. set window x offset (from -1 to 1) (default -1)
-  - name: wy
-    description: <float> ..FV.....T. set window y offset (from -1 to 1) (default -1)
-  - name: subfilters
-    description: <string> ..FV....... set postprocess subfilters (default "de")
-  - name: inplace
-    description: <boolean> ..FV....... enable inplace mode (default false)
-  - name: saturatio
-    description: <float> ..FV....... Output video saturation (from 0 to 10) (default 1)
-  - name: source
-    description: <string> ..FV....... OpenCL program source file
-  - name: index
-    description: <int> ..FV.....T. set component as base (from 0 to 3) (default 0)
-  - name: stats_file
-    description: <string> ..FV....... Set file where to store per-frame difference information
-  - name: stats_version
-    description: <int> ..FV....... Set the format version for the stats file. (from 1 to 2) (default 1)
-  - name: output_max
-    description: <boolean> ..FV....... Add raw stats (max values) to the output log. (default false)
-  - name: jl
-    description: <int> ..FV....... set left junk size (from 0 to INT_MAX) (default 1)
-  - name: jr
-    description: <int> ..FV....... set right junk size (from 0 to INT_MAX) (default 1)
-  - name: jt
-    description: <int> ..FV....... set top junk size (from 1 to INT_MAX) (default 4)
-  - name: jb
-    description: <int> ..FV....... set bottom junk size (from 1 to INT_MAX) (default 4)
-  - name: sb
-    description: <boolean> ..FV....... set strict breaks (default false)
-  - name: mp
-    description: <int> ..FV....... set metric plane (from 0 to 2) (default y) y 0 ..FV....... luma u 1 ..FV....... chroma blue v 2 ..FV....... chroma red
-  - name: scan_min
-    description: <int> ..FV.....T. set from which line to scan for codes (from 0 to INT_MAX) (default 0)
-  - name: scan_max
-    description: <int> ..FV.....T. set to which line to scan for codes (from 0 to INT_MAX) (default 29)
-  - name: spw
-    description: <float> ..FV.....T. set ratio of width reserved for sync code detection (from 0.1 to 0.7) (default 0.27)
-  - name: chp
-    description: <boolean> ..FV.....T. check and apply parity bit (default false)
-  - name: thr_b
-    description: <double> ..FV....... black color threshold (from 0 to 1) (default 0.2)
-  - name: thr_w
-    description: <double> ..FV....... white color threshold (from 0 to 1) (default 0.6)
-  - name: m0
-    description: <int> ..FV....... set mode for 1st plane (from 0 to 24) (default 0)
-  - name: rv
-    description: <int> ..FV.....T. shift red vertically (from -255 to 255) (default 0)
-  - name: gv
-    description: <int> ..FV.....T. shift green vertically (from -255 to 255) (default 0)
-  - name: bv
-    description: <int> ..FV.....T. shift blue vertically (from -255 to 255) (default 0)
-  - name: ah
-    description: <int> ..FV.....T. shift alpha horizontally (from -255 to 255) (default 0)
-  - name: av
-    description: <int> ..FV.....T. shift alpha vertically (from -255 to 255) (default 0)
-  - name: ow
-    description: <string> ..FV....... set output width expression (default "iw")
-  - name: oh
-    description: <string> ..FV....... set output height expression (default "ih")
-  - name: bilinear
-    description: <boolean> ..FV....... use bilinear interpolation (default true)
-  - name: lpfr
-    description: <float> ..FV....... set luma pre-filter radius (from 0.1 to 2) (default 1)
-  - name: cpfr
-    description: <float> ..FV....... set chroma pre-filter radius (from -0.9 to 2) (default -0.9)
-  - name: interl
-    description: <boolean> ..FV....... set interlacing (default false)
-  - name: in_color_matrix
-    description: <string> ..FV....... set input YCbCr type (default "auto") auto ..FV....... bt601 ..FV....... bt470 ..FV....... smpte170m ..FV....... bt709 ..FV....... fcc ..FV....... smpte240m ..FV....... bt2020 ..FV.......
-  - name: out_color_matrix
-    description: <string> ..FV....... set output YCbCr type auto ..FV....... bt601 ..FV....... bt470 ..FV....... smpte170m ..FV....... bt709 ..FV....... fcc ..FV....... smpte240m ..FV....... bt2020 ..FV.......
-  - name: in_range
-    description: <int> ..FV....... set input color range (from 0 to 2) (default auto) auto 0 ..FV....... unknown 0 ..FV....... full 2 ..FV....... limited 1 ..FV....... jpeg 2 ..FV....... mpeg 1 ..FV....... tv 1 ..FV....... pc 2 ..FV.......
-  - name: out_range
-    description: <int> ..FV....... set output color range (from 0 to 2) (default auto) auto 0 ..FV....... unknown 0 ..FV....... full 2 ..FV....... limited 1 ..FV....... jpeg 2 ..FV....... mpeg 1 ..FV....... tv 1 ..FV....... pc 2 ..FV.......
-  - name: in_v_chr_pos
-    description: <int> ..FV....... input vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
-  - name: in_h_chr_pos
-    description: <int> ..FV....... input horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
-  - name: out_v_chr_pos
-    description: <int> ..FV....... output vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
-  - name: out_h_chr_pos
-    description: <int> ..FV....... output horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
-  - name: param0
-    description: <double> ..FV....... Scaler param 0 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
-  - name: param1
-    description: <double> ..FV....... Scaler param 1 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
-  - name: interp_algo
-    description: <int> ..FV....... Interpolation algorithm used for resizing (from 0 to 4) (default 0) nearest 1 ..FV....... nearest neighbour bilinear 2 ..FV....... bilinear bicubic 3 ..FV....... bicubic lanczos 4 ..FV....... lanczos
-  - name: passthrough
-    description: <boolean> ..FV....... Do not process frames at all if parameters match (default true)
-  - name: scaler
-    description: <int> ..FV....... Scaler function (from 0 to 2) (default bilinear) bilinear 0 ..FV....... Bilinear interpolation (fastest) nearest 1 ..FV....... Nearest (useful for pixel art)
-  - name: sc_pass
-    description: <boolean> ..FV....... Set the flag to pass scene change frames (default false)
-  - name: horizontal
-    description: <float> ..FV.....T. set the horizontal scrolling speed (from -1 to 1) (default 0)
-  - name: vertical
-    description: <float> ..FV.....T. set the vertical scrolling speed (from -1 to 1) (default 0)
-  - name: hpos
-    description: <float> ..FV....... set initial horizontal position (from 0 to 1) (default 0)
-  - name: vpos
-    description: <float> ..FV....... set initial vertical position (from 0 to 1) (default 0)
-  - name: reds
-    description: <string> ..FV....... adjust red regions
-  - name: yellows
-    description: <string> ..FV....... adjust yellow regions
-  - name: greens
-    description: <string> ..FV....... adjust green regions
-  - name: cyans
-    description: <string> ..FV....... adjust cyan regions
-  - name: blues
-    description: <string> ..FV....... adjust blue regions
-  - name: magentas
-    description: <string> ..FV....... adjust magenta regions
-  - name: whites
-    description: <string> ..FV....... adjust white regions
-  - name: neutrals
-    description: <string> ..FV....... adjust neutral regions
-  - name: blacks
-    description: <string> ..FV....... adjust black regions
-  - name: dar
-    description: <string> ..FV....... set display aspect ratio (default "0")
-  - name: field_mode
-    description: <int> ..FV....... select interlace mode (from -1 to 2) (default auto) auto -1 ..FV....... keep the same input field bff 0 ..FV....... mark as bottom-field-first tff 1 ..FV....... mark as top-field-first prog 2 ..FV....... mark as progressive
-  - name: sar
-    description: <string> ..FV....... set sample (pixel) aspect ratio (default "0")
-  - name: sharpness
-    description: <int> ..FV....... sharpness level (from 0 to 64) (default 44)
-  - name: shx
-    description: <float> ..FV.....T. set x shear factor (from -2 to 2) (default 0)
-  - name: shy
-    description: <float> ..FV.....T. set y shear factor (from -2 to 2) (default 0)
-  - name: checksum
-    description: <boolean> ..FV....... calculate checksums (default true)
-  - name: map0
-    description: <int> ..FV....... Index of the input plane to be used as the first output plane (from 0 to 3) (default 0)
-  - name: map1
-    description: <int> ..FV....... Index of the input plane to be used as the second output plane (from 0 to 3) (default 1)
-  - name: map2
-    description: <int> ..FV....... Index of the input plane to be used as the third output plane (from 0 to 3) (default 2)
-  - name: map3
-    description: <int> ..FV....... Index of the input plane to be used as the fourth output plane (from 0 to 3) (default 3)
-  - name: stat
-    description: <flags> ..FV....... set statistics filters (default 0) tout ..FV....... analyze pixels for temporal outliers vrep ..FV....... analyze video lines for vertical line repetition brng ..FV....... analyze for pixels outside of broadcast range
-  - name: out
-    description: <int> ..FV....... set video filter (from -1 to 2) (default -1) tout 0 ..FV....... highlight pixels that depict temporal outliers vrep 1 ..FV....... highlight video lines that depict vertical line repetition brng 2 ..FV....... highlight pixels that are outside of broadcast range
-  - name: detectmode
-    description: <int> ..FV....... set the detectmode (from 0 to 2) (default off) off 0 ..FV....... full 1 ..FV....... fast 2 ..FV.......
-  - name: th_d
-    description: <int> ..FV....... threshold to detect one word as similar (from 1 to INT_MAX) (default 9000)
-  - name: th_dc
-    description: <int> ..FV....... threshold to detect all words as similar (from 1 to INT_MAX) (default 60000)
-  - name: th_xh
-    description: <int> ..FV....... threshold to detect frames as similar (from 1 to INT_MAX) (default 116)
-  - name: th_di
-    description: <int> ..FV....... minimum length of matching sequence in frames (from 0 to INT_MAX) (default 0)
-  - name: th_it
-    description: <double> ..FV....... threshold for relation of good to all frames (from 0 to 1) (default 0.5)
-  - name: print_summary
-    description: <boolean> ..FV....... Print summary showing average values (default false)
-  - name: luma_threshold
-    description: <int> ..FV....... set luma threshold (from -30 to 30) (default 0)
-  - name: chroma_threshold
-    description: <int> ..FV....... set chroma threshold (from -31 to 30) (default -31)
-  - name: scale_factor
-    description: <int> ..FV....... scale factor for SRCNN model (from 2 to 4) (default 2)
-  - name: compute_chroma
-    description: <int> ..FV....... Specifies if non-luma channels must be computed (from 0 to 1) (default 1)
-  - name: frame_skip_ratio
-    description: <int> ..FV....... Specifies the number of frames to be skipped from evaluation, for every evaluated frame (from 0 to 1e+06) (default 0)
-  - name: ref_projection
-    description: <int> ..FV....... projection of the reference video (from 0 to 4) (default e) e 4 ..FV....... equirectangular equirect 4 ..FV....... equirectangular c3x2 0 ..FV....... cubemap 3x2 c2x3 1 ..FV....... cubemap 2x3 barrel 2 ..FV....... barrel facebook's 360 format barrelsplit 3 ..FV....... barrel split facebook's 360 format
-  - name: main_projection
-    description: <int> ..FV....... projection of the main video (from 0 to 5) (default 5) e 4 ..FV....... equirectangular equirect 4 ..FV....... equirectangular c3x2 0 ..FV....... cubemap 3x2 c2x3 1 ..FV....... cubemap 2x3 barrel 2 ..FV....... barrel facebook's 360 format barrelsplit 3 ..FV....... barrel split facebook's 360 format
-  - name: ref_stereo
-    description: <int> ..FV....... stereo format of the reference video (from 0 to 2) (default mono) mono 2 ..FV....... tb 0 ..FV....... lr 1 ..FV.......
-  - name: main_stereo
-    description: <int> ..FV....... stereo format of main video (from 0 to 3) (default 3) mono 2 ..FV....... tb 0 ..FV....... lr 1 ..FV.......
-  - name: ref_pad
-    description: <float> ..FV....... Expansion (padding) coefficient for each cube face of the reference video (from 0 to 10) (default 0)
-  - name: main_pad
-    description: <float> ..FV....... Expansion (padding) coeffiecient for each cube face of the main video (from 0 to 10) (default 0)
-  - name: use_tape
-    description: <int> ..FV....... Specifies if the tape based SSIM 360 algorithm must be used independent of the input video types (from 0 to 1) (default 0)
-  - name: heatmap_str
-    description: <string> ..FV....... Heatmap data for view-based evaluation. For heatmap file format, please refer to EntSphericalVideoHeatmapData.
-  - name: in
-    description: <int> ..FV....... set input format (from 16 to 32) (default sbsl) ab2l 24 ..FV....... above below half height left first tb2l 24 ..FV....... above below half height left first ab2r 25 ..FV....... above below half height right first tb2r 25 ..FV....... above below half height right first abl 22 ..FV....... above below left first tbl 22 ..FV....... above below left first abr 23 ..FV....... above below right first tbr 23 ..FV....... above below right first al 26 ..FV....... alternating frames left first ar 27 ..FV....... alternating frames right first sbs2l 20 ..FV....... side by side half width left first sbs2r 21 ..FV....... side by side half width right first sbsl 18 ..FV....... side by side left first sbsr 19 ..FV....... side by side right first irl 16 ..FV....... interleave rows left first irr 17 ..FV....... interleave rows right first icl 30 ..FV....... interleave columns left first icr 31 ..FV....... interleave columns right first
-  - name: charenc
-    description: <string> ..FV....... set input character encoding
-  - name: stream_index
-    description: <int> ..FV....... set stream index (from -1 to INT_MAX) (default -1)
-  - name: si
-    description: <int> ..FV....... set stream index (from -1 to INT_MAX) (default -1)
-  - name: force_style
-    description: <string> ..FV....... force subtitle style
-  - name: wrap_unicode
-    description: <boolean> ..FV....... break lines according to the Unicode Line Breaking Algorithm (default auto)
-  - name: envelope
-    description: <boolean> ..FV....... display envelope (default false)
-  - name: ecolor
-    description: <color> ..FV....... set envelope color (default "gold")
-  - name: ec
-    description: <color> ..FV....... set envelope color (default "gold")
-  - name: log
-    description: <int> ..FV....... force stats logging level (from INT_MIN to INT_MAX) (default info) quiet -8 ..FV....... logging disabled info 32 ..FV....... information logging level verbose 40 ..FV....... verbose logging level
-  - name: layout
-    description: <image_size> ..FV....... set grid size (default "6x5")
-  - name: margin
-    description: <int> ..FV....... set outer border margin in pixels (from 0 to 1024) (default 0)
-  - name: padding
-    description: <int> ..FV....... set inner border thickness in pixels (from 0 to 1024) (default 0)
-  - name: init_padding
-    description: <int> ..FV....... set how many frames to initially pad (from 0 to INT_MAX) (default 0)
-  - name: tonemap
-    description: <int> ..FV....... tonemap algorithm selection (from 0 to 6) (default none) none 0 ..FV....... linear 1 ..FV....... gamma 2 ..FV....... clip 3 ..FV....... reinhard 4 ..FV....... hable 5 ..FV....... mobius 6 ..FV.......
-  - name: desat
-    description: <double> ..FV....... desaturation strength (from 0 to DBL_MAX) (default 2)
-  - name: matrix
-    description: <int> ..FV....... set colorspace matrix (from -1 to INT_MAX) (default -1) bt709 1 ..FV....... bt2020 9 ..FV.......
-  - name: stop
-    description: <int> ..FV....... set the number of frames to add after input finished (from -1 to INT_MAX) (default 0)
-  - name: dir
-    description: <int> ..FV....... set transpose direction (from 0 to 7) (default cclock_flip) cclock_flip 0 ..FV....... rotate counter-clockwise with vertical flip clock 1 ..FV....... rotate clockwise cclock 2 ..FV....... rotate counter-clockwise clock_flip 3 ..FV....... rotate clockwise with vertical flip
-  - name: end_frame
-    description: <int64> ..FV....... Number of the first frame that should be dropped again (from 0 to I64_MAX) (default I64_MAX)
-  - name: luma_msize_x
-    description: <int> ..FV....... set luma matrix horizontal size (from 3 to 23) (default 5)
-  - name: lx
-    description: <int> ..FV....... set luma matrix horizontal size (from 3 to 23) (default 5)
-  - name: luma_msize_y
-    description: <int> ..FV....... set luma matrix vertical size (from 3 to 23) (default 5)
-  - name: ly
-    description: <int> ..FV....... set luma matrix vertical size (from 3 to 23) (default 5)
-  - name: luma_amount
-    description: <float> ..FV....... set luma effect strength (from -2 to 5) (default 1)
-  - name: la
-    description: <float> ..FV....... set luma effect strength (from -2 to 5) (default 1)
-  - name: chroma_msize_x
-    description: <int> ..FV....... set chroma matrix horizontal size (from 3 to 23) (default 5)
-  - name: chroma_msize_y
-    description: <int> ..FV....... set chroma matrix vertical size (from 3 to 23) (default 5)
-  - name: chroma_amount
-    description: <float> ..FV....... set chroma effect strength (from -2 to 5) (default 0)
-  - name: ca
-    description: <float> ..FV....... set chroma effect strength (from -2 to 5) (default 0)
-  - name: alpha_msize_x
-    description: <int> ..FV....... set alpha matrix horizontal size (from 3 to 23) (default 5)
-  - name: ax
-    description: <int> ..FV....... set alpha matrix horizontal size (from 3 to 23) (default 5)
-  - name: alpha_msize_y
-    description: <int> ..FV....... set alpha matrix vertical size (from 3 to 23) (default 5)
-  - name: ay
-    description: <int> ..FV....... set alpha matrix vertical size (from 3 to 23) (default 5)
-  - name: alpha_amount
-    description: <float> ..FV....... set alpha effect strength (from -2 to 5) (default 0)
-  - name: codec
-    description: <string> ..FV....... Codec name (default "snow")
-  - name: in_stereo
-    description: <int> ..FV....... input stereo format (from 0 to 2) (default 2d) 2d 0 ..FV....... 2d mono sbs 1 ..FV....... side by side tb 2 ..FV....... top bottom
-  - name: out_stereo
-    description: <int> ..FV....... output stereo format (from 0 to 2) (default 2d) 2d 0 ..FV....... 2d mono sbs 1 ..FV....... side by side tb 2 ..FV....... top bottom
-  - name: in_forder
-    description: <string> ..FV....... input cubemap face order (default "rludfb")
-  - name: out_forder
-    description: <string> ..FV....... output cubemap face order (default "rludfb")
-  - name: in_frot
-    description: <string> ..FV....... input cubemap face rotation (default "000000")
-  - name: out_frot
-    description: <string> ..FV....... output cubemap face rotation (default "000000")
-  - name: in_pad
-    description: <float> ..FV.....T. percent input cubemap pads (from 0 to 0.1) (default 0)
-  - name: out_pad
-    description: <float> ..FV.....T. percent output cubemap pads (from 0 to 0.1) (default 0)
-  - name: fin_pad
-    description: <int> ..FV.....T. fixed input cubemap pads (from 0 to 100) (default 0)
-  - name: fout_pad
-    description: <int> ..FV.....T. fixed output cubemap pads (from 0 to 100) (default 0)
-  - name: yaw
-    description: <float> ..FV.....T. yaw rotation (from -180 to 180) (default 0)
-  - name: roll
-    description: <float> ..FV.....T. roll rotation (from -180 to 180) (default 0)
-  - name: rorder
-    description: <string> ..FV.....T. rotation order (default "ypr")
-  - name: h_fov
-    description: <float> ..FV.....T. output horizontal field of view (from 0 to 360) (default 0)
-  - name: v_fov
-    description: <float> ..FV.....T. output vertical field of view (from 0 to 360) (default 0)
-  - name: d_fov
-    description: <float> ..FV.....T. output diagonal field of view (from 0 to 360) (default 0)
-  - name: h_flip
-    description: <boolean> ..FV.....T. flip out video horizontally (default false)
-  - name: v_flip
-    description: <boolean> ..FV.....T. flip out video vertically (default false)
-  - name: d_flip
-    description: <boolean> ..FV.....T. flip out video indepth (default false)
-  - name: ih_flip
-    description: <boolean> ..FV.....T. flip in video horizontally (default false)
-  - name: iv_flip
-    description: <boolean> ..FV.....T. flip in video vertically (default false)
-  - name: in_trans
-    description: <boolean> ..FV....... transpose video input (default false)
-  - name: out_trans
-    description: <boolean> ..FV....... transpose video output (default false)
-  - name: ih_fov
-    description: <float> ..FV.....T. input horizontal field of view (from 0 to 360) (default 0)
-  - name: iv_fov
-    description: <float> ..FV.....T. input vertical field of view (from 0 to 360) (default 0)
-  - name: id_fov
-    description: <float> ..FV.....T. input diagonal field of view (from 0 to 360) (default 0)
-  - name: h_offset
-    description: <float> ..FV.....T. output horizontal off-axis offset (from -1 to 1) (default 0)
-  - name: v_offset
-    description: <float> ..FV.....T. output vertical off-axis offset (from -1 to 1) (default 0)
-  - name: alpha_mask
-    description: <boolean> ..FV....... build mask in alpha plane (default false)
-  - name: reset_rot
-    description: <boolean> ..FV.....T. reset rotation (default false)
-  - name: nsteps
-    description: <int> ..FV....... set number of steps (from 1 to 32) (default 6)
-  - name: min_r
-    description: <int> ..FV.....T. set min blur radius (from 0 to 254) (default 0)
-  - name: max_r
-    description: <int> ..FV.....T. set max blur radius (from 1 to 255) (default 8)
-  - name: graticule
-    description: <int> ..FV....... set graticule (from 0 to 3) (default none) none 0 ..FV....... green 1 ..FV....... color 2 ..FV....... invert 3 ..FV.......
-  - name: lthreshold
-    description: <float> ..FV....... set low threshold (from 0 to 1) (default 0)
-  - name: hthreshold
-    description: <float> ..FV....... set high threshold (from 0 to 1) (default 1)
-  - name: tint0
-    description: <float> ..FV.....T. set 1st tint (from -1 to 1) (default 0)
-  - name: t0
-    description: <float> ..FV.....T. set 1st tint (from -1 to 1) (default 0)
-  - name: tint1
-    description: <float> ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
-  - name: t1
-    description: <float> ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
-  - name: rbal
-    description: <float> ..FV.....T. set the red balance value (from -10 to 10) (default 1)
-  - name: gbal
-    description: <float> ..FV.....T. set the green balance value (from -10 to 10) (default 1)
-  - name: bbal
-    description: <float> ..FV.....T. set the blue balance value (from -10 to 10) (default 1)
-  - name: rlum
-    description: <float> ..FV.....T. set the red luma coefficient (from 0 to 1) (default 0.072186)
-  - name: glum
-    description: <float> ..FV.....T. set the green luma coefficient (from 0 to 1) (default 0.715158)
-  - name: blum
-    description: <float> ..FV.....T. set the blue luma coefficient (from 0 to 1) (default 0.212656)
-  - name: alternate
-    description: <boolean> ..FV.....T. use alternate colors (default false)
-  - name: result
-    description: <string> ..FV....... path to the file used to write the transforms (default "transforms.trf")
-  - name: shakiness
-    description: '<int> ..FV....... how shaky is the video and how quick is the camera? 1: little (fast) 10: very strong/quick (slow) (from 1 to 10) (default 5)'
-  - name: stepsize
-    description: <int> ..FV....... region around minimum is scanned with 1 pixel resolution (from 1 to 32) (default 6)
-  - name: mincontrast
-    description: <double> ..FV....... below this contrast a field is discarded (0-1) (from 0 to 1) (default 0.25)
-  - name: optalgo
-    description: <int> ..FV....... set camera path optimization algo (from 0 to 2) (default opt) opt 0 ..FV....... global optimization gauss 1 ..FV....... gaussian kernel avg 2 ..FV....... simple averaging on motion
-  - name: maxshift
-    description: <int> ..FV....... set maximal number of pixels to translate image (from -1 to 500) (default -1)
-  - name: maxangle
-    description: <double> ..FV....... set maximal angle in rad to rotate image (from -1 to 3.14) (default -1)
-  - name: crop
-    description: <int> ..FV....... set cropping mode (from 0 to 1) (default keep) keep 0 ..FV....... keep border black 1 ..FV....... black border
-  - name: relative
-    description: <int> ..FV....... consider transforms as relative (from 0 to 1) (default 1)
-  - name: zoom
-    description: '<double> ..FV....... set percentage to zoom (>0: zoom in, <0: zoom out (from -100 to 100) (default 0)'
-  - name: optzoom
-    description: '<int> ..FV....... set optimal zoom (0: nothing, 1: optimal static zoom, 2: optimal dynamic zoom) (from 0 to 2) (default 1)'
-  - name: zoomspeed
-    description: '<double> ..FV....... for adative zoom: percent to zoom maximally each frame (from 0 to 5) (default 0.25)'
-  - name: interpol
-    description: <int> ..FV....... set type of interpolation (from 0 to 3) (default bilinear) no 0 ..FV....... no interpolation linear 1 ..FV....... linear (horizontal) bilinear 2 ..FV....... bi-linear bicubic 3 ..FV....... bi-cubic
-  - name: mirror
-    description: <boolean> ..FV....... set mirroring (default true)
-  - name: display
-    description: <int> ..FV....... set display mode (from 0 to 2) (default stack) overlay 0 ..FV....... stack 1 ..FV....... parade 2 ..FV.......
-  - name: fl
-    description: <flags> ..FV.....T. set graticule flags (default numbers) numbers ..FV.....T. draw numbers dots ..FV.....T. draw dots instead of lines
-  - name: fitmode
-    description: <int> ..FV....... set fit mode (from 0 to 1) (default none) none 0 ..FV....... size 1 ..FV.......
-  - name: fm
-    description: <int> ..FV....... set fit mode (from 0 to 1) (default none) none 0 ..FV....... size 1 ..FV.......
-  - name: secondary
-    description: <int> ..FV....... when to process secondary frame (from 0 to 1) (default all) first 0 ..FV....... process only first secondary frame, ignore rest all 1 ..FV....... process all secondary frames
-  - name: transition
-    description: <int> ..FV....... set cross fade transition (from -1 to 57) (default fade) custom -1 ..FV....... custom transition fade 0 ..FV....... fade transition wipeleft 1 ..FV....... wipe left transition wiperight 2 ..FV....... wipe right transition wipeup 3 ..FV....... wipe up transition wipedown 4 ..FV....... wipe down transition slideleft 5 ..FV....... slide left transition slideright 6 ..FV....... slide right transition slideup 7 ..FV....... slide up transition slidedown 8 ..FV....... slide down transition circlecrop 9 ..FV....... circle crop transition rectcrop 10 ..FV....... rect crop transition distance 11 ..FV....... distance transition fadeblack 12 ..FV....... fadeblack transition fadewhite 13 ..FV....... fadewhite transition radial 14 ..FV....... radial transition smoothleft 15 ..FV....... smoothleft transition smoothright 16 ..FV....... smoothright transition smoothup 17 ..FV....... smoothup transition smoothdown 18 ..FV....... smoothdown transition circleopen 19 ..FV....... circleopen transition circleclose 20 ..FV....... circleclose transition vertopen 21 ..FV....... vert open transition vertclose 22 ..FV....... vert close transition horzopen 23 ..FV....... horz open transition horzclose 24 ..FV....... horz close transition dissolve 25 ..FV....... dissolve transition pixelize 26 ..FV....... pixelize transition diagtl 27 ..FV....... diag tl transition diagtr 28 ..FV....... diag tr transition diagbl 29 ..FV....... diag bl transition diagbr 30 ..FV....... diag br transition hlslice 31 ..FV....... hl slice transition hrslice 32 ..FV....... hr slice transition vuslice 33 ..FV....... vu slice transition vdslice 34 ..FV....... vd slice transition hblur 35 ..FV....... hblur transition fadegrays 36 ..FV....... fadegrays transition wipetl 37 ..FV....... wipe tl transition wipetr 38 ..FV....... wipe tr transition wipebl 39 ..FV....... wipe bl transition wipebr 40 ..FV....... wipe br transition squeezeh 41 ..FV....... squeeze h transition squeezev 42 ..FV....... squeeze v transition zoomin 43 ..FV....... zoom in transition fadefast 44 ..FV....... fast fade transition fadeslow 45 ..FV....... slow fade transition hlwind 46 ..FV....... hl wind transition hrwind 47 ..FV....... hr wind transition vuwind 48 ..FV....... vu wind transition vdwind 49 ..FV....... vd wind transition coverleft 50 ..FV....... cover left transition coverright 51 ..FV....... cover right transition coverup 52 ..FV....... cover up transition coverdown 53 ..FV....... cover down transition revealleft 54 ..FV....... reveal left transition revealright 55 ..FV....... reveal right transition revealup 56 ..FV....... reveal up transition revealdown 57 ..FV....... reveal down transition
-  - name: grid
-    description: <image_size> ..FV....... set fixed size grid layout
-  - name: rangein
-    description: <int> ..FV....... set input color range (from -1 to 1) (default input) input -1 ..FV....... limited 0 ..FV....... full 1 ..FV....... unknown -1 ..FV....... tv 0 ..FV....... pc 1 ..FV.......
-  - name: rin
-    description: <int> ..FV....... set input color range (from -1 to 1) (default input) input -1 ..FV....... limited 0 ..FV....... full 1 ..FV....... unknown -1 ..FV....... tv 0 ..FV....... pc 1 ..FV.......
-  - name: primariesin
-    description: <int> ..FV....... set input color primaries (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 170m 6 ..FV....... 240m 7 ..FV....... 2020 9 ..FV....... unknown 2 ..FV....... bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... film 8 ..FV....... bt2020 9 ..FV....... smpte428 10 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
-  - name: pin
-    description: <int> ..FV....... set input color primaries (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 170m 6 ..FV....... 240m 7 ..FV....... 2020 9 ..FV....... unknown 2 ..FV....... bt709 1 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... film 8 ..FV....... bt2020 9 ..FV....... smpte428 10 ..FV....... smpte431 11 ..FV....... smpte432 12 ..FV....... jedec-p22 22 ..FV....... ebu3213 22 ..FV.......
-  - name: transferin
-    description: <int> ..FV....... set input transfer characteristic (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 601 6 ..FV....... linear 8 ..FV....... 2020_10 14 ..FV....... 2020_12 15 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... bt709 1 ..FV....... linear 8 ..FV....... log100 9 ..FV....... log316 10 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV....... smpte2084 16 ..FV....... iec61966-2-4 11 ..FV....... iec61966-2-1 13 ..FV....... arib-std-b67 18 ..FV.......
-  - name: tin
-    description: <int> ..FV....... set input transfer characteristic (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 601 6 ..FV....... linear 8 ..FV....... 2020_10 14 ..FV....... 2020_12 15 ..FV....... unknown 2 ..FV....... bt470m 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... bt709 1 ..FV....... linear 8 ..FV....... log100 9 ..FV....... log316 10 ..FV....... bt2020-10 14 ..FV....... bt2020-12 15 ..FV....... smpte2084 16 ..FV....... iec61966-2-4 11 ..FV....... iec61966-2-1 13 ..FV....... arib-std-b67 18 ..FV.......
-  - name: matrixin
-    description: <int> ..FV....... set input colorspace matrix (from -1 to INT_MAX) (default input) input -1 ..FV....... 709 1 ..FV....... unspecified 2 ..FV....... 470bg 5 ..FV....... 170m 6 ..FV....... 2020_ncl 9 ..FV....... 2020_cl 10 ..FV....... unknown 2 ..FV....... gbr 0 ..FV....... bt709 1 ..FV....... fcc 4 ..FV....... bt470bg 5 ..FV....... smpte170m 6 ..FV....... smpte240m 7 ..FV....... ycgco 8 ..FV....... bt2020nc 9 ..FV....... bt2020c 10 ..FV....... chroma-derived-nc 12 ..FV....... chroma-derived-c 13 ..FV....... ictcp 14 ..FV.......
-  - name: chromal
-    description: <int> ..FV....... set output chroma location (from -1 to 5) (default input) input -1 ..FV....... left 0 ..FV....... center 1 ..FV....... topleft 2 ..FV....... top 3 ..FV....... bottomleft 4 ..FV....... bottom 5 ..FV.......
-  - name: chromalin
-    description: <int> ..FV....... set input chroma location (from -1 to 5) (default input) input -1 ..FV....... left 0 ..FV....... center 1 ..FV....... topleft 2 ..FV....... top 3 ..FV....... bottomleft 4 ..FV....... bottom 5 ..FV.......
-  - name: cin
-    description: <int> ..FV....... set input chroma location (from -1 to 5) (default input) input -1 ..FV....... left 0 ..FV....... center 1 ..FV....... topleft 2 ..FV....... top 3 ..FV....... bottomleft 4 ..FV....... bottom 5 ..FV.......
-  - name: npl
-    description: <double> ..FV....... set nominal peak luminance (from 0 to DBL_MAX) (default nan)
-  - name: agamma
-    description: <boolean> ..FV....... allow approximate gamma (default true)
-  - name: param_a
-    description: <double> ..FV....... parameter A, which is parameter "b" for bicubic, and the number of filter taps for lanczos (from -DBL_MAX to DBL_MAX) (default nan)
-  - name: param_b
-    description: <double> ..FV....... parameter B, which is parameter "c" for bicubic (from -DBL_MAX to DBL_MAX) (default nan)
-  - name: grid_tile_size
-    description: <image_size> ..FV....... set tile size in grid layout
-  - name: rule
-    description: <int> ..FV....... set rule (from 0 to 255) (default 110)
-  - name: random_seed
-    description: <int64> ..FV....... set the seed for filling the initial grid randomly (from -1 to UINT32_MAX) (default -1)
-  - name: scroll
-    description: <boolean> ..FV....... scroll pattern downward (default true)
-  - name: start_full
-    description: <boolean> ..FV....... start filling the whole video (default false)
-  - name: full
-    description: <boolean> ..FV....... start filling the whole video (default true)
-  - name: stitch
-    description: <boolean> ..FV....... stitch boundaries (default true)
-  - name: framerate
-    description: <video_rate> ..FV....... (default "25")
-  - name: c4
-    description: <color> ..FV....... set 5th color (default "random")
-  - name: c5
-    description: <color> ..FV....... set 6th color (default "random")
-  - name: c6
-    description: <color> ..FV....... set 7th color (default "random")
-  - name: c7
-    description: <color> ..FV....... set 8th color (default "random")
-  - name: nb_colors
-    description: <int> ..FV....... set the number of colors (from 2 to 8) (default 2)
-  - name: mold
-    description: <int> ..FV....... set mold speed for dead cells (from 0 to 255) (default 0)
-  - name: life_color
-    description: <color> ..FV....... set life color (default "white")
-  - name: death_color
-    description: <color> ..FV....... set death color (default "black")
-  - name: mold_color
-    description: <color> ..FV....... set mold color (default "black")
-  - name: maxiter
-    description: <int> ..FV....... set max iterations number (from 1 to INT_MAX) (default 7189)
-  - name: start_x
-    description: <double> ..FV....... set the initial x position (from -100 to 100) (default -0.743644)
-  - name: start_y
-    description: <double> ..FV....... set the initial y position (from -100 to 100) (default -0.131826)
-  - name: start_scale
-    description: <double> ..FV....... set the initial scale value (from 0 to FLT_MAX) (default 3)
-  - name: end_scale
-    description: <double> ..FV....... set the terminal scale value (from 0 to FLT_MAX) (default 0.3)
-  - name: bailout
-    description: <double> ..FV....... set the bailout value (from 0 to FLT_MAX) (default 10)
-  - name: morphxf
-    description: <double> ..FV....... set morph x frequency (from -FLT_MAX to FLT_MAX) (default 0.01)
-  - name: morphyf
-    description: <double> ..FV....... set morph y frequency (from -FLT_MAX to FLT_MAX) (default 0.0123)
-  - name: morphamp
-    description: <double> ..FV....... set morph amplitude (from -FLT_MAX to FLT_MAX) (default 0)
-  - name: outer
-    description: <int> ..FV....... set outer coloring mode (from 0 to INT_MAX) (default normalized_iteration_count) iteration_count 0 ..FV....... set iteration count mode normalized_iteration_count 1 ..FV....... set normalized iteration count mode white 2 ..FV....... set white mode outz 3 ..FV....... set outz mode
-  - name: inner
-    description: <int> ..FV....... set inner coloring mode (from 0 to INT_MAX) (default mincol) black 0 ..FV....... set black mode period 1 ..FV....... set period mode convergence 2 ..FV....... show time until convergence mincol 3 ..FV....... color based on point closest to the origin of the iterations
-  - name: test
-    description: <int> ..FV....... set test to perform (from 0 to INT_MAX) (default all) dc_luma 0 ..FV....... dc_chroma 1 ..FV....... freq_luma 2 ..FV....... freq_chroma 3 ..FV....... amp_luma 4 ..FV....... amp_chroma 5 ..FV....... cbp 6 ..FV....... mv 7 ..FV....... ring1 8 ..FV....... ring2 9 ..FV....... all 10 ..FV.......
-  - name: max_frames
-    description: <int64> ..FV....... Set the maximum number of frames generated for each test (from 1 to I64_MAX) (default 30)
-  - name: complement
-    description: <boolean> ..FV....... set complement colors (default false)
-  - name: co
-    description: <boolean> ..FV....... set complement colors (default false)
-  - name: jump
-    description: <int> ..FV....... set the jump (from 1 to 10000) (default 100)
-  - name: decimals
-    description: <int> ..FV....... set number of decimals to show (from 0 to 17) (default 0)
-  - name: xo
-    description: <int> ..FV.....T. set X-axis offset (from INT_MIN to INT_MAX) (default 0)
-  - name: yo
-    description: <int> ..FV.....T. set Y-axis offset (from INT_MIN to INT_MAX) (default 0)
-  - name: to
-    description: <int> ..FV.....T. set T-axis offset (from INT_MIN to INT_MAX) (default 0)
-  - name: k0
-    description: <int> ..FV.....T. set 0-order phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kx
-    description: <int> ..FV.....T. set 1-order X-axis phase (from INT_MIN to INT_MAX) (default 0)
-  - name: ky
-    description: <int> ..FV.....T. set 1-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kt
-    description: <int> ..FV.....T. set 1-order T-axis phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kxt
-    description: <int> ..FV.....T. set X-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kyt
-    description: <int> ..FV.....T. set Y-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kxy
-    description: <int> ..FV.....T. set X-axis*Y-axis product phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kx2
-    description: <int> ..FV.....T. set 2-order X-axis phase (from INT_MIN to INT_MAX) (default 0)
-  - name: ky2
-    description: <int> ..FV.....T. set 2-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kt2
-    description: <int> ..FV.....T. set 2-order T-axis phase (from INT_MIN to INT_MAX) (default 0)
-  - name: ku
-    description: <int> ..FV.....T. set 0-order U-color phase (from INT_MIN to INT_MAX) (default 0)
-  - name: kv
-    description: <int> ..FV.....T. set 0-order V-color phase (from INT_MIN to INT_MAX) (default 0)
-  - name: fov
-    description: <float> ..FV.....T. set camera FoV (from 40 to 150) (default 90)
-  - name: xzoom
-    description: <float> ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
-  - name: yzoom
-    description: <float> ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
-  - name: zzoom
-    description: <float> ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
-  - name: xpos
-    description: <float> ..FV.....T. set camera position (from -60 to 60) (default 0)
-  - name: ypos
-    description: <float> ..FV.....T. set camera position (from -60 to 60) (default 0)
-  - name: zpos
-    description: <float> ..FV.....T. set camera position (from -60 to 60) (default 0)
-  - name: dmode
-    description: <int> ..FV....... set method to display channels (from 0 to 1) (default single) single 0 ..FV....... all channels use single histogram separate 1 ..FV....... each channel have own histogram
-  - name: ascale
-    description: <int> ..FV....... set amplitude scale (from 0 to 1) (default log) log 1 ..FV....... logarithmic lin 0 ..FV....... linear
-  - name: acount
-    description: <int> ..FV....... how much frames to accumulate (from -1 to 100) (default 1)
-  - name: rheight
-    description: <float> ..FV....... set histogram ratio of window height (from 0 to 1) (default 0.1)
-  - name: hmode
-    description: <int> ..FV....... set histograms mode (from 0 to 1) (default abs) abs 0 ..FV....... use absolute samples sign 1 ..FV....... use unchanged samples
-  - name: gc
-    description: <int> ..FV....... set green contrast (from 0 to 255) (default 7)
-  - name: bc
-    description: <int> ..FV....... set blue contrast (from 0 to 255) (default 1)
-  - name: mpc
-    description: <string> ..FV....... set median phase color (default "none")
-  - name: phasing
-    description: <boolean> ..FV....... set mono and out-of-phase detection output (default false)
-  - name: ac
-    description: <int> ..FV.....T. set alpha contrast (from 0 to 255) (default 255)
-  - name: gf
-    description: <int> ..FV.....T. set green fade (from 0 to 255) (default 10)
-  - name: bf
-    description: <int> ..FV.....T. set blue fade (from 0 to 255) (default 5)
-  - name: af
-    description: <int> ..FV.....T. set alpha fade (from 0 to 255) (default 5)
-  - name: draw
-    description: <int> ..FV.....T. set draw mode (from 0 to 2) (default dot) dot 0 ..FV.....T. draw dots line 1 ..FV.....T. draw lines aaline 2 ..FV.....T. draw anti-aliased lines
-  - name: swap
-    description: <boolean> ..FV.....T. swap x axis with y axis (default true)
-  - name: unsafe
-    description: <boolean> ..FVA...... enable unsafe mode (default false)
-  - name: bar_h
-    description: <int> ..FV....... set bargraph height (from -1 to INT_MAX) (default -1)
-  - name: axis_h
-    description: <int> ..FV....... set axis height (from -1 to INT_MAX) (default -1)
-  - name: sono_h
-    description: <int> ..FV....... set sonogram height (from -1 to INT_MAX) (default -1)
-  - name: fullhd
-    description: <boolean> ..FV....... set fullhd size (default true)
-  - name: sono_v
-    description: <string> ..FV....... set sonogram volume (default "16")
-  - name: bar_v
-    description: <string> ..FV....... set bargraph volume (default "sono_v")
-  - name: volume2
-    description: <string> ..FV....... set bargraph volume (default "sono_v")
-  - name: sono_g
-    description: <float> ..FV....... set sonogram gamma (from 1 to 7) (default 3)
-  - name: bar_g
-    description: <float> ..FV....... set bargraph gamma (from 1 to 7) (default 1)
-  - name: gamma2
-    description: <float> ..FV....... set bargraph gamma (from 1 to 7) (default 1)
-  - name: bar_t
-    description: <float> ..FV....... set bar transparency (from 0 to 1) (default 1)
-  - name: timeclamp
-    description: <double> ..FV....... set timeclamp (from 0.002 to 1) (default 0.17)
-  - name: endfreq
-    description: <double> ..FV....... set end frequency (from 10 to 100000) (default 20495.6)
-  - name: coeffclamp
-    description: <float> ..FV....... set coeffclamp (from 0.1 to 10) (default 1)
-  - name: tlength
-    description: <string> ..FV....... set tlength (default "384*tc/(384+tc*f)")
-  - name: count
-    description: <int> ..FV....... set transform count (from 1 to 30) (default 6)
-  - name: fcount
-    description: <int> ..FV....... set frequency count (from 0 to 10) (default 0)
-  - name: axisfile
-    description: <string> ..FV....... set axis image
-  - name: csp
-    description: <int> ..FV....... set color space (from 0 to INT_MAX) (default unspecified) unspecified 2 ..FV....... unspecified bt709 1 ..FV....... bt709 fcc 4 ..FV....... fcc bt470bg 5 ..FV....... bt470bg smpte170m 6 ..FV....... smpte170m smpte240m 7 ..FV....... smpte240m bt2020ncl 9 ..FV....... bt2020ncl
-  - name: cscheme
-    description: <string> ..FV....... set color scheme (default "1|0.5|0|0|0.5|1")
-  - name: iscale
-    description: <int> ..FV....... set intensity scale (from 0 to 4) (default log) linear 1 ..FV....... linear log 0 ..FV....... logarithmic sqrt 2 ..FV....... sqrt cbrt 3 ..FV....... cbrt qdrt 4 ..FV....... qdrt
-  - name: imin
-    description: <float> ..FV....... set minimum intensity (from 0 to 1) (default 0)
-  - name: imax
-    description: <float> ..FV....... set maximum intensity (from 0 to 1) (default 1)
-  - name: logb
-    description: <float> ..FV....... set logarithmic basis (from 0 to 1) (default 0.0001)
-  - name: deviation
-    description: <float> ..FV....... set frequency deviation (from 0 to 100) (default 1)
-  - name: pps
-    description: <int> ..FV....... set pixels per second (from 1 to 1024) (default 64)
-  - name: bar
-    description: <float> ..FV....... set bar ratio (from 0 to 1) (default 0)
-  - name: averaging
-    description: <int> ..FV....... set time averaging (from 0 to INT_MAX) (default 1)
-  - name: cmode
-    description: <int> ..FV....... set channel mode (from 0 to 1) (default combined) combined 0 ..FV....... show all channels in same window separate 1 ..FV....... show each channel in own window
-  - name: minamp
-    description: <float> ..FV....... set minimum amplitude (from FLT_MIN to 1e-06) (default 1e-06)
-  - name: data
-    description: <int> ..FV....... set data mode (from 0 to 2) (default magnitude) magnitude 0 ..FV....... show magnitude phase 1 ..FV....... show phase delay 2 ..FV....... show group delay
-  - name: orientation
-    description: <int> ..FV....... set orientation (from 0 to 1) (default vertical) vertical 0 ..FV....... horizontal 1 ..FV.......
-  - name: legend
-    description: <boolean> ..FV....... draw legend (default false)
-  - name: drange
-    description: <float> ..FV....... set dynamic range in dBFS (from 10 to 200) (default 120)
-  - name: dm
-    description: <double> ..FV....... duration for max value display (from 0 to 9000) (default 0)
-  - name: dmc
-    description: <color> ..FV....... set color of the max value line (default "orange")
-  - name: ds
-    description: <int> ..FV....... set display scale (from 0 to 1) (default lin) lin 0 ..FV....... linear log 1 ..FV....... log
-  - name: split_channels
-    description: <boolean> ..FV....... draw channels separately (default false)
-  - name: fr
-    description: <video_rate> ..FV....... set frame rate (default "30")
-  - name: samplerate
-    description: <int> ..F.A...... set sample rate (from 8000 to 384000) (default 44100)
-  - name: sr
-    description: <int> ..F.A...... set sample rate (from 8000 to 384000) (default 44100)
-  - name: period
-    description: <int> ..F.A...... set beep period (from 1 to 99) (default 3)
-  - name: dl
-    description: <int> ..FV.....T. set flash delay (from -30 to 30) (default 0)
-  - name: fg
-    description: <color> ..FV....... set foreground color (default "white")
-  - name: format_name
-    description: <string> ..FVA...... set format name
-  - name: seek_point
-    description: <double> ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
-  - name: sp
-    description: <double> ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
-  - name: streams
-    description: <string> ..FVA...... set streams
-  - name: discontinuity
-    description: <duration> ..FVA...... set discontinuity threshold (default 0)
-  - name: dec_threads
-    description: <int> ..FVA...... set the number of threads for decoding (from 0 to INT_MAX) (default 0)
-  - name: format_opts
-    description: <dictionary> ..FVA...... set format options for the opened file
-  - name: time_base
-    description: <rational> ..F.A...... (from 0 to INT_MAX) (default 0/1)
-  - name: sample_fmt
-    description: <sample_fmt> ..F.A...... (default none)
-  - name: video_size
-    description: <image_size> ..FV.......
-  - name: pix_fmt
-    description: <pix_fmt> ..FV....... (default none)
-  - name: pixel_aspect
-    description: <rational> ..FV....... sample aspect ratio (from 0 to DBL_MAX) (default 0/1)
-  - name: frame_rate
-    description: <rational> ..FV....... (from 0 to DBL_MAX) (default 0/1)
-  - name: channel_counts
-    description: <binary> ..F.A.....P set the supported channel counts (deprecated, use ch_layouts)
-  - name: ch_layouts
-    description: <string> ..F.A...... set a '|'-separated list of supported channel layouts
+  - thread_type
+  - enable
+  - threads
+  - extra_hw_frames
+  - action
+  - level_in
+  - mode
+  - threshold
+  - ratio
+  - attack
+  - release
+  - makeup
+  - knee
+  - link
+  - detection
+  - level_sc
+  - mix
+  - contrast
+  - cue
+  - preroll
+  - buffer
+  - nb_samples
+  - ns
+  - duration
+  - d
+  - overlap
+  - o
+  - curve1
+  - c1
+  - curve2
+  - c2
+  - split
+  - order
+  - level
+  - gain
+  - precision
+  - level_out
+  - bits
+  - dc
+  - aa
+  - samples
+  - lfo
+  - lforange
+  - lforate
+  - window
+  - w
+  - arorder
+  - a
+  - t
+  - burst
+  - b
+  - method
+  - m
+  - hsize
+  - n
+  - stages
+  - seed
+  - delays
+  - all
+  - type
+  - transfer
+  - channels
+  - dfrequency
+  - dqfactor
+  - tfrequency
+  - tqfactor
+  - range
+  - dftype
+  - tftype
+  - direction
+  - auto
+  - sensitivity
+  - basefreq
+  - in_gain
+  - out_gain
+  - decays
+  - exprs
+  - channel_layout
+  - c
+  - amount
+  - drive
+  - blend
+  - freq
+  - ceil
+  - listen
+  - start_sample
+  - ss
+  - start_time
+  - st
+  - curve
+  - silence
+  - unity
+  - noise_reduction
+  - nr
+  - noise_floor
+  - nf
+  - noise_type
+  - nt
+  - band_noise
+  - bn
+  - residual_floor
+  - rf
+  - track_noise
+  - tn
+  - track_residual
+  - tr
+  - output_mode
+  - om
+  - adaptivity
+  - ad
+  - floor_offset
+  - fo
+  - noise_link
+  - nl
+  - band_multiplier
+  - bm
+  - sample_noise
+  - sn
+  - gain_smooth
+  - gs
+  - real
+  - imag
+  - win_size
+  - win_func
+  - dry
+  - wet
+  - length
+  - gtype
+  - irgain
+  - irfmt
+  - maxir
+  - response
+  - channel
+  - size
+  - rate
+  - minp
+  - maxp
+  - nbirs
+  - ir
+  - irload
+  - sample_fmts
+  - f
+  - sample_rates
+  - r
+  - channel_layouts
+  - cl
+  - shift
+  - sigma
+  - levels
+  - wavet
+  - percent
+  - profile
+  - adaptive
+  - softness
+  - zeros
+  - z
+  - poles
+  - p
+  - gains
+  - k
+  - format
+  - process
+  - e
+  - normalize
+  - nb_inputs
+  - limit
+  - asc
+  - asc_level
+  - latency
+  - frequency
+  - width_type
+  - width
+  - transform
+  - loop
+  - start
+  - time
+  - inputs
+  - key
+  - value
+  - function
+  - expr
+  - file
+  - direct
+  - weights
+  - params
+  - curves
+  - mgain
+  - fscale
+  - colors
+  - strength
+  - s
+  - patch
+  - research
+  - output
+  - smooth
+  - mu
+  - eps
+  - leakage
+  - out_mode
+  - packet_size
+  - pad_len
+  - whole_len
+  - pad_dur
+  - whole_dur
+  - delay
+  - decay
+  - speed
+  - clip
+  - diff
+  - iterations
+  - offset_l
+  - offset_r
+  - timing
+  - bpm
+  - ms
+  - hz
+  - sample_rate
+  - lambda
+  - delta
+  - model
+  - timestamps
+  - outputs
+  - commands
+  - filename
+  - nb_out_samples
+  - pad
+  - tb
+  - param
+  - oversample
+  - measure
+  - hmm
+  - dict
+  - lm
+  - lmctl
+  - lmname
+  - logfn
+  - metadata
+  - reset
+  - measure_overall
+  - map
+  - boost
+  - feedback
+  - cutoff
+  - slope
+  - centerf
+  - qfactor
+  - tempo
+  - starti
+  - end
+  - endi
+  - start_pts
+  - end_pts
+  - durationi
+  - end_sample
+  - algo
+  - bind_address
+  - csg
+  - blocksize
+  - g
+  - a0
+  - a1
+  - a2
+  - b0
+  - b1
+  - b2
+  - fcut
+  - feed
+  - speeds
+  - depths
+  - attacks
+  - points
+  - soft-knee
+  - volume
+  - mm
+  - cm
+  - temp
+  - block_size
+  - i
+  - limitergain
+  - original
+  - enhance
+  - voice
+  - framelen
+  - gausssize
+  - peak
+  - maxgain
+  - targetrms
+  - coupling
+  - correctdc
+  - altboundary
+  - compress
+  - h
+  - v
+  - video
+  - meter
+  - framelog
+  - dualmono
+  - panlaw
+  - target
+  - gauge
+  - scale
+  - integrated
+  - lra_low
+  - lra_high
+  - sample_peak
+  - true_peak
+  - gain_entry
+  - accuracy
+  - wfunc
+  - fixed
+  - multi
+  - zero_phase
+  - dumpfile
+  - dumpscale
+  - fft2
+  - min_phase
+  - depth
+  - regen
+  - shape
+  - phase
+  - interp
+  - side_gain
+  - middle_source
+  - middle_phase
+  - left_delay
+  - left_balance
+  - left_gain
+  - left_phase
+  - right_delay
+  - right_balance
+  - right_gain
+  - right_phase
+  - process_stereo
+  - cdt_ms
+  - force_pe
+  - analyze_mode
+  - bits_per_sample
+  - lfe
+  - hrir
+  - plugin
+  - controls
+  - l
+  - lra
+  - tp
+  - measured_i
+  - measured_lra
+  - measured_tp
+  - measured_thresh
+  - offset
+  - linear
+  - dual_mono
+  - print_format
+  - args
+  - track_gain
+  - track_peak
+  - pitch
+  - transients
+  - detector
+  - smoothing
+  - formant
+  - pitchq
+  - noise
+  - mono
+  - start_periods
+  - start_duration
+  - start_threshold
+  - start_silence
+  - start_mode
+  - stop_periods
+  - stop_duration
+  - stop_threshold
+  - stop_silence
+  - stop_mode
+  - timestamp
+  - sofa
+  - rotation
+  - elevation
+  - radius
+  - speakers
+  - lfegain
+  - framesize
+  - interpolate
+  - minphase
+  - anglestep
+  - radstep
+  - expansion
+  - compression
+  - raise
+  - fall
+  - invert
+  - rms
+  - balance_in
+  - balance_out
+  - softclip
+  - mutel
+  - muter
+  - phasel
+  - phaser
+  - slev
+  - sbal
+  - mlev
+  - mpan
+  - base
+  - sclevel
+  - bmode_in
+  - bmode_out
+  - crossfeed
+  - drymix
+  - chl_out
+  - chl_in
+  - lfe_low
+  - lfe_high
+  - lfe_mode
+  - angle
+  - focus
+  - fc_in
+  - fc_out
+  - fl_in
+  - fl_out
+  - fr_in
+  - fr_out
+  - sl_in
+  - sl_out
+  - sr_in
+  - sr_out
+  - bl_in
+  - bl_out
+  - br_in
+  - br_out
+  - bc_in
+  - bc_out
+  - lfe_in
+  - lfe_out
+  - allx
+  - ally
+  - fcx
+  - flx
+  - frx
+  - blx
+  - brx
+  - slx
+  - srx
+  - bcx
+  - fcy
+  - fly
+  - fry
+  - bly
+  - bry
+  - sly
+  - sry
+  - bcy
+  - eval
+  - replaygain
+  - taps
+  - preset
+  - bands
+  - magnitude
+  - amplitude
+  - color
+  - colour
+  - density
+  - list_voices
+  - text
+  - textfile
+  - hp
+  - lp
+  - beta
+  - att
+  - round
+  - hptaps
+  - lptaps
+  - beep_factor
+  - x
+  - y
+  - qoffset
+  - clear
+  - eof_action
+  - shortest
+  - repeatlast
+  - ts_sync_mode
+  - factor
+  - tolerance
+  - low
+  - high
+  - planes
+  - original_size
+  - fontsdir
+  - alpha
+  - shaping
+  - similarity
+  - min_val
+  - window_size
+  - bitplane
+  - filter
+  - pic_th
+  - pixel_black_th
+  - pix_th
+  - thresh
+  - c0_mode
+  - c1_mode
+  - c2_mode
+  - c3_mode
+  - all_mode
+  - c0_expr
+  - c1_expr
+  - c2_expr
+  - c3_expr
+  - all_expr
+  - c0_opacity
+  - c1_opacity
+  - c2_opacity
+  - c3_opacity
+  - all_opacity
+  - period_min
+  - period_max
+  - block_pct
+  - block_width
+  - block_height
+  - block
+  - bstep
+  - group
+  - mstep
+  - thmse
+  - hdthr
+  - estim
+  - ref
+  - luma_radius
+  - lr
+  - luma_power
+  - chroma_radius
+  - cr
+  - chroma_power
+  - cp
+  - alpha_radius
+  - ar
+  - alpha_power
+  - ap
+  - parity
+  - deint
+  - dist_x
+  - dist_y
+  - yuv
+  - thres
+  - sizew
+  - sizeh
+  - stepw
+  - steph
+  - threy
+  - threu
+  - threv
+  - distance
+  - cbh
+  - cbv
+  - crh
+  - crv
+  - edge
+  - system
+  - cie
+  - gamuts
+  - intensity
+  - corrgamma
+  - showwhite
+  - gamma
+  - fill
+  - mv
+  - qp
+  - mv_type
+  - mvt
+  - frame_type
+  - ft
+  - rs
+  - bs
+  - rm
+  - gm
+  - rh
+  - gh
+  - bh
+  - pl
+  - rr
+  - rg
+  - rb
+  - ra
+  - gr
+  - gg
+  - gb
+  - ga
+  - br
+  - bg
+  - bb
+  - ba
+  - ag
+  - ab
+  - pc
+  - pa
+  - rc
+  - by
+  - rcw
+  - gmw
+  - byw
+  - rl
+  - bl
+  - saturation
+  - analyze
+  - hue
+  - lightness
+  - rimin
+  - gimin
+  - bimin
+  - aimin
+  - rimax
+  - gimax
+  - bimax
+  - aimax
+  - romin
+  - gomin
+  - bomin
+  - aomin
+  - romax
+  - gomax
+  - bomax
+  - aomax
+  - preserve
+  - patch_size
+  - nb_patches
+  - kernel
+  - src
+  - dst
+  - space
+  - primaries
+  - trc
+  - fast
+  - dither
+  - wpadapt
+  - iall
+  - ispace
+  - irange
+  - iprimaries
+  - itrc
+  - temperature
+  - impulse
+  - cover
+  - out_w
+  - out_h
+  - keep_aspect
+  - exact
+  - skip
+  - reset_count
+  - max_outliers
+  - mv_threshold
+  - master
+  - red
+  - green
+  - blue
+  - psfile
+  - plot
+  - axis
+  - opacity
+  - components
+  - blur
+  - cycle
+  - dupthresh
+  - scthresh
+  - blockx
+  - blocky
+  - ppsrc
+  - chroma
+  - mixed
+  - lt
+  - tl
+  - tc
+  - ct
+  - threshold0
+  - threshold1
+  - threshold2
+  - threshold3
+  - bypass
+  - show
+  - denoise
+  - filter_type
+  - dnn_backend
+  - input
+  - rx
+  - ry
+  - search
+  - opencl
+  - tripod
+  - debug
+  - adaptive_crop
+  - refine_features
+  - smooth_strength
+  - expand
+  - brightness
+  - first_field
+  - pattern
+  - start_frame
+  - coordinates
+  - backend_configs
+  - options
+  - async
+  - confidence
+  - labels
+  - height
+  - thickness
+  - replace
+  - box_source
+  - m1
+  - fg1
+  - m2
+  - fg2
+  - m3
+  - fg3
+  - m4
+  - fg4
+  - min
+  - max
+  - slide
+  - fontfile
+  - fontcolor
+  - fontcolor_expr
+  - boxcolor
+  - bordercolor
+  - shadowcolor
+  - box
+  - boxborderw
+  - line_spacing
+  - fontsize
+  - text_align
+  - boxw
+  - boxh
+  - shadowx
+  - shadowy
+  - borderw
+  - tabsize
+  - basetime
+  - font
+  - y_align
+  - timecode
+  - tc24hmax
+  - timecode_rate
+  - reload
+  - fix_bounds
+  - start_number
+  - text_source
+  - text_shaping
+  - ft_load_flags
+  - codebook_length
+  - nb_steps
+  - pal8
+  - use_alpha
+  - gamma_r
+  - gamma_g
+  - gamma_b
+  - gamma_weight
+  - rslope
+  - redge
+  - ecost
+  - mcost
+  - dcost
+  - exposure
+  - black
+  - nb_frames
+  - prev
+  - next
+  - hint
+  - field
+  - mchroma
+  - y0
+  - y1
+  - combmatch
+  - combdbg
+  - cthresh
+  - combpel
+  - left
+  - right
+  - top
+  - bottom
+  - object
+  - mipmaps
+  - xmin
+  - ymin
+  - xmax
+  - ymax
+  - discard
+  - s0
+  - s1
+  - s2
+  - s3
+  - d0
+  - d1
+  - d2
+  - d3
+  - pix_fmts
+  - fps
+  - interp_start
+  - interp_end
+  - scene
+  - flags
+  - step
+  - first
+  - last
+  - filter_name
+  - filter_params
+  - quality
+  - use_bframe_qp
+  - steps
+  - lum_expr
+  - lum
+  - cb_expr
+  - cb
+  - cr_expr
+  - alpha_expr
+  - red_expr
+  - green_expr
+  - blue_expr
+  - interpolation
+  - difford
+  - minknorm
+  - sub
+  - guidance
+  - clut
+  - antibanding
+  - level_height
+  - scale_height
+  - display_mode
+  - levels_mode
+  - fgopacity
+  - bgopacity
+  - colors_mode
+  - luma_spatial
+  - chroma_spatial
+  - luma_tmp
+  - chroma_tmp
+  - sat
+  - val
+  - rw
+  - gw
+  - bw
+  - derive_device
+  - reverse
+  - device
+  - intl_thres
+  - prog_thres
+  - rep_thres
+  - half_life
+  - luma_mode
+  - chroma_mode
+  - alpha_mode
+  - luma_swap
+  - ls
+  - chroma_swap
+  - cs
+  - alpha_swap
+  - as
+  - scan
+  - lowpass
+  - sharp
+  - twoway
+  - cx
+  - cy
+  - k1
+  - k2
+  - fc
+  - crop_x
+  - crop_y
+  - crop_w
+  - crop_h
+  - pos_x
+  - pos_y
+  - pos_w
+  - pos_h
+  - normalize_sar
+  - pad_crop_ratio
+  - fillcolor
+  - corner_rounding
+  - extra_opts
+  - colorspace
+  - color_primaries
+  - color_trc
+  - upscaler
+  - downscaler
+  - frame_mixer
+  - lut_entries
+  - antiringing
+  - sigmoid
+  - apply_filmgrain
+  - deband
+  - deband_threshold
+  - deband_radius
+  - deband_grain
+  - peak_detect
+  - smoothing_period
+  - minimum_peak
+  - percentile
+  - gamut_mode
+  - tonemapping
+  - gamut_warning
+  - gamut_clipping
+  - intent
+  - tonemapping_mode
+  - overshoot
+  - hybrid_mix
+  - dithering
+  - dither_lut_size
+  - dither_temporal
+  - cones
+  - cone-strength
+  - skip_aa
+  - polar_cutoff
+  - disable_linear
+  - disable_builtin
+  - force_icc_lut
+  - force_dither
+  - disable_fbos
+  - elasticity
+  - reference
+  - c0
+  - c3
+  - u
+  - undershoot
+  - sum
+  - mapping
+  - map0s
+  - map0p
+  - map1s
+  - map1p
+  - map2s
+  - map2p
+  - map3s
+  - map3p
+  - mb_size
+  - search_param
+  - mi_mode
+  - mc_mode
+  - me_mode
+  - me
+  - vsbmc
+  - scd
+  - scd_threshold
+  - structure
+  - keep
+  - hi
+  - lo
+  - frac
+  - negate_alpha
+  - s4
+  - p1
+  - p2
+  - p3
+  - p4
+  - nsize
+  - nns
+  - qual
+  - etype
+  - pscrn
+  - all_seed
+  - all_strength
+  - alls
+  - all_flags
+  - allf
+  - c0_seed
+  - c0_strength
+  - c0s
+  - c0_flags
+  - c0f
+  - c1_seed
+  - c1_strength
+  - c1s
+  - c1_flags
+  - c1f
+  - c2_seed
+  - c2_strength
+  - c2s
+  - c2_flags
+  - c2f
+  - c3_seed
+  - c3_strength
+  - c3s
+  - c3_flags
+  - c3f
+  - blackpt
+  - whitept
+  - independence
+  - tx
+  - ty
+  - tw
+  - th
+  - sc
+  - luma_strength
+  - chroma_strength
+  - aspect
+  - max_colors
+  - stats_mode
+  - bayer_scale
+  - diff_mode
+  - new
+  - alpha_threshold
+  - debug_kdtree
+  - x0
+  - x1
+  - x2
+  - y2
+  - x3
+  - y3
+  - sense
+  - frames
+  - wx
+  - wy
+  - subfilters
+  - inplace
+  - saturatio
+  - source
+  - index
+  - stats_file
+  - stats_version
+  - output_max
+  - jl
+  - jr
+  - jt
+  - jb
+  - sb
+  - mp
+  - scan_min
+  - scan_max
+  - spw
+  - chp
+  - thr_b
+  - thr_w
+  - m0
+  - rv
+  - gv
+  - bv
+  - ah
+  - av
+  - ow
+  - oh
+  - bilinear
+  - lpfr
+  - cpfr
+  - interl
+  - in_color_matrix
+  - out_color_matrix
+  - in_range
+  - out_range
+  - in_v_chr_pos
+  - in_h_chr_pos
+  - out_v_chr_pos
+  - out_h_chr_pos
+  - param0
+  - param1
+  - interp_algo
+  - passthrough
+  - scaler
+  - sc_pass
+  - horizontal
+  - vertical
+  - hpos
+  - vpos
+  - reds
+  - yellows
+  - greens
+  - cyans
+  - blues
+  - magentas
+  - whites
+  - neutrals
+  - blacks
+  - dar
+  - field_mode
+  - sar
+  - sharpness
+  - shx
+  - shy
+  - checksum
+  - map0
+  - map1
+  - map2
+  - map3
+  - stat
+  - out
+  - detectmode
+  - th_d
+  - th_dc
+  - th_xh
+  - th_di
+  - th_it
+  - print_summary
+  - luma_threshold
+  - chroma_threshold
+  - scale_factor
+  - compute_chroma
+  - frame_skip_ratio
+  - ref_projection
+  - main_projection
+  - ref_stereo
+  - main_stereo
+  - ref_pad
+  - main_pad
+  - use_tape
+  - heatmap_str
+  - in
+  - charenc
+  - stream_index
+  - si
+  - force_style
+  - wrap_unicode
+  - envelope
+  - ecolor
+  - ec
+  - log
+  - layout
+  - margin
+  - padding
+  - init_padding
+  - tonemap
+  - desat
+  - matrix
+  - stop
+  - dir
+  - end_frame
+  - luma_msize_x
+  - lx
+  - luma_msize_y
+  - ly
+  - luma_amount
+  - la
+  - chroma_msize_x
+  - chroma_msize_y
+  - chroma_amount
+  - ca
+  - alpha_msize_x
+  - ax
+  - alpha_msize_y
+  - ay
+  - alpha_amount
+  - codec
+  - in_stereo
+  - out_stereo
+  - in_forder
+  - out_forder
+  - in_frot
+  - out_frot
+  - in_pad
+  - out_pad
+  - fin_pad
+  - fout_pad
+  - yaw
+  - roll
+  - rorder
+  - h_fov
+  - v_fov
+  - d_fov
+  - h_flip
+  - v_flip
+  - d_flip
+  - ih_flip
+  - iv_flip
+  - in_trans
+  - out_trans
+  - ih_fov
+  - iv_fov
+  - id_fov
+  - h_offset
+  - v_offset
+  - alpha_mask
+  - reset_rot
+  - nsteps
+  - min_r
+  - max_r
+  - graticule
+  - lthreshold
+  - hthreshold
+  - tint0
+  - t0
+  - tint1
+  - t1
+  - rbal
+  - gbal
+  - bbal
+  - rlum
+  - glum
+  - blum
+  - alternate
+  - result
+  - shakiness
+  - stepsize
+  - mincontrast
+  - optalgo
+  - maxshift
+  - maxangle
+  - crop
+  - relative
+  - zoom
+  - optzoom
+  - zoomspeed
+  - interpol
+  - mirror
+  - display
+  - fl
+  - fitmode
+  - fm
+  - secondary
+  - transition
+  - grid
+  - rangein
+  - rin
+  - primariesin
+  - pin
+  - transferin
+  - tin
+  - matrixin
+  - chromal
+  - chromalin
+  - cin
+  - npl
+  - agamma
+  - param_a
+  - param_b
+  - grid_tile_size
+  - rule
+  - random_seed
+  - scroll
+  - start_full
+  - full
+  - stitch
+  - framerate
+  - c4
+  - c5
+  - c6
+  - c7
+  - nb_colors
+  - mold
+  - life_color
+  - death_color
+  - mold_color
+  - maxiter
+  - start_x
+  - start_y
+  - start_scale
+  - end_scale
+  - bailout
+  - morphxf
+  - morphyf
+  - morphamp
+  - outer
+  - inner
+  - test
+  - max_frames
+  - complement
+  - co
+  - jump
+  - decimals
+  - xo
+  - yo
+  - to
+  - k0
+  - kx
+  - ky
+  - kt
+  - kxt
+  - kyt
+  - kxy
+  - kx2
+  - ky2
+  - kt2
+  - ku
+  - kv
+  - fov
+  - xzoom
+  - yzoom
+  - zzoom
+  - xpos
+  - ypos
+  - zpos
+  - dmode
+  - ascale
+  - acount
+  - rheight
+  - hmode
+  - gc
+  - bc
+  - mpc
+  - phasing
+  - ac
+  - gf
+  - bf
+  - af
+  - draw
+  - swap
+  - unsafe
+  - bar_h
+  - axis_h
+  - sono_h
+  - fullhd
+  - sono_v
+  - bar_v
+  - volume2
+  - sono_g
+  - bar_g
+  - gamma2
+  - bar_t
+  - timeclamp
+  - endfreq
+  - coeffclamp
+  - tlength
+  - count
+  - fcount
+  - axisfile
+  - csp
+  - cscheme
+  - iscale
+  - imin
+  - imax
+  - logb
+  - deviation
+  - pps
+  - bar
+  - averaging
+  - cmode
+  - minamp
+  - data
+  - orientation
+  - legend
+  - drange
+  - dm
+  - dmc
+  - ds
+  - split_channels
+  - fr
+  - samplerate
+  - sr
+  - period
+  - dl
+  - fg
+  - format_name
+  - seek_point
+  - sp
+  - streams
+  - discontinuity
+  - dec_threads
+  - format_opts
+  - time_base
+  - sample_fmt
+  - video_size
+  - pix_fmt
+  - pixel_aspect
+  - frame_rate
+  - channel_counts
+  - ch_layouts
   single_dash: true
   group: 'libdc1394 indev AVOptions:'
   description: <string> .D......... (default "ntsc")

--- a/corpus/ffplay/6.1.1-3ubuntu5/help.stderr.txt
+++ b/corpus/ffplay/6.1.1-3ubuntu5/help.stderr.txt
@@ -1,0 +1,11 @@
+ffplay version 6.1.1-3ubuntu5 Copyright (c) 2003-2023 the FFmpeg developers
+  built with gcc 13 (Ubuntu 13.2.0-23ubuntu3)
+  configuration: --prefix=/usr --extra-version=3ubuntu5 --toolchain=hardened --libdir=/usr/lib/aarch64-linux-gnu --incdir=/usr/include/aarch64-linux-gnu --arch=arm64 --enable-gpl --disable-stripping --disable-omx --enable-gnutls --enable-libaom --enable-libass --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libglslang --enable-libgme --enable-libgsm --enable-libharfbuzz --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-openal --enable-opencl --enable-opengl --disable-sndio --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-ladspa --enable-libbluray --enable-libjack --enable-libpulse --enable-librabbitmq --enable-librist --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libx264 --enable-libzmq --enable-libzvbi --enable-lv2 --enable-sdl2 --enable-libplacebo --enable-librav1e --enable-pocketsphinx --enable-librsvg --enable-libjxl --enable-shared
+  libavutil      58. 29.100 / 58. 29.100
+  libavcodec     60. 31.102 / 60. 31.102
+  libavformat    60. 16.100 / 60. 16.100
+  libavdevice    60.  3.100 / 60.  3.100
+  libavfilter     9. 12.100 /  9. 12.100
+  libswscale      7.  5.100 /  7.  5.100
+  libswresample   4. 12.100 /  4. 12.100
+  libpostproc    57.  3.100 / 57.  3.100

--- a/corpus/ffplay/6.1.1-3ubuntu5/help.txt
+++ b/corpus/ffplay/6.1.1-3ubuntu5/help.txt
@@ -1,0 +1,11611 @@
+Simple media player
+usage: ffplay [options] input_file
+
+Main options:
+-L                  show license
+-h topic            show help
+-? topic            show help
+-help topic         show help
+--help topic        show help
+-version            show version
+-buildconf          show build configuration
+-formats            show available formats
+-muxers             show available muxers
+-demuxers           show available demuxers
+-devices            show available devices
+-codecs             show available codecs
+-decoders           show available decoders
+-encoders           show available encoders
+-bsfs               show available bit stream filters
+-protocols          show available protocols
+-filters            show available filters
+-pix_fmts           show available pixel formats
+-layouts            show standard channel layouts
+-sample_fmts        show available audio sample formats
+-dispositions       show available stream dispositions
+-colors             show available color names
+-loglevel loglevel  set logging level
+-v loglevel         set logging level
+-report             generate a report
+-max_alloc bytes    set maximum size of a single allocated block
+-sources device     list sources of the input device
+-sinks device       list sinks of the output device
+-x width            force displayed width
+-y height           force displayed height
+-fs                 force full screen
+-an                 disable audio
+-vn                 disable video
+-sn                 disable subtitling
+-ss pos             seek to a given position in seconds
+-t duration         play  "duration" seconds of audio/video
+-bytes val          seek by bytes 0=off 1=on -1=auto
+-seek_interval seconds  set seek interval for left/right keys, in seconds
+-nodisp             disable graphical display
+-noborder           borderless window
+-alwaysontop        window always on top
+-volume volume      set startup volume 0=min 100=max
+-f fmt              force format
+-window_title window title  set window title
+-af filter_graph    set audio filters
+-showmode mode      select show mode (0 = video, 1 = waves, 2 = RDFT)
+-i input_file       read specified file
+-codec decoder_name  force decoder
+-autorotate         automatically rotate video
+
+Advanced options:
+-cpuflags flags     force specific cpu flags
+-cpucount count     force specific cpu count
+-hide_banner hide_banner  do not show program banner
+-ast stream_specifier  select desired audio stream
+-vst stream_specifier  select desired video stream
+-sst stream_specifier  select desired subtitle stream
+-stats              show status
+-fast               non spec compliant optimizations
+-genpts             generate pts
+-drp                let decoder reorder pts 0=off 1=on -1=auto
+-lowres             
+-sync type          set audio-video sync. type (type=audio/video/ext)
+-autoexit           exit at the end
+-exitonkeydown      exit on key down
+-exitonmousedown    exit on mouse down
+-loop loop count    set number of times the playback shall be looped
+-framedrop          drop frames when cpu is too slow
+-infbuf             don't limit the input buffer size (useful with realtime streams)
+-left x pos         set the x position for the left of the window
+-top y pos          set the y position for the top of the window
+-vf filter_graph    set video filters
+-rdftspeed msecs    rdft speed
+-acodec decoder_name  force audio decoder
+-scodec decoder_name  force subtitle decoder
+-vcodec decoder_name  force video decoder
+-find_stream_info   read and decode the streams to fill missing information with heuristics
+-filter_threads     number of filter threads per graph
+
+
+AVCodecContext AVOptions:
+  -flags             <flags>      ED.VAS..... (default 0)
+     unaligned                    .D.V....... allow decoders to produce unaligned output
+     gray                         ED.V....... only decode/encode grayscale
+     low_delay                    ED.V....... force low delay
+     bitexact                     ED.VAS..... use only bitexact functions (except (I)DCT)
+     output_corrupt               .D.V....... Output even potentially corrupted frames
+     drop_changed                 .D.VA.....P Drop frames whose parameters differ from first decoded frame
+  -flags2            <flags>      ED.VAS..... (default 0)
+     ignorecrop                   .D.V....... ignore cropping information from sps
+     chunks                       .D.V....... Frame data might be split into multiple chunks
+     showall                      .D.V....... Show all frames before the first keyframe
+     export_mvs                   .D.V....... export motion vectors through frame side data
+     skip_manual                  .D..A...... do not skip samples and export skip information as frame side data
+     ass_ro_flush_noop              .D...S..... do not reset ASS ReadOrder field on flush
+     icc_profiles                 .D...S..... generate/parse embedded ICC profiles from/to colorimetry tags
+  -export_side_data  <flags>      ED.VAS..... Export metadata as side data (default 0)
+     mvs                          .D.V....... export motion vectors through frame side data
+     venc_params                  .D.V....... export video encoding parameters through frame side data
+     film_grain                   .D.V....... export film grain parameters through frame side data
+  -ar                <int>        ED..A...... set audio sampling rate (in Hz) (from 0 to INT_MAX) (default 0)
+  -ac                <int>        ED..A...... set number of audio channels (from 0 to INT_MAX) (default 0)
+  -bug               <flags>      .D.V....... work around not autodetected encoder bugs (default autodetect)
+     autodetect                   .D.V.......
+     xvid_ilace                   .D.V....... Xvid interlacing bug (autodetected if FOURCC == XVIX)
+     ump4                         .D.V....... (autodetected if FOURCC == UMP4)
+     no_padding                   .D.V....... padding bug (autodetected)
+     amv                          .D.V.......
+     qpel_chroma                  .D.V.......
+     std_qpel                     .D.V....... old standard qpel (autodetected per FOURCC/version)
+     qpel_chroma2                 .D.V.......
+     direct_blocksize              .D.V....... direct-qpel-blocksize bug (autodetected per FOURCC/version)
+     edge                         .D.V....... edge padding bug (autodetected per FOURCC/version)
+     hpel_chroma                  .D.V.......
+     dc_clip                      .D.V.......
+     ms                           .D.V....... work around various bugs in Microsoft's broken decoders
+     trunc                        .D.V....... truncated frames
+     iedge                        .D.V.......
+  -strict            <int>        ED.VA...... how strictly to follow the standards (from INT_MIN to INT_MAX) (default normal)
+     very            2            ED.VA...... strictly conform to a older more strict version of the spec or reference software
+     strict          1            ED.VA...... strictly conform to all the things in the spec no matter what the consequences
+     normal          0            ED.VA......
+     unofficial      -1           ED.VA...... allow unofficial extensions
+     experimental    -2           ED.VA...... allow non-standardized experimental things
+  -err_detect        <flags>      ED.VAS..... set error detection flags (default 0)
+     crccheck                     ED.VAS..... verify embedded CRCs
+     bitstream                    ED.VAS..... detect bitstream specification deviations
+     buffer                       ED.VAS..... detect improper bitstream length
+     explode                      ED.VAS..... abort decoding on minor error detection
+     ignore_err                   ED.VAS..... ignore errors
+     careful                      ED.VAS..... consider things that violate the spec, are fast to check and have not been seen in the wild as errors
+     compliant                    ED.VAS..... consider all spec non compliancies as errors
+     aggressive                   ED.VAS..... consider things that a sane encoder should not do as an error
+  -idct              <int>        ED.V....... select IDCT implementation (from 0 to INT_MAX) (default auto)
+     auto            0            ED.V.......
+     int             1            ED.V.......
+     simple          2            ED.V.......
+     simplemmx       3            ED.V.......
+     arm             7            ED.V.......
+     altivec         8            ED.V.......
+     simplearm       10           ED.V.......
+     simplearmv5te   16           ED.V.......
+     simplearmv6     17           ED.V.......
+     simpleneon      22           ED.V.......
+     xvid            14           ED.V.......
+     xvidmmx         14           ED.V....... deprecated, for compatibility only
+     faani           20           ED.V....... floating point AAN IDCT
+     simpleauto      128          ED.V.......
+  -ec                <flags>      .D.V....... set error concealment strategy (default guess_mvs+deblock)
+     guess_mvs                    .D.V....... iterative motion vector (MV) search (slow)
+     deblock                      .D.V....... use strong deblock filter for damaged MBs
+     favor_inter                  .D.V....... favor predicting from the previous frame
+  -debug             <flags>      ED.VAS..... print specific debug info (default 0)
+     pict                         .D.V....... picture info
+     bitstream                    .D.V.......
+     mb_type                      .D.V....... macroblock (MB) type
+     qp                           .D.V....... per-block quantization parameter (QP)
+     dct_coeff                    .D.V.......
+     green_metadata               .D.V.......
+     skip                         .D.V.......
+     startcode                    .D.V.......
+     er                           .D.V....... error recognition
+     mmco                         .D.V....... memory management control operations (H.264)
+     bugs                         .D.V.......
+     buffers                      .D.V....... picture buffer allocations
+     thread_ops                   .D.VA...... threading operations
+     nomc                         .D.VA...... skip motion compensation
+  -threads           <int>        ED.VA...... set the number of threads (from 0 to INT_MAX) (default 1)
+     auto            0            ED.V....... autodetect a suitable number of threads to use
+  -skip_top          <int>        .D.V....... number of macroblock rows at the top which are skipped (from INT_MIN to INT_MAX) (default 0)
+  -skip_bottom       <int>        .D.V....... number of macroblock rows at the bottom which are skipped (from INT_MIN to INT_MAX) (default 0)
+  -lowres            <int>        .D.VA...... decode at 1= 1/2, 2=1/4, 3=1/8 resolutions (from 0 to INT_MAX) (default 0)
+  -skip_loop_filter  <int>        .D.V....... skip loop filtering process for the selected frames (from INT_MIN to INT_MAX) (default default)
+     none            -16          .D.V....... discard no frame
+     default         0            .D.V....... discard useless frames
+     noref           8            .D.V....... discard all non-reference frames
+     bidir           16           .D.V....... discard all bidirectional frames
+     nointra         24           .D.V....... discard all frames except I frames
+     nokey           32           .D.V....... discard all frames except keyframes
+     all             48           .D.V....... discard all frames
+  -skip_idct         <int>        .D.V....... skip IDCT/dequantization for the selected frames (from INT_MIN to INT_MAX) (default default)
+     none            -16          .D.V....... discard no frame
+     default         0            .D.V....... discard useless frames
+     noref           8            .D.V....... discard all non-reference frames
+     bidir           16           .D.V....... discard all bidirectional frames
+     nointra         24           .D.V....... discard all frames except I frames
+     nokey           32           .D.V....... discard all frames except keyframes
+     all             48           .D.V....... discard all frames
+  -skip_frame        <int>        .D.V....... skip decoding for the selected frames (from INT_MIN to INT_MAX) (default default)
+     none            -16          .D.V....... discard no frame
+     default         0            .D.V....... discard useless frames
+     noref           8            .D.V....... discard all non-reference frames
+     bidir           16           .D.V....... discard all bidirectional frames
+     nointra         24           .D.V....... discard all frames except I frames
+     nokey           32           .D.V....... discard all frames except keyframes
+     all             48           .D.V....... discard all frames
+  -ch_layout         <channel_layout> ED..A......
+  -channel_layout    <channel_layout> ED..A...... (default 0x0)
+  -request_channel_layout <channel_layout> .D..A...... (default 0x0)
+  -ticks_per_frame   <int>        ED.VA...... (from 1 to INT_MAX) (default 1)
+  -color_primaries   <int>        ED.V....... color primaries (from 1 to INT_MAX) (default unknown)
+     bt709           1            ED.V....... BT.709
+     unknown         2            ED.V....... Unspecified
+     bt470m          4            ED.V....... BT.470 M
+     bt470bg         5            ED.V....... BT.470 BG
+     smpte170m       6            ED.V....... SMPTE 170 M
+     smpte240m       7            ED.V....... SMPTE 240 M
+     film            8            ED.V....... Film
+     bt2020          9            ED.V....... BT.2020
+     smpte428        10           ED.V....... SMPTE 428-1
+     smpte428_1      10           ED.V....... SMPTE 428-1
+     smpte431        11           ED.V....... SMPTE 431-2
+     smpte432        12           ED.V....... SMPTE 422-1
+     jedec-p22       22           ED.V....... JEDEC P22
+     ebu3213         22           ED.V....... EBU 3213-E
+     unspecified     2            ED.V....... Unspecified
+  -color_trc         <int>        ED.V....... color transfer characteristics (from 1 to INT_MAX) (default unknown)
+     bt709           1            ED.V....... BT.709
+     unknown         2            ED.V....... Unspecified
+     gamma22         4            ED.V....... BT.470 M
+     gamma28         5            ED.V....... BT.470 BG
+     smpte170m       6            ED.V....... SMPTE 170 M
+     smpte240m       7            ED.V....... SMPTE 240 M
+     linear          8            ED.V....... Linear
+     log100          9            ED.V....... Log
+     log316          10           ED.V....... Log square root
+     iec61966-2-4    11           ED.V....... IEC 61966-2-4
+     bt1361e         12           ED.V....... BT.1361
+     iec61966-2-1    13           ED.V....... IEC 61966-2-1
+     bt2020-10       14           ED.V....... BT.2020 - 10 bit
+     bt2020-12       15           ED.V....... BT.2020 - 12 bit
+     smpte2084       16           ED.V....... SMPTE 2084
+     smpte428        17           ED.V....... SMPTE 428-1
+     arib-std-b67    18           ED.V....... ARIB STD-B67
+     unspecified     2            ED.V....... Unspecified
+     log             9            ED.V....... Log
+     log_sqrt        10           ED.V....... Log square root
+     iec61966_2_4    11           ED.V....... IEC 61966-2-4
+     bt1361          12           ED.V....... BT.1361
+     iec61966_2_1    13           ED.V....... IEC 61966-2-1
+     bt2020_10bit    14           ED.V....... BT.2020 - 10 bit
+     bt2020_12bit    15           ED.V....... BT.2020 - 12 bit
+     smpte428_1      17           ED.V....... SMPTE 428-1
+  -colorspace        <int>        ED.V....... color space (from 0 to INT_MAX) (default unknown)
+     rgb             0            ED.V....... RGB
+     bt709           1            ED.V....... BT.709
+     unknown         2            ED.V....... Unspecified
+     fcc             4            ED.V....... FCC
+     bt470bg         5            ED.V....... BT.470 BG
+     smpte170m       6            ED.V....... SMPTE 170 M
+     smpte240m       7            ED.V....... SMPTE 240 M
+     ycgco           8            ED.V....... YCGCO
+     bt2020nc        9            ED.V....... BT.2020 NCL
+     bt2020c         10           ED.V....... BT.2020 CL
+     smpte2085       11           ED.V....... SMPTE 2085
+     chroma-derived-nc 12           ED.V....... Chroma-derived NCL
+     chroma-derived-c 13           ED.V....... Chroma-derived CL
+     ictcp           14           ED.V....... ICtCp
+     unspecified     2            ED.V....... Unspecified
+     ycocg           8            ED.V....... YCGCO
+     bt2020_ncl      9            ED.V....... BT.2020 NCL
+     bt2020_cl       10           ED.V....... BT.2020 CL
+  -color_range       <int>        ED.V....... color range (from 0 to INT_MAX) (default unknown)
+     unknown         0            ED.V....... Unspecified
+     tv              1            ED.V....... MPEG (219*2^(n-8))
+     pc              2            ED.V....... JPEG (2^n-1)
+     unspecified     0            ED.V....... Unspecified
+     mpeg            1            ED.V....... MPEG (219*2^(n-8))
+     jpeg            2            ED.V....... JPEG (2^n-1)
+     limited         1            ED.V....... MPEG (219*2^(n-8))
+     full            2            ED.V....... JPEG (2^n-1)
+  -chroma_sample_location <int>        ED.V....... chroma sample location (from 0 to INT_MAX) (default unknown)
+     unknown         0            ED.V....... Unspecified
+     left            1            ED.V....... Left
+     center          2            ED.V....... Center
+     topleft         3            ED.V....... Top-left
+     top             4            ED.V....... Top
+     bottomleft      5            ED.V....... Bottom-left
+     bottom          6            ED.V....... Bottom
+     unspecified     0            ED.V....... Unspecified
+  -thread_type       <flags>      ED.VA...... select multithreading type (default slice+frame)
+     slice                        ED.V.......
+     frame                        ED.V.......
+  -request_sample_fmt <sample_fmt> .D..A...... sample format audio decoders should prefer (default none)
+  -sub_charenc       <string>     .D...S..... set input text subtitles character encoding
+  -sub_charenc_mode  <flags>      .D...S..... set input text subtitles character encoding mode (default 0)
+     do_nothing                   .D...S.....
+     auto                         .D...S.....
+     pre_decoder                  .D...S.....
+     ignore                       .D...S.....
+  -apply_cropping    <boolean>    .D.V....... (default true)
+  -skip_alpha        <boolean>    .D.V....... Skip processing alpha (default false)
+  -field_order       <int>        ED.V....... Field order (from 0 to 5) (default 0)
+     progressive     1            ED.V.......
+     tt              2            ED.V.......
+     bb              3            ED.V.......
+     tb              4            ED.V.......
+     bt              5            ED.V.......
+  -dump_separator    <string>     ED.VAS..... set information dump field separator
+  -codec_whitelist   <string>     .D.VAS..... List of decoders that are allowed to be used
+  -max_pixels        <int64>      ED.VAS..... Maximum number of pixels (from 0 to INT_MAX) (default INT_MAX)
+  -max_samples       <int64>      ED..A...... Maximum number of samples (from 0 to INT_MAX) (default INT_MAX)
+  -hwaccel_flags     <flags>      .D.V....... (default ignore_level)
+     ignore_level                 .D.V....... ignore level even if the codec level used is unknown or higher than the maximum supported level reported by the hardware driver
+     allow_high_depth              .D.V....... allow to output YUV pixel formats with a different chroma sampling than 4:2:0 and/or other than 8 bits per component
+     allow_profile_mismatch              .D.V....... attempt to decode anyway if HW accelerated decoder's supported profiles do not exactly match the stream
+     unsafe_output                .D.V....... allow potentially unsafe hwaccel frame output that might require special care to process successfully
+  -extra_hw_frames   <int>        .D.V....... Number of extra hardware frames to allocate for the user (from -1 to INT_MAX) (default -1)
+  -discard_damaged_percentage <int>        .D.V....... Percentage of damaged samples to discard a frame (from 0 to 100) (default 95)
+
+amv encoder AVOptions:
+
+(A)PNG encoder AVOptions:
+
+cfhd AVOptions:
+
+cinepak AVOptions:
+
+cljr encoder AVOptions:
+
+dnxhd AVOptions:
+
+dvvideo encoder AVOptions:
+
+exr AVOptions:
+
+ffv1 encoder AVOptions:
+
+ffvhuff AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+GIF encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+H.263 encoder AVOptions:
+
+H.263p encoder AVOptions:
+
+Hap encoder AVOptions:
+
+huffyuv AVOptions:
+
+jpeg 2000 encoder AVOptions:
+
+jpegls AVOptions:
+
+ljpeg AVOptions:
+
+magicyuv AVOptions:
+
+mjpeg encoder AVOptions:
+
+mpeg1video encoder AVOptions:
+
+mpeg2video encoder AVOptions:
+
+MPEG4 encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+(A)PNG encoder AVOptions:
+
+ProRes encoder AVOptions:
+
+ProRes encoder AVOptions:
+
+ProRes encoder AVOptions:
+
+RoQ AVOptions:
+
+rpza AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+sgi AVOptions:
+
+snow encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+sunrast AVOptions:
+
+svq1enc AVOptions:
+
+targa AVOptions:
+
+TIFF encoder AVOptions:
+
+utvideo AVOptions:
+
+VBN encoder AVOptions:
+
+SMPTE VC-2 encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+generic mpegvideo encoder AVOptions:
+
+AAC encoder AVOptions:
+
+AC-3 Encoder AVOptions:
+
+AC-3 Encoder AVOptions:
+
+alacenc AVOptions:
+
+DCA (DTS Coherent Acoustics) AVOptions:
+
+E-AC-3 Encoder AVOptions:
+
+FLAC encoder AVOptions:
+
+mlpenc AVOptions:
+
+Opus encoder AVOptions:
+
+sbc encoder AVOptions:
+
+mlpenc AVOptions:
+
+WavPack encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+g726 AVOptions:
+
+g726 AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+ADPCM encoder AVOptions:
+
+VOBSUB subtitle encoder AVOptions:
+
+MOV text enoder AVOptions:
+
+libaom-av1 encoder AVOptions:
+
+libcodec2 encoder AVOptions:
+
+libjxl AVOptions:
+
+libmp3lame encoder AVOptions:
+
+libopenjpeg AVOptions:
+
+libopus AVOptions:
+
+librav1e AVOptions:
+
+libspeex AVOptions:
+
+libsvtav1 AVOptions:
+
+libtwolame encoder AVOptions:
+
+libvorbis AVOptions:
+
+libvpx-vp8 encoder AVOptions:
+
+libvpx-vp9 encoder AVOptions:
+
+libwebp encoder AVOptions:
+
+libwebp encoder AVOptions:
+
+libx264 AVOptions:
+
+libx264rgb AVOptions:
+
+libx265 AVOptions:
+
+libxvid AVOptions:
+
+h263_v4l2m2m_encoder AVOptions:
+
+av1_nvenc AVOptions:
+
+av1_vaapi AVOptions:
+
+h264_nvenc AVOptions:
+
+h264_v4l2m2m_encoder AVOptions:
+
+h264_vaapi AVOptions:
+
+hevc_nvenc AVOptions:
+
+hevc_v4l2m2m_encoder AVOptions:
+
+h265_vaapi AVOptions:
+
+mjpeg_vaapi AVOptions:
+
+mpeg2_vaapi AVOptions:
+
+mpeg4_v4l2m2m_encoder AVOptions:
+
+vp8_v4l2m2m_encoder AVOptions:
+
+vp8_vaapi AVOptions:
+
+vp9_vaapi AVOptions:
+
+EXR AVOptions:
+  -layer             <string>     .D.V....... Set the decoding layer (default "")
+  -part              <int>        .D.V....... Set the decoding part (from 0 to INT_MAX) (default 0)
+  -gamma             <float>      .D.V....... Set the float gamma value when decoding (from 0.001 to FLT_MAX) (default 1)
+  -apply_trc         <int>        .D.V....... color transfer characteristics to apply to EXR linear input (from 1 to 18) (default gamma)
+     bt709           1            .D.V....... BT.709
+     gamma           2            .D.V....... gamma
+     gamma22         4            .D.V....... BT.470 M
+     gamma28         5            .D.V....... BT.470 BG
+     smpte170m       6            .D.V....... SMPTE 170 M
+     smpte240m       7            .D.V....... SMPTE 240 M
+     linear          8            .D.V....... Linear
+     log             9            .D.V....... Log
+     log_sqrt        10           .D.V....... Log square root
+     iec61966_2_4    11           .D.V....... IEC 61966-2-4
+     bt1361          12           .D.V....... BT.1361
+     iec61966_2_1    13           .D.V....... IEC 61966-2-1
+     bt2020_10bit    14           .D.V....... BT.2020 - 10 bit
+     bt2020_12bit    15           .D.V....... BT.2020 - 12 bit
+     smpte2084       16           .D.V....... SMPTE ST 2084
+     smpte428_1      17           .D.V....... SMPTE ST 428-1
+
+FIC decoder AVOptions:
+  -skip_cursor       <boolean>    .D.V....... skip the cursor (default false)
+
+FITS decoder AVOptions:
+  -blank_value       <int>        .D.V....... value that is used to replace BLANK pixels in data array (from 0 to 65535) (default 0)
+
+frwu Decoder AVOptions:
+  -change_field_order <boolean>    .D.V....... Change field order (default false)
+
+gif decoder AVOptions:
+  -trans_color       <int>        .D.V....... color value (ARGB) that is used instead of transparent color (from 0 to UINT32_MAX) (default 16777215)
+
+h263_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+H264 Decoder AVOptions:
+  -is_avc            <boolean>    .D.V..X.... is avc (default false)
+  -nal_length_size   <int>        .D.V..X.... nal_length_size (from 0 to 4) (default 0)
+  -enable_er         <boolean>    .D.V....... Enable error resilience on damaged frames (unsafe) (default auto)
+  -x264_build        <int>        .D.V....... Assume this x264 version if no x264 version found in any SEI (from -1 to INT_MAX) (default -1)
+
+h264_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+HEVC decoder AVOptions:
+  -apply_defdispwin  <boolean>    .D.V....... Apply default display window from VUI (default false)
+  -strict-displaywin <boolean>    .D.V....... stricly apply default display window size (default false)
+
+hevc_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+jpeg2000 AVOptions:
+  -lowres            <int>        .D.V....... Lower the decoding resolution by a power of two (from 0 to 33) (default 0)
+
+MJPEG decoder AVOptions:
+  -extern_huff       <boolean>    .D.V....... Use external huffman table. (default false)
+
+MPEG4 Video Decoder AVOptions:
+
+mpeg4_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+mpeg1_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+mpeg2_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+photocd AVOptions:
+  -lowres            <int>        .D.V....... Lower the decoding resolution by a power of two (from 0 to 4) (default 0)
+
+rasc decoder AVOptions:
+  -skip_cursor       <boolean>    .D.V....... skip the cursor (default false)
+
+rawdec AVOptions:
+  -top               <boolean>    .D.V....... top field first (default auto)
+
+SMPTE 302M Decoder AVOptions:
+  -non_pcm_mode      <int>        .D..A...... Chooses what to do with NON-PCM (from 0 to 3) (default decode_drop)
+     copy            0            .D..A...... Pass NON-PCM through unchanged
+     drop            1            .D..A...... Drop NON-PCM
+     decode_copy     2            .D..A...... Decode if possible else passthrough
+     decode_drop     3            .D..A...... Decode if possible else drop
+
+TIFF decoder AVOptions:
+  -subimage          <boolean>    .D.V....... decode subimage instead if available (default false)
+  -thumbnail         <boolean>    .D.V....... decode embedded thumbnail subimage instead if available (default false)
+  -page              <int>        .D.V....... page number of multi-page image to decode (starting from 1) (from 0 to 65535) (default 0)
+
+V210 Decoder AVOptions:
+  -custom_stride     <int>        .D.V....... Custom V210 stride (from -1 to INT_MAX) (default 0)
+
+vc1_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+vp8_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+vp9_v4l2m2m_decoder AVOptions:
+  -num_output_buffers <int>        .D.V....... Number of buffers in the output context (from 2 to INT_MAX) (default 16)
+  -num_capture_buffers <int>        .D.V....... Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
+
+AAC decoder AVOptions:
+  -dual_mono_mode    <int>        .D..A...... Select the channel to decode for dual mono (from -1 to 2) (default auto)
+     auto            -1           .D..A...... autoselection
+     main            1            .D..A...... Select Main/Left channel
+     sub             2            .D..A...... Select Sub/Right channel
+     both            0            .D..A...... Select both channels
+  -channel_order     <int>        .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+     default         0            .D..A...... normal libavcodec channel order
+     coded           1            .D..A...... order in which the channels are coded in the bitstream
+
+AAC decoder AVOptions:
+  -dual_mono_mode    <int>        .D..A...... Select the channel to decode for dual mono (from -1 to 2) (default auto)
+     auto            -1           .D..A...... autoselection
+     main            1            .D..A...... Select Main/Left channel
+     sub             2            .D..A...... Select Sub/Right channel
+     both            0            .D..A...... Select both channels
+  -channel_order     <int>        .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+     default         0            .D..A...... normal libavcodec channel order
+     coded           1            .D..A...... order in which the channels are coded in the bitstream
+
+(E-)AC3 decoder AVOptions:
+  -cons_noisegen     <boolean>    .D..A...... enable consistent noise generation (default false)
+  -drc_scale         <float>      .D..A...... percentage of dynamic range compression to apply (from 0 to 6) (default 1)
+  -heavy_compr       <boolean>    .D..A...... enable heavy dynamic range compression (default false)
+  -target_level      <int>        .D..A...... target level in -dBFS (0 not applied) (from -31 to 0) (default 0)
+  -downmix           <channel_layout> .D..A...... Request a specific channel layout from the decoder
+
+Fixed-Point AC-3 Decoder AVOptions:
+  -cons_noisegen     <boolean>    .D..A...... enable consistent noise generation (default false)
+  -drc_scale         <float>      .D..A...... percentage of dynamic range compression to apply (from 0 to 6) (default 1)
+  -heavy_compr       <boolean>    .D..A...... enable heavy dynamic range compression (default false)
+  -downmix           <channel_layout> .D..A...... Request a specific channel layout from the decoder
+
+alac AVOptions:
+  -extra_bits_bug    <boolean>    .D..A...... Force non-standard decoding process (default false)
+
+APE decoder AVOptions:
+  -max_samples       <int>        .D..A...... maximum number of samples decoded per call (from 1 to INT_MAX) (default 4608)
+     all             2147483647   .D..A...... no maximum. decode all samples for each packet at once
+
+DCA decoder AVOptions:
+  -core_only         <boolean>    .D..A...... Decode core only without extensions (default false)
+  -channel_order     <int>        .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+     default         0            .D..A...... normal libavcodec channel order
+     coded           1            .D..A...... order in which the channels are coded in the bitstream
+  -downmix           <channel_layout> .D..A...... Request a specific channel layout from the decoder
+
+Dolby E decoder AVOptions:
+  -channel_order     <int>        .D..A...... Order in which the channels are to be exported (from 0 to 1) (default default)
+     default         0            .D..A...... normal libavcodec channel order
+     coded           1            .D..A...... order in which the channels are coded in the bitstream
+
+(E-)AC3 decoder AVOptions:
+  -cons_noisegen     <boolean>    .D..A...... enable consistent noise generation (default false)
+  -drc_scale         <float>      .D..A...... percentage of dynamic range compression to apply (from 0 to 6) (default 1)
+  -heavy_compr       <boolean>    .D..A...... enable heavy dynamic range compression (default false)
+  -target_level      <int>        .D..A...... target level in -dBFS (0 not applied) (from -31 to 0) (default 0)
+  -downmix           <channel_layout> .D..A...... Request a specific channel layout from the decoder
+
+evrc AVOptions:
+  -postfilter        <boolean>    .D..A...... enable postfilter (default true)
+
+FLAC decoder AVOptions:
+  -use_buggy_lpc     <boolean>    .D..A...... emulate old buggy lavc behavior (default false)
+
+G.723.1 decoder AVOptions:
+  -postfilter        <boolean>    .D..A...... enable postfilter (default true)
+
+MLP decoder AVOptions:
+  -downmix           <channel_layout> .D..A...... Request a specific channel layout from the decoder
+
+Opus Decoder AVOptions:
+  -apply_phase_inv   <boolean>    .D..A...... Apply intensity stereo phase inversion (default true)
+
+TrueHD decoder AVOptions:
+  -downmix           <channel_layout> .D..A...... Request a specific channel layout from the decoder
+
+TTA Decoder AVOptions:
+  -password          <string>     .D..A...... Set decoding password
+
+g722 decoder AVOptions:
+  -bits_per_codeword <int>        .D..A...... Bits per G722 codeword (from 6 to 8) (default 8)
+
+Closed caption Decoder AVOptions:
+  -real_time         <boolean>    .D...S..... emit subtitle events as they are decoded for real-time display (default false)
+  -real_time_latency_msec <int>        .D...S..... minimum elapsed time between emitting real-time subtitle events (from 0 to 500) (default 200)
+  -data_field        <int>        .D...S..... select data field (from -1 to 1) (default auto)
+     auto            -1           .D...S..... pick first one that appears
+     first           0            .D...S.....
+     second          1            .D...S.....
+
+DVB Sub Decoder AVOptions:
+  -compute_edt       <boolean>    .D...S..... compute end of time using pts or timeout (default false)
+  -compute_clut      <boolean>    .D...S..... compute clut when not available(-1) or only once (-2) or always(1) or never(0) (default auto)
+  -dvb_substream     <int>        .D...S.....  (from -1 to 63) (default -1)
+
+dvdsubdec AVOptions:
+  -palette           <string>     .D...S..... set the global palette
+  -ifo_palette       <string>     .D...S..... obtain the global palette from .IFO file
+  -forced_subs_only  <boolean>    .D...S..... Only show forced subtitles (default false)
+
+MOV text decoder AVOptions:
+  -width             <int>        .D...S..... Frame width, usually video width (from 0 to INT_MAX) (default 0)
+  -height            <int>        .D...S..... Frame height, usually video height (from 0 to INT_MAX) (default 0)
+
+PGS subtitle decoder AVOptions:
+  -forced_subs_only  <boolean>    .D...S..... Only show forced subtitles (default false)
+
+text/vplayer/stl/pjs/subviewer1 decoder AVOptions:
+  -keep_ass_markup   <boolean>    .D...S..... Set if ASS tags must be escaped (default false)
+
+text/vplayer/stl/pjs/subviewer1 decoder AVOptions:
+  -keep_ass_markup   <boolean>    .D...S..... Set if ASS tags must be escaped (default false)
+
+text/vplayer/stl/pjs/subviewer1 decoder AVOptions:
+  -keep_ass_markup   <boolean>    .D...S..... Set if ASS tags must be escaped (default false)
+
+text/vplayer/stl/pjs/subviewer1 decoder AVOptions:
+  -keep_ass_markup   <boolean>    .D...S..... Set if ASS tags must be escaped (default false)
+
+text/vplayer/stl/pjs/subviewer1 decoder AVOptions:
+  -keep_ass_markup   <boolean>    .D...S..... Set if ASS tags must be escaped (default false)
+
+libdav1d decoder AVOptions:
+  -tilethreads       <int>        .D.V......P Tile threads (from 0 to 256) (default 0)
+  -framethreads      <int>        .D.V......P Frame threads (from 0 to 256) (default 0)
+  -max_frame_delay   <int>        .D.V....... Max frame delay (from 0 to 256) (default 0)
+  -filmgrain         <boolean>    .D.V......P Apply Film Grain (default auto)
+  -oppoint           <int>        .D.V....... Select an operating point of the scalable bitstream (from -1 to 31) (default -1)
+  -alllayers         <boolean>    .D.V....... Output all spatial layers (default false)
+
+libopusdec AVOptions:
+  -apply_phase_inv   <boolean>    .D..A...... Apply intensity stereo phase inversion (default true)
+
+Librsvg AVOptions:
+  -width             <int>        .D.V....... Width to render to (0 for default) (from 0 to INT_MAX) (default 0)
+  -height            <int>        .D.V....... Height to render to (0 for default) (from 0 to INT_MAX) (default 0)
+  -keep_ar           <boolean>    .D.V....... Keep aspect ratio with custom width/height (default true)
+
+libzvbi_teletextdec AVOptions:
+  -txt_page          <string>     .D...S..... page numbers to decode, subtitle for subtitles, * for all (default "*")
+  -txt_default_region <int>        .D...S..... default G0 character set used for decoding (from -1 to 87) (default -1)
+  -txt_chop_top      <int>        .D...S..... discards the top teletext line (from 0 to 1) (default 1)
+  -txt_format        <int>        .D...S..... format of the subtitles (bitmap or text or ass) (from 0 to 2) (default bitmap)
+     bitmap          0            .D...S.....
+     text            1            .D...S.....
+     ass             2            .D...S.....
+  -txt_left          <int>        .D...S..... x offset of generated bitmaps (from 0 to 65535) (default 0)
+  -txt_top           <int>        .D...S..... y offset of generated bitmaps (from 0 to 65535) (default 0)
+  -txt_chop_spaces   <int>        .D...S..... chops leading and trailing spaces from text (from 0 to 1) (default 1)
+  -txt_duration      <int>        .D...S..... display duration of teletext pages in msecs (from -1 to 8.64e+07) (default -1)
+  -txt_transparent   <int>        .D...S..... force transparent background of the teletext (from 0 to 1) (default 0)
+  -txt_opacity       <int>        .D...S..... set opacity of the transparent background (from -1 to 255) (default -1)
+
+AV1 decoder AVOptions:
+  -operating_point   <int>        .D.V....... Select an operating point of the scalable bitstream (from 0 to 31) (default 0)
+
+av1_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+h264_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+hevc_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+mjpeg_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+mpeg1_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+mpeg2_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+mpeg4_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+vc1_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+vp8_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+vp9_cuvid AVOptions:
+  -deint             <int>        .D.V....... Set deinterlacing mode (from 0 to 2) (default weave)
+     weave           0            .D.V....... Weave deinterlacing (do nothing)
+     bob             1            .D.V....... Bob deinterlacing
+     adaptive        2            .D.V....... Adaptive deinterlacing
+  -gpu               <string>     .D.V....... GPU to be used for decoding
+  -surfaces          <int>        .D.V......P Maximum surfaces to be used for decoding (from -1 to INT_MAX) (default -1)
+  -drop_second_field <boolean>    .D.V....... Drop second field when deinterlacing (default false)
+  -crop              <string>     .D.V....... Crop (top)x(bottom)x(left)x(right)
+  -resize            <string>     .D.V....... Resize (width)x(height)
+
+AVFormatContext AVOptions:
+  -avioflags         <flags>      ED......... (default 0)
+     direct                       ED......... reduce buffering
+  -probesize         <int64>      .D......... set probing size (from 32 to I64_MAX) (default 5000000)
+  -formatprobesize   <int>        .D......... number of bytes to probe file format (from 0 to 2.14748e+09) (default 1048576)
+  -fflags            <flags>      ED......... (default autobsf)
+     ignidx                       .D......... ignore index
+     genpts                       .D......... generate pts
+     nofillin                     .D......... do not fill in missing values that can be exactly calculated
+     noparse                      .D......... disable AVParsers, this needs nofillin too
+     igndts                       .D......... ignore dts
+     discardcorrupt               .D......... discard corrupted frames
+     sortdts                      .D......... try to interleave outputted packets by dts
+     fastseek                     .D......... fast but inaccurate seeks
+     nobuffer                     .D......... reduce the latency introduced by optional buffering
+  -seek2any          <boolean>    .D......... allow seeking to non-keyframes on demuxer level when supported (default false)
+  -analyzeduration   <int64>      .D......... specify how many microseconds are analyzed to probe the input (from 0 to I64_MAX) (default 0)
+  -cryptokey         <binary>     .D......... decryption key
+  -indexmem          <int>        .D......... max memory used for timestamp index (per stream) (from 0 to INT_MAX) (default 1048576)
+  -rtbufsize         <int>        .D......... max memory used for buffering real-time frames (from 0 to INT_MAX) (default 3041280)
+  -fdebug            <flags>      ED......... print specific debug info (default 0)
+     ts                           ED.........
+  -max_delay         <int>        ED......... maximum muxing or demuxing delay in microseconds (from -1 to INT_MAX) (default -1)
+  -fpsprobesize      <int>        .D......... number of frames used to probe fps (from -1 to 2.14748e+09) (default -1)
+  -f_err_detect      <flags>      .D......... set error detection flags (deprecated; use err_detect, save via avconv) (default crccheck)
+     crccheck                     .D......... verify embedded CRCs
+     bitstream                    .D......... detect bitstream specification deviations
+     buffer                       .D......... detect improper bitstream length
+     explode                      .D......... abort decoding on minor error detection
+     ignore_err                   .D......... ignore errors
+     careful                      .D......... consider things that violate the spec, are fast to check and have not been seen in the wild as errors
+     compliant                    .D......... consider all spec non compliancies as errors
+     aggressive                   .D......... consider things that a sane encoder shouldn't do as an error
+  -err_detect        <flags>      .D......... set error detection flags (default crccheck)
+     crccheck                     .D......... verify embedded CRCs
+     bitstream                    .D......... detect bitstream specification deviations
+     buffer                       .D......... detect improper bitstream length
+     explode                      .D......... abort decoding on minor error detection
+     ignore_err                   .D......... ignore errors
+     careful                      .D......... consider things that violate the spec, are fast to check and have not been seen in the wild as errors
+     compliant                    .D......... consider all spec non compliancies as errors
+     aggressive                   .D......... consider things that a sane encoder shouldn't do as an error
+  -use_wallclock_as_timestamps <boolean>    .D......... use wallclock as timestamps (default false)
+  -skip_initial_bytes <int64>      .D......... set number of bytes to skip before reading header and frames (from 0 to I64_MAX) (default 0)
+  -correct_ts_overflow <boolean>    .D......... correct single timestamp overflows (default true)
+  -f_strict          <int>        ED......... how strictly to follow the standards (deprecated; use strict, save via avconv) (from INT_MIN to INT_MAX) (default normal)
+     very            2            ED......... strictly conform to a older more strict version of the spec or reference software
+     strict          1            ED......... strictly conform to all the things in the spec no matter what the consequences
+     normal          0            ED.........
+     unofficial      -1           ED......... allow unofficial extensions
+     experimental    -2           ED......... allow non-standardized experimental variants
+  -strict            <int>        ED......... how strictly to follow the standards (from INT_MIN to INT_MAX) (default normal)
+     very            2            ED......... strictly conform to a older more strict version of the spec or reference software
+     strict          1            ED......... strictly conform to all the things in the spec no matter what the consequences
+     normal          0            ED.........
+     unofficial      -1           ED......... allow unofficial extensions
+     experimental    -2           ED......... allow non-standardized experimental variants
+  -max_ts_probe      <int>        .D......... maximum number of packets to read while waiting for the first timestamp (from 0 to INT_MAX) (default 50)
+  -dump_separator    <string>     ED......... set information dump field separator (default ", ")
+  -codec_whitelist   <string>     .D......... List of decoders that are allowed to be used
+  -format_whitelist  <string>     .D......... List of demuxers that are allowed to be used
+  -protocol_whitelist <string>     .D......... List of protocols that are allowed to be used
+  -protocol_blacklist <string>     .D......... List of protocols that are not allowed to be used
+  -max_streams       <int>        .D......... maximum number of streams (from 0 to INT_MAX) (default 1000)
+  -skip_estimate_duration_from_pts <boolean>    .D......... skip duration calculation in estimate_timings_from_pts (default false)
+  -max_probe_packets <int>        .D......... Maximum number of packets to probe a codec (from 0 to INT_MAX) (default 2500)
+
+AVIOContext AVOptions:
+  -protocol_whitelist <string>     .D......... List of protocols that are allowed to be used
+
+URLContext AVOptions:
+  -protocol_whitelist <string>     .D......... List of protocols that are allowed to be used
+  -protocol_blacklist <string>     .D......... List of protocols that are not allowed to be used
+  -rw_timeout        <int64>      ED......... Timeout for IO operations (in microseconds) (from 0 to I64_MAX) (default 0)
+
+Async AVOptions:
+
+bluray AVOptions:
+  -playlist          <int>        .D.........  (from -1 to 99999) (default -1)
+  -angle             <int>        .D.........  (from 0 to 254) (default 0)
+  -chapter           <int>        .D.........  (from 1 to 65534) (default 1)
+
+cache AVOptions:
+  -read_ahead_limit  <int>        .D......... Amount in bytes that may be read ahead when seeking isn't supported, -1 for unlimited (from -1 to INT_MAX) (default 65536)
+
+crypto AVOptions:
+  -key               <binary>     ED......... AES encryption/decryption key
+  -iv                <binary>     ED......... AES encryption/decryption initialization vector
+  -decryption_key    <binary>     .D......... AES decryption key
+  -decryption_iv     <binary>     .D......... AES decryption initialization vector
+
+fd AVOptions:
+
+ffrtmphttp AVOptions:
+  -ffrtmphttp_tls    <boolean>    .D......... Use a HTTPS tunneling connection (RTMPTS). (default false)
+
+file AVOptions:
+  -follow            <int>        .D......... Follow a file as it is being written (from 0 to 1) (default 0)
+  -seekable          <int>        ED......... Sets if the file is seekable (from -1 to 0) (default -1)
+
+ftp AVOptions:
+  -timeout           <int>        ED......... set timeout of socket I/O operations (from -1 to INT_MAX) (default -1)
+  -ftp-anonymous-password <string>     ED......... password for anonymous login. E-mail address should be used.
+  -ftp-user          <string>     ED......... user for FTP login. Overridden by whatever is in the URL.
+  -ftp-password      <string>     ED......... password for FTP login. Overridden by whatever is in the URL.
+
+http AVOptions:
+  -seekable          <boolean>    .D......... control seekability of connection (default auto)
+  -http_proxy        <string>     ED......... set HTTP proxy to tunnel through
+  -headers           <string>     ED......... set custom HTTP headers, can override built in default headers
+  -content_type      <string>     ED......... set a specific content type for the POST messages
+  -user_agent        <string>     .D......... override User-Agent header (default "Lavf/60.16.100")
+  -referer           <string>     .D......... override referer header
+  -multiple_requests <boolean>    ED......... use persistent connections (default false)
+  -post_data         <binary>     ED......... set custom HTTP post data
+  -cookies           <string>     .D......... set cookies to be sent in applicable future requests, use newline delimited Set-Cookie HTTP field value syntax
+  -icy               <boolean>    .D......... request ICY metadata (default true)
+  -auth_type         <int>        ED......... HTTP authentication type (from 0 to 1) (default none)
+     none            0            ED......... No auth method set, autodetect
+     basic           1            ED......... HTTP basic authentication
+  -location          <string>     ED......... The actual location of the data received
+  -offset            <int64>      .D......... initial byte offset (from 0 to I64_MAX) (default 0)
+  -end_offset        <int64>      .D......... try to limit the request to bytes preceding this offset (from 0 to I64_MAX) (default 0)
+  -method            <string>     ED......... Override the HTTP method or set the expected HTTP method from a client
+  -reconnect         <boolean>    .D......... auto reconnect after disconnect before EOF (default false)
+  -reconnect_at_eof  <boolean>    .D......... auto reconnect at EOF (default false)
+  -reconnect_on_network_error <boolean>    .D......... auto reconnect in case of tcp/tls error during connect (default false)
+  -reconnect_on_http_error <string>     .D......... list of http status codes to reconnect on
+  -reconnect_streamed <boolean>    .D......... auto reconnect streamed / non seekable streams (default false)
+  -reconnect_delay_max <int>        .D......... max reconnect delay in seconds after which to give up (from 0 to 4294) (default 120)
+  -listen            <int>        ED......... listen on HTTP (from 0 to 2) (default 0)
+  -short_seek_size   <int>        .D......... Threshold to favor readahead over seek. (from 0 to INT_MAX) (default 0)
+
+https AVOptions:
+  -seekable          <boolean>    .D......... control seekability of connection (default auto)
+  -http_proxy        <string>     ED......... set HTTP proxy to tunnel through
+  -headers           <string>     ED......... set custom HTTP headers, can override built in default headers
+  -content_type      <string>     ED......... set a specific content type for the POST messages
+  -user_agent        <string>     .D......... override User-Agent header (default "Lavf/60.16.100")
+  -referer           <string>     .D......... override referer header
+  -multiple_requests <boolean>    ED......... use persistent connections (default false)
+  -post_data         <binary>     ED......... set custom HTTP post data
+  -cookies           <string>     .D......... set cookies to be sent in applicable future requests, use newline delimited Set-Cookie HTTP field value syntax
+  -icy               <boolean>    .D......... request ICY metadata (default true)
+  -auth_type         <int>        ED......... HTTP authentication type (from 0 to 1) (default none)
+     none            0            ED......... No auth method set, autodetect
+     basic           1            ED......... HTTP basic authentication
+  -location          <string>     ED......... The actual location of the data received
+  -offset            <int64>      .D......... initial byte offset (from 0 to I64_MAX) (default 0)
+  -end_offset        <int64>      .D......... try to limit the request to bytes preceding this offset (from 0 to I64_MAX) (default 0)
+  -method            <string>     ED......... Override the HTTP method or set the expected HTTP method from a client
+  -reconnect         <boolean>    .D......... auto reconnect after disconnect before EOF (default false)
+  -reconnect_at_eof  <boolean>    .D......... auto reconnect at EOF (default false)
+  -reconnect_on_network_error <boolean>    .D......... auto reconnect in case of tcp/tls error during connect (default false)
+  -reconnect_on_http_error <string>     .D......... list of http status codes to reconnect on
+  -reconnect_streamed <boolean>    .D......... auto reconnect streamed / non seekable streams (default false)
+  -reconnect_delay_max <int>        .D......... max reconnect delay in seconds after which to give up (from 0 to 4294) (default 120)
+  -listen            <int>        ED......... listen on HTTP (from 0 to 2) (default 0)
+  -short_seek_size   <int>        .D......... Threshold to favor readahead over seek. (from 0 to INT_MAX) (default 0)
+
+icecast AVOptions:
+
+pipe AVOptions:
+
+prompeg AVOptions:
+
+rtmp AVOptions:
+  -rtmp_app          <string>     ED......... Name of application to connect to on the RTMP server
+  -rtmp_buffer       <int>        ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  -rtmp_conn         <string>     ED......... Append arbitrary AMF data to the Connect message
+  -rtmp_flashver     <string>     ED......... Version of the Flash plugin used to run the SWF player.
+  -rtmp_live         <int>        .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+     any             -2           .D......... both
+     live            -1           .D......... live stream
+     recorded        0            .D......... recorded stream
+  -rtmp_pageurl      <string>     .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  -rtmp_playpath     <string>     ED......... Stream identifier to play or to publish
+  -rtmp_subscribe    <string>     .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  -rtmp_swfhash      <binary>     .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  -rtmp_swfsize      <int>        .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  -rtmp_swfurl       <string>     ED......... URL of the SWF player. By default no value will be sent
+  -rtmp_swfverify    <string>     .D......... URL to player swf file, compute hash/size automatically.
+  -rtmp_tcurl        <string>     ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  -rtmp_listen       <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -listen            <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -tcp_nodelay       <int>        ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  -timeout           <int>        .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+
+rtmps AVOptions:
+  -rtmp_app          <string>     ED......... Name of application to connect to on the RTMP server
+  -rtmp_buffer       <int>        ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  -rtmp_conn         <string>     ED......... Append arbitrary AMF data to the Connect message
+  -rtmp_flashver     <string>     ED......... Version of the Flash plugin used to run the SWF player.
+  -rtmp_live         <int>        .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+     any             -2           .D......... both
+     live            -1           .D......... live stream
+     recorded        0            .D......... recorded stream
+  -rtmp_pageurl      <string>     .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  -rtmp_playpath     <string>     ED......... Stream identifier to play or to publish
+  -rtmp_subscribe    <string>     .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  -rtmp_swfhash      <binary>     .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  -rtmp_swfsize      <int>        .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  -rtmp_swfurl       <string>     ED......... URL of the SWF player. By default no value will be sent
+  -rtmp_swfverify    <string>     .D......... URL to player swf file, compute hash/size automatically.
+  -rtmp_tcurl        <string>     ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  -rtmp_listen       <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -listen            <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -tcp_nodelay       <int>        ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  -timeout           <int>        .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+
+rtmpt AVOptions:
+  -rtmp_app          <string>     ED......... Name of application to connect to on the RTMP server
+  -rtmp_buffer       <int>        ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  -rtmp_conn         <string>     ED......... Append arbitrary AMF data to the Connect message
+  -rtmp_flashver     <string>     ED......... Version of the Flash plugin used to run the SWF player.
+  -rtmp_live         <int>        .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+     any             -2           .D......... both
+     live            -1           .D......... live stream
+     recorded        0            .D......... recorded stream
+  -rtmp_pageurl      <string>     .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  -rtmp_playpath     <string>     ED......... Stream identifier to play or to publish
+  -rtmp_subscribe    <string>     .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  -rtmp_swfhash      <binary>     .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  -rtmp_swfsize      <int>        .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  -rtmp_swfurl       <string>     ED......... URL of the SWF player. By default no value will be sent
+  -rtmp_swfverify    <string>     .D......... URL to player swf file, compute hash/size automatically.
+  -rtmp_tcurl        <string>     ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  -rtmp_listen       <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -listen            <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -tcp_nodelay       <int>        ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  -timeout           <int>        .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+
+rtmpts AVOptions:
+  -rtmp_app          <string>     ED......... Name of application to connect to on the RTMP server
+  -rtmp_buffer       <int>        ED......... Set buffer time in milliseconds. The default is 3000. (from 0 to INT_MAX) (default 3000)
+  -rtmp_conn         <string>     ED......... Append arbitrary AMF data to the Connect message
+  -rtmp_flashver     <string>     ED......... Version of the Flash plugin used to run the SWF player.
+  -rtmp_live         <int>        .D......... Specify that the media is a live stream. (from INT_MIN to INT_MAX) (default any)
+     any             -2           .D......... both
+     live            -1           .D......... live stream
+     recorded        0            .D......... recorded stream
+  -rtmp_pageurl      <string>     .D......... URL of the web page in which the media was embedded. By default no value will be sent.
+  -rtmp_playpath     <string>     ED......... Stream identifier to play or to publish
+  -rtmp_subscribe    <string>     .D......... Name of live stream to subscribe to. Defaults to rtmp_playpath.
+  -rtmp_swfhash      <binary>     .D......... SHA256 hash of the decompressed SWF file (32 bytes).
+  -rtmp_swfsize      <int>        .D......... Size of the decompressed SWF file, required for SWFVerification. (from 0 to INT_MAX) (default 0)
+  -rtmp_swfurl       <string>     ED......... URL of the SWF player. By default no value will be sent
+  -rtmp_swfverify    <string>     .D......... URL to player swf file, compute hash/size automatically.
+  -rtmp_tcurl        <string>     ED......... URL of the target stream. Defaults to proto://host[:port]/app.
+  -rtmp_listen       <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -listen            <int>        .D......... Listen for incoming rtmp connections (from INT_MIN to INT_MAX) (default 0)
+  -tcp_nodelay       <int>        ED......... Use TCP_NODELAY to disable Nagle's algorithm (from 0 to 1) (default 0)
+  -timeout           <int>        .D......... Maximum timeout (in seconds) to wait for incoming connections. -1 is infinite. Implies -rtmp_listen 1 (from INT_MIN to INT_MAX) (default -1)
+
+rtp AVOptions:
+  -ttl               <int>        ED......... Time to live (multicast only) (from -1 to 255) (default -1)
+  -buffer_size       <int>        ED......... Send/Receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -rtcp_port         <int>        ED......... Custom rtcp port (from -1 to INT_MAX) (default -1)
+  -local_rtpport     <int>        ED......... Local rtp port (from -1 to INT_MAX) (default -1)
+  -local_rtcpport    <int>        ED......... Local rtcp port (from -1 to INT_MAX) (default -1)
+  -connect           <boolean>    ED......... Connect socket (default false)
+  -write_to_source   <boolean>    ED......... Send packets to the source address of the latest received packet (default false)
+  -pkt_size          <int>        ED......... Maximum packet size (from -1 to INT_MAX) (default -1)
+  -dscp              <int>        ED......... DSCP class (from -1 to INT_MAX) (default -1)
+  -timeout           <int64>      ED......... set timeout (in microseconds) of socket I/O operations (from -1 to I64_MAX) (default -1)
+  -sources           <string>     ED......... Source list
+  -block             <string>     ED......... Block list
+  -localaddr         <string>     ED......... Local address
+
+sctp AVOptions:
+  -listen            <boolean>    ED......... Listen for incoming connections (default false)
+  -timeout           <int>        ED......... Connection timeout (in milliseconds) (from INT_MIN to INT_MAX) (default 10000)
+  -listen_timeout    <int>        ED......... Bind timeout (in milliseconds) (from INT_MIN to INT_MAX) (default -1)
+  -max_streams       <int>        ED......... Max stream to allocate (from 0 to 32767) (default 0)
+
+srtp AVOptions:
+  -srtp_in_suite     <string>     .D......... 
+  -srtp_in_params    <string>     .D......... 
+
+subfile AVOptions:
+  -start             <int64>      .D......... start offset (from 0 to I64_MAX) (default 0)
+  -end               <int64>      .D......... end offset (from 0 to I64_MAX) (default 0)
+
+tcp AVOptions:
+  -listen            <int>        ED......... Listen for incoming connections (from 0 to 2) (default 0)
+  -local_port        <string>     ED......... Local port
+  -local_addr        <string>     ED......... Local address
+  -timeout           <int>        ED......... set timeout (in microseconds) of socket I/O operations (from -1 to INT_MAX) (default -1)
+  -listen_timeout    <int>        ED......... Connection awaiting timeout (in milliseconds) (from -1 to INT_MAX) (default -1)
+  -send_buffer_size  <int>        ED......... Socket send buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -recv_buffer_size  <int>        ED......... Socket receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -tcp_nodelay       <boolean>    ED......... Use TCP_NODELAY to disable nagle's algorithm (default false)
+  -tcp_mss           <int>        ED......... Maximum segment size for outgoing TCP packets (from -1 to INT_MAX) (default -1)
+
+tls AVOptions:
+  -ca_file           <string>     ED......... Certificate Authority database file
+  -cafile            <string>     ED......... Certificate Authority database file
+  -tls_verify        <int>        ED......... Verify the peer certificate (from 0 to 1) (default 0)
+  -cert_file         <string>     ED......... Certificate file
+  -key_file          <string>     ED......... Private key file
+  -listen            <int>        ED......... Listen for incoming connections (from 0 to 1) (default 0)
+  -verifyhost        <string>     ED......... Verify against a specific hostname
+  -http_proxy        <string>     ED......... Set proxy to tunnel through
+
+udp AVOptions:
+  -buffer_size       <int>        ED......... System data size (in bytes) (from -1 to INT_MAX) (default -1)
+  -localport         <int>        ED......... Local port (from -1 to INT_MAX) (default -1)
+  -local_port        <int>        ED......... Local port (from -1 to INT_MAX) (default -1)
+  -localaddr         <string>     ED......... Local address
+  -udplite_coverage  <int>        ED......... choose UDPLite head size which should be validated by checksum (from 0 to INT_MAX) (default 0)
+  -pkt_size          <int>        ED......... Maximum UDP packet size (from -1 to INT_MAX) (default 1472)
+  -reuse             <boolean>    ED......... explicitly allow reusing UDP sockets (default auto)
+  -reuse_socket      <boolean>    ED......... explicitly allow reusing UDP sockets (default auto)
+  -connect           <boolean>    ED......... set if connect() should be called on socket (default false)
+  -fifo_size         <int>        .D......... set the UDP receiving circular buffer size, expressed as a number of packets with size of 188 bytes (from 0 to INT_MAX) (default 28672)
+  -overrun_nonfatal  <boolean>    .D......... survive in case of UDP receiving circular buffer overrun (default false)
+  -timeout           <int>        .D......... set raise error timeout, in microseconds (only in read mode) (from 0 to INT_MAX) (default 0)
+  -sources           <string>     ED......... Source list
+  -block             <string>     ED......... Block list
+
+udplite AVOptions:
+  -buffer_size       <int>        ED......... System data size (in bytes) (from -1 to INT_MAX) (default -1)
+  -localport         <int>        ED......... Local port (from -1 to INT_MAX) (default -1)
+  -local_port        <int>        ED......... Local port (from -1 to INT_MAX) (default -1)
+  -localaddr         <string>     ED......... Local address
+  -udplite_coverage  <int>        ED......... choose UDPLite head size which should be validated by checksum (from 0 to INT_MAX) (default 0)
+  -pkt_size          <int>        ED......... Maximum UDP packet size (from -1 to INT_MAX) (default 1472)
+  -reuse             <boolean>    ED......... explicitly allow reusing UDP sockets (default auto)
+  -reuse_socket      <boolean>    ED......... explicitly allow reusing UDP sockets (default auto)
+  -connect           <boolean>    ED......... set if connect() should be called on socket (default false)
+  -fifo_size         <int>        .D......... set the UDP receiving circular buffer size, expressed as a number of packets with size of 188 bytes (from 0 to INT_MAX) (default 28672)
+  -overrun_nonfatal  <boolean>    .D......... survive in case of UDP receiving circular buffer overrun (default false)
+  -timeout           <int>        .D......... set raise error timeout, in microseconds (only in read mode) (from 0 to INT_MAX) (default 0)
+  -sources           <string>     ED......... Source list
+  -block             <string>     ED......... Block list
+
+unix AVOptions:
+  -listen            <boolean>    ED......... Open socket for listening (default false)
+  -timeout           <int>        ED......... Timeout in ms (from -1 to INT_MAX) (default -1)
+  -type              <int>        ED......... Socket type (from INT_MIN to INT_MAX) (default stream)
+     stream          1            ED......... Stream (reliable stream-oriented)
+     datagram        2            ED......... Datagram (unreliable packet-oriented)
+     seqpacket       5            ED......... Seqpacket (reliable packet-oriented
+
+amqp AVOptions:
+  -pkt_size          <int>        ED......... Maximum send/read packet size (from 4096 to INT_MAX) (default 131072)
+  -exchange          <string>     ED......... Exchange to send/read packets (default "amq.direct")
+  -routing_key       <string>     ED......... Key to filter streams (default "amqp")
+  -connection_timeout <duration>   ED......... Initial connection timeout (default -0.000001)
+
+librist AVOptions:
+  -rist_profile      <int>        ED......... set profile (from 0 to 2) (default main)
+     simple          0            ED.........
+     main            1            ED.........
+     advanced        2            ED.........
+  -buffer_size       <int>        ED......... set buffer_size in ms (from 0 to 30000) (default 0)
+  -fifo_size         <int>        ED......... set fifo buffer size, must be a power of 2 (from 32 to 262144) (default 8192)
+  -overrun_nonfatal  <boolean>    .D......... survive in case of receiving fifo buffer overrun (default false)
+  -pkt_size          <int>        ED......... set packet size (from 1 to 9972) (default 1316)
+  -log_level         <int>        ED......... set loglevel (from -1 to INT_MAX) (default 6)
+  -secret            <string>     ED......... set encryption secret
+  -encryption        <int>        ED......... set encryption type (from 0 to INT_MAX) (default 0)
+
+libsrt AVOptions:
+  -timeout           <int64>      ED......... Timeout of socket I/O operations (in microseconds) (from -1 to I64_MAX) (default -1)
+  -listen_timeout    <int64>      ED......... Connection awaiting timeout (in microseconds) (from -1 to I64_MAX) (default -1)
+  -send_buffer_size  <int>        ED......... Socket send buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -recv_buffer_size  <int>        ED......... Socket receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -pkt_size          <int>        ED......... Maximum SRT packet size (from -1 to 1456) (default -1)
+     ts_size         1316         ED.........
+     max_size        1456         ED.........
+  -payload_size      <int>        ED......... Maximum SRT packet size (from -1 to 1456) (default -1)
+     ts_size         1316         ED.........
+     max_size        1456         ED.........
+  -maxbw             <int64>      ED......... Maximum bandwidth (bytes per second) that the connection can use (from -1 to I64_MAX) (default -1)
+  -pbkeylen          <int>        ED......... Crypto key len in bytes {16,24,32} Default: 16 (128-bit) (from -1 to 32) (default -1)
+  -passphrase        <string>     ED......... Crypto PBKDF2 Passphrase size[0,10..64] 0:disable crypto
+  -enforced_encryption <boolean>    ED......... Enforces that both connection parties have the same passphrase set (default auto)
+  -kmrefreshrate     <int>        ED......... The number of packets to be transmitted after which the encryption key is switched to a new key (from -1 to INT_MAX) (default -1)
+  -kmpreannounce     <int>        ED......... The interval between when a new encryption key is sent and when switchover occurs (from -1 to INT_MAX) (default -1)
+  -snddropdelay      <int64>      ED......... The sender's extra delay(in microseconds) before dropping packets (from -2 to I64_MAX) (default -2)
+  -mss               <int>        ED......... The Maximum Segment Size (from -1 to 1500) (default -1)
+  -ffs               <int>        ED......... Flight flag size (window size) (in bytes) (from -1 to INT_MAX) (default -1)
+  -ipttl             <int>        ED......... IP Time To Live (from -1 to 255) (default -1)
+  -iptos             <int>        ED......... IP Type of Service (from -1 to 255) (default -1)
+  -inputbw           <int64>      ED......... Estimated input stream rate (from -1 to I64_MAX) (default -1)
+  -oheadbw           <int>        ED......... MaxBW ceiling based on % over input stream rate (from -1 to 100) (default -1)
+  -latency           <int64>      ED......... receiver delay (in microseconds) to absorb bursts of missed packet retransmissions (from -1 to I64_MAX) (default -1)
+  -tsbpddelay        <int64>      ED......... deprecated, same effect as latency option (from -1 to I64_MAX) (default -1)
+  -rcvlatency        <int64>      ED......... receive latency (in microseconds) (from -1 to I64_MAX) (default -1)
+  -peerlatency       <int64>      ED......... peer latency (in microseconds) (from -1 to I64_MAX) (default -1)
+  -tlpktdrop         <boolean>    ED......... Enable too-late pkt drop (default auto)
+  -nakreport         <boolean>    ED......... Enable receiver to send periodic NAK reports (default auto)
+  -connect_timeout   <int64>      ED......... Connect timeout(in milliseconds). Caller default: 3000, rendezvous (x 10) (from -1 to I64_MAX) (default -1)
+  -mode              <int>        ED......... Connection mode (caller, listener, rendezvous) (from 0 to 2) (default caller)
+     caller          0            ED.........
+     listener        1            ED.........
+     rendezvous      2            ED.........
+  -sndbuf            <int>        ED......... Send buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -rcvbuf            <int>        ED......... Receive buffer size (in bytes) (from -1 to INT_MAX) (default -1)
+  -lossmaxttl        <int>        ED......... Maximum possible packet reorder tolerance (from -1 to INT_MAX) (default -1)
+  -minversion        <int>        ED......... The minimum SRT version that is required from the peer (from -1 to INT_MAX) (default -1)
+  -streamid          <string>     ED......... A string of up to 512 characters that an Initiator can pass to a Responder
+  -srt_streamid      <string>     ED......... A string of up to 512 characters that an Initiator can pass to a Responder
+  -smoother          <string>     ED......... The type of Smoother used for the transmission for that socket
+  -messageapi        <boolean>    ED......... Enable message API (default auto)
+  -transtype         <int>        ED......... The transmission type for the socket (from 0 to 2) (default 2)
+     live            0            ED.........
+     file            1            ED.........
+  -linger            <int>        ED......... Number of seconds that the socket waits for unsent data when closing (from -1 to INT_MAX) (default -1)
+  -tsbpd             <boolean>    ED......... Timestamp-based packet delivery (default auto)
+
+libssh AVOptions:
+  -timeout           <int>        ED......... set timeout of socket I/O operations (from -1 to INT_MAX) (default -1)
+  -private_key       <string>     ED......... set path to private key
+
+zmq AVOptions:
+  -pkt_size          <int>        ED......... Maximum send/read packet size (from -1 to INT_MAX) (default 131072)
+
+IPFS Gateway AVOptions:
+  -gateway           <string>     .D......... The gateway to ask for IPFS data.
+
+IPFS Gateway AVOptions:
+  -gateway           <string>     .D......... The gateway to ask for IPFS data.
+
+AC4 muxer AVOptions:
+
+ADTS muxer AVOptions:
+
+AIFF muxer AVOptions:
+
+alp AVOptions:
+
+APNG muxer AVOptions:
+
+argo_asf_muxer AVOptions:
+
+argo_cvg_muxer AVOptions:
+
+ASF (stream) muxer AVOptions:
+
+ass muxer AVOptions:
+
+AST muxer AVOptions:
+
+ASF (stream) muxer AVOptions:
+
+AVI muxer AVOptions:
+
+avif muxer AVOptions:
+
+dash muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+Fifo muxer AVOptions:
+
+Fifo test muxer AVOptions:
+
+flac muxer AVOptions:
+
+flv muxer AVOptions:
+
+frame hash muxer AVOptions:
+
+frame MD5 muxer AVOptions:
+
+GIF muxer AVOptions:
+
+(stream) hash muxer AVOptions:
+
+HDS muxer AVOptions:
+
+hls muxer AVOptions:
+
+image2 muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+LATM/LOAS muxer AVOptions:
+
+MD5 muxer AVOptions:
+
+matroska/webm muxer AVOptions:
+
+matroska/webm muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+MP3 muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+mpeg/(s)vcd/vob/dvd muxer AVOptions:
+
+mpeg/(s)vcd/vob/dvd muxer AVOptions:
+
+mpeg/(s)vcd/vob/dvd muxer AVOptions:
+
+mpeg/(s)vcd/vob/dvd muxer AVOptions:
+
+mpeg/(s)vcd/vob/dvd muxer AVOptions:
+
+MPEGTS muxer AVOptions:
+
+mpjpeg_muxer AVOptions:
+
+MXF muxer AVOptions:
+
+MXF-D10 muxer AVOptions:
+
+MXF-OPAtom muxer AVOptions:
+
+nutenc AVOptions:
+
+Ogg (audio/video/Speex/Opus) muxer AVOptions:
+
+Ogg (audio/video/Speex/Opus) muxer AVOptions:
+
+Ogg (audio/video/Speex/Opus) muxer AVOptions:
+
+Ogg (audio/video/Speex/Opus) muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+RTP muxer AVOptions:
+
+rtp_mpegts muxer AVOptions:
+
+RTSP muxer AVOptions:
+  -initial_pause     <boolean>    .D......... do not start playing the stream immediately (default false)
+  -rtsp_transport    <flags>      ED......... set RTSP transport protocols (default 0)
+     udp                          ED......... UDP
+     tcp                          ED......... TCP
+     udp_multicast                .D......... UDP multicast
+     http                         .D......... HTTP tunneling
+     https                        .D......... HTTPS tunneling
+  -rtsp_flags        <flags>      .D......... set RTSP flags (default 0)
+     filter_src                   .D......... only receive packets from the negotiated peer IP
+     listen                       .D......... wait for incoming connections
+     prefer_tcp                   ED......... try RTP via TCP first, if available
+     satip_raw                    .D......... export raw MPEG-TS stream instead of demuxing
+  -allowed_media_types <flags>      .D......... set media types to accept from the server (default video+audio+data+subtitle)
+     video                        .D......... Video
+     audio                        .D......... Audio
+     data                         .D......... Data
+     subtitle                     .D......... Subtitle
+  -min_port          <int>        ED......... set minimum local UDP port (from 0 to 65535) (default 5000)
+  -max_port          <int>        ED......... set maximum local UDP port (from 0 to 65535) (default 65000)
+  -listen_timeout    <int>        .D......... set maximum timeout (in seconds) to wait for incoming connections (-1 is infinite, imply flag listen) (from INT_MIN to INT_MAX) (default -1)
+  -timeout           <int64>      .D......... set timeout (in microseconds) of socket I/O operations (from INT_MIN to I64_MAX) (default 0)
+  -reorder_queue_size <int>        .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  -buffer_size       <int>        ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+  -user_agent        <string>     .D......... override User-Agent header (default "Lavf60.16.100")
+
+(stream) segment muxer AVOptions:
+
+(stream) segment muxer AVOptions:
+
+smooth streaming muxer AVOptions:
+
+Ogg (audio/video/Speex/Opus) muxer AVOptions:
+
+spdif AVOptions:
+
+(stream) hash muxer AVOptions:
+
+Tee muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+mov/mp4/tgp/psp/tg2/ipod/ismv/f4v muxer AVOptions:
+
+WAV muxer AVOptions:
+
+matroska/webm muxer AVOptions:
+
+WebM DASH Manifest muxer AVOptions:
+
+WebM Chunk Muxer AVOptions:
+
+WebP muxer AVOptions:
+
+chromaprint muxer AVOptions:
+
+caca outdev AVOptions:
+
+fbdev outdev AVOptions:
+
+opengl outdev AVOptions:
+
+PulseAudio outdev AVOptions:
+
+sdl2 outdev AVOptions:
+
+xvideo outdev AVOptions:
+
+aa AVOptions:
+  -aa_fixed_key      <binary>     .D......... Fixed key used for handling Audible AA files
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+Artworx Data Format demuxer AVOptions:
+  -linespeed         <int>        .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  -video_size        <image_size> .D......... set video size, such as 640x480 or hd720.
+  -framerate         <video_rate> .D......... set framerate (frames per second) (default "25")
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+APNG demuxer AVOptions:
+  -ignore_loop       <boolean>    .D......... ignore loop setting (default true)
+  -max_fps           <int>        .D......... maximum framerate (0 is no limit) (from 0 to INT_MAX) (default 0)
+  -default_fps       <int>        .D......... default framerate (0 is as fast as possible) (from 0 to INT_MAX) (default 15)
+
+aptx (hd) demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 48000)
+
+aptx (hd) demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 48000)
+
+aqtdec AVOptions:
+  -subfps            <rational>   .D...S..... set the movie frame rate (from 0 to INT_MAX) (default 25/1)
+
+asf demuxer AVOptions:
+  -no_resync_search  <boolean>    .D......... Don't try to resynchronize by looking for a certain optional start code (default false)
+  -export_xmp        <boolean>    .D......... Export full XMP metadata (default false)
+
+AV1 Annex B/low overhead OBU demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+
+avi AVOptions:
+  -use_odml          <boolean>    .D......... use odml index (default true)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+Binary text demuxer AVOptions:
+  -linespeed         <int>        .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  -video_size        <image_size> .D......... set video size, such as 640x480 or hd720.
+  -framerate         <video_rate> .D......... set framerate (frames per second) (default "25")
+
+bitpacked demuxer AVOptions:
+  -pixel_format      <string>     .D......... set pixel format (default "yuv420p")
+  -video_size        <image_size> .D......... set frame size
+  -framerate         <video_rate> .D......... set frame rate (default "25")
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+CDXL demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 8000 to INT_MAX) (default 11025)
+  -frame_rate        <video_rate> .D.........  (default "15")
+
+codec2 demuxer AVOptions:
+  -frames_per_packet <int>        .D......... Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
+
+codec2raw demuxer AVOptions:
+  -mode              <int>        .D......... codec2 mode [mandatory] (from -1 to 8) (default -1)
+     3200            0            .D......... 3200
+     2400            1            .D......... 2400
+     1600            2            .D......... 1600
+     1400            3            .D......... 1400
+     1300            4            .D......... 1300
+     1200            5            .D......... 1200
+     700             6            .D......... 700
+     700B            7            .D......... 700B
+     700C            8            .D......... 700C
+  -frames_per_packet <int>        .D......... Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
+
+concat demuxer AVOptions:
+  -safe              <boolean>    .D......... enable safe mode (default true)
+  -auto_convert      <boolean>    .D......... automatically convert bitstream format (default true)
+  -segment_time_metadata <boolean>    .D......... output file segment start time and duration as packet metadata (default false)
+
+dash AVOptions:
+  -allowed_extensions <string>     .D......... List of file extensions that dash is allowed to access (default "aac,m4a,m4s,m4v,mov,mp4,webm,ts")
+  -cenc_decryption_key <string>     .D......... Media decryption key (hex)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+dfpwm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 48000)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+ea demuxer AVOptions:
+  -merge_alpha       <boolean>    .D.V....... return VP6 alpha in the main video stream (default false)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+EVC Annex B demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+
+FITS demuxer AVOptions:
+  -framerate         <video_rate> .D......... set the framerate (default "1")
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+(live) flv/kux demuxer AVOptions:
+  -flv_metadata      <boolean>    .D.V....... Allocate streams according to the onMetaData array (default false)
+  -flv_full_metadata <boolean>    .D.V....... Dump full metadata of the onMetadata (default false)
+  -flv_ignore_prevtag <boolean>    .D.V....... Ignore the Size of previous tag (default false)
+  -missing_streams   <int>        .D.V..XR...  (from 0 to 255) (default 0)
+
+(live) flv/kux demuxer AVOptions:
+  -flv_metadata      <boolean>    .D.V....... Allocate streams according to the onMetaData array (default false)
+  -flv_full_metadata <boolean>    .D.V....... Dump full metadata of the onMetadata (default false)
+  -flv_ignore_prevtag <boolean>    .D.V....... Ignore the Size of previous tag (default false)
+  -missing_streams   <int>        .D.V..XR...  (from 0 to 255) (default 0)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+G.726 demuxer AVOptions:
+  -code_size         <int>        .D......... Bits per G.726 code (from 2 to 5) (default 4)
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 8000)
+
+G.726 demuxer AVOptions:
+  -code_size         <int>        .D......... Bits per G.726 code (from 2 to 5) (default 4)
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 8000)
+
+g729 demuxer AVOptions:
+  -bit_rate          <int>        .D.........  (from 0 to INT_MAX) (default 8000)
+
+GIF demuxer AVOptions:
+  -min_delay         <int>        .D......... minimum valid delay between frames (in hundredths of second) (from 0 to 6000) (default 2)
+  -max_gif_delay     <int>        .D......... maximum valid delay between frames (in hundredths of seconds) (from 0 to 65535) (default 65535)
+  -default_delay     <int>        .D......... default delay between frames (in hundredths of second) (from 0 to 6000) (default 10)
+  -ignore_loop       <boolean>    .D......... ignore loop setting (netscape extension) (default true)
+
+gsm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 1 to 6.50753e+07) (default 8000)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+hca AVOptions:
+  -hca_lowkey        <int64>      .D......... Low key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
+  -hca_highkey       <int64>      .D......... High key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
+  -hca_subkey        <int>        .D......... Subkey used for handling CRI HCA files (from 0 to 65535) (default 0)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+hls demuxer AVOptions:
+  -live_start_index  <int>        .D......... segment index to start live streams at (negative values are from the end) (from INT_MIN to INT_MAX) (default -3)
+  -prefer_x_start    <boolean>    .D......... prefer to use #EXT-X-START if it's in playlist instead of live_start_index (default false)
+  -allowed_extensions <string>     .D......... List of file extensions that hls is allowed to access (default "3gp,aac,avi,ac3,eac3,flac,mkv,m3u8,m4a,m4s,m4v,mpg,mov,mp2,mp3,mp4,mpeg,mpegts,ogg,ogv,oga,ts,vob,wav")
+  -max_reload        <int>        .D......... Maximum number of times a insufficient list is attempted to be reloaded (from 0 to INT_MAX) (default 3)
+  -m3u8_hold_counters <int>        .D......... The maximum number of times to load m3u8 when it refreshes without new segments (from 0 to INT_MAX) (default 1000)
+  -http_persistent   <boolean>    .D......... Use persistent HTTP connections (default true)
+  -http_multiple     <boolean>    .D......... Use multiple HTTP connections for fetching segments (default auto)
+  -http_seekable     <boolean>    .D......... Use HTTP partial requests, 0 = disable, 1 = enable, -1 = auto (default auto)
+  -seg_format_options <dictionary> .D......... Set options for segment demuxer
+  -seg_max_retry     <int>        .D......... Maximum number of times to reload a segment on error. (from 0 to INT_MAX) (default 0)
+
+iCE Draw File demuxer AVOptions:
+  -linespeed         <int>        .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  -video_size        <image_size> .D......... set video size, such as 640x480 or hd720.
+  -framerate         <video_rate> .D......... set framerate (frames per second) (default "25")
+
+image2 demuxer AVOptions:
+  -pattern_type      <int>        .D......... set pattern type (from 0 to INT_MAX) (default 4)
+     glob_sequence   0            .D......... select glob/sequence pattern type
+     glob            1            .D......... select glob pattern type
+     sequence        2            .D......... select sequence pattern type
+     none            3            .D......... disable pattern matching
+  -start_number      <int>        .D......... set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
+  -start_number_range <int>        .D......... set range for looking at the first sequence number (from 1 to INT_MAX) (default 5)
+  -ts_from_file      <int>        .D......... set frame timestamp from file's one (from 0 to 2) (default none)
+     none            0            .D......... none
+     sec             1            .D......... second precision
+     ns              2            .D......... nano second precision
+  -export_path_metadata <boolean>    .D......... enable metadata containing input path information (default false)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+alias_pix demuxer AVOptions:
+  -pattern_type      <int>        .D......... set pattern type (from 0 to INT_MAX) (default 4)
+     glob_sequence   0            .D......... select glob/sequence pattern type
+     glob            1            .D......... select glob pattern type
+     sequence        2            .D......... select sequence pattern type
+     none            3            .D......... disable pattern matching
+  -start_number      <int>        .D......... set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
+  -start_number_range <int>        .D......... set range for looking at the first sequence number (from 1 to INT_MAX) (default 5)
+  -ts_from_file      <int>        .D......... set frame timestamp from file's one (from 0 to 2) (default none)
+     none            0            .D......... none
+     sec             1            .D......... second precision
+     ns              2            .D......... nano second precision
+  -export_path_metadata <boolean>    .D......... enable metadata containing input path information (default false)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+brender_pix demuxer AVOptions:
+  -pattern_type      <int>        .D......... set pattern type (from 0 to INT_MAX) (default 4)
+     glob_sequence   0            .D......... select glob/sequence pattern type
+     glob            1            .D......... select glob pattern type
+     sequence        2            .D......... select sequence pattern type
+     none            3            .D......... disable pattern matching
+  -start_number      <int>        .D......... set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
+  -start_number_range <int>        .D......... set range for looking at the first sequence number (from 1 to INT_MAX) (default 5)
+  -ts_from_file      <int>        .D......... set frame timestamp from file's one (from 0 to 2) (default none)
+     none            0            .D......... none
+     sec             1            .D......... second precision
+     ns              2            .D......... nano second precision
+  -export_path_metadata <boolean>    .D......... enable metadata containing input path information (default false)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imf AVOptions:
+  -assetmaps         <string>     .D......... Comma-separated paths to ASSETMAP files.If not specified, the `ASSETMAP.xml` file in the same directory as the CPL is used.
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+(live) flv/kux demuxer AVOptions:
+  -flv_metadata      <boolean>    .D.V....... Allocate streams according to the onMetaData array (default false)
+  -flv_full_metadata <boolean>    .D.V....... Dump full metadata of the onMetadata (default false)
+  -flv_ignore_prevtag <boolean>    .D.V....... Ignore the Size of previous tag (default false)
+  -missing_streams   <int>        .D.V..XR...  (from 0 to 255) (default 0)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+microdvddec AVOptions:
+  -subfps            <rational>   .D...S..... set the movie frame rate fallback (from 0 to INT_MAX) (default 0/1)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+mov,mp4,m4a,3gp,3g2,mj2 AVOptions:
+  -use_absolute_path <boolean>    .D.V....... allow using absolute path when opening alias, this is a possible security issue (default false)
+  -seek_streams_individually <boolean>    .D.V....... Seek each stream individually to the closest point (default true)
+  -ignore_editlist   <boolean>    .D.V....... Ignore the edit list atom. (default false)
+  -advanced_editlist <boolean>    .D.V....... Modify the AVIndex according to the editlists. Use this option to decode in the order specified by the edits. (default true)
+  -ignore_chapters   <boolean>    .D.V.......  (default false)
+  -use_mfra_for      <int>        .D.V....... use mfra for fragment timestamps (from -1 to 2) (default auto)
+     auto            -1           .D.V....... auto
+     dts             1            .D.V....... dts
+     pts             2            .D.V....... pts
+  -use_tfdt          <boolean>    .D.V....... use tfdt for fragment timestamps (default true)
+  -export_all        <boolean>    .D.V....... Export unrecognized metadata entries (default false)
+  -export_xmp        <boolean>    .D.V....... Export full XMP metadata (default false)
+  -activation_bytes  <binary>     .D......... Secret bytes for Audible AAX files
+  -audible_key       <binary>     .D......... AES-128 Key for Audible AAXC files
+  -audible_iv        <binary>     .D......... AES-128 IV for Audible AAXC files
+  -audible_fixed_key <binary>     .D......... Fixed key used for handling Audible AAX files
+  -decryption_key    <binary>     .D......... The media decryption key (hex)
+  -enable_drefs      <boolean>    .D.V....... Enable external track support. (default false)
+  -max_stts_delta    <int>        .D......... treat offsets above this value as invalid (from 0 to UINT32_MAX) (default 4294487295)
+  -interleaved_read  <boolean>    .D......... Interleave packets from multiple tracks at demuxer level (default true)
+
+mp3 AVOptions:
+  -usetoc            <boolean>    .D......... use table of contents (default false)
+
+mpegts demuxer AVOptions:
+  -resync_size       <int>        .D......... set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
+  -fix_teletext_pts  <boolean>    .D......... try to fix pts values of dvb teletext streams (default true)
+  -ts_packetsize     <int>        .D....XR... output option carrying the raw packet size (from 0 to 0) (default 0)
+  -scan_all_pmts     <boolean>    .D......... scan and combine all PMTs (default auto)
+  -skip_unknown_pmt  <boolean>    .D......... skip PMTs for programs not advertised in the PAT (default false)
+  -merge_pmt_versions <boolean>    .D......... re-use streams when PMT's version/pids change (default false)
+  -max_packet_size   <int>        .D......... maximum size of emitted packet (from 1 to 1.07374e+09) (default 204800)
+
+mpegtsraw demuxer AVOptions:
+  -resync_size       <int>        .D......... set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
+  -compute_pcr       <boolean>    .D......... compute exact PCR for each transport stream packet (default false)
+  -ts_packetsize     <int>        .D....XR... output option carrying the raw packet size (from 0 to 0) (default 0)
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+MPJPEG demuxer AVOptions:
+  -strict_mime_boundary <boolean>    .D......... require MIME boundaries match (default false)
+
+mxf AVOptions:
+  -eia608_extract    <boolean>    .D......... extract eia 608 captions from s436m track (default false)
+
+AV1 Annex B/low overhead OBU demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+pcm demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 44100)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+rawvideo demuxer AVOptions:
+  -pixel_format      <string>     .D......... set pixel format (default "yuv420p")
+  -video_size        <image_size> .D......... set frame size
+  -framerate         <video_rate> .D......... set frame rate (default "25")
+
+RTP demuxer AVOptions:
+  -rtp_flags         <flags>      .D......... set RTP flags (default 0)
+     filter_src                   .D......... only receive packets from the negotiated peer IP
+  -listen_timeout    <duration>   .D......... set maximum timeout (in seconds) to wait for incoming connections (default 10)
+  -localaddr         <string>     .D......... local address
+  -allowed_media_types <flags>      .D......... set media types to accept from the server (default video+audio+data+subtitle)
+     video                        .D......... Video
+     audio                        .D......... Audio
+     data                         .D......... Data
+     subtitle                     .D......... Subtitle
+  -reorder_queue_size <int>        .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  -buffer_size       <int>        ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+
+RTSP demuxer AVOptions:
+  -initial_pause     <boolean>    .D......... do not start playing the stream immediately (default false)
+  -rtsp_transport    <flags>      ED......... set RTSP transport protocols (default 0)
+     udp                          ED......... UDP
+     tcp                          ED......... TCP
+     udp_multicast                .D......... UDP multicast
+     http                         .D......... HTTP tunneling
+     https                        .D......... HTTPS tunneling
+  -rtsp_flags        <flags>      .D......... set RTSP flags (default 0)
+     filter_src                   .D......... only receive packets from the negotiated peer IP
+     listen                       .D......... wait for incoming connections
+     prefer_tcp                   ED......... try RTP via TCP first, if available
+     satip_raw                    .D......... export raw MPEG-TS stream instead of demuxing
+  -allowed_media_types <flags>      .D......... set media types to accept from the server (default video+audio+data+subtitle)
+     video                        .D......... Video
+     audio                        .D......... Audio
+     data                         .D......... Data
+     subtitle                     .D......... Subtitle
+  -min_port          <int>        ED......... set minimum local UDP port (from 0 to 65535) (default 5000)
+  -max_port          <int>        ED......... set maximum local UDP port (from 0 to 65535) (default 65000)
+  -listen_timeout    <int>        .D......... set maximum timeout (in seconds) to wait for incoming connections (-1 is infinite, imply flag listen) (from INT_MIN to INT_MAX) (default -1)
+  -timeout           <int64>      .D......... set timeout (in microseconds) of socket I/O operations (from INT_MIN to I64_MAX) (default 0)
+  -reorder_queue_size <int>        .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  -buffer_size       <int>        ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+  -user_agent        <string>     .D......... override User-Agent header (default "Lavf60.16.100")
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+sbg_demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 0)
+  -frame_size        <int>        .D.........  (from 0 to INT_MAX) (default 0)
+  -max_file_size     <int>        .D.........  (from 0 to INT_MAX) (default 5000000)
+
+SDP demuxer AVOptions:
+  -sdp_flags         <flags>      .D......... SDP flags (default 0)
+     filter_src                   .D......... only receive packets from the negotiated peer IP
+     custom_io                    .D......... use custom I/O
+     rtcp_to_source               .D......... send RTCP packets to the source address of received packets
+  -listen_timeout    <duration>   .D......... set maximum timeout (in seconds) to wait for incoming connections (default 10)
+  -localaddr         <string>     .D......... local address
+  -allowed_media_types <flags>      .D......... set media types to accept from the server (default video+audio+data+subtitle)
+     video                        .D......... Video
+     audio                        .D......... Audio
+     data                         .D......... Data
+     subtitle                     .D......... Subtitle
+  -reorder_queue_size <int>        .D......... set number of packets to buffer for handling of reordered packets (from -1 to INT_MAX) (default -1)
+  -buffer_size       <int>        ED......... Underlying protocol send/receive buffer size (from -1 to INT_MAX) (default -1)
+
+ser demuxer AVOptions:
+  -framerate         <video_rate> .D......... set frame rate (default "25")
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+sln demuxer AVOptions:
+  -sample_rate       <int>        .D.........  (from 0 to INT_MAX) (default 8000)
+  -channels          <int>        .D........P  (from 0 to INT_MAX) (default 1)
+  -ch_layout         <channel_layout> .D......... 
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+tedcaptions_demuxer AVOptions:
+  -start_time        <int64>      .D...S..... set the start time (offset) of the subtitles, in ms (from I64_MIN to I64_MAX) (default 15000)
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+TTY demuxer AVOptions:
+  -chars_per_frame   <int>        .D.........  (from 1 to INT_MAX) (default 6000)
+  -video_size        <image_size> .D......... A string describing frame size, such as 640x480 or hd720.
+  -framerate         <video_rate> .D.........  (default "25")
+
+v210(x) demuxer AVOptions:
+  -video_size        <image_size> .D......... set frame size
+  -framerate         <video_rate> .D......... set frame rate (default "25")
+
+v210(x) demuxer AVOptions:
+  -video_size        <image_size> .D......... set frame size
+  -framerate         <video_rate> .D......... set frame rate (default "25")
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+vobsub AVOptions:
+  -sub_name          <string>     .D......... URI for .sub file
+
+generic raw video demuxer AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+W64 demuxer AVOptions:
+  -max_size          <int>        .D......... max size of single packet (from 1024 to 4.1943e+06) (default 4096)
+
+WAV demuxer AVOptions:
+  -ignore_length     <boolean>    .D......... Ignore length (default false)
+  -max_size          <int>        .D......... max size of single packet (from 1024 to 4.1943e+06) (default 4096)
+
+WebM DASH Manifest demuxer AVOptions:
+  -live              <boolean>    .D......... flag indicating that the input is a live file that only has the headers. (default false)
+  -bandwidth         <int>        .D......... bandwidth of this stream to be specified in the DASH manifest. (from 0 to INT_MAX) (default 0)
+
+WebVTT demuxer AVOptions:
+  -kind              <int>        .D...S..... Set kind of WebVTT track (from 0 to INT_MAX) (default subtitles)
+     subtitles       0            .D...S..... WebVTT subtitles kind
+     captions        65536        .D...S..... WebVTT captions kind
+     descriptions    131072       .D...S..... WebVTT descriptions kind
+     metadata        262144       .D...S..... WebVTT metadata kind
+
+generic raw demuxer AVOptions:
+  -raw_packet_size   <int>        .D.........  (from 1 to INT_MAX) (default 1024)
+
+eXtended BINary text (XBIN) demuxer AVOptions:
+  -linespeed         <int>        .D......... set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
+  -video_size        <image_size> .D......... set video size, such as 640x480 or hd720.
+  -framerate         <video_rate> .D......... set framerate (frames per second) (default "25")
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+imagepipe demuxer AVOptions:
+  -frame_size        <int>        .D......... force frame size in bytes (from 0 to INT_MAX) (default 0)
+  -framerate         <video_rate> .D......... set the video framerate (default "25")
+  -pixel_format      <string>     .D......... set video pixel format
+  -video_size        <image_size> .D......... set video size
+  -loop              <boolean>    .D......... force loop over input file sequence (default false)
+
+Game Music Emu demuxer AVOptions:
+  -track_index       <int>        .D..A...... set track that should be played (from 0 to INT_MAX) (default 0)
+  -sample_rate       <int>        .D..A...... set sample rate (from 1000 to 999999) (default 44100)
+  -max_size          <int64>      .D..A...... set max file size supported (in bytes) (from 0 to 1.84467e+19) (default 52428800)
+
+libopenmpt AVOptions:
+  -sample_rate       <int>        .D..A...... set sample rate (from 1000 to INT_MAX) (default 48000)
+  -layout            <channel_layout> .D..A...... set channel layout (default "stereo")
+  -subsong           <int>        .D..A...... set subsong (from -2 to INT_MAX) (default auto)
+     all             -1           .D..A...... all
+     auto            -2           .D..A...... auto
+
+ALSA indev AVOptions:
+  -sample_rate       <int>        .D.........  (from 1 to INT_MAX) (default 48000)
+  -channels          <int>        .D.........  (from 1 to INT_MAX) (default 2)
+
+fbdev indev AVOptions:
+  -framerate         <video_rate> .D.........  (default "25")
+
+iec61883 indev AVOptions:
+  -dvtype            <int>        .D......... override autodetection of DV/HDV (from 0 to 2) (default auto)
+     auto            0            .D......... auto detect DV/HDV
+     dv              1            .D......... force device being treated as DV device
+     hdv             2            .D......... force device being treated as HDV device
+  -dvbuffer          <int>        .D......... set queue buffer size (in packets) (from 0 to INT_MAX) (default 0)
+  -dvguid            <string>     .D......... select one of multiple DV devices by its GUID
+
+JACK indev AVOptions:
+  -channels          <int>        .D......... Number of audio channels. (from 1 to INT_MAX) (default 2)
+
+kmsgrab indev AVOptions:
+  -device            <string>     .D......... DRM device path (default "/dev/dri/card0")
+  -format            <pix_fmt>    .D......... Pixel format for framebuffer (default none)
+  -format_modifier   <int64>      .D......... DRM format modifier for framebuffer (from 0 to I64_MAX) (default 72057594037927935)
+  -crtc_id           <int64>      .D......... CRTC ID to define capture source (from 0 to UINT32_MAX) (default 0)
+  -plane_id          <int64>      .D......... Plane ID to define capture source (from 0 to UINT32_MAX) (default 0)
+  -framerate         <rational>   .D......... Framerate to capture at (from 0 to 1000) (default 30/1)
+
+lavfi indev AVOptions:
+  -graph             <string>     .D......... set libavfilter graph
+  -graph_file        <string>     .D......... set libavfilter graph filename
+  -dumpgraph         <string>     .D......... dump graph to stderr
+
+openal indev AVOptions:
+  -channels          <int>        .D......... set number of channels (from 1 to 2) (default 2)
+  -sample_rate       <int>        .D......... set sample rate (from 1 to 192000) (default 44100)
+  -sample_size       <int>        .D......... set sample size (from 8 to 16) (default 16)
+  -list_devices      <int>        .D......... list available devices (from 0 to 1) (default false)
+     true            1            .D......... 
+     false           0            .D......... 
+
+OSS indev AVOptions:
+  -sample_rate       <int>        .D.........  (from 1 to INT_MAX) (default 48000)
+  -channels          <int>        .D.........  (from 1 to INT_MAX) (default 2)
+
+Pulse indev AVOptions:
+  -server            <string>     .D......... set PulseAudio server
+  -name              <string>     .D......... set application name (default "Lavf60.16.100")
+  -stream_name       <string>     .D......... set stream description (default "record")
+  -sample_rate       <int>        .D......... set sample rate in Hz (from 1 to INT_MAX) (default 48000)
+  -channels          <int>        .D......... set number of audio channels (from 1 to INT_MAX) (default 2)
+  -frame_size        <int>        .D........P set number of bytes per frame (from 1 to INT_MAX) (default 1024)
+  -fragment_size     <int>        .D......... set buffering size, affects latency and cpu usage (from -1 to INT_MAX) (default -1)
+  -wallclock         <int>        .D......... set the initial pts using the current time (from -1 to 1) (default 1)
+
+V4L2 indev AVOptions:
+  -standard          <string>     .D......... set TV standard, used only by analog frame grabber
+  -channel           <int>        .D......... set TV channel, used only by frame grabber (from -1 to INT_MAX) (default -1)
+  -video_size        <image_size> .D......... set frame size
+  -pixel_format      <string>     .D......... set preferred pixel format
+  -input_format      <string>     .D......... set preferred pixel format (for raw video) or codec name
+  -framerate         <string>     .D......... set frame rate
+  -list_formats      <int>        .D......... list available formats and exit (from 0 to INT_MAX) (default 0)
+     all             3            .D......... show all available formats
+     raw             1            .D......... show only non-compressed formats
+     compressed      2            .D......... show only compressed formats
+  -list_standards    <int>        .D......... list supported standards and exit (from 0 to 1) (default 0)
+     all             1            .D......... show all supported standards
+  -timestamps        <int>        .D......... set type of timestamps for grabbed frames (from 0 to 2) (default default)
+     default         0            .D......... use timestamps from the kernel
+     abs             1            .D......... use absolute timestamps (wall clock)
+     mono2abs        2            .D......... force conversion from monotonic to absolute timestamps
+  -ts                <int>        .D......... set type of timestamps for grabbed frames (from 0 to 2) (default default)
+     default         0            .D......... use timestamps from the kernel
+     abs             1            .D......... use absolute timestamps (wall clock)
+     mono2abs        2            .D......... force conversion from monotonic to absolute timestamps
+  -use_libv4l2       <boolean>    .D......... use libv4l2 (v4l-utils) conversion functions (default false)
+
+xcbgrab indev AVOptions:
+  -window_id         <int>        .D......... Window to capture. (from 0 to UINT32_MAX) (default 0)
+  -x                 <int>        .D......... Initial x coordinate. (from 0 to INT_MAX) (default 0)
+  -y                 <int>        .D......... Initial y coordinate. (from 0 to INT_MAX) (default 0)
+  -grab_x            <int>        .D......... Initial x coordinate. (from 0 to INT_MAX) (default 0)
+  -grab_y            <int>        .D......... Initial y coordinate. (from 0 to INT_MAX) (default 0)
+  -video_size        <image_size> .D......... A string describing frame size, such as 640x480 or hd720.
+  -framerate         <string>     .D.........  (default "ntsc")
+  -draw_mouse        <int>        .D......... Draw the mouse pointer. (from 0 to 1) (default 1)
+  -follow_mouse      <int>        .D......... Move the grabbing region when the mouse pointer reaches within specified amount of pixels to the edge of region. (from -1 to INT_MAX) (default 0)
+     centered        -1           .D......... Keep the mouse pointer at the center of grabbing region when following.
+  -show_region       <int>        .D......... Show the grabbing region. (from 0 to 1) (default 0)
+  -region_border     <int>        .D......... Set the region border thickness. (from 1 to 128) (default 3)
+  -select_region     <boolean>    .D......... Select the grabbing region graphically using the pointer. (default false)
+
+libcdio indev AVOptions:
+  -speed             <int>        .D......... set drive reading speed (from 0 to INT_MAX) (default 0)
+  -paranoia_mode     <flags>      .D......... set error recovery mode (default 0)
+     disable                      .D......... apply no fixups
+     verify                       .D......... verify data integrity in overlap area
+     overlap                      .D......... perform overlapped reads
+     neverskip                    .D......... do not skip failed reads
+     full                         .D......... apply all recovery modes
+
+libdc1394 indev AVOptions:
+  -video_size        <string>     .D......... A string describing frame size, such as 640x480 or hd720. (default "qvga")
+  -pixel_format      <string>     .D.........  (default "uyvy422")
+  -framerate         <string>     .D.........  (default "ntsc")
+
+AVFilter AVOptions:
+   thread_type       <flags>      ..F........ Allowed thread types (default slice)
+     slice                        ..F........
+   enable            <string>     ..F......T. set enable expression
+   threads           <int>        ..F........ Allowed number of threads (from 0 to INT_MAX) (default 0)
+   extra_hw_frames   <int>        ..F........ Number of extra hardware frames to allocate for the user (from -1 to INT_MAX) (default -1)
+
+abench AVOptions:
+   action            <int>        ..F.A...... set action (from 0 to 1) (default start)
+     start           0            ..F.A...... start timer
+     stop            1            ..F.A...... stop timer
+
+acompressor/sidechaincompress AVOptions:
+   level_in          <double>     ..F.A....T. set input gain (from 0.015625 to 64) (default 1)
+   mode              <int>        ..F.A....T. set mode (from 0 to 1) (default downward)
+     downward        0            ..F.A....T.
+     upward          1            ..F.A....T.
+   threshold         <double>     ..F.A....T. set threshold (from 0.000976563 to 1) (default 0.125)
+   ratio             <double>     ..F.A....T. set ratio (from 1 to 20) (default 2)
+   attack            <double>     ..F.A....T. set attack (from 0.01 to 2000) (default 20)
+   release           <double>     ..F.A....T. set release (from 0.01 to 9000) (default 250)
+   makeup            <double>     ..F.A....T. set make up gain (from 1 to 64) (default 1)
+   knee              <double>     ..F.A....T. set knee (from 1 to 8) (default 2.82843)
+   link              <int>        ..F.A....T. set link type (from 0 to 1) (default average)
+     average         0            ..F.A....T.
+     maximum         1            ..F.A....T.
+   detection         <int>        ..F.A....T. set detection (from 0 to 1) (default rms)
+     peak            0            ..F.A....T.
+     rms             1            ..F.A....T.
+   level_sc          <double>     ..F.A....T. set sidechain gain (from 0.015625 to 64) (default 1)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+
+acontrast AVOptions:
+   contrast          <float>      ..F.A...... set contrast (from 0 to 100) (default 33)
+
+(a)cue AVOptions:
+   cue               <int64>      ..FVA...... cue unix timestamp in microseconds (from 0 to I64_MAX) (default 0)
+   preroll           <duration>   ..FVA...... preroll duration in seconds (default 0)
+   buffer            <duration>   ..FVA...... buffer duration in seconds (default 0)
+
+acrossfade AVOptions:
+   nb_samples        <int>        ..F.A...... set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
+   ns                <int>        ..F.A...... set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
+   duration          <duration>   ..F.A...... set cross fade duration (default 0)
+   d                 <duration>   ..F.A...... set cross fade duration (default 0)
+   overlap           <boolean>    ..F.A...... overlap 1st stream end with 2nd stream start (default true)
+   o                 <boolean>    ..F.A...... overlap 1st stream end with 2nd stream start (default true)
+   curve1            <int>        ..F.A...... set fade curve type for 1st stream (from -1 to 22) (default tri)
+     nofade          -1           ..F.A...... no fade; keep audio as-is
+     tri             0            ..F.A...... linear slope
+     qsin            1            ..F.A...... quarter of sine wave
+     esin            2            ..F.A...... exponential sine wave
+     hsin            3            ..F.A...... half of sine wave
+     log             4            ..F.A...... logarithmic
+     ipar            5            ..F.A...... inverted parabola
+     qua             6            ..F.A...... quadratic
+     cub             7            ..F.A...... cubic
+     squ             8            ..F.A...... square root
+     cbr             9            ..F.A...... cubic root
+     par             10           ..F.A...... parabola
+     exp             11           ..F.A...... exponential
+     iqsin           12           ..F.A...... inverted quarter of sine wave
+     ihsin           13           ..F.A...... inverted half of sine wave
+     dese            14           ..F.A...... double-exponential seat
+     desi            15           ..F.A...... double-exponential sigmoid
+     losi            16           ..F.A...... logistic sigmoid
+     sinc            17           ..F.A...... sine cardinal function
+     isinc           18           ..F.A...... inverted sine cardinal function
+     quat            19           ..F.A...... quartic
+     quatr           20           ..F.A...... quartic root
+     qsin2           21           ..F.A...... squared quarter of sine wave
+     hsin2           22           ..F.A...... squared half of sine wave
+   c1                <int>        ..F.A...... set fade curve type for 1st stream (from -1 to 22) (default tri)
+     nofade          -1           ..F.A...... no fade; keep audio as-is
+     tri             0            ..F.A...... linear slope
+     qsin            1            ..F.A...... quarter of sine wave
+     esin            2            ..F.A...... exponential sine wave
+     hsin            3            ..F.A...... half of sine wave
+     log             4            ..F.A...... logarithmic
+     ipar            5            ..F.A...... inverted parabola
+     qua             6            ..F.A...... quadratic
+     cub             7            ..F.A...... cubic
+     squ             8            ..F.A...... square root
+     cbr             9            ..F.A...... cubic root
+     par             10           ..F.A...... parabola
+     exp             11           ..F.A...... exponential
+     iqsin           12           ..F.A...... inverted quarter of sine wave
+     ihsin           13           ..F.A...... inverted half of sine wave
+     dese            14           ..F.A...... double-exponential seat
+     desi            15           ..F.A...... double-exponential sigmoid
+     losi            16           ..F.A...... logistic sigmoid
+     sinc            17           ..F.A...... sine cardinal function
+     isinc           18           ..F.A...... inverted sine cardinal function
+     quat            19           ..F.A...... quartic
+     quatr           20           ..F.A...... quartic root
+     qsin2           21           ..F.A...... squared quarter of sine wave
+     hsin2           22           ..F.A...... squared half of sine wave
+   curve2            <int>        ..F.A...... set fade curve type for 2nd stream (from -1 to 22) (default tri)
+     nofade          -1           ..F.A...... no fade; keep audio as-is
+     tri             0            ..F.A...... linear slope
+     qsin            1            ..F.A...... quarter of sine wave
+     esin            2            ..F.A...... exponential sine wave
+     hsin            3            ..F.A...... half of sine wave
+     log             4            ..F.A...... logarithmic
+     ipar            5            ..F.A...... inverted parabola
+     qua             6            ..F.A...... quadratic
+     cub             7            ..F.A...... cubic
+     squ             8            ..F.A...... square root
+     cbr             9            ..F.A...... cubic root
+     par             10           ..F.A...... parabola
+     exp             11           ..F.A...... exponential
+     iqsin           12           ..F.A...... inverted quarter of sine wave
+     ihsin           13           ..F.A...... inverted half of sine wave
+     dese            14           ..F.A...... double-exponential seat
+     desi            15           ..F.A...... double-exponential sigmoid
+     losi            16           ..F.A...... logistic sigmoid
+     sinc            17           ..F.A...... sine cardinal function
+     isinc           18           ..F.A...... inverted sine cardinal function
+     quat            19           ..F.A...... quartic
+     quatr           20           ..F.A...... quartic root
+     qsin2           21           ..F.A...... squared quarter of sine wave
+     hsin2           22           ..F.A...... squared half of sine wave
+   c2                <int>        ..F.A...... set fade curve type for 2nd stream (from -1 to 22) (default tri)
+     nofade          -1           ..F.A...... no fade; keep audio as-is
+     tri             0            ..F.A...... linear slope
+     qsin            1            ..F.A...... quarter of sine wave
+     esin            2            ..F.A...... exponential sine wave
+     hsin            3            ..F.A...... half of sine wave
+     log             4            ..F.A...... logarithmic
+     ipar            5            ..F.A...... inverted parabola
+     qua             6            ..F.A...... quadratic
+     cub             7            ..F.A...... cubic
+     squ             8            ..F.A...... square root
+     cbr             9            ..F.A...... cubic root
+     par             10           ..F.A...... parabola
+     exp             11           ..F.A...... exponential
+     iqsin           12           ..F.A...... inverted quarter of sine wave
+     ihsin           13           ..F.A...... inverted half of sine wave
+     dese            14           ..F.A...... double-exponential seat
+     desi            15           ..F.A...... double-exponential sigmoid
+     losi            16           ..F.A...... logistic sigmoid
+     sinc            17           ..F.A...... sine cardinal function
+     isinc           18           ..F.A...... inverted sine cardinal function
+     quat            19           ..F.A...... quartic
+     quatr           20           ..F.A...... quartic root
+     qsin2           21           ..F.A...... squared quarter of sine wave
+     hsin2           22           ..F.A...... squared half of sine wave
+
+acrossover AVOptions:
+   split             <string>     ..F.A...... set split frequencies (default "500")
+   order             <int>        ..F.A...... set filter order (from 0 to 9) (default 4th)
+     2nd             0            ..F.A...... 2nd order (12 dB/8ve)
+     4th             1            ..F.A...... 4th order (24 dB/8ve)
+     6th             2            ..F.A...... 6th order (36 dB/8ve)
+     8th             3            ..F.A...... 8th order (48 dB/8ve)
+     10th            4            ..F.A...... 10th order (60 dB/8ve)
+     12th            5            ..F.A...... 12th order (72 dB/8ve)
+     14th            6            ..F.A...... 14th order (84 dB/8ve)
+     16th            7            ..F.A...... 16th order (96 dB/8ve)
+     18th            8            ..F.A...... 18th order (108 dB/8ve)
+     20th            9            ..F.A...... 20th order (120 dB/8ve)
+   level             <float>      ..F.A...... set input gain (from 0 to 1) (default 1)
+   gain              <string>     ..F.A...... set output bands gain (default "1.f")
+   precision         <int>        ..F.A...... set processing precision (from 0 to 2) (default auto)
+     auto            0            ..F.A...... set auto processing precision
+     float           1            ..F.A...... set single-floating point processing precision
+     double          2            ..F.A...... set double-floating point processing precision
+
+acrusher AVOptions:
+   level_in          <double>     ..F.A....T. set level in (from 0.015625 to 64) (default 1)
+   level_out         <double>     ..F.A....T. set level out (from 0.015625 to 64) (default 1)
+   bits              <double>     ..F.A....T. set bit reduction (from 1 to 64) (default 8)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 0.5)
+   mode              <int>        ..F.A....T. set mode (from 0 to 1) (default lin)
+     lin             0            ..F.A....T. linear
+     log             1            ..F.A....T. logarithmic
+   dc                <double>     ..F.A....T. set DC (from 0.25 to 4) (default 1)
+   aa                <double>     ..F.A....T. set anti-aliasing (from 0 to 1) (default 0.5)
+   samples           <double>     ..F.A....T. set sample reduction (from 1 to 250) (default 1)
+   lfo               <boolean>    ..F.A....T. enable LFO (default false)
+   lforange          <double>     ..F.A....T. set LFO depth (from 1 to 250) (default 20)
+   lforate           <double>     ..F.A....T. set LFO rate (from 0.01 to 200) (default 0.3)
+
+adeclick AVOptions:
+   window            <double>     ..F.A...... set window size (from 10 to 100) (default 55)
+   w                 <double>     ..F.A...... set window size (from 10 to 100) (default 55)
+   overlap           <double>     ..F.A...... set window overlap (from 50 to 95) (default 75)
+   o                 <double>     ..F.A...... set window overlap (from 50 to 95) (default 75)
+   arorder           <double>     ..F.A...... set autoregression order (from 0 to 25) (default 2)
+   a                 <double>     ..F.A...... set autoregression order (from 0 to 25) (default 2)
+   threshold         <double>     ..F.A...... set threshold (from 1 to 100) (default 2)
+   t                 <double>     ..F.A...... set threshold (from 1 to 100) (default 2)
+   burst             <double>     ..F.A...... set burst fusion (from 0 to 10) (default 2)
+   b                 <double>     ..F.A...... set burst fusion (from 0 to 10) (default 2)
+   method            <int>        ..F.A...... set overlap method (from 0 to 1) (default add)
+     add             0            ..F.A...... overlap-add
+     a               0            ..F.A...... overlap-add
+     save            1            ..F.A...... overlap-save
+     s               1            ..F.A...... overlap-save
+   m                 <int>        ..F.A...... set overlap method (from 0 to 1) (default add)
+     add             0            ..F.A...... overlap-add
+     a               0            ..F.A...... overlap-add
+     save            1            ..F.A...... overlap-save
+     s               1            ..F.A...... overlap-save
+
+adeclip AVOptions:
+   window            <double>     ..F.A...... set window size (from 10 to 100) (default 55)
+   w                 <double>     ..F.A...... set window size (from 10 to 100) (default 55)
+   overlap           <double>     ..F.A...... set window overlap (from 50 to 95) (default 75)
+   o                 <double>     ..F.A...... set window overlap (from 50 to 95) (default 75)
+   arorder           <double>     ..F.A...... set autoregression order (from 0 to 25) (default 8)
+   a                 <double>     ..F.A...... set autoregression order (from 0 to 25) (default 8)
+   threshold         <double>     ..F.A...... set threshold (from 1 to 100) (default 10)
+   t                 <double>     ..F.A...... set threshold (from 1 to 100) (default 10)
+   hsize             <int>        ..F.A...... set histogram size (from 100 to 9999) (default 1000)
+   n                 <int>        ..F.A...... set histogram size (from 100 to 9999) (default 1000)
+   method            <int>        ..F.A...... set overlap method (from 0 to 1) (default add)
+     add             0            ..F.A...... overlap-add
+     a               0            ..F.A...... overlap-add
+     save            1            ..F.A...... overlap-save
+     s               1            ..F.A...... overlap-save
+   m                 <int>        ..F.A...... set overlap method (from 0 to 1) (default add)
+     add             0            ..F.A...... overlap-add
+     a               0            ..F.A...... overlap-add
+     save            1            ..F.A...... overlap-save
+     s               1            ..F.A...... overlap-save
+
+adecorrelate AVOptions:
+   stages            <int>        ..F.A...... set filtering stages (from 1 to 16) (default 6)
+   seed              <int64>      ..F.A...... set random seed (from -1 to UINT32_MAX) (default -1)
+
+adelay AVOptions:
+   delays            <string>     ..F.A....T. set list of delays for each channel
+   all               <boolean>    ..F.A...... use last available delay for remained channels (default false)
+
+adenorm AVOptions:
+   level             <double>     ..F.A....T. set level (from -451 to -90) (default -351)
+   type              <int>        ..F.A....T. set type (from 0 to 3) (default dc)
+     dc              0            ..F.A....T.
+     ac              1            ..F.A....T.
+     square          2            ..F.A....T.
+     pulse           3            ..F.A....T.
+
+aderivative/aintegral AVOptions:
+
+adrc AVOptions:
+   transfer          <string>     ..F.A....T. set the transfer expression (default "p")
+   attack            <double>     ..F.A....T. set the attack (from 1 to 1000) (default 50)
+   release           <double>     ..F.A....T. set the release (from 5 to 2000) (default 100)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+
+adynamicequalizer AVOptions:
+   threshold         <double>     ..F.A....T. set detection threshold (from 0 to 100) (default 0)
+   dfrequency        <double>     ..F.A....T. set detection frequency (from 2 to 1e+06) (default 1000)
+   dqfactor          <double>     ..F.A....T. set detection Q factor (from 0.001 to 1000) (default 1)
+   tfrequency        <double>     ..F.A....T. set target frequency (from 2 to 1e+06) (default 1000)
+   tqfactor          <double>     ..F.A....T. set target Q factor (from 0.001 to 1000) (default 1)
+   attack            <double>     ..F.A....T. set attack duration (from 1 to 2000) (default 20)
+   release           <double>     ..F.A....T. set release duration (from 1 to 2000) (default 200)
+   ratio             <double>     ..F.A....T. set ratio factor (from 0 to 30) (default 1)
+   makeup            <double>     ..F.A....T. set makeup gain (from 0 to 100) (default 0)
+   range             <double>     ..F.A....T. set max gain (from 1 to 200) (default 50)
+   mode              <int>        ..F.A....T. set mode (from -1 to 1) (default cut)
+     listen          -1           ..F.A....T.
+     cut             0            ..F.A....T.
+     boost           1            ..F.A....T.
+   dftype            <int>        ..F.A....T. set detection filter type (from 0 to 3) (default bandpass)
+     bandpass        0            ..F.A....T.
+     lowpass         1            ..F.A....T.
+     highpass        2            ..F.A....T.
+     peak            3            ..F.A....T.
+   tftype            <int>        ..F.A....T. set target filter type (from 0 to 2) (default bell)
+     bell            0            ..F.A....T.
+     lowshelf        1            ..F.A....T.
+     highshelf       2            ..F.A....T.
+   direction         <int>        ..F.A....T. set direction (from 0 to 1) (default downward)
+     downward        0            ..F.A....T.
+     upward          1            ..F.A....T.
+   auto              <int>        ..F.A....T. set auto threshold (from -1 to 1) (default disabled)
+     disabled        -1           ..F.A....T.
+     off             0            ..F.A....T.
+     on              1            ..F.A....T.
+   precision         <int>        ..F.A...... set processing precision (from 0 to 2) (default auto)
+     auto            0            ..F.A...... set auto processing precision
+     float           1            ..F.A...... set single-floating point processing precision
+     double          2            ..F.A...... set double-floating point processing precision
+
+adynamicsmooth AVOptions:
+   sensitivity       <double>     ..F.A....T. set smooth sensitivity (from 0 to 1e+06) (default 2)
+   basefreq          <double>     ..F.A....T. set base frequency (from 2 to 1e+06) (default 22050)
+
+aecho AVOptions:
+   in_gain           <float>      ..F.A...... set signal input gain (from 0 to 1) (default 0.6)
+   out_gain          <float>      ..F.A...... set signal output gain (from 0 to 1) (default 0.3)
+   delays            <string>     ..F.A...... set list of signal delays (default "1000")
+   decays            <string>     ..F.A...... set list of signal decays (default "0.5")
+
+aemphasis AVOptions:
+   level_in          <double>     ..F.A....T. set input gain (from 0 to 64) (default 1)
+   level_out         <double>     ..F.A....T. set output gain (from 0 to 64) (default 1)
+   mode              <int>        ..F.A....T. set filter mode (from 0 to 1) (default reproduction)
+     reproduction    0            ..F.A....T.
+     production      1            ..F.A....T.
+   type              <int>        ..F.A....T. set filter type (from 0 to 8) (default cd)
+     col             0            ..F.A....T. Columbia
+     emi             1            ..F.A....T. EMI
+     bsi             2            ..F.A....T. BSI (78RPM)
+     riaa            3            ..F.A....T. RIAA
+     cd              4            ..F.A....T. Compact Disc (CD)
+     50fm            5            ..F.A....T. 50µs (FM)
+     75fm            6            ..F.A....T. 75µs (FM)
+     50kf            7            ..F.A....T. 50µs (FM-KF)
+     75kf            8            ..F.A....T. 75µs (FM-KF)
+
+aeval AVOptions:
+   exprs             <string>     ..F.A...... set the '|'-separated list of channels expressions
+   channel_layout    <string>     ..F.A...... set channel layout
+   c                 <string>     ..F.A...... set channel layout
+
+aexciter AVOptions:
+   level_in          <double>     ..F.A....T. set level in (from 0 to 64) (default 1)
+   level_out         <double>     ..F.A....T. set level out (from 0 to 64) (default 1)
+   amount            <double>     ..F.A....T. set amount (from 0 to 64) (default 1)
+   drive             <double>     ..F.A....T. set harmonics (from 0.1 to 10) (default 8.5)
+   blend             <double>     ..F.A....T. set blend harmonics (from -10 to 10) (default 0)
+   freq              <double>     ..F.A....T. set scope (from 2000 to 12000) (default 7500)
+   ceil              <double>     ..F.A....T. set ceiling (from 9999 to 20000) (default 9999)
+   listen            <boolean>    ..F.A....T. enable listen mode (default false)
+
+afade AVOptions:
+   type              <int>        ..F.A....T. set the fade direction (from 0 to 1) (default in)
+     in              0            ..F.A....T. fade-in
+     out             1            ..F.A....T. fade-out
+   t                 <int>        ..F.A....T. set the fade direction (from 0 to 1) (default in)
+     in              0            ..F.A....T. fade-in
+     out             1            ..F.A....T. fade-out
+   start_sample      <int64>      ..F.A....T. set number of first sample to start fading (from 0 to I64_MAX) (default 0)
+   ss                <int64>      ..F.A....T. set number of first sample to start fading (from 0 to I64_MAX) (default 0)
+   nb_samples        <int64>      ..F.A....T. set number of samples for fade duration (from 1 to I64_MAX) (default 44100)
+   ns                <int64>      ..F.A....T. set number of samples for fade duration (from 1 to I64_MAX) (default 44100)
+   start_time        <duration>   ..F.A....T. set time to start fading (default 0)
+   st                <duration>   ..F.A....T. set time to start fading (default 0)
+   duration          <duration>   ..F.A....T. set fade duration (default 0)
+   d                 <duration>   ..F.A....T. set fade duration (default 0)
+   curve             <int>        ..F.A....T. set fade curve type (from -1 to 22) (default tri)
+     nofade          -1           ..F.A....T. no fade; keep audio as-is
+     tri             0            ..F.A....T. linear slope
+     qsin            1            ..F.A....T. quarter of sine wave
+     esin            2            ..F.A....T. exponential sine wave
+     hsin            3            ..F.A....T. half of sine wave
+     log             4            ..F.A....T. logarithmic
+     ipar            5            ..F.A....T. inverted parabola
+     qua             6            ..F.A....T. quadratic
+     cub             7            ..F.A....T. cubic
+     squ             8            ..F.A....T. square root
+     cbr             9            ..F.A....T. cubic root
+     par             10           ..F.A....T. parabola
+     exp             11           ..F.A....T. exponential
+     iqsin           12           ..F.A....T. inverted quarter of sine wave
+     ihsin           13           ..F.A....T. inverted half of sine wave
+     dese            14           ..F.A....T. double-exponential seat
+     desi            15           ..F.A....T. double-exponential sigmoid
+     losi            16           ..F.A....T. logistic sigmoid
+     sinc            17           ..F.A....T. sine cardinal function
+     isinc           18           ..F.A....T. inverted sine cardinal function
+     quat            19           ..F.A....T. quartic
+     quatr           20           ..F.A....T. quartic root
+     qsin2           21           ..F.A....T. squared quarter of sine wave
+     hsin2           22           ..F.A....T. squared half of sine wave
+   c                 <int>        ..F.A....T. set fade curve type (from -1 to 22) (default tri)
+     nofade          -1           ..F.A....T. no fade; keep audio as-is
+     tri             0            ..F.A....T. linear slope
+     qsin            1            ..F.A....T. quarter of sine wave
+     esin            2            ..F.A....T. exponential sine wave
+     hsin            3            ..F.A....T. half of sine wave
+     log             4            ..F.A....T. logarithmic
+     ipar            5            ..F.A....T. inverted parabola
+     qua             6            ..F.A....T. quadratic
+     cub             7            ..F.A....T. cubic
+     squ             8            ..F.A....T. square root
+     cbr             9            ..F.A....T. cubic root
+     par             10           ..F.A....T. parabola
+     exp             11           ..F.A....T. exponential
+     iqsin           12           ..F.A....T. inverted quarter of sine wave
+     ihsin           13           ..F.A....T. inverted half of sine wave
+     dese            14           ..F.A....T. double-exponential seat
+     desi            15           ..F.A....T. double-exponential sigmoid
+     losi            16           ..F.A....T. logistic sigmoid
+     sinc            17           ..F.A....T. sine cardinal function
+     isinc           18           ..F.A....T. inverted sine cardinal function
+     quat            19           ..F.A....T. quartic
+     quatr           20           ..F.A....T. quartic root
+     qsin2           21           ..F.A....T. squared quarter of sine wave
+     hsin2           22           ..F.A....T. squared half of sine wave
+   silence           <double>     ..F.A....T. set the silence gain (from 0 to 1) (default 0)
+   unity             <double>     ..F.A....T. set the unity gain (from 0 to 1) (default 1)
+
+afftdn AVOptions:
+   noise_reduction   <float>      ..F.A....T. set the noise reduction (from 0.01 to 97) (default 12)
+   nr                <float>      ..F.A....T. set the noise reduction (from 0.01 to 97) (default 12)
+   noise_floor       <float>      ..F.A....T. set the noise floor (from -80 to -20) (default -50)
+   nf                <float>      ..F.A....T. set the noise floor (from -80 to -20) (default -50)
+   noise_type        <int>        ..F.A...... set the noise type (from 0 to 3) (default white)
+     white           0            ..F.A...... white noise
+     w               0            ..F.A...... white noise
+     vinyl           1            ..F.A...... vinyl noise
+     v               1            ..F.A...... vinyl noise
+     shellac         2            ..F.A...... shellac noise
+     s               2            ..F.A...... shellac noise
+     custom          3            ..F.A...... custom noise
+     c               3            ..F.A...... custom noise
+   nt                <int>        ..F.A...... set the noise type (from 0 to 3) (default white)
+     white           0            ..F.A...... white noise
+     w               0            ..F.A...... white noise
+     vinyl           1            ..F.A...... vinyl noise
+     v               1            ..F.A...... vinyl noise
+     shellac         2            ..F.A...... shellac noise
+     s               2            ..F.A...... shellac noise
+     custom          3            ..F.A...... custom noise
+     c               3            ..F.A...... custom noise
+   band_noise        <string>     ..F.A...... set the custom bands noise
+   bn                <string>     ..F.A...... set the custom bands noise
+   residual_floor    <float>      ..F.A....T. set the residual floor (from -80 to -20) (default -38)
+   rf                <float>      ..F.A....T. set the residual floor (from -80 to -20) (default -38)
+   track_noise       <boolean>    ..F.A....T. track noise (default false)
+   tn                <boolean>    ..F.A....T. track noise (default false)
+   track_residual    <boolean>    ..F.A....T. track residual (default false)
+   tr                <boolean>    ..F.A....T. track residual (default false)
+   output_mode       <int>        ..F.A....T. set output mode (from 0 to 2) (default output)
+     input           0            ..F.A....T. input
+     i               0            ..F.A....T. input
+     output          1            ..F.A....T. output
+     o               1            ..F.A....T. output
+     noise           2            ..F.A....T. noise
+     n               2            ..F.A....T. noise
+   om                <int>        ..F.A....T. set output mode (from 0 to 2) (default output)
+     input           0            ..F.A....T. input
+     i               0            ..F.A....T. input
+     output          1            ..F.A....T. output
+     o               1            ..F.A....T. output
+     noise           2            ..F.A....T. noise
+     n               2            ..F.A....T. noise
+   adaptivity        <float>      ..F.A....T. set adaptivity factor (from 0 to 1) (default 0.5)
+   ad                <float>      ..F.A....T. set adaptivity factor (from 0 to 1) (default 0.5)
+   floor_offset      <float>      ..F.A....T. set noise floor offset factor (from -2 to 2) (default 1)
+   fo                <float>      ..F.A....T. set noise floor offset factor (from -2 to 2) (default 1)
+   noise_link        <int>        ..F.A....T. set the noise floor link (from 0 to 3) (default min)
+     none            0            ..F.A....T. none
+     min             1            ..F.A....T. min
+     max             2            ..F.A....T. max
+     average         3            ..F.A....T. average
+   nl                <int>        ..F.A....T. set the noise floor link (from 0 to 3) (default min)
+     none            0            ..F.A....T. none
+     min             1            ..F.A....T. min
+     max             2            ..F.A....T. max
+     average         3            ..F.A....T. average
+   band_multiplier   <float>      ..F.A...... set band multiplier (from 0.2 to 5) (default 1.25)
+   bm                <float>      ..F.A...... set band multiplier (from 0.2 to 5) (default 1.25)
+   sample_noise      <int>        ..F.A....T. set sample noise mode (from 0 to 2) (default none)
+     none            0            ..F.A....T. none
+     start           1            ..F.A....T. start
+     begin           1            ..F.A....T. start
+     stop            2            ..F.A....T. stop
+     end             2            ..F.A....T. stop
+   sn                <int>        ..F.A....T. set sample noise mode (from 0 to 2) (default none)
+     none            0            ..F.A....T. none
+     start           1            ..F.A....T. start
+     begin           1            ..F.A....T. start
+     stop            2            ..F.A....T. stop
+     end             2            ..F.A....T. stop
+   gain_smooth       <int>        ..F.A....T. set gain smooth radius (from 0 to 50) (default 0)
+   gs                <int>        ..F.A....T. set gain smooth radius (from 0 to 50) (default 0)
+
+afftfilt AVOptions:
+   real              <string>     ..F.A...... set channels real expressions (default "re")
+   imag              <string>     ..F.A...... set channels imaginary expressions (default "im")
+   win_size          <int>        ..F.A...... set window size (from 16 to 131072) (default 4096)
+   win_func          <int>        ..F.A...... set window function (from 0 to 20) (default hann)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+   overlap           <float>      ..F.A...... set window overlap (from 0 to 1) (default 0.75)
+
+afir AVOptions:
+   dry               <float>      ..F.A....T. set dry gain (from 0 to 10) (default 1)
+   wet               <float>      ..F.A....T. set wet gain (from 0 to 10) (default 1)
+   length            <float>      ..F.A...... set IR length (from 0 to 1) (default 1)
+   gtype             <int>        ..F.A...... set IR auto gain type (from -1 to 4) (default peak)
+     none            -1           ..F.A...... without auto gain
+     peak            0            ..F.A...... peak gain
+     dc              1            ..F.A...... DC gain
+     gn              2            ..F.A...... gain to noise
+     ac              3            ..F.A...... AC gain
+     rms             4            ..F.A...... RMS gain
+   irgain            <float>      ..F.A...... set IR gain (from 0 to 1) (default 1)
+   irfmt             <int>        ..F.A...... set IR format (from 0 to 1) (default input)
+     mono            0            ..F.A...... single channel
+     input           1            ..F.A...... same as input
+   maxir             <float>      ..F.A...... set max IR length (from 0.1 to 60) (default 30)
+   response          <boolean>    ..FV....... show IR frequency response (default false)
+   channel           <int>        ..FV....... set IR channel to display frequency response (from 0 to 1024) (default 0)
+   size              <image_size> ..FV....... set video size (default "hd720")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   minp              <int>        ..F.A...... set min partition size (from 1 to 65536) (default 8192)
+   maxp              <int>        ..F.A...... set max partition size (from 8 to 65536) (default 8192)
+   nbirs             <int>        ..F.A...... set number of input IRs (from 1 to 32) (default 1)
+   ir                <int>        ..F.A....T. select IR (from 0 to 31) (default 0)
+   precision         <int>        ..F.A...... set processing precision (from 0 to 2) (default auto)
+     auto            0            ..F.A...... set auto processing precision
+     float           1            ..F.A...... set single-floating point processing precision
+     double          2            ..F.A...... set double-floating point processing precision
+   irload            <int>        ..F.A...... set IR loading type (from 0 to 1) (default init)
+     init            0            ..F.A...... load all IRs on init
+     access          1            ..F.A...... load IR on access
+
+aformat AVOptions:
+   sample_fmts       <string>     ..F.A...... A '|'-separated list of sample formats.
+   f                 <string>     ..F.A...... A '|'-separated list of sample formats.
+   sample_rates      <string>     ..F.A...... A '|'-separated list of sample rates.
+   r                 <string>     ..F.A...... A '|'-separated list of sample rates.
+   channel_layouts   <string>     ..F.A...... A '|'-separated list of channel layouts.
+   cl                <string>     ..F.A...... A '|'-separated list of channel layouts.
+
+afreqshift AVOptions:
+   shift             <double>     ..F.A....T. set frequency shift (from -2.14748e+09 to INT_MAX) (default 0)
+   level             <double>     ..F.A....T. set output level (from 0 to 1) (default 1)
+   order             <int>        ..F.A....T. set filter order (from 1 to 16) (default 8)
+
+afwtdn AVOptions:
+   sigma             <double>     ..F.A....T. set noise sigma (from 0 to 1) (default 0)
+   levels            <int>        ..F.A...... set number of wavelet levels (from 1 to 12) (default 10)
+   wavet             <int>        ..F.A...... set wavelet type (from 0 to 6) (default sym10)
+     sym2            0            ..F.A...... sym2
+     sym4            1            ..F.A...... sym4
+     rbior68         2            ..F.A...... rbior68
+     deb10           3            ..F.A...... deb10
+     sym10           4            ..F.A...... sym10
+     coif5           5            ..F.A...... coif5
+     bl3             6            ..F.A...... bl3
+   percent           <double>     ..F.A....T. set percent of full denoising (from 0 to 100) (default 85)
+   profile           <boolean>    ..F.A....T. profile noise (default false)
+   adaptive          <boolean>    ..F.A....T. adaptive profiling of noise (default false)
+   samples           <int>        ..F.A...... set frame size in number of samples (from 512 to 65536) (default 8192)
+   softness          <double>     ..F.A....T. set thresholding softness (from 0 to 10) (default 1)
+
+agate/sidechaingate AVOptions:
+   level_in          <double>     ..F.A....T. set input level (from 0.015625 to 64) (default 1)
+   mode              <int>        ..F.A....T. set mode (from 0 to 1) (default downward)
+     downward        0            ..F.A....T.
+     upward          1            ..F.A....T.
+   range             <double>     ..F.A....T. set max gain reduction (from 0 to 1) (default 0.06125)
+   threshold         <double>     ..F.A....T. set threshold (from 0 to 1) (default 0.125)
+   ratio             <double>     ..F.A....T. set ratio (from 1 to 9000) (default 2)
+   attack            <double>     ..F.A....T. set attack (from 0.01 to 9000) (default 20)
+   release           <double>     ..F.A....T. set release (from 0.01 to 9000) (default 250)
+   makeup            <double>     ..F.A....T. set makeup gain (from 1 to 64) (default 1)
+   knee              <double>     ..F.A....T. set knee (from 1 to 8) (default 2.82843)
+   detection         <int>        ..F.A....T. set detection (from 0 to 1) (default rms)
+     peak            0            ..F.A....T.
+     rms             1            ..F.A....T.
+   link              <int>        ..F.A....T. set link (from 0 to 1) (default average)
+     average         0            ..F.A....T.
+     maximum         1            ..F.A....T.
+   level_sc          <double>     ..F.A....T. set sidechain gain (from 0.015625 to 64) (default 1)
+
+aiir AVOptions:
+   zeros             <string>     ..F.A...... set B/numerator/zeros/reflection coefficients (default "1+0i 1-0i")
+   z                 <string>     ..F.A...... set B/numerator/zeros/reflection coefficients (default "1+0i 1-0i")
+   poles             <string>     ..F.A...... set A/denominator/poles/ladder coefficients (default "1+0i 1-0i")
+   p                 <string>     ..F.A...... set A/denominator/poles/ladder coefficients (default "1+0i 1-0i")
+   gains             <string>     ..F.A...... set channels gains (default "1|1")
+   k                 <string>     ..F.A...... set channels gains (default "1|1")
+   dry               <double>     ..F.A...... set dry gain (from 0 to 1) (default 1)
+   wet               <double>     ..F.A...... set wet gain (from 0 to 1) (default 1)
+   format            <int>        ..F.A...... set coefficients format (from -2 to 4) (default zp)
+     ll              -2           ..F.A...... lattice-ladder function
+     sf              -1           ..F.A...... analog transfer function
+     tf              0            ..F.A...... digital transfer function
+     zp              1            ..F.A...... Z-plane zeros/poles
+     pr              2            ..F.A...... Z-plane zeros/poles (polar radians)
+     pd              3            ..F.A...... Z-plane zeros/poles (polar degrees)
+     sp              4            ..F.A...... S-plane zeros/poles
+   f                 <int>        ..F.A...... set coefficients format (from -2 to 4) (default zp)
+     ll              -2           ..F.A...... lattice-ladder function
+     sf              -1           ..F.A...... analog transfer function
+     tf              0            ..F.A...... digital transfer function
+     zp              1            ..F.A...... Z-plane zeros/poles
+     pr              2            ..F.A...... Z-plane zeros/poles (polar radians)
+     pd              3            ..F.A...... Z-plane zeros/poles (polar degrees)
+     sp              4            ..F.A...... S-plane zeros/poles
+   process           <int>        ..F.A...... set kind of processing (from 0 to 2) (default s)
+     d               0            ..F.A...... direct
+     s               1            ..F.A...... serial
+     p               2            ..F.A...... parallel
+   r                 <int>        ..F.A...... set kind of processing (from 0 to 2) (default s)
+     d               0            ..F.A...... direct
+     s               1            ..F.A...... serial
+     p               2            ..F.A...... parallel
+   precision         <int>        ..F.A...... set filtering precision (from 0 to 3) (default dbl)
+     dbl             0            ..F.A...... double-precision floating-point
+     flt             1            ..F.A...... single-precision floating-point
+     i32             2            ..F.A...... 32-bit integers
+     i16             3            ..F.A...... 16-bit integers
+   e                 <int>        ..F.A...... set precision (from 0 to 3) (default dbl)
+     dbl             0            ..F.A...... double-precision floating-point
+     flt             1            ..F.A...... single-precision floating-point
+     i32             2            ..F.A...... 32-bit integers
+     i16             3            ..F.A...... 16-bit integers
+   normalize         <boolean>    ..F.A...... normalize coefficients (default true)
+   n                 <boolean>    ..F.A...... normalize coefficients (default true)
+   mix               <double>     ..F.A...... set mix (from 0 to 1) (default 1)
+   response          <boolean>    ..FV....... show IR frequency response (default false)
+   channel           <int>        ..FV....... set IR channel to display frequency response (from 0 to 1024) (default 0)
+   size              <image_size> ..FV....... set video size (default "hd720")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+
+aderivative/aintegral AVOptions:
+
+ainterleave AVOptions:
+   nb_inputs         <int>        ..F.A...... set number of inputs (from 1 to INT_MAX) (default 2)
+   n                 <int>        ..F.A...... set number of inputs (from 1 to INT_MAX) (default 2)
+   duration          <int>        ..F.A...... how to determine the end-of-stream (from 0 to 2) (default longest)
+     longest         0            ..F.A...... Duration of longest input
+     shortest        1            ..F.A...... Duration of shortest input
+     first           2            ..F.A...... Duration of first input
+
+alimiter AVOptions:
+   level_in          <double>     ..F.A....T. set input level (from 0.015625 to 64) (default 1)
+   level_out         <double>     ..F.A....T. set output level (from 0.015625 to 64) (default 1)
+   limit             <double>     ..F.A....T. set limit (from 0.0625 to 1) (default 1)
+   attack            <double>     ..F.A....T. set attack (from 0.1 to 80) (default 5)
+   release           <double>     ..F.A....T. set release (from 1 to 8000) (default 50)
+   asc               <boolean>    ..F.A....T. enable asc (default false)
+   asc_level         <double>     ..F.A....T. set asc level (from 0 to 1) (default 0.5)
+   level             <boolean>    ..F.A....T. auto level (default true)
+   latency           <boolean>    ..F.A....T. compensate delay (default false)
+
+allpass AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.707)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.707)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   order             <int>        ..F.A....T. set filter order (from 1 to 2) (default 2)
+   o                 <int>        ..F.A....T. set filter order (from 1 to 2) (default 2)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+
+aloop AVOptions:
+   loop              <int>        ..F.A...... number of loops (from -1 to INT_MAX) (default 0)
+   size              <int64>      ..F.A...... max number of samples to loop (from 0 to INT_MAX) (default 0)
+   start             <int64>      ..F.A...... set the loop start sample (from -1 to I64_MAX) (default 0)
+   time              <duration>   ..F.A...... set the loop start time (default INT64_MAX)
+
+amerge AVOptions:
+   inputs            <int>        ..F.A...... specify the number of inputs (from 1 to 64) (default 2)
+
+ametadata AVOptions:
+   mode              <int>        ..F.A...... set a mode of operation (from 0 to 4) (default select)
+     select          0            ..F.A...... select frame
+     add             1            ..F.A...... add new metadata
+     modify          2            ..F.A...... modify metadata
+     delete          3            ..F.A...... delete metadata
+     print           4            ..F.A...... print metadata
+   key               <string>     ..F.A...... set metadata key
+   value             <string>     ..F.A...... set metadata value
+   function          <int>        ..F.A...... function for comparing values (from 0 to 6) (default same_str)
+     same_str        0            ..F.A......
+     starts_with     1            ..F.A......
+     less            2            ..F.A......
+     equal           3            ..F.A......
+     greater         4            ..F.A......
+     expr            5            ..F.A......
+     ends_with       6            ..F.A......
+   expr              <string>     ..F.A...... set expression for expr function
+   file              <string>     ..F.A...... set file where to print metadata information
+   direct            <boolean>    ..F.A...... reduce buffering when printing to user-set file or pipe (default false)
+
+amix AVOptions:
+   inputs            <int>        ..F.A...... Number of inputs. (from 1 to 32767) (default 2)
+   duration          <int>        ..F.A...... How to determine the end-of-stream. (from 0 to 2) (default longest)
+     longest         0            ..F.A...... Duration of longest input.
+     shortest        1            ..F.A...... Duration of shortest input.
+     first           2            ..F.A...... Duration of first input.
+   dropout_transition <float>      ..F.A...... Transition time, in seconds, for volume renormalization when an input stream ends. (from 0 to INT_MAX) (default 2)
+   weights           <string>     ..F.A....T. Set weight for each input. (default "1 1")
+   normalize         <boolean>    ..F.A....T. Scale inputs (default true)
+
+anequalizer AVOptions:
+   params            <string>     ..F.A...... (default "")
+   curves            <boolean>    ..FV....... draw frequency response curves (default false)
+   size              <image_size> ..FV....... set video size (default "hd720")
+   mgain             <double>     ..FV....... set max gain (from -900 to 900) (default 60)
+   fscale            <int>        ..FV....... set frequency scale (from 0 to 1) (default log)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+   colors            <string>     ..FV....... set channels curves colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+
+anlmdn AVOptions:
+   strength          <float>      ..F.A....T. set denoising strength (from 1e-05 to 10000) (default 1e-05)
+   s                 <float>      ..F.A....T. set denoising strength (from 1e-05 to 10000) (default 1e-05)
+   patch             <duration>   ..F.A....T. set patch duration (default 0.002)
+   p                 <duration>   ..F.A....T. set patch duration (default 0.002)
+   research          <duration>   ..F.A....T. set research duration (default 0.006)
+   r                 <duration>   ..F.A....T. set research duration (default 0.006)
+   output            <int>        ..F.A....T. set output mode (from 0 to 2) (default o)
+     i               0            ..F.A....T. input
+     o               1            ..F.A....T. output
+     n               2            ..F.A....T. noise
+   o                 <int>        ..F.A....T. set output mode (from 0 to 2) (default o)
+     i               0            ..F.A....T. input
+     o               1            ..F.A....T. output
+     n               2            ..F.A....T. noise
+   smooth            <float>      ..F.A....T. set smooth factor (from 1 to 1000) (default 11)
+   m                 <float>      ..F.A....T. set smooth factor (from 1 to 1000) (default 11)
+
+anlm(f|s) AVOptions:
+   order             <int>        ..F.A...... set the filter order (from 1 to 32767) (default 256)
+   mu                <float>      ..F.A....T. set the filter mu (from 0 to 2) (default 0.75)
+   eps               <float>      ..F.A....T. set the filter eps (from 0 to 1) (default 1)
+   leakage           <float>      ..F.A....T. set the filter leakage (from 0 to 1) (default 0)
+   out_mode          <int>        ..F.A....T. set output mode (from 0 to 4) (default o)
+     i               0            ..F.A....T. input
+     d               1            ..F.A....T. desired
+     o               2            ..F.A....T. output
+     n               3            ..F.A....T. noise
+     e               4            ..F.A....T. error
+
+anlm(f|s) AVOptions:
+   order             <int>        ..F.A...... set the filter order (from 1 to 32767) (default 256)
+   mu                <float>      ..F.A....T. set the filter mu (from 0 to 2) (default 0.75)
+   eps               <float>      ..F.A....T. set the filter eps (from 0 to 1) (default 1)
+   leakage           <float>      ..F.A....T. set the filter leakage (from 0 to 1) (default 0)
+   out_mode          <int>        ..F.A....T. set output mode (from 0 to 4) (default o)
+     i               0            ..F.A....T. input
+     d               1            ..F.A....T. desired
+     o               2            ..F.A....T. output
+     n               3            ..F.A....T. noise
+     e               4            ..F.A....T. error
+
+apad AVOptions:
+   packet_size       <int>        ..F.A...... set silence packet size (from 0 to INT_MAX) (default 4096)
+   pad_len           <int64>      ..F.A...... set number of samples of silence to add (from -1 to I64_MAX) (default -1)
+   whole_len         <int64>      ..F.A...... set minimum target number of samples in the audio stream (from -1 to I64_MAX) (default -1)
+   pad_dur           <duration>   ..F.A...... set duration of silence to add (default -0.000001)
+   whole_dur         <duration>   ..F.A...... set minimum target duration in the audio stream (default -0.000001)
+
+(a)perms AVOptions:
+   mode              <int>        ..FVA....T. select permissions mode (from 0 to 4) (default none)
+     none            0            ..FVA....T. do nothing
+     ro              1            ..FVA....T. set all output frames read-only
+     rw              2            ..FVA....T. set all output frames writable
+     toggle          3            ..FVA....T. switch permissions
+     random          4            ..FVA....T. set permissions randomly
+   seed              <int64>      ..FVA...... set the seed for the random mode (from -1 to UINT32_MAX) (default -1)
+
+aphaser AVOptions:
+   in_gain           <double>     ..F.A...... set input gain (from 0 to 1) (default 0.4)
+   out_gain          <double>     ..F.A...... set output gain (from 0 to 1e+09) (default 0.74)
+   delay             <double>     ..F.A...... set delay in milliseconds (from 0 to 5) (default 3)
+   decay             <double>     ..F.A...... set decay (from 0 to 0.99) (default 0.4)
+   speed             <double>     ..F.A...... set modulation speed (from 0.1 to 2) (default 0.5)
+   type              <int>        ..F.A...... set modulation type (from 0 to 1) (default triangular)
+     triangular      1            ..F.A......
+     t               1            ..F.A......
+     sinusoidal      0            ..F.A......
+     s               0            ..F.A......
+
+aphaseshift AVOptions:
+   shift             <double>     ..F.A....T. set phase shift (from -1 to 1) (default 0)
+   level             <double>     ..F.A....T. set output level (from 0 to 1) (default 1)
+   order             <int>        ..F.A....T. set filter order (from 1 to 16) (default 8)
+
+apsyclip AVOptions:
+   level_in          <double>     ..F.A....T. set input level (from 0.015625 to 64) (default 1)
+   level_out         <double>     ..F.A....T. set output level (from 0.015625 to 64) (default 1)
+   clip              <double>     ..F.A....T. set clip level (from 0.015625 to 1) (default 1)
+   diff              <boolean>    ..F.A....T. enable difference (default false)
+   adaptive          <double>     ..F.A....T. set adaptive distortion (from 0 to 1) (default 0.5)
+   iterations        <int>        ..F.A....T. set iterations (from 1 to 20) (default 10)
+   level             <boolean>    ..F.A....T. set auto level (default false)
+
+apulsator AVOptions:
+   level_in          <double>     ..F.A...... set input gain (from 0.015625 to 64) (default 1)
+   level_out         <double>     ..F.A...... set output gain (from 0.015625 to 64) (default 1)
+   mode              <int>        ..F.A...... set mode (from 0 to 4) (default sine)
+     sine            0            ..F.A......
+     triangle        1            ..F.A......
+     square          2            ..F.A......
+     sawup           3            ..F.A......
+     sawdown         4            ..F.A......
+   amount            <double>     ..F.A...... set modulation (from 0 to 1) (default 1)
+   offset_l          <double>     ..F.A...... set offset L (from 0 to 1) (default 0)
+   offset_r          <double>     ..F.A...... set offset R (from 0 to 1) (default 0.5)
+   width             <double>     ..F.A...... set pulse width (from 0 to 2) (default 1)
+   timing            <int>        ..F.A...... set timing (from 0 to 2) (default hz)
+     bpm             0            ..F.A......
+     ms              1            ..F.A......
+     hz              2            ..F.A......
+   bpm               <double>     ..F.A...... set BPM (from 30 to 300) (default 120)
+   ms                <int>        ..F.A...... set ms (from 10 to 2000) (default 500)
+   hz                <double>     ..F.A...... set frequency (from 0.01 to 100) (default 2)
+
+(a)realtime AVOptions:
+   limit             <duration>   ..FVA....T. sleep time limit (default 2)
+   speed             <double>     ..FVA....T. speed factor (from DBL_MIN to DBL_MAX) (default 1)
+
+aresample AVOptions:
+   sample_rate       <int>        ..F.A...... (from 0 to INT_MAX) (default 0)
+
+SWResampler AVOptions:
+
+arls AVOptions:
+   order             <int>        ..F.A...... set the filter order (from 1 to 32767) (default 16)
+   lambda            <float>      ..F.A....T. set the filter lambda (from 0 to 1) (default 1)
+   delta             <float>      ..F.A...... set the filter delta (from 0 to 32767) (default 2)
+   out_mode          <int>        ..F.A....T. set output mode (from 0 to 4) (default o)
+     i               0            ..F.A....T. input
+     d               1            ..F.A....T. desired
+     o               2            ..F.A....T. output
+     n               3            ..F.A....T. noise
+     e               4            ..F.A....T. error
+
+arnndn AVOptions:
+   model             <string>     ..F.A....T. set model name
+   m                 <string>     ..F.A....T. set model name
+   mix               <float>      ..F.A....T. set output vs input mix (from -1 to 1) (default 1)
+
+asegment AVOptions:
+   timestamps        <string>     ..F.A...... timestamps of input at which to split input
+   samples           <string>     ..F.A...... samples at which to split input
+
+aselect AVOptions:
+   expr              <string>     ..F.A...... set an expression to use for selecting frames (default "1")
+   e                 <string>     ..F.A...... set an expression to use for selecting frames (default "1")
+   outputs           <int>        ..F.A...... set the number of outputs (from 1 to INT_MAX) (default 1)
+   n                 <int>        ..F.A...... set the number of outputs (from 1 to INT_MAX) (default 1)
+
+(a)sendcmd AVOptions:
+   commands          <string>     ..FVA...... set commands
+   c                 <string>     ..FVA...... set commands
+   filename          <string>     ..FVA...... set commands file
+   f                 <string>     ..FVA...... set commands file
+
+asetnsamples AVOptions:
+   nb_out_samples    <int>        ..F.A....T. set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A....T. set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)
+   pad               <boolean>    ..F.A....T. pad last frame with zeros (default true)
+   p                 <boolean>    ..F.A....T. pad last frame with zeros (default true)
+
+asetpts AVOptions:
+   expr              <string>     ..F.A....T. Expression determining the frame timestamp (default "PTS")
+
+asetrate AVOptions:
+   sample_rate       <int>        ..F.A...... set the sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set the sample rate (from 1 to INT_MAX) (default 44100)
+
+asettb AVOptions:
+   expr              <string>     ..F.A...... set expression determining the output timebase (default "intb")
+   tb                <string>     ..F.A...... set expression determining the output timebase (default "intb")
+
+asidedata AVOptions:
+   mode              <int>        ..F.A...... set a mode of operation (from 0 to 1) (default select)
+     select          0            ..F.A...... select frame
+     delete          1            ..F.A...... delete side data
+   type              <int>        ..F.A...... set side data type (from -1 to INT_MAX) (default -1)
+     PANSCAN         0            ..F.A...... 
+     A53_CC          1            ..F.A...... 
+     STEREO3D        2            ..F.A...... 
+     MATRIXENCODING  3            ..F.A...... 
+     DOWNMIX_INFO    4            ..F.A...... 
+     REPLAYGAIN      5            ..F.A...... 
+     DISPLAYMATRIX   6            ..F.A...... 
+     AFD             7            ..F.A...... 
+     MOTION_VECTORS  8            ..F.A...... 
+     SKIP_SAMPLES    9            ..F.A...... 
+     AUDIO_SERVICE_TYPE 10           ..F.A...... 
+     MASTERING_DISPLAY_METADATA 11           ..F.A...... 
+     GOP_TIMECODE    12           ..F.A...... 
+     SPHERICAL       13           ..F.A...... 
+     CONTENT_LIGHT_LEVEL 14           ..F.A...... 
+     ICC_PROFILE     15           ..F.A...... 
+     S12M_TIMECOD    16           ..F.A...... 
+     DYNAMIC_HDR_PLUS 17           ..F.A...... 
+     REGIONS_OF_INTEREST 18           ..F.A...... 
+     DETECTION_BOUNDING_BOXES 22           ..F.A...... 
+     SEI_UNREGISTERED 20           ..F.A...... 
+
+asoftclip AVOptions:
+   type              <int>        ..F.A....T. set softclip type (from -1 to 7) (default tanh)
+     hard            -1           ..F.A....T.
+     tanh            0            ..F.A....T.
+     atan            1            ..F.A....T.
+     cubic           2            ..F.A....T.
+     exp             3            ..F.A....T.
+     alg             4            ..F.A....T.
+     quintic         5            ..F.A....T.
+     sin             6            ..F.A....T.
+     erf             7            ..F.A....T.
+   threshold         <double>     ..F.A....T. set softclip threshold (from 1e-06 to 1) (default 1)
+   output            <double>     ..F.A....T. set softclip output gain (from 1e-06 to 16) (default 1)
+   param             <double>     ..F.A....T. set softclip parameter (from 0.01 to 3) (default 1)
+   oversample        <int>        ..F.A....T. set oversample factor (from 1 to 64) (default 1)
+
+aspectralstats AVOptions:
+   win_size          <int>        ..F.A...... set the window size (from 32 to 65536) (default 2048)
+   win_func          <int>        ..F.A...... set window function (from 0 to 20) (default hann)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+   overlap           <float>      ..F.A...... set window overlap (from 0 to 1) (default 0.5)
+   measure           <flags>      ..F.A...... select the parameters which are measured (default all+mean+variance+centroid+spread+skewness+kurtosis+entropy+flatness+crest+flux+slope+decrease+rolloff)
+     none                         ..F.A...... 
+     all                          ..F.A...... 
+     mean                         ..F.A...... 
+     variance                     ..F.A...... 
+     centroid                     ..F.A...... 
+     spread                       ..F.A...... 
+     skewness                     ..F.A...... 
+     kurtosis                     ..F.A...... 
+     entropy                      ..F.A...... 
+     flatness                     ..F.A...... 
+     crest                        ..F.A...... 
+     flux                         ..F.A...... 
+     slope                        ..F.A...... 
+     decrease                     ..F.A...... 
+     rolloff                      ..F.A...... 
+
+(a)split AVOptions:
+   outputs           <int>        ..FVA...... set number of outputs (from 1 to INT_MAX) (default 2)
+
+asr AVOptions:
+   rate              <int>        ..F.A...... set sampling rate (from 0 to INT_MAX) (default 16000)
+   hmm               <string>     ..F.A...... set directory containing acoustic model files
+   dict              <string>     ..F.A...... set pronunciation dictionary
+   lm                <string>     ..F.A...... set language model file
+   lmctl             <string>     ..F.A...... set language model set
+   lmname            <string>     ..F.A...... set which language model to use
+   logfn             <string>     ..F.A...... set output for log messages (default "/dev/null")
+
+astats AVOptions:
+   length            <double>     ..F.A...... set the window length (from 0 to 10) (default 0.05)
+   metadata          <boolean>    ..F.A...... inject metadata in the filtergraph (default false)
+   reset             <int>        ..F.A...... Set the number of frames over which cumulative stats are calculated before being reset (from 0 to INT_MAX) (default 0)
+   measure_perchannel <flags>      ..F.A...... Select the parameters which are measured per channel (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count)
+     none                         ..F.A...... 
+     all                          ..F.A...... 
+     Bit_depth                    ..F.A...... 
+     Crest_factor                 ..F.A...... 
+     DC_offset                    ..F.A...... 
+     Dynamic_range                ..F.A...... 
+     Entropy                      ..F.A...... 
+     Flat_factor                  ..F.A...... 
+     Max_difference               ..F.A...... 
+     Max_level                    ..F.A...... 
+     Mean_difference              ..F.A...... 
+     Min_difference               ..F.A...... 
+     Min_level                    ..F.A...... 
+     Noise_floor                  ..F.A...... 
+     Noise_floor_count              ..F.A...... 
+     Number_of_Infs               ..F.A...... 
+     Number_of_NaNs               ..F.A...... 
+     Number_of_denormals              ..F.A...... 
+     Number_of_samples              ..F.A...... 
+     Peak_count                   ..F.A...... 
+     Peak_level                   ..F.A...... 
+     RMS_difference               ..F.A...... 
+     RMS_level                    ..F.A...... 
+     RMS_peak                     ..F.A...... 
+     RMS_trough                   ..F.A...... 
+     Zero_crossings               ..F.A...... 
+     Zero_crossings_rate              ..F.A...... 
+     Abs_Peak_count               ..F.A...... 
+   measure_overall   <flags>      ..F.A...... Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count)
+     none                         ..F.A...... 
+     all                          ..F.A...... 
+     Bit_depth                    ..F.A...... 
+     Crest_factor                 ..F.A...... 
+     DC_offset                    ..F.A...... 
+     Dynamic_range                ..F.A...... 
+     Entropy                      ..F.A...... 
+     Flat_factor                  ..F.A...... 
+     Max_difference               ..F.A...... 
+     Max_level                    ..F.A...... 
+     Mean_difference              ..F.A...... 
+     Min_difference               ..F.A...... 
+     Min_level                    ..F.A...... 
+     Noise_floor                  ..F.A...... 
+     Noise_floor_count              ..F.A...... 
+     Number_of_Infs               ..F.A...... 
+     Number_of_NaNs               ..F.A...... 
+     Number_of_denormals              ..F.A...... 
+     Number_of_samples              ..F.A...... 
+     Peak_count                   ..F.A...... 
+     Peak_level                   ..F.A...... 
+     RMS_difference               ..F.A...... 
+     RMS_level                    ..F.A...... 
+     RMS_peak                     ..F.A...... 
+     RMS_trough                   ..F.A...... 
+     Zero_crossings               ..F.A...... 
+     Zero_crossings_rate              ..F.A...... 
+     Abs_Peak_count               ..F.A...... 
+
+(a)streamselect AVOptions:
+   inputs            <int>        ..FVA...... number of input streams (from 2 to INT_MAX) (default 2)
+   map               <string>     ..FVA....T. input indexes to remap to outputs
+
+asubboost AVOptions:
+   dry               <double>     ..F.A....T. set dry gain (from 0 to 1) (default 1)
+   wet               <double>     ..F.A....T. set wet gain (from 0 to 1) (default 1)
+   boost             <double>     ..F.A....T. set max boost (from 1 to 12) (default 2)
+   decay             <double>     ..F.A....T. set decay (from 0 to 1) (default 0)
+   feedback          <double>     ..F.A....T. set feedback (from 0 to 1) (default 0.9)
+   cutoff            <double>     ..F.A....T. set cutoff (from 50 to 900) (default 100)
+   slope             <double>     ..F.A....T. set slope (from 0.0001 to 1) (default 0.5)
+   delay             <double>     ..F.A....T. set delay (from 1 to 100) (default 20)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+
+asubcut AVOptions:
+   cutoff            <double>     ..F.A....T. set cutoff frequency (from 2 to 200) (default 20)
+   order             <int>        ..F.A....T. set filter order (from 3 to 20) (default 10)
+   level             <double>     ..F.A....T. set input level (from 0 to 1) (default 1)
+
+asupercut AVOptions:
+   cutoff            <double>     ..F.A....T. set cutoff frequency (from 20000 to 192000) (default 20000)
+   order             <int>        ..F.A....T. set filter order (from 3 to 20) (default 10)
+   level             <double>     ..F.A....T. set input level (from 0 to 1) (default 1)
+
+asuperpass/asuperstop AVOptions:
+   centerf           <double>     ..F.A....T. set center frequency (from 2 to 999999) (default 1000)
+   order             <int>        ..F.A....T. set filter order (from 4 to 20) (default 4)
+   qfactor           <double>     ..F.A....T. set Q-factor (from 0.01 to 100) (default 1)
+   level             <double>     ..F.A....T. set input level (from 0 to 2) (default 1)
+
+asuperpass/asuperstop AVOptions:
+   centerf           <double>     ..F.A....T. set center frequency (from 2 to 999999) (default 1000)
+   order             <int>        ..F.A....T. set filter order (from 4 to 20) (default 4)
+   qfactor           <double>     ..F.A....T. set Q-factor (from 0.01 to 100) (default 1)
+   level             <double>     ..F.A....T. set input level (from 0 to 2) (default 1)
+
+atempo AVOptions:
+   tempo             <double>     ..F.A....T. set tempo scale factor (from 0.5 to 100) (default 1)
+
+atilt AVOptions:
+   freq              <double>     ..F.A....T. set central frequency (from 20 to 192000) (default 10000)
+   slope             <double>     ..F.A....T. set filter slope (from -1 to 1) (default 0)
+   width             <double>     ..F.A....T. set filter width (from 100 to 10000) (default 1000)
+   order             <int>        ..F.A....T. set filter order (from 2 to 30) (default 5)
+   level             <double>     ..F.A....T. set input level (from 0 to 4) (default 1)
+
+atrim AVOptions:
+   start             <duration>   ..F.A...... Timestamp of the first frame that should be passed (default INT64_MAX)
+   starti            <duration>   ..F.A...... Timestamp of the first frame that should be passed (default INT64_MAX)
+   end               <duration>   ..F.A...... Timestamp of the first frame that should be dropped again (default INT64_MAX)
+   endi              <duration>   ..F.A...... Timestamp of the first frame that should be dropped again (default INT64_MAX)
+   start_pts         <int64>      ..F.A...... Timestamp of the first frame that should be  passed (from I64_MIN to I64_MAX) (default I64_MIN)
+   end_pts           <int64>      ..F.A...... Timestamp of the first frame that should be dropped again (from I64_MIN to I64_MAX) (default I64_MIN)
+   duration          <duration>   ..F.A...... Maximum duration of the output (default 0)
+   durationi         <duration>   ..F.A...... Maximum duration of the output (default 0)
+   start_sample      <int64>      ..F.A...... Number of the first audio sample that should be passed to the output (from -1 to I64_MAX) (default -1)
+   end_sample        <int64>      ..F.A...... Number of the first audio sample that should be dropped again (from 0 to I64_MAX) (default I64_MAX)
+
+axcorrelate AVOptions:
+   size              <int>        ..F.A...... set the segment size (from 2 to 131072) (default 256)
+   algo              <int>        ..F.A...... set the algorithm (from 0 to 2) (default best)
+     slow            0            ..F.A...... slow algorithm
+     fast            1            ..F.A...... fast algorithm
+     best            2            ..F.A...... best algorithm
+
+(a)zmq AVOptions:
+   bind_address      <string>     ..FVA...... set bind address (default "tcp://*:5555")
+   b                 <string>     ..FVA...... set bind address (default "tcp://*:5555")
+
+bandpass AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   csg               <boolean>    ..F.A....T. use constant skirt gain (default false)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+bandreject AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+bass/lowshelf AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 100)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 100)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   gain              <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   g                 <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+biquad AVOptions:
+   a0                <double>     ..F.A....T. (from INT_MIN to INT_MAX) (default 1)
+   a1                <double>     ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+   a2                <double>     ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+   b0                <double>     ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+   b1                <double>     ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+   b2                <double>     ..F.A....T. (from INT_MIN to INT_MAX) (default 0)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+bs2b AVOptions:
+   profile           <int>        ..F.A...... Apply a pre-defined crossfeed level (from 0 to INT_MAX) (default default)
+     default         2949820      ..F.A...... default profile
+     cmoy            3932860      ..F.A...... Chu Moy circuit
+     jmeier          6226570      ..F.A...... Jan Meier circuit
+   fcut              <int>        ..F.A...... Set cut frequency (in Hz) (from 0 to 2000) (default 0)
+   feed              <int>        ..F.A...... Set feed level (in Hz) (from 0 to 150) (default 0)
+
+channelmap AVOptions:
+   map               <string>     ..F.A...... A comma-separated list of input channel numbers in output order.
+   channel_layout    <string>     ..F.A...... Output channel layout.
+
+channelsplit AVOptions:
+   channel_layout    <string>     ..F.A...... Input channel layout. (default "stereo")
+   channels          <string>     ..F.A...... Channels to extract. (default "all")
+
+chorus AVOptions:
+   in_gain           <float>      ..F.A...... set input gain (from 0 to 1) (default 0.4)
+   out_gain          <float>      ..F.A...... set output gain (from 0 to 1) (default 0.4)
+   delays            <string>     ..F.A...... set delays
+   decays            <string>     ..F.A...... set decays
+   speeds            <string>     ..F.A...... set speeds
+   depths            <string>     ..F.A...... set depths
+
+compand AVOptions:
+   attacks           <string>     ..F.A...... set time over which increase of volume is determined (default "0")
+   decays            <string>     ..F.A...... set time over which decrease of volume is determined (default "0.8")
+   points            <string>     ..F.A...... set points of transfer function (default "-70/-70|-60/-20|1/0")
+   soft-knee         <double>     ..F.A...... set soft-knee (from 0.01 to 900) (default 0.01)
+   gain              <double>     ..F.A...... set output gain (from -900 to 900) (default 0)
+   volume            <double>     ..F.A...... set initial volume (from -900 to 0) (default 0)
+   delay             <double>     ..F.A...... set delay for samples before sending them to volume adjuster (from 0 to 20) (default 0)
+
+compensationdelay AVOptions:
+   mm                <int>        ..F.A....T. set mm distance (from 0 to 10) (default 0)
+   cm                <int>        ..F.A....T. set cm distance (from 0 to 100) (default 0)
+   m                 <int>        ..F.A....T. set meter distance (from 0 to 100) (default 0)
+   dry               <double>     ..F.A....T. set dry amount (from 0 to 1) (default 0)
+   wet               <double>     ..F.A....T. set wet amount (from 0 to 1) (default 1)
+   temp              <int>        ..F.A....T. set temperature °C (from -50 to 50) (default 20)
+
+crossfeed AVOptions:
+   strength          <double>     ..F.A....T. set crossfeed strength (from 0 to 1) (default 0.2)
+   range             <double>     ..F.A....T. set soundstage wideness (from 0 to 1) (default 0.5)
+   slope             <double>     ..F.A....T. set curve slope (from 0.01 to 1) (default 0.5)
+   level_in          <double>     ..F.A....T. set level in (from 0 to 1) (default 0.9)
+   level_out         <double>     ..F.A....T. set level out (from 0 to 1) (default 1)
+   block_size        <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+crystalizer AVOptions:
+   i                 <float>      ..F.A....T. set intensity (from -10 to 10) (default 2)
+   c                 <boolean>    ..F.A....T. enable clipping (default true)
+
+dcshift AVOptions:
+   shift             <double>     ..F.A...... set DC shift (from -1 to 1) (default 0)
+   limitergain       <double>     ..F.A...... set limiter gain (from 0 to 1) (default 0)
+
+deesser AVOptions:
+   i                 <double>     ..F.A...... set intensity (from 0 to 1) (default 0)
+   m                 <double>     ..F.A...... set max deessing (from 0 to 1) (default 0.5)
+   f                 <double>     ..F.A...... set frequency (from 0 to 1) (default 0.5)
+   s                 <int>        ..F.A...... set output mode (from 0 to 2) (default o)
+     i               0            ..F.A...... input
+     o               1            ..F.A...... output
+     e               2            ..F.A...... ess
+
+dialoguenhance AVOptions:
+   original          <double>     ..F.A....T. set original center factor (from 0 to 1) (default 1)
+   enhance           <double>     ..F.A....T. set dialogue enhance factor (from 0 to 3) (default 1)
+   voice             <double>     ..F.A....T. set voice detection factor (from 2 to 32) (default 2)
+
+drmeter AVOptions:
+   length            <double>     ..F.A...... set the window length (from 0.01 to 10) (default 3)
+
+dynaudnorm AVOptions:
+   framelen          <int>        ..F.A....T. set the frame length in msec (from 10 to 8000) (default 500)
+   f                 <int>        ..F.A....T. set the frame length in msec (from 10 to 8000) (default 500)
+   gausssize         <int>        ..F.A....T. set the filter size (from 3 to 301) (default 31)
+   g                 <int>        ..F.A....T. set the filter size (from 3 to 301) (default 31)
+   peak              <double>     ..F.A....T. set the peak value (from 0 to 1) (default 0.95)
+   p                 <double>     ..F.A....T. set the peak value (from 0 to 1) (default 0.95)
+   maxgain           <double>     ..F.A....T. set the max amplification (from 1 to 100) (default 10)
+   m                 <double>     ..F.A....T. set the max amplification (from 1 to 100) (default 10)
+   targetrms         <double>     ..F.A....T. set the target RMS (from 0 to 1) (default 0)
+   r                 <double>     ..F.A....T. set the target RMS (from 0 to 1) (default 0)
+   coupling          <boolean>    ..F.A....T. set channel coupling (default true)
+   n                 <boolean>    ..F.A....T. set channel coupling (default true)
+   correctdc         <boolean>    ..F.A....T. set DC correction (default false)
+   c                 <boolean>    ..F.A....T. set DC correction (default false)
+   altboundary       <boolean>    ..F.A....T. set alternative boundary mode (default false)
+   b                 <boolean>    ..F.A....T. set alternative boundary mode (default false)
+   compress          <double>     ..F.A....T. set the compress factor (from 0 to 30) (default 0)
+   s                 <double>     ..F.A....T. set the compress factor (from 0 to 30) (default 0)
+   threshold         <double>     ..F.A....T. set the threshold value (from 0 to 1) (default 0)
+   t                 <double>     ..F.A....T. set the threshold value (from 0 to 1) (default 0)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   h                 <string>     ..F.A....T. set channels to filter (default "all")
+   overlap           <double>     ..F.A....T. set the frame overlap (from 0 to 1) (default 0)
+   o                 <double>     ..F.A....T. set the frame overlap (from 0 to 1) (default 0)
+   curve             <string>     ..F.A....T. set the custom peak mapping curve
+   v                 <string>     ..F.A....T. set the custom peak mapping curve
+
+ebur128 AVOptions:
+   video             <boolean>    ..FV....... set video output (default false)
+   size              <image_size> ..FV....... set video size (default "640x480")
+   meter             <int>        ..FV....... set scale meter (+9 to +18) (from 9 to 18) (default 9)
+   framelog          <int>        ..FVA...... force frame logging level (from INT_MIN to INT_MAX) (default -1)
+     quiet           -8           ..FVA...... logging disabled
+     info            32           ..FVA...... information logging level
+     verbose         40           ..FVA...... verbose logging level
+   metadata          <boolean>    ..FVA...... inject metadata in the filtergraph (default false)
+   peak              <flags>      ..F.A...... set peak mode (default 0)
+     none                         ..F.A...... disable any peak mode
+     sample                       ..F.A...... enable peak-sample mode
+     true                         ..F.A...... enable true-peak mode
+   dualmono          <boolean>    ..F.A...... treat mono input files as dual-mono (default false)
+   panlaw            <double>     ..F.A...... set a specific pan law for dual-mono files (from -10 to 0) (default -3.0103)
+   target            <int>        ..FV....... set a specific target level in LUFS (-23 to 0) (from -23 to 0) (default -23)
+   gauge             <int>        ..FV....... set gauge display type (from 0 to 1) (default momentary)
+     momentary       0            ..FV....... display momentary value
+     m               0            ..FV....... display momentary value
+     shortterm       1            ..FV....... display short-term value
+     s               1            ..FV....... display short-term value
+   scale             <int>        ..FV....... sets display method for the stats (from 0 to 1) (default absolute)
+     absolute        0            ..FV....... display absolute values (LUFS)
+     LUFS            0            ..FV....... display absolute values (LUFS)
+     relative        1            ..FV....... display values relative to target (LU)
+     LU              1            ..FV....... display values relative to target (LU)
+   integrated        <double>     ..F.A.XR... integrated loudness (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
+   range             <double>     ..F.A.XR... loudness range (LU) (from -DBL_MAX to DBL_MAX) (default 0)
+   lra_low           <double>     ..F.A.XR... LRA low (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
+   lra_high          <double>     ..F.A.XR... LRA high (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
+   sample_peak       <double>     ..F.A.XR... sample peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
+   true_peak         <double>     ..F.A.XR... true peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
+
+equalizer AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 0)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 0)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 1)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 1)
+   gain              <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   g                 <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+extrastereo AVOptions:
+   m                 <float>      ..F.A....T. set the difference coefficient (from -10 to 10) (default 2.5)
+   c                 <boolean>    ..F.A....T. enable clipping (default true)
+
+firequalizer AVOptions:
+   gain              <string>     ..F.A....T. set gain curve (default "gain_interpolate(f)")
+   gain_entry        <string>     ..F.A....T. set gain entry
+   delay             <double>     ..F.A...... set delay (from 0 to 1e+10) (default 0.01)
+   accuracy          <double>     ..F.A...... set accuracy (from 0 to 1e+10) (default 5)
+   wfunc             <int>        ..F.A...... set window function (from 0 to 9) (default hann)
+     rectangular     0            ..F.A...... rectangular window
+     hann            1            ..F.A...... hann window
+     hamming         2            ..F.A...... hamming window
+     blackman        3            ..F.A...... blackman window
+     nuttall3        4            ..F.A...... 3-term nuttall window
+     mnuttall3       5            ..F.A...... minimum 3-term nuttall window
+     nuttall         6            ..F.A...... nuttall window
+     bnuttall        7            ..F.A...... blackman-nuttall window
+     bharris         8            ..F.A...... blackman-harris window
+     tukey           9            ..F.A...... tukey window
+   fixed             <boolean>    ..F.A...... set fixed frame samples (default false)
+   multi             <boolean>    ..F.A...... set multi channels mode (default false)
+   zero_phase        <boolean>    ..F.A...... set zero phase mode (default false)
+   scale             <int>        ..F.A...... set gain scale (from 0 to 3) (default linlog)
+     linlin          0            ..F.A...... linear-freq linear-gain
+     linlog          1            ..F.A...... linear-freq logarithmic-gain
+     loglin          2            ..F.A...... logarithmic-freq linear-gain
+     loglog          3            ..F.A...... logarithmic-freq logarithmic-gain
+   dumpfile          <string>     ..F.A...... set dump file
+   dumpscale         <int>        ..F.A...... set dump scale (from 0 to 3) (default linlog)
+     linlin          0            ..F.A...... linear-freq linear-gain
+     linlog          1            ..F.A...... linear-freq logarithmic-gain
+     loglin          2            ..F.A...... logarithmic-freq linear-gain
+     loglog          3            ..F.A...... logarithmic-freq logarithmic-gain
+   fft2              <boolean>    ..F.A...... set 2-channels fft (default false)
+   min_phase         <boolean>    ..F.A...... set minimum phase mode (default false)
+
+flanger AVOptions:
+   delay             <double>     ..F.A...... base delay in milliseconds (from 0 to 30) (default 0)
+   depth             <double>     ..F.A...... added swept delay in milliseconds (from 0 to 10) (default 2)
+   regen             <double>     ..F.A...... percentage regeneration (delayed signal feedback) (from -95 to 95) (default 0)
+   width             <double>     ..F.A...... percentage of delayed signal mixed with original (from 0 to 100) (default 71)
+   speed             <double>     ..F.A...... sweeps per second (Hz) (from 0.1 to 10) (default 0.5)
+   shape             <int>        ..F.A...... swept wave shape (from 0 to 1) (default sinusoidal)
+     triangular      1            ..F.A......
+     t               1            ..F.A......
+     sinusoidal      0            ..F.A......
+     s               0            ..F.A......
+   phase             <double>     ..F.A...... swept wave percentage phase-shift for multi-channel (from 0 to 100) (default 25)
+   interp            <int>        ..F.A...... delay-line interpolation (from 0 to 1) (default linear)
+     linear          0            ..F.A......
+     quadratic       1            ..F.A......
+
+haas AVOptions:
+   level_in          <double>     ..F.A...... set level in (from 0.015625 to 64) (default 1)
+   level_out         <double>     ..F.A...... set level out (from 0.015625 to 64) (default 1)
+   side_gain         <double>     ..F.A...... set side gain (from 0.015625 to 64) (default 1)
+   middle_source     <int>        ..F.A...... set middle source (from 0 to 3) (default mid)
+     left            0            ..F.A......
+     right           1            ..F.A......
+     mid             2            ..F.A...... L+R
+     side            3            ..F.A...... L-R
+   middle_phase      <boolean>    ..F.A...... set middle phase (default false)
+   left_delay        <double>     ..F.A...... set left delay (from 0 to 40) (default 2.05)
+   left_balance      <double>     ..F.A...... set left balance (from -1 to 1) (default -1)
+   left_gain         <double>     ..F.A...... set left gain (from 0.015625 to 64) (default 1)
+   left_phase        <boolean>    ..F.A...... set left phase (default false)
+   right_delay       <double>     ..F.A...... set right delay (from 0 to 40) (default 2.12)
+   right_balance     <double>     ..F.A...... set right balance (from -1 to 1) (default 1)
+   right_gain        <double>     ..F.A...... set right gain (from 0.015625 to 64) (default 1)
+   right_phase       <boolean>    ..F.A...... set right phase (default true)
+
+hdcd AVOptions:
+   disable_autoconvert <boolean>    ..F.A...... Disable any format conversion or resampling in the filter graph. (default true)
+   process_stereo    <boolean>    ..F.A...... Process stereo channels together. Only apply target_gain when both channels match. (default true)
+   cdt_ms            <int>        ..F.A...... Code detect timer period in ms. (from 100 to 60000) (default 2000)
+   force_pe          <boolean>    ..F.A...... Always extend peaks above -3dBFS even when PE is not signaled. (default false)
+   analyze_mode      <int>        ..F.A...... Replace audio with solid tone and signal some processing aspect in the amplitude. (from 0 to 4) (default off)
+     off             0            ..F.A...... disabled
+     lle             1            ..F.A...... gain adjustment level at each sample
+     pe              2            ..F.A...... samples where peak extend occurs
+     cdt             3            ..F.A...... samples where the code detect timer is active
+     tgm             4            ..F.A...... samples where the target gain does not match between channels
+   bits_per_sample   <int>        ..F.A...... Valid bits per sample (location of the true LSB). (from 16 to 24) (default 16)
+     16              16           ..F.A...... 16-bit (in s32 or s16)
+     20              20           ..F.A...... 20-bit (in s32)
+     24              24           ..F.A...... 24-bit (in s32)
+
+headphone AVOptions:
+   map               <string>     ..F.A...... set channels convolution mappings
+   gain              <float>      ..F.A...... set gain in dB (from -20 to 40) (default 0)
+   lfe               <float>      ..F.A...... set lfe gain in dB (from -20 to 40) (default 0)
+   type              <int>        ..F.A...... set processing (from 0 to 1) (default freq)
+     time            0            ..F.A...... time domain
+     freq            1            ..F.A...... frequency domain
+   size              <int>        ..F.A...... set frame size (from 1024 to 96000) (default 1024)
+   hrir              <int>        ..F.A...... set hrir format (from 0 to 1) (default stereo)
+     stereo          0            ..F.A...... hrir files have exactly 2 channels
+     multich         1            ..F.A...... single multichannel hrir file
+
+highpass AVOptions:
+   frequency         <double>     ..F.A....T. set frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.707)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.707)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+treble/high/tiltshelf AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   gain              <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   g                 <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+join AVOptions:
+   inputs            <int>        ..F.A...... Number of input streams. (from 1 to INT_MAX) (default 2)
+   channel_layout    <string>     ..F.A...... Channel layout of the output stream. (default "stereo")
+   map               <string>     ..F.A...... A comma-separated list of channels maps in the format 'input_stream.input_channel-output_channel.
+
+ladspa AVOptions:
+   file              <string>     ..F.A...... set library name or full path
+   f                 <string>     ..F.A...... set library name or full path
+   plugin            <string>     ..F.A...... set plugin name
+   p                 <string>     ..F.A...... set plugin name
+   controls          <string>     ..F.A...... set plugin options
+   c                 <string>     ..F.A...... set plugin options
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   s                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   duration          <duration>   ..F.A...... set audio duration (default -0.000001)
+   d                 <duration>   ..F.A...... set audio duration (default -0.000001)
+   latency           <boolean>    ..F.A...... enable latency compensation (default false)
+   l                 <boolean>    ..F.A...... enable latency compensation (default false)
+
+loudnorm AVOptions:
+   I                 <double>     ..F.A...... set integrated loudness target (from -70 to -5) (default -24)
+   i                 <double>     ..F.A...... set integrated loudness target (from -70 to -5) (default -24)
+   LRA               <double>     ..F.A...... set loudness range target (from 1 to 50) (default 7)
+   lra               <double>     ..F.A...... set loudness range target (from 1 to 50) (default 7)
+   TP                <double>     ..F.A...... set maximum true peak (from -9 to 0) (default -2)
+   tp                <double>     ..F.A...... set maximum true peak (from -9 to 0) (default -2)
+   measured_I        <double>     ..F.A...... measured IL of input file (from -99 to 0) (default 0)
+   measured_i        <double>     ..F.A...... measured IL of input file (from -99 to 0) (default 0)
+   measured_LRA      <double>     ..F.A...... measured LRA of input file (from 0 to 99) (default 0)
+   measured_lra      <double>     ..F.A...... measured LRA of input file (from 0 to 99) (default 0)
+   measured_TP       <double>     ..F.A...... measured true peak of input file (from -99 to 99) (default 99)
+   measured_tp       <double>     ..F.A...... measured true peak of input file (from -99 to 99) (default 99)
+   measured_thresh   <double>     ..F.A...... measured threshold of input file (from -99 to 0) (default -70)
+   offset            <double>     ..F.A...... set offset gain (from -99 to 99) (default 0)
+   linear            <boolean>    ..F.A...... normalize linearly if possible (default true)
+   dual_mono         <boolean>    ..F.A...... treat mono input as dual-mono (default false)
+   print_format      <int>        ..F.A...... set print format for stats (from 0 to 2) (default none)
+     none            0            ..F.A......
+     json            1            ..F.A......
+     summary         2            ..F.A......
+
+lowpass AVOptions:
+   frequency         <double>     ..F.A....T. set frequency (from 0 to 999999) (default 500)
+   f                 <double>     ..F.A....T. set frequency (from 0 to 999999) (default 500)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.707)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.707)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+bass/lowshelf AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 100)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 100)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   gain              <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   g                 <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+lv2 AVOptions:
+   plugin            <string>     ..F.A...... set plugin uri
+   p                 <string>     ..F.A...... set plugin uri
+   controls          <string>     ..F.A...... set plugin options
+   c                 <string>     ..F.A...... set plugin options
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   s                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   duration          <duration>   ..F.A...... set audio duration (default -0.000001)
+   d                 <duration>   ..F.A...... set audio duration (default -0.000001)
+
+mcompand AVOptions:
+   args              <string>     ..F.A...... set parameters for each band (default "0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000")
+
+pan AVOptions:
+   args              <string>     ..F.A......
+
+replaygain AVOptions:
+   track_gain        <float>      ..F.A.XR... track gain (dB) (from -FLT_MAX to FLT_MAX) (default 0)
+   track_peak        <float>      ..F.A.XR... track peak (from -FLT_MAX to FLT_MAX) (default 0)
+
+rubberband AVOptions:
+   tempo             <double>     ..F.A....T. set tempo scale factor (from 0.01 to 100) (default 1)
+   pitch             <double>     ..F.A....T. set pitch scale factor (from 0.01 to 100) (default 1)
+   transients        <int>        ..F.A...... set transients (from 0 to INT_MAX) (default crisp)
+     crisp           0            ..F.A......
+     mixed           256          ..F.A......
+     smooth          512          ..F.A......
+   detector          <int>        ..F.A...... set detector (from 0 to INT_MAX) (default compound)
+     compound        0            ..F.A......
+     percussive      1024         ..F.A......
+     soft            2048         ..F.A......
+   phase             <int>        ..F.A...... set phase (from 0 to INT_MAX) (default laminar)
+     laminar         0            ..F.A......
+     independent     8192         ..F.A......
+   window            <int>        ..F.A...... set window (from 0 to INT_MAX) (default standard)
+     standard        0            ..F.A......
+     short           1048576      ..F.A......
+     long            2097152      ..F.A......
+   smoothing         <int>        ..F.A...... set smoothing (from 0 to INT_MAX) (default off)
+     off             0            ..F.A......
+     on              8388608      ..F.A......
+   formant           <int>        ..F.A...... set formant (from 0 to INT_MAX) (default shifted)
+     shifted         0            ..F.A......
+     preserved       16777216     ..F.A......
+   pitchq            <int>        ..F.A...... set pitch quality (from 0 to INT_MAX) (default speed)
+     quality         33554432     ..F.A......
+     speed           0            ..F.A......
+     consistency     67108864     ..F.A......
+   channels          <int>        ..F.A...... set channels (from 0 to INT_MAX) (default apart)
+     apart           0            ..F.A......
+     together        268435456    ..F.A......
+
+acompressor/sidechaincompress AVOptions:
+   level_in          <double>     ..F.A....T. set input gain (from 0.015625 to 64) (default 1)
+   mode              <int>        ..F.A....T. set mode (from 0 to 1) (default downward)
+     downward        0            ..F.A....T.
+     upward          1            ..F.A....T.
+   threshold         <double>     ..F.A....T. set threshold (from 0.000976563 to 1) (default 0.125)
+   ratio             <double>     ..F.A....T. set ratio (from 1 to 20) (default 2)
+   attack            <double>     ..F.A....T. set attack (from 0.01 to 2000) (default 20)
+   release           <double>     ..F.A....T. set release (from 0.01 to 9000) (default 250)
+   makeup            <double>     ..F.A....T. set make up gain (from 1 to 64) (default 1)
+   knee              <double>     ..F.A....T. set knee (from 1 to 8) (default 2.82843)
+   link              <int>        ..F.A....T. set link type (from 0 to 1) (default average)
+     average         0            ..F.A....T.
+     maximum         1            ..F.A....T.
+   detection         <int>        ..F.A....T. set detection (from 0 to 1) (default rms)
+     peak            0            ..F.A....T.
+     rms             1            ..F.A....T.
+   level_sc          <double>     ..F.A....T. set sidechain gain (from 0.015625 to 64) (default 1)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+
+agate/sidechaingate AVOptions:
+   level_in          <double>     ..F.A....T. set input level (from 0.015625 to 64) (default 1)
+   mode              <int>        ..F.A....T. set mode (from 0 to 1) (default downward)
+     downward        0            ..F.A....T.
+     upward          1            ..F.A....T.
+   range             <double>     ..F.A....T. set max gain reduction (from 0 to 1) (default 0.06125)
+   threshold         <double>     ..F.A....T. set threshold (from 0 to 1) (default 0.125)
+   ratio             <double>     ..F.A....T. set ratio (from 1 to 9000) (default 2)
+   attack            <double>     ..F.A....T. set attack (from 0.01 to 9000) (default 20)
+   release           <double>     ..F.A....T. set release (from 0.01 to 9000) (default 250)
+   makeup            <double>     ..F.A....T. set makeup gain (from 1 to 64) (default 1)
+   knee              <double>     ..F.A....T. set knee (from 1 to 8) (default 2.82843)
+   detection         <int>        ..F.A....T. set detection (from 0 to 1) (default rms)
+     peak            0            ..F.A....T.
+     rms             1            ..F.A....T.
+   link              <int>        ..F.A....T. set link (from 0 to 1) (default average)
+     average         0            ..F.A....T.
+     maximum         1            ..F.A....T.
+   level_sc          <double>     ..F.A....T. set sidechain gain (from 0.015625 to 64) (default 1)
+
+silencedetect AVOptions:
+   n                 <double>     ..F.A...... set noise tolerance (from 0 to DBL_MAX) (default 0.001)
+   noise             <double>     ..F.A...... set noise tolerance (from 0 to DBL_MAX) (default 0.001)
+   d                 <duration>   ..F.A...... set minimum duration in seconds (default 2)
+   duration          <duration>   ..F.A...... set minimum duration in seconds (default 2)
+   mono              <boolean>    ..F.A...... check each channel separately (default false)
+   m                 <boolean>    ..F.A...... check each channel separately (default false)
+
+silenceremove AVOptions:
+   start_periods     <int>        ..F.A...... set periods of silence parts to skip from start (from 0 to 9000) (default 0)
+   start_duration    <duration>   ..F.A...... set start duration of non-silence part (default 0)
+   start_threshold   <double>     ..F.A....T. set threshold for start silence detection (from 0 to DBL_MAX) (default 0)
+   start_silence     <duration>   ..F.A...... set start duration of silence part to keep (default 0)
+   start_mode        <int>        ..F.A....T. set which channel will trigger trimming from start (from 0 to 1) (default any)
+     any             0            ..F.A....T.
+     all             1            ..F.A....T.
+   stop_periods      <int>        ..F.A...... set periods of silence parts to skip from end (from -9000 to 9000) (default 0)
+   stop_duration     <duration>   ..F.A...... set stop duration of silence part (default 0)
+   stop_threshold    <double>     ..F.A....T. set threshold for stop silence detection (from 0 to DBL_MAX) (default 0)
+   stop_silence      <duration>   ..F.A...... set stop duration of silence part to keep (default 0)
+   stop_mode         <int>        ..F.A....T. set which channel will trigger trimming from end (from 0 to 1) (default all)
+     any             0            ..F.A....T.
+     all             1            ..F.A....T.
+   detection         <int>        ..F.A...... set how silence is detected (from 0 to 5) (default rms)
+     avg             0            ..F.A...... use mean absolute values of samples
+     rms             1            ..F.A...... use root mean squared values of samples
+     peak            2            ..F.A...... use max absolute values of samples
+     median          3            ..F.A...... use median of absolute values of samples
+     ptp             4            ..F.A...... use absolute of max peak to min peak difference
+     dev             5            ..F.A...... use standard deviation from values of samples
+   window            <duration>   ..F.A...... set duration of window for silence detection (default 0.02)
+   timestamp         <int>        ..F.A...... set how every output frame timestamp is processed (from 0 to 1) (default write)
+     write           0            ..F.A...... full timestamps rewrite, keep only the start time
+     copy            1            ..F.A...... non-dropped frames are left with same timestamp
+
+sofalizer AVOptions:
+   sofa              <string>     ..F.A...... sofa filename
+   gain              <float>      ..F.A...... set gain in dB (from -20 to 40) (default 0)
+   rotation          <float>      ..F.A...... set rotation (from -360 to 360) (default 0)
+   elevation         <float>      ..F.A...... set elevation (from -90 to 90) (default 0)
+   radius            <float>      ..F.A...... set radius (from 0 to 5) (default 1)
+   type              <int>        ..F.A...... set processing (from 0 to 1) (default freq)
+     time            0            ..F.A...... time domain
+     freq            1            ..F.A...... frequency domain
+   speakers          <string>     ..F.A...... set speaker custom positions
+   lfegain           <float>      ..F.A...... set lfe gain (from -20 to 40) (default 0)
+   framesize         <int>        ..F.A...... set frame size (from 1024 to 96000) (default 1024)
+   normalize         <boolean>    ..F.A...... normalize IRs (default true)
+   interpolate       <boolean>    ..F.A...... interpolate IRs from neighbors (default false)
+   minphase          <boolean>    ..F.A...... minphase IRs (default false)
+   anglestep         <float>      ..F.A...... set neighbor search angle step (from 0.01 to 10) (default 0.5)
+   radstep           <float>      ..F.A...... set neighbor search radius step (from 0.01 to 1) (default 0.01)
+
+speechnorm AVOptions:
+   peak              <double>     ..F.A....T. set the peak value (from 0 to 1) (default 0.95)
+   p                 <double>     ..F.A....T. set the peak value (from 0 to 1) (default 0.95)
+   expansion         <double>     ..F.A....T. set the max expansion factor (from 1 to 50) (default 2)
+   e                 <double>     ..F.A....T. set the max expansion factor (from 1 to 50) (default 2)
+   compression       <double>     ..F.A....T. set the max compression factor (from 1 to 50) (default 2)
+   c                 <double>     ..F.A....T. set the max compression factor (from 1 to 50) (default 2)
+   threshold         <double>     ..F.A....T. set the threshold value (from 0 to 1) (default 0)
+   t                 <double>     ..F.A....T. set the threshold value (from 0 to 1) (default 0)
+   raise             <double>     ..F.A....T. set the expansion raising amount (from 0 to 1) (default 0.001)
+   r                 <double>     ..F.A....T. set the expansion raising amount (from 0 to 1) (default 0.001)
+   fall              <double>     ..F.A....T. set the compression raising amount (from 0 to 1) (default 0.001)
+   f                 <double>     ..F.A....T. set the compression raising amount (from 0 to 1) (default 0.001)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   h                 <string>     ..F.A....T. set channels to filter (default "all")
+   invert            <boolean>    ..F.A....T. set inverted filtering (default false)
+   i                 <boolean>    ..F.A....T. set inverted filtering (default false)
+   link              <boolean>    ..F.A....T. set linked channels filtering (default false)
+   l                 <boolean>    ..F.A....T. set linked channels filtering (default false)
+   rms               <double>     ..F.A....T. set the RMS value (from 0 to 1) (default 0)
+   m                 <double>     ..F.A....T. set the RMS value (from 0 to 1) (default 0)
+
+stereotools AVOptions:
+   level_in          <double>     ..F.A....T. set level in (from 0.015625 to 64) (default 1)
+   level_out         <double>     ..F.A....T. set level out (from 0.015625 to 64) (default 1)
+   balance_in        <double>     ..F.A....T. set balance in (from -1 to 1) (default 0)
+   balance_out       <double>     ..F.A....T. set balance out (from -1 to 1) (default 0)
+   softclip          <boolean>    ..F.A....T. enable softclip (default false)
+   mutel             <boolean>    ..F.A....T. mute L (default false)
+   muter             <boolean>    ..F.A....T. mute R (default false)
+   phasel            <boolean>    ..F.A....T. phase L (default false)
+   phaser            <boolean>    ..F.A....T. phase R (default false)
+   mode              <int>        ..F.A....T. set stereo mode (from 0 to 10) (default lr>lr)
+     lr>lr           0            ..F.A....T.
+     lr>ms           1            ..F.A....T.
+     ms>lr           2            ..F.A....T.
+     lr>ll           3            ..F.A....T.
+     lr>rr           4            ..F.A....T.
+     lr>l+r          5            ..F.A....T.
+     lr>rl           6            ..F.A....T.
+     ms>ll           7            ..F.A....T.
+     ms>rr           8            ..F.A....T.
+     ms>rl           9            ..F.A....T.
+     lr>l-r          10           ..F.A....T.
+   slev              <double>     ..F.A....T. set side level (from 0.015625 to 64) (default 1)
+   sbal              <double>     ..F.A....T. set side balance (from -1 to 1) (default 0)
+   mlev              <double>     ..F.A....T. set middle level (from 0.015625 to 64) (default 1)
+   mpan              <double>     ..F.A....T. set middle pan (from -1 to 1) (default 0)
+   base              <double>     ..F.A....T. set stereo base (from -1 to 1) (default 0)
+   delay             <double>     ..F.A....T. set delay (from -20 to 20) (default 0)
+   sclevel           <double>     ..F.A....T. set S/C level (from 1 to 100) (default 1)
+   phase             <double>     ..F.A....T. set stereo phase (from 0 to 360) (default 0)
+   bmode_in          <int>        ..F.A....T. set balance in mode (from 0 to 2) (default balance)
+     balance         0            ..F.A....T.
+     amplitude       1            ..F.A....T.
+     power           2            ..F.A....T.
+   bmode_out         <int>        ..F.A....T. set balance out mode (from 0 to 2) (default balance)
+     balance         0            ..F.A....T.
+     amplitude       1            ..F.A....T.
+     power           2            ..F.A....T.
+
+stereowiden AVOptions:
+   delay             <float>      ..F.A...... set delay time (from 1 to 100) (default 20)
+   feedback          <float>      ..F.A....T. set feedback gain (from 0 to 0.9) (default 0.3)
+   crossfeed         <float>      ..F.A....T. set cross feed (from 0 to 0.8) (default 0.3)
+   drymix            <float>      ..F.A....T. set dry-mix (from 0 to 1) (default 0.8)
+
+superequalizer AVOptions:
+   1b                <float>      ..F.A...... set 65Hz band gain (from 0 to 20) (default 1)
+   2b                <float>      ..F.A...... set 92Hz band gain (from 0 to 20) (default 1)
+   3b                <float>      ..F.A...... set 131Hz band gain (from 0 to 20) (default 1)
+   4b                <float>      ..F.A...... set 185Hz band gain (from 0 to 20) (default 1)
+   5b                <float>      ..F.A...... set 262Hz band gain (from 0 to 20) (default 1)
+   6b                <float>      ..F.A...... set 370Hz band gain (from 0 to 20) (default 1)
+   7b                <float>      ..F.A...... set 523Hz band gain (from 0 to 20) (default 1)
+   8b                <float>      ..F.A...... set 740Hz band gain (from 0 to 20) (default 1)
+   9b                <float>      ..F.A...... set 1047Hz band gain (from 0 to 20) (default 1)
+   10b               <float>      ..F.A...... set 1480Hz band gain (from 0 to 20) (default 1)
+   11b               <float>      ..F.A...... set 2093Hz band gain (from 0 to 20) (default 1)
+   12b               <float>      ..F.A...... set 2960Hz band gain (from 0 to 20) (default 1)
+   13b               <float>      ..F.A...... set 4186Hz band gain (from 0 to 20) (default 1)
+   14b               <float>      ..F.A...... set 5920Hz band gain (from 0 to 20) (default 1)
+   15b               <float>      ..F.A...... set 8372Hz band gain (from 0 to 20) (default 1)
+   16b               <float>      ..F.A...... set 11840Hz band gain (from 0 to 20) (default 1)
+   17b               <float>      ..F.A...... set 16744Hz band gain (from 0 to 20) (default 1)
+   18b               <float>      ..F.A...... set 20000Hz band gain (from 0 to 20) (default 1)
+
+surround AVOptions:
+   chl_out           <string>     ..F.A...... set output channel layout (default "5.1")
+   chl_in            <string>     ..F.A...... set input channel layout (default "stereo")
+   level_in          <float>      ..F.A....T. set input level (from 0 to 10) (default 1)
+   level_out         <float>      ..F.A....T. set output level (from 0 to 10) (default 1)
+   lfe               <boolean>    ..F.A....T. output LFE (default true)
+   lfe_low           <int>        ..F.A...... LFE low cut off (from 0 to 256) (default 128)
+   lfe_high          <int>        ..F.A...... LFE high cut off (from 0 to 512) (default 256)
+   lfe_mode          <int>        ..F.A....T. set LFE channel mode (from 0 to 1) (default add)
+     add             0            ..F.A....T. just add LFE channel
+     sub             1            ..F.A....T. substract LFE channel with others
+   smooth            <float>      ..F.A....T. set temporal smoothness strength (from 0 to 1) (default 0)
+   angle             <float>      ..F.A....T. set soundfield transform angle (from 0 to 360) (default 90)
+   focus             <float>      ..F.A....T. set soundfield transform focus (from -1 to 1) (default 0)
+   fc_in             <float>      ..F.A....T. set front center channel input level (from 0 to 10) (default 1)
+   fc_out            <float>      ..F.A....T. set front center channel output level (from 0 to 10) (default 1)
+   fl_in             <float>      ..F.A....T. set front left channel input level (from 0 to 10) (default 1)
+   fl_out            <float>      ..F.A....T. set front left channel output level (from 0 to 10) (default 1)
+   fr_in             <float>      ..F.A....T. set front right channel input level (from 0 to 10) (default 1)
+   fr_out            <float>      ..F.A....T. set front right channel output level (from 0 to 10) (default 1)
+   sl_in             <float>      ..F.A....T. set side left channel input level (from 0 to 10) (default 1)
+   sl_out            <float>      ..F.A....T. set side left channel output level (from 0 to 10) (default 1)
+   sr_in             <float>      ..F.A....T. set side right channel input level (from 0 to 10) (default 1)
+   sr_out            <float>      ..F.A....T. set side right channel output level (from 0 to 10) (default 1)
+   bl_in             <float>      ..F.A....T. set back left channel input level (from 0 to 10) (default 1)
+   bl_out            <float>      ..F.A....T. set back left channel output level (from 0 to 10) (default 1)
+   br_in             <float>      ..F.A....T. set back right channel input level (from 0 to 10) (default 1)
+   br_out            <float>      ..F.A....T. set back right channel output level (from 0 to 10) (default 1)
+   bc_in             <float>      ..F.A....T. set back center channel input level (from 0 to 10) (default 1)
+   bc_out            <float>      ..F.A....T. set back center channel output level (from 0 to 10) (default 1)
+   lfe_in            <float>      ..F.A....T. set lfe channel input level (from 0 to 10) (default 1)
+   lfe_out           <float>      ..F.A....T. set lfe channel output level (from 0 to 10) (default 1)
+   allx              <float>      ..F.A....T. set all channel's x spread (from -1 to 15) (default -1)
+   ally              <float>      ..F.A....T. set all channel's y spread (from -1 to 15) (default -1)
+   fcx               <float>      ..F.A....T. set front center channel x spread (from 0.06 to 15) (default 0.5)
+   flx               <float>      ..F.A....T. set front left channel x spread (from 0.06 to 15) (default 0.5)
+   frx               <float>      ..F.A....T. set front right channel x spread (from 0.06 to 15) (default 0.5)
+   blx               <float>      ..F.A....T. set back left channel x spread (from 0.06 to 15) (default 0.5)
+   brx               <float>      ..F.A....T. set back right channel x spread (from 0.06 to 15) (default 0.5)
+   slx               <float>      ..F.A....T. set side left channel x spread (from 0.06 to 15) (default 0.5)
+   srx               <float>      ..F.A....T. set side right channel x spread (from 0.06 to 15) (default 0.5)
+   bcx               <float>      ..F.A....T. set back center channel x spread (from 0.06 to 15) (default 0.5)
+   fcy               <float>      ..F.A....T. set front center channel y spread (from 0.06 to 15) (default 0.5)
+   fly               <float>      ..F.A....T. set front left channel y spread (from 0.06 to 15) (default 0.5)
+   fry               <float>      ..F.A....T. set front right channel y spread (from 0.06 to 15) (default 0.5)
+   bly               <float>      ..F.A....T. set back left channel y spread (from 0.06 to 15) (default 0.5)
+   bry               <float>      ..F.A....T. set back right channel y spread (from 0.06 to 15) (default 0.5)
+   sly               <float>      ..F.A....T. set side left channel y spread (from 0.06 to 15) (default 0.5)
+   sry               <float>      ..F.A....T. set side right channel y spread (from 0.06 to 15) (default 0.5)
+   bcy               <float>      ..F.A....T. set back center channel y spread (from 0.06 to 15) (default 0.5)
+   win_size          <int>        ..F.A...... set window size (from 1024 to 65536) (default 4096)
+   win_func          <int>        ..F.A...... set window function (from 0 to 20) (default hann)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+   overlap           <float>      ..F.A....T. set window overlap (from 0 to 1) (default 0.5)
+
+treble/high/tiltshelf AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   gain              <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   g                 <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+treble/high/tiltshelf AVOptions:
+   frequency         <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   f                 <double>     ..F.A....T. set central frequency (from 0 to 999999) (default 3000)
+   width_type        <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   t                 <int>        ..F.A....T. set filter-width type (from 1 to 5) (default q)
+     h               1            ..F.A....T. Hz
+     q               3            ..F.A....T. Q-Factor
+     o               2            ..F.A....T. octave
+     s               4            ..F.A....T. slope
+     k               5            ..F.A....T. kHz
+   width             <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   w                 <double>     ..F.A....T. set width (from 0 to 99999) (default 0.5)
+   gain              <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   g                 <double>     ..F.A....T. set gain (from -900 to 900) (default 0)
+   poles             <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   p                 <int>        ..F.A...... set number of poles (from 1 to 2) (default 2)
+   mix               <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   m                 <double>     ..F.A....T. set mix (from 0 to 1) (default 1)
+   channels          <string>     ..F.A....T. set channels to filter (default "all")
+   c                 <string>     ..F.A....T. set channels to filter (default "all")
+   normalize         <boolean>    ..F.A....T. normalize coefficients (default false)
+   n                 <boolean>    ..F.A....T. normalize coefficients (default false)
+   transform         <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   a                 <int>        ..F.A...... set transform type (from 0 to 6) (default di)
+     di              0            ..F.A...... direct form I
+     dii             1            ..F.A...... direct form II
+     tdi             2            ..F.A...... transposed direct form I
+     tdii            3            ..F.A...... transposed direct form II
+     latt            4            ..F.A...... lattice-ladder form
+     svf             5            ..F.A...... state variable filter form
+     zdf             6            ..F.A...... zero-delay filter form
+   precision         <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   r                 <int>        ..F.A...... set filtering precision (from -1 to 3) (default auto)
+     auto            -1           ..F.A...... automatic
+     s16             0            ..F.A...... signed 16-bit
+     s32             1            ..F.A...... signed 32-bit
+     f32             2            ..F.A...... floating-point single
+     f64             3            ..F.A...... floating-point double
+   blocksize         <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+   b                 <int>        ..F.A...... set the block size (from 0 to 32768) (default 0)
+
+tremolo AVOptions:
+   f                 <double>     ..F.A...... set frequency in hertz (from 0.1 to 20000) (default 5)
+   d                 <double>     ..F.A...... set depth as percentage (from 0 to 1) (default 0.5)
+
+vibrato AVOptions:
+   f                 <double>     ..F.A...... set frequency in hertz (from 0.1 to 20000) (default 5)
+   d                 <double>     ..F.A...... set depth as percentage (from 0 to 1) (default 0.5)
+
+virtualbass AVOptions:
+   cutoff            <double>     ..F.A...... set virtual bass cutoff (from 100 to 500) (default 250)
+   strength          <double>     ..F.A....T. set virtual bass strength (from 0.5 to 3) (default 3)
+
+volume AVOptions:
+   volume            <string>     ..F.A....T. set volume adjustment expression (default "1.0")
+   precision         <int>        ..F.A...... select mathematical precision (from 0 to 2) (default float)
+     fixed           0            ..F.A...... select 8-bit fixed-point
+     float           1            ..F.A...... select 32-bit floating-point
+     double          2            ..F.A...... select 64-bit floating-point
+   eval              <int>        ..F.A...... specify when to evaluate expressions (from 0 to 1) (default once)
+     once            0            ..F.A...... eval volume expression once
+     frame           1            ..F.A...... eval volume expression per-frame
+   replaygain        <int>        ..F.A...... Apply replaygain side data when present (from 0 to 3) (default drop)
+     drop            0            ..F.A...... replaygain side data is dropped
+     ignore          1            ..F.A...... replaygain side data is ignored
+     track           2            ..F.A...... track gain is preferred
+     album           3            ..F.A...... album gain is preferred
+   replaygain_preamp <double>     ..F.A...... Apply replaygain pre-amplification (from -15 to 15) (default 0)
+   replaygain_noclip <boolean>    ..F.A...... Apply replaygain clipping prevention (default true)
+
+aevalsrc AVOptions:
+   exprs             <string>     ..F.A...... set the '|'-separated list of channels expressions
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 0 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 0 to INT_MAX) (default 1024)
+   sample_rate       <string>     ..F.A...... set the sample rate (default "44100")
+   s                 <string>     ..F.A...... set the sample rate (default "44100")
+   duration          <duration>   ..F.A...... set audio duration (default -0.000001)
+   d                 <duration>   ..F.A...... set audio duration (default -0.000001)
+   channel_layout    <string>     ..F.A...... set channel layout
+   c                 <string>     ..F.A...... set channel layout
+
+afdelaysrc AVOptions:
+   delay             <double>     ..F.A...... set fractional delay (from 0 to 32767) (default 0)
+   d                 <double>     ..F.A...... set fractional delay (from 0 to 32767) (default 0)
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   taps              <int>        ..F.A...... set number of taps for delay filter (from 0 to 32768) (default 0)
+   t                 <int>        ..F.A...... set number of taps for delay filter (from 0 to 32768) (default 0)
+   channel_layout    <string>     ..F.A...... set channel layout (default "stereo")
+   c                 <string>     ..F.A...... set channel layout (default "stereo")
+
+afireqsrc AVOptions:
+   preset            <int>        ..F.A...... set equalizer preset (from -1 to 17) (default flat)
+     custom          -1           ..F.A......
+     flat            0            ..F.A......
+     acoustic        1            ..F.A......
+     bass            2            ..F.A......
+     beats           3            ..F.A......
+     classic         4            ..F.A......
+     clear           5            ..F.A......
+     deep bass       6            ..F.A......
+     dubstep         7            ..F.A......
+     electronic      8            ..F.A......
+     hardstyle       9            ..F.A......
+     hip-hop         10           ..F.A......
+     jazz            11           ..F.A......
+     metal           12           ..F.A......
+     movie           13           ..F.A......
+     pop             14           ..F.A......
+     r&b             15           ..F.A......
+     rock            16           ..F.A......
+     vocal booster   17           ..F.A......
+   p                 <int>        ..F.A...... set equalizer preset (from -1 to 17) (default flat)
+     custom          -1           ..F.A......
+     flat            0            ..F.A......
+     acoustic        1            ..F.A......
+     bass            2            ..F.A......
+     beats           3            ..F.A......
+     classic         4            ..F.A......
+     clear           5            ..F.A......
+     deep bass       6            ..F.A......
+     dubstep         7            ..F.A......
+     electronic      8            ..F.A......
+     hardstyle       9            ..F.A......
+     hip-hop         10           ..F.A......
+     jazz            11           ..F.A......
+     metal           12           ..F.A......
+     movie           13           ..F.A......
+     pop             14           ..F.A......
+     r&b             15           ..F.A......
+     rock            16           ..F.A......
+     vocal booster   17           ..F.A......
+   gains             <string>     ..F.A...... set gain values per band (default "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0")
+   g                 <string>     ..F.A...... set gain values per band (default "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0")
+   bands             <string>     ..F.A...... set central frequency values per band (default "25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000")
+   b                 <string>     ..F.A...... set central frequency values per band (default "25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000")
+   taps              <int>        ..F.A...... set number of taps (from 16 to 65535) (default 4096)
+   t                 <int>        ..F.A...... set number of taps (from 16 to 65535) (default 4096)
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   interp            <int>        ..F.A...... set the interpolation (from 0 to 1) (default linear)
+     linear          0            ..F.A......
+     cubic           1            ..F.A......
+   i                 <int>        ..F.A...... set the interpolation (from 0 to 1) (default linear)
+     linear          0            ..F.A......
+     cubic           1            ..F.A......
+   phase             <int>        ..F.A...... set the phase (from 0 to 1) (default min)
+     linear          0            ..F.A...... linear phase
+     min             1            ..F.A...... minimum phase
+   h                 <int>        ..F.A...... set the phase (from 0 to 1) (default min)
+     linear          0            ..F.A...... linear phase
+     min             1            ..F.A...... minimum phase
+
+afirsrc AVOptions:
+   taps              <int>        ..F.A...... set number of taps (from 9 to 65535) (default 1025)
+   t                 <int>        ..F.A...... set number of taps (from 9 to 65535) (default 1025)
+   frequency         <string>     ..F.A...... set frequency points (default "0 1")
+   f                 <string>     ..F.A...... set frequency points (default "0 1")
+   magnitude         <string>     ..F.A...... set magnitude values (default "1 1")
+   m                 <string>     ..F.A...... set magnitude values (default "1 1")
+   phase             <string>     ..F.A...... set phase values (default "0 0")
+   p                 <string>     ..F.A...... set phase values (default "0 0")
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   win_func          <int>        ..F.A...... set window function (from 0 to 20) (default blackman)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+   w                 <int>        ..F.A...... set window function (from 0 to 20) (default blackman)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+
+anoisesrc AVOptions:
+   sample_rate       <int>        ..F.A...... set sample rate (from 15 to INT_MAX) (default 48000)
+   r                 <int>        ..F.A...... set sample rate (from 15 to INT_MAX) (default 48000)
+   amplitude         <double>     ..F.A...... set amplitude (from 0 to 1) (default 1)
+   a                 <double>     ..F.A...... set amplitude (from 0 to 1) (default 1)
+   duration          <duration>   ..F.A...... set duration (default 0)
+   d                 <duration>   ..F.A...... set duration (default 0)
+   color             <int>        ..F.A...... set noise color (from 0 to 5) (default white)
+     white           0            ..F.A......
+     pink            1            ..F.A......
+     brown           2            ..F.A......
+     blue            3            ..F.A......
+     violet          4            ..F.A......
+     velvet          5            ..F.A......
+   colour            <int>        ..F.A...... set noise color (from 0 to 5) (default white)
+     white           0            ..F.A......
+     pink            1            ..F.A......
+     brown           2            ..F.A......
+     blue            3            ..F.A......
+     violet          4            ..F.A......
+     velvet          5            ..F.A......
+   c                 <int>        ..F.A...... set noise color (from 0 to 5) (default white)
+     white           0            ..F.A......
+     pink            1            ..F.A......
+     brown           2            ..F.A......
+     blue            3            ..F.A......
+     violet          4            ..F.A......
+     velvet          5            ..F.A......
+   seed              <int64>      ..F.A...... set random seed (from -1 to UINT32_MAX) (default -1)
+   s                 <int64>      ..F.A...... set random seed (from -1 to UINT32_MAX) (default -1)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   density           <double>     ..F.A...... set density (from 0 to 1) (default 0.05)
+
+anullsrc AVOptions:
+   channel_layout    <string>     ..F.A...... set channel_layout (default "stereo")
+   cl                <string>     ..F.A...... set channel_layout (default "stereo")
+   sample_rate       <string>     ..F.A...... set sample rate (default "44100")
+   r                 <string>     ..F.A...... set sample rate (default "44100")
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to 65535) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to 65535) (default 1024)
+   duration          <duration>   ..F.A...... set the audio duration (default -0.000001)
+   d                 <duration>   ..F.A...... set the audio duration (default -0.000001)
+
+flite AVOptions:
+   list_voices       <boolean>    ..F.A...... list voices and exit (default false)
+   nb_samples        <int>        ..F.A...... set number of samples per frame (from 0 to INT_MAX) (default 512)
+   n                 <int>        ..F.A...... set number of samples per frame (from 0 to INT_MAX) (default 512)
+   text              <string>     ..F.A...... set text to speak
+   textfile          <string>     ..F.A...... set filename of the text to speak
+   v                 <string>     ..F.A...... set voice (default "kal")
+   voice             <string>     ..F.A...... set voice (default "kal")
+
+hilbert AVOptions:
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   taps              <int>        ..F.A...... set number of taps (from 11 to 65535) (default 22051)
+   t                 <int>        ..F.A...... set number of taps (from 11 to 65535) (default 22051)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   win_func          <int>        ..F.A...... set window function (from 0 to 20) (default blackman)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+   w                 <int>        ..F.A...... set window function (from 0 to 20) (default blackman)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+
+sinc AVOptions:
+   sample_rate       <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set sample rate (from 1 to INT_MAX) (default 44100)
+   nb_samples        <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   n                 <int>        ..F.A...... set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+   hp                <float>      ..F.A...... set high-pass filter frequency (from 0 to INT_MAX) (default 0)
+   lp                <float>      ..F.A...... set low-pass filter frequency (from 0 to INT_MAX) (default 0)
+   phase             <float>      ..F.A...... set filter phase response (from 0 to 100) (default 50)
+   beta              <float>      ..F.A...... set kaiser window beta (from -1 to 256) (default -1)
+   att               <float>      ..F.A...... set stop-band attenuation (from 40 to 180) (default 120)
+   round             <boolean>    ..F.A...... enable rounding (default false)
+   hptaps            <int>        ..F.A...... set number of taps for high-pass filter (from 0 to 32768) (default 0)
+   lptaps            <int>        ..F.A...... set number of taps for low-pass filter (from 0 to 32768) (default 0)
+
+sine AVOptions:
+   frequency         <double>     ..F.A...... set the sine frequency (from 0 to DBL_MAX) (default 440)
+   f                 <double>     ..F.A...... set the sine frequency (from 0 to DBL_MAX) (default 440)
+   beep_factor       <double>     ..F.A...... set the beep frequency factor (from 0 to DBL_MAX) (default 0)
+   b                 <double>     ..F.A...... set the beep frequency factor (from 0 to DBL_MAX) (default 0)
+   sample_rate       <int>        ..F.A...... set the sample rate (from 1 to INT_MAX) (default 44100)
+   r                 <int>        ..F.A...... set the sample rate (from 1 to INT_MAX) (default 44100)
+   duration          <duration>   ..F.A...... set the audio duration (default 0)
+   d                 <duration>   ..F.A...... set the audio duration (default 0)
+   samples_per_frame <string>     ..F.A...... set the number of samples per frame (default "1024")
+
+addroi AVOptions:
+   x                 <string>     ..FV....... Region distance from left edge of frame. (default "0")
+   y                 <string>     ..FV....... Region distance from top edge of frame. (default "0")
+   w                 <string>     ..FV....... Region width. (default "0")
+   h                 <string>     ..FV....... Region height. (default "0")
+   qoffset           <rational>   ..FV....... Quantisation offset to apply in the region. (from -1 to 1) (default -1/10)
+   clear             <boolean>    ..FV....... Remove any existing regions of interest before adding the new one. (default false)
+
+alphamerge AVOptions:
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+amplify AVOptions:
+   radius            <int>        ..FV....... set radius (from 1 to 63) (default 2)
+   factor            <float>      ..FV.....T. set factor (from 0 to 65535) (default 2)
+   threshold         <float>      ..FV.....T. set threshold (from 0 to 65535) (default 10)
+   tolerance         <float>      ..FV.....T. set tolerance (from 0 to 65535) (default 0)
+   low               <float>      ..FV.....T. set low limit for amplification (from 0 to 65535) (default 65535)
+   high              <float>      ..FV.....T. set high limit for amplification (from 0 to 65535) (default 65535)
+   planes            <flags>      ..FV.....T. set what planes to filter (default 7)
+
+ass AVOptions:
+   filename          <string>     ..FV....... set the filename of file to read
+   f                 <string>     ..FV....... set the filename of file to read
+   original_size     <image_size> ..FV....... set the size of the original video (used to scale fonts)
+   fontsdir          <string>     ..FV....... set the directory containing the fonts to read
+   alpha             <boolean>    ..FV....... enable processing of alpha channel (default false)
+   shaping           <int>        ..FV....... set shaping engine (from -1 to 1) (default auto)
+     auto            -1           ..FV.......
+     simple          0            ..FV....... simple shaping
+     complex         1            ..FV....... complex shaping
+
+atadenoise AVOptions:
+   0a                <float>      ..FV.....T. set threshold A for 1st plane (from 0 to 0.3) (default 0.02)
+   0b                <float>      ..FV.....T. set threshold B for 1st plane (from 0 to 5) (default 0.04)
+   1a                <float>      ..FV.....T. set threshold A for 2nd plane (from 0 to 0.3) (default 0.02)
+   1b                <float>      ..FV.....T. set threshold B for 2nd plane (from 0 to 5) (default 0.04)
+   2a                <float>      ..FV.....T. set threshold A for 3rd plane (from 0 to 0.3) (default 0.02)
+   2b                <float>      ..FV.....T. set threshold B for 3rd plane (from 0 to 5) (default 0.04)
+   s                 <int>        ..FV....... set how many frames to use (from 5 to 129) (default 9)
+   p                 <flags>      ..FV.....T. set what planes to filter (default 7)
+   a                 <int>        ..FV.....T. set variant of algorithm (from 0 to 1) (default p)
+     p               0            ..FV.....T. parallel
+     s               1            ..FV.....T. serial
+   0s                <float>      ..FV.....T. set sigma for 1st plane (from 0 to 32767) (default 32767)
+   1s                <float>      ..FV.....T. set sigma for 2nd plane (from 0 to 32767) (default 32767)
+   2s                <float>      ..FV.....T. set sigma for 3rd plane (from 0 to 32767) (default 32767)
+
+avgblur AVOptions:
+   sizeX             <int>        ..FV.....T. set horizontal size (from 1 to 1024) (default 1)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   sizeY             <int>        ..FV.....T. set vertical size (from 0 to 1024) (default 0)
+
+avgblur_opencl AVOptions:
+   sizeX             <int>        ..FV....... set horizontal size (from 1 to 1024) (default 1)
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 15)
+   sizeY             <int>        ..FV....... set vertical size (from 0 to 1024) (default 0)
+
+avgblur_vulkan AVOptions:
+   sizeX             <int>        ..FV....... Set horizontal radius (from 1 to 32) (default 3)
+   sizeY             <int>        ..FV....... Set vertical radius (from 1 to 32) (default 3)
+   planes            <int>        ..FV....... Set planes to filter (bitmask) (from 0 to 15) (default 15)
+
+backgroundkey AVOptions:
+   threshold         <float>      ..FV.....T. set the scene change threshold (from 0 to 1) (default 0.08)
+   similarity        <float>      ..FV.....T. set the similarity (from 0 to 1) (default 0.1)
+   blend             <float>      ..FV.....T. set the blend value (from 0 to 1) (default 0)
+
+bbox AVOptions:
+   min_val           <int>        ..FV.....T. set minimum luminance value for bounding box (from 0 to 65535) (default 16)
+
+bench AVOptions:
+   action            <int>        ..FV....... set action (from 0 to 1) (default start)
+     start           0            ..FV....... start timer
+     stop            1            ..FV....... stop timer
+
+bilateral AVOptions:
+   sigmaS            <float>      ..FV.....T. set spatial sigma (from 0 to 512) (default 0.1)
+   sigmaR            <float>      ..FV.....T. set range sigma (from 0 to 1) (default 0.1)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 1)
+
+cudabilateral AVOptions:
+   sigmaS            <float>      ..FV....... set spatial sigma (from 0.1 to 512) (default 0.1)
+   sigmaR            <float>      ..FV....... set range sigma (from 0.1 to 512) (default 0.1)
+   window_size       <int>        ..FV....... set neighbours window_size (from 1 to 255) (default 1)
+
+bitplanenoise AVOptions:
+   bitplane          <int>        ..FV....... set bit plane to use for measuring noise (from 1 to 16) (default 1)
+   filter            <boolean>    ..FV....... show noisy pixels (default false)
+
+blackdetect AVOptions:
+   d                 <double>     ..FV....... set minimum detected black duration in seconds (from 0 to DBL_MAX) (default 2)
+   black_min_duration <double>     ..FV....... set minimum detected black duration in seconds (from 0 to DBL_MAX) (default 2)
+   picture_black_ratio_th <double>     ..FV....... set the picture black ratio threshold (from 0 to 1) (default 0.98)
+   pic_th            <double>     ..FV....... set the picture black ratio threshold (from 0 to 1) (default 0.98)
+   pixel_black_th    <double>     ..FV....... set the pixel black threshold (from 0 to 1) (default 0.1)
+   pix_th            <double>     ..FV....... set the pixel black threshold (from 0 to 1) (default 0.1)
+
+blackframe AVOptions:
+   amount            <int>        ..FV....... percentage of the pixels that have to be below the threshold for the frame to be considered black (from 0 to 100) (default 98)
+   threshold         <int>        ..FV....... threshold below which a pixel value is considered black (from 0 to 255) (default 32)
+   thresh            <int>        ..FV....... threshold below which a pixel value is considered black (from 0 to 255) (default 32)
+
+blend AVOptions:
+   c0_mode           <int>        ..FV.....T. set component #0 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c1_mode           <int>        ..FV.....T. set component #1 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c2_mode           <int>        ..FV.....T. set component #2 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c3_mode           <int>        ..FV.....T. set component #3 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   all_mode          <int>        ..FV.....T. set blend mode for all components (from -1 to 39) (default -1)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c0_expr           <string>     ..FV.....T. set color component #0 expression
+   c1_expr           <string>     ..FV.....T. set color component #1 expression
+   c2_expr           <string>     ..FV.....T. set color component #2 expression
+   c3_expr           <string>     ..FV.....T. set color component #3 expression
+   all_expr          <string>     ..FV.....T. set expression for all color components
+   c0_opacity        <double>     ..FV.....T. set color component #0 opacity (from 0 to 1) (default 1)
+   c1_opacity        <double>     ..FV.....T. set color component #1 opacity (from 0 to 1) (default 1)
+   c2_opacity        <double>     ..FV.....T. set color component #2 opacity (from 0 to 1) (default 1)
+   c3_opacity        <double>     ..FV.....T. set color component #3 opacity (from 0 to 1) (default 1)
+   all_opacity       <double>     ..FV.....T. set opacity for all color components (from 0 to 1) (default 1)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+blend_vulkan AVOptions:
+   c0_mode           <int>        ..FV....... set component #0 blend mode (from 0 to 39) (default normal)
+     normal          0            ..FV....... 
+     multiply        13           ..FV....... 
+   c1_mode           <int>        ..FV....... set component #1 blend mode (from 0 to 39) (default normal)
+     normal          0            ..FV....... 
+     multiply        13           ..FV....... 
+   c2_mode           <int>        ..FV....... set component #2 blend mode (from 0 to 39) (default normal)
+     normal          0            ..FV....... 
+     multiply        13           ..FV....... 
+   c3_mode           <int>        ..FV....... set component #3 blend mode (from 0 to 39) (default normal)
+     normal          0            ..FV....... 
+     multiply        13           ..FV....... 
+   all_mode          <int>        ..FV....... set blend mode for all components (from -1 to 39) (default -1)
+     normal          0            ..FV....... 
+     multiply        13           ..FV....... 
+   c0_opacity        <double>     ..FV....... set color component #0 opacity (from 0 to 1) (default 1)
+   c1_opacity        <double>     ..FV....... set color component #1 opacity (from 0 to 1) (default 1)
+   c2_opacity        <double>     ..FV....... set color component #2 opacity (from 0 to 1) (default 1)
+   c3_opacity        <double>     ..FV....... set color component #3 opacity (from 0 to 1) (default 1)
+   all_opacity       <double>     ..FV....... set opacity for all color components (from 0 to 1) (default 1)
+
+blockdetect AVOptions:
+   period_min        <int>        ..FV....... Minimum period to search for (from 2 to 32) (default 3)
+   period_max        <int>        ..FV....... Maximum period to search for (from 2 to 64) (default 24)
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 1)
+
+blurdetect AVOptions:
+   high              <float>      ..FV....... set high threshold (from 0 to 1) (default 0.117647)
+   low               <float>      ..FV....... set low threshold (from 0 to 1) (default 0.0588235)
+   radius            <int>        ..FV....... search radius for maxima detection (from 1 to 100) (default 50)
+   block_pct         <int>        ..FV....... block pooling threshold when calculating blurriness (from 1 to 100) (default 80)
+   block_width       <int>        ..FV....... block size for block-based abbreviation of blurriness (from -1 to INT_MAX) (default -1)
+   block_height      <int>        ..FV....... block size for block-based abbreviation of blurriness (from -1 to INT_MAX) (default -1)
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 1)
+
+bm3d AVOptions:
+   sigma             <float>      ..FV....... set denoising strength (from 0 to 99999.9) (default 1)
+   block             <int>        ..FV....... set size of local patch (from 8 to 64) (default 16)
+   bstep             <int>        ..FV....... set sliding step for processing blocks (from 1 to 64) (default 4)
+   group             <int>        ..FV....... set maximal number of similar blocks (from 1 to 256) (default 1)
+   range             <int>        ..FV....... set block matching range (from 1 to INT_MAX) (default 9)
+   mstep             <int>        ..FV....... set step for block matching (from 1 to 64) (default 1)
+   thmse             <float>      ..FV....... set threshold of mean square error for block matching (from 0 to INT_MAX) (default 0)
+   hdthr             <float>      ..FV....... set hard threshold for 3D transfer domain (from 0 to INT_MAX) (default 2.7)
+   estim             <int>        ..FV....... set filtering estimation mode (from 0 to 1) (default basic)
+     basic           0            ..FV....... basic estimate
+     final           1            ..FV....... final estimate
+   ref               <boolean>    ..FV....... have reference stream (default false)
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 7)
+
+boxblur AVOptions:
+   luma_radius       <string>     ..FV....... Radius of the luma blurring box (default "2")
+   lr                <string>     ..FV....... Radius of the luma blurring box (default "2")
+   luma_power        <int>        ..FV....... How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
+   lp                <int>        ..FV....... How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
+   chroma_radius     <string>     ..FV....... Radius of the chroma blurring box
+   cr                <string>     ..FV....... Radius of the chroma blurring box
+   chroma_power      <int>        ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+   cp                <int>        ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+   alpha_radius      <string>     ..FV....... Radius of the alpha blurring box
+   ar                <string>     ..FV....... Radius of the alpha blurring box
+   alpha_power       <int>        ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+   ap                <int>        ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+
+boxblur_opencl AVOptions:
+   luma_radius       <string>     ..FV....... Radius of the luma blurring box (default "2")
+   lr                <string>     ..FV....... Radius of the luma blurring box (default "2")
+   luma_power        <int>        ..FV....... How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
+   lp                <int>        ..FV....... How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
+   chroma_radius     <string>     ..FV....... Radius of the chroma blurring box
+   cr                <string>     ..FV....... Radius of the chroma blurring box
+   chroma_power      <int>        ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+   cp                <int>        ..FV....... How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+   alpha_radius      <string>     ..FV....... Radius of the alpha blurring box
+   ar                <string>     ..FV....... Radius of the alpha blurring box
+   alpha_power       <int>        ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+   ap                <int>        ..FV....... How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+
+bwdif AVOptions:
+   mode              <int>        ..FV....... specify the interlacing mode (from 0 to 1) (default send_field)
+     send_frame      0            ..FV....... send one frame for each frame
+     send_field      1            ..FV....... send one frame for each field
+   parity            <int>        ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV....... assume top field first
+     bff             1            ..FV....... assume bottom field first
+     auto            -1           ..FV....... auto detect parity
+   deint             <int>        ..FV....... specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV....... deinterlace all frames
+     interlaced      1            ..FV....... only deinterlace frames marked as interlaced
+
+bwdif_cuda AVOptions:
+   mode              <int>        ..FV....... specify the interlacing mode (from 0 to 3) (default send_frame)
+     send_frame      0            ..FV....... send one frame for each frame
+     send_field      1            ..FV....... send one frame for each field
+     send_frame_nospatial 2            ..FV....... send one frame for each frame, but skip spatial interlacing check
+     send_field_nospatial 3            ..FV....... send one frame for each field, but skip spatial interlacing check
+   parity            <int>        ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV....... assume top field first
+     bff             1            ..FV....... assume bottom field first
+     auto            -1           ..FV....... auto detect parity
+   deint             <int>        ..FV....... specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV....... deinterlace all frames
+     interlaced      1            ..FV....... only deinterlace frames marked as interlaced
+
+bwdif_vulkan AVOptions:
+   mode              <int>        ..FV....... specify the interlacing mode (from 0 to 3) (default send_frame)
+     send_frame      0            ..FV....... send one frame for each frame
+     send_field      1            ..FV....... send one frame for each field
+     send_frame_nospatial 2            ..FV....... send one frame for each frame, but skip spatial interlacing check
+     send_field_nospatial 3            ..FV....... send one frame for each field, but skip spatial interlacing check
+   parity            <int>        ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV....... assume top field first
+     bff             1            ..FV....... assume bottom field first
+     auto            -1           ..FV....... auto detect parity
+   deint             <int>        ..FV....... specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV....... deinterlace all frames
+     interlaced      1            ..FV....... only deinterlace frames marked as interlaced
+
+cas AVOptions:
+   strength          <float>      ..FV.....T. set the sharpening strength (from 0 to 1) (default 0)
+   planes            <flags>      ..FV.....T. set what planes to filter (default 7)
+
+ccrepack AVOptions:
+
+chromaber_vulkan AVOptions:
+   dist_x            <float>      ..FV....... Set horizontal distortion amount (from -10 to 10) (default 0)
+   dist_y            <float>      ..FV....... Set vertical distortion amount (from -10 to 10) (default 0)
+
+chromahold AVOptions:
+   color             <color>      ..FV.....T. set the chromahold key color (default "black")
+   similarity        <float>      ..FV.....T. set the chromahold similarity value (from 1e-05 to 1) (default 0.01)
+   blend             <float>      ..FV.....T. set the chromahold blend value (from 0 to 1) (default 0)
+   yuv               <boolean>    ..FV.....T. color parameter is in yuv instead of rgb (default false)
+
+chromakey AVOptions:
+   color             <color>      ..FV.....T. set the chromakey key color (default "black")
+   similarity        <float>      ..FV.....T. set the chromakey similarity value (from 1e-05 to 1) (default 0.01)
+   blend             <float>      ..FV.....T. set the chromakey key blend value (from 0 to 1) (default 0)
+   yuv               <boolean>    ..FV.....T. color parameter is in yuv instead of rgb (default false)
+
+cudachromakey AVOptions:
+   color             <color>      ..FV....... set the chromakey key color (default "black")
+   similarity        <float>      ..FV....... set the chromakey similarity value (from 0.01 to 1) (default 0.01)
+   blend             <float>      ..FV....... set the chromakey key blend value (from 0 to 1) (default 0)
+   yuv               <boolean>    ..FV....... color parameter is in yuv instead of rgb (default false)
+
+chromanr AVOptions:
+   thres             <float>      ..FV.....T. set y+u+v threshold (from 1 to 200) (default 30)
+   sizew             <int>        ..FV.....T. set horizontal patch size (from 1 to 100) (default 5)
+   sizeh             <int>        ..FV.....T. set vertical patch size (from 1 to 100) (default 5)
+   stepw             <int>        ..FV.....T. set horizontal step (from 1 to 50) (default 1)
+   steph             <int>        ..FV.....T. set vertical step (from 1 to 50) (default 1)
+   threy             <float>      ..FV.....T. set y threshold (from 1 to 200) (default 200)
+   threu             <float>      ..FV.....T. set u threshold (from 1 to 200) (default 200)
+   threv             <float>      ..FV.....T. set v threshold (from 1 to 200) (default 200)
+   distance          <int>        ..FV.....T. set distance type (from 0 to 1) (default manhattan)
+     manhattan       0            ..FV.....T. 
+     euclidean       1            ..FV.....T. 
+
+chromashift AVOptions:
+   cbh               <int>        ..FV.....T. shift chroma-blue horizontally (from -255 to 255) (default 0)
+   cbv               <int>        ..FV.....T. shift chroma-blue vertically (from -255 to 255) (default 0)
+   crh               <int>        ..FV.....T. shift chroma-red horizontally (from -255 to 255) (default 0)
+   crv               <int>        ..FV.....T. shift chroma-red vertically (from -255 to 255) (default 0)
+   edge              <int>        ..FV.....T. set edge operation (from 0 to 1) (default smear)
+     smear           0            ..FV.....T.
+     wrap            1            ..FV.....T.
+
+ciescope AVOptions:
+   system            <int>        ..FV....... set color system (from 0 to 9) (default hdtv)
+     ntsc            0            ..FV....... NTSC 1953 Y'I'O' (ITU-R BT.470 System M)
+     470m            0            ..FV....... NTSC 1953 Y'I'O' (ITU-R BT.470 System M)
+     ebu             1            ..FV....... EBU Y'U'V' (PAL/SECAM) (ITU-R BT.470 System B, G)
+     470bg           1            ..FV....... EBU Y'U'V' (PAL/SECAM) (ITU-R BT.470 System B, G)
+     smpte           2            ..FV....... SMPTE-C RGB
+     240m            3            ..FV....... SMPTE-240M Y'PbPr
+     apple           4            ..FV....... Apple RGB
+     widergb         5            ..FV....... Adobe Wide Gamut RGB
+     cie1931         6            ..FV....... CIE 1931 RGB
+     hdtv            7            ..FV....... ITU.BT-709 Y'CbCr
+     rec709          7            ..FV....... ITU.BT-709 Y'CbCr
+     uhdtv           8            ..FV....... ITU-R.BT-2020
+     rec2020         8            ..FV....... ITU-R.BT-2020
+     dcip3           9            ..FV....... DCI-P3
+   cie               <int>        ..FV....... set cie system (from 0 to 2) (default xyy)
+     xyy             0            ..FV....... CIE 1931 xyY
+     ucs             1            ..FV....... CIE 1960 UCS
+     luv             2            ..FV....... CIE 1976 Luv
+   gamuts            <flags>      ..FV....... set what gamuts to draw (default 0)
+     ntsc                         ..FV.......
+     470m                         ..FV.......
+     ebu                          ..FV.......
+     470bg                        ..FV.......
+     smpte                        ..FV.......
+     240m                         ..FV.......
+     apple                        ..FV.......
+     widergb                      ..FV.......
+     cie1931                      ..FV.......
+     hdtv                         ..FV.......
+     rec709                       ..FV.......
+     uhdtv                        ..FV.......
+     rec2020                      ..FV.......
+     dcip3                        ..FV.......
+   size              <int>        ..FV....... set ciescope size (from 256 to 8192) (default 512)
+   s                 <int>        ..FV....... set ciescope size (from 256 to 8192) (default 512)
+   intensity         <float>      ..FV....... set ciescope intensity (from 0 to 1) (default 0.001)
+   i                 <float>      ..FV....... set ciescope intensity (from 0 to 1) (default 0.001)
+   contrast          <float>      ..FV....... (from 0 to 1) (default 0.75)
+   corrgamma         <boolean>    ..FV....... (default true)
+   showwhite         <boolean>    ..FV....... (default false)
+   gamma             <double>     ..FV....... (from 0.1 to 6) (default 2.6)
+   fill              <boolean>    ..FV....... fill with CIE colors (default true)
+
+codecview AVOptions:
+   mv                <flags>      ..FV....... set motion vectors to visualize (default 0)
+     pf                           ..FV....... forward predicted MVs of P-frames
+     bf                           ..FV....... forward predicted MVs of B-frames
+     bb                           ..FV....... backward predicted MVs of B-frames
+   qp                <boolean>    ..FV....... (default false)
+   mv_type           <flags>      ..FV....... set motion vectors type (default 0)
+     fp                           ..FV....... forward predicted MVs
+     bp                           ..FV....... backward predicted MVs
+   mvt               <flags>      ..FV....... set motion vectors type (default 0)
+     fp                           ..FV....... forward predicted MVs
+     bp                           ..FV....... backward predicted MVs
+   frame_type        <flags>      ..FV....... set frame types to visualize motion vectors of (default 0)
+     if                           ..FV....... I-frames
+     pf                           ..FV....... P-frames
+     bf                           ..FV....... B-frames
+   ft                <flags>      ..FV....... set frame types to visualize motion vectors of (default 0)
+     if                           ..FV....... I-frames
+     pf                           ..FV....... P-frames
+     bf                           ..FV....... B-frames
+   block             <boolean>    ..FV....... set block partitioning structure to visualize (default false)
+
+colorbalance AVOptions:
+   rs                <float>      ..FV.....T. set red shadows (from -1 to 1) (default 0)
+   gs                <float>      ..FV.....T. set green shadows (from -1 to 1) (default 0)
+   bs                <float>      ..FV.....T. set blue shadows (from -1 to 1) (default 0)
+   rm                <float>      ..FV.....T. set red midtones (from -1 to 1) (default 0)
+   gm                <float>      ..FV.....T. set green midtones (from -1 to 1) (default 0)
+   bm                <float>      ..FV.....T. set blue midtones (from -1 to 1) (default 0)
+   rh                <float>      ..FV.....T. set red highlights (from -1 to 1) (default 0)
+   gh                <float>      ..FV.....T. set green highlights (from -1 to 1) (default 0)
+   bh                <float>      ..FV.....T. set blue highlights (from -1 to 1) (default 0)
+   pl                <boolean>    ..FV.....T. preserve lightness (default false)
+
+colorchannelmixer AVOptions:
+   rr                <double>     ..FV.....T. set the red gain for the red channel (from -2 to 2) (default 1)
+   rg                <double>     ..FV.....T. set the green gain for the red channel (from -2 to 2) (default 0)
+   rb                <double>     ..FV.....T. set the blue gain for the red channel (from -2 to 2) (default 0)
+   ra                <double>     ..FV.....T. set the alpha gain for the red channel (from -2 to 2) (default 0)
+   gr                <double>     ..FV.....T. set the red gain for the green channel (from -2 to 2) (default 0)
+   gg                <double>     ..FV.....T. set the green gain for the green channel (from -2 to 2) (default 1)
+   gb                <double>     ..FV.....T. set the blue gain for the green channel (from -2 to 2) (default 0)
+   ga                <double>     ..FV.....T. set the alpha gain for the green channel (from -2 to 2) (default 0)
+   br                <double>     ..FV.....T. set the red gain for the blue channel (from -2 to 2) (default 0)
+   bg                <double>     ..FV.....T. set the green gain for the blue channel (from -2 to 2) (default 0)
+   bb                <double>     ..FV.....T. set the blue gain for the blue channel (from -2 to 2) (default 1)
+   ba                <double>     ..FV.....T. set the alpha gain for the blue channel (from -2 to 2) (default 0)
+   ar                <double>     ..FV.....T. set the red gain for the alpha channel (from -2 to 2) (default 0)
+   ag                <double>     ..FV.....T. set the green gain for the alpha channel (from -2 to 2) (default 0)
+   ab                <double>     ..FV.....T. set the blue gain for the alpha channel (from -2 to 2) (default 0)
+   aa                <double>     ..FV.....T. set the alpha gain for the alpha channel (from -2 to 2) (default 1)
+   pc                <int>        ..FV.....T. set the preserve color mode (from 0 to 6) (default none)
+     none            0            ..FV.....T. disabled
+     lum             1            ..FV.....T. luminance
+     max             2            ..FV.....T. max
+     avg             3            ..FV.....T. average
+     sum             4            ..FV.....T. sum
+     nrm             5            ..FV.....T. norm
+     pwr             6            ..FV.....T. power
+   pa                <double>     ..FV.....T. set the preserve color amount (from 0 to 1) (default 0)
+
+colorcontrast AVOptions:
+   rc                <float>      ..FV.....T. set the red-cyan contrast (from -1 to 1) (default 0)
+   gm                <float>      ..FV.....T. set the green-magenta contrast (from -1 to 1) (default 0)
+   by                <float>      ..FV.....T. set the blue-yellow contrast (from -1 to 1) (default 0)
+   rcw               <float>      ..FV.....T. set the red-cyan weight (from 0 to 1) (default 0)
+   gmw               <float>      ..FV.....T. set the green-magenta weight (from 0 to 1) (default 0)
+   byw               <float>      ..FV.....T. set the blue-yellow weight (from 0 to 1) (default 0)
+   pl                <float>      ..FV.....T. set the amount of preserving lightness (from 0 to 1) (default 0)
+
+colorcorrect AVOptions:
+   rl                <float>      ..FV.....T. set the red shadow spot (from -1 to 1) (default 0)
+   bl                <float>      ..FV.....T. set the blue shadow spot (from -1 to 1) (default 0)
+   rh                <float>      ..FV.....T. set the red highlight spot (from -1 to 1) (default 0)
+   bh                <float>      ..FV.....T. set the blue highlight spot (from -1 to 1) (default 0)
+   saturation        <float>      ..FV.....T. set the amount of saturation (from -3 to 3) (default 1)
+   analyze           <int>        ..FV.....T. set the analyze mode (from 0 to 3) (default manual)
+     manual          0            ..FV.....T. manually set options
+     average         1            ..FV.....T. use average pixels
+     minmax          2            ..FV.....T. use minmax pixels
+     median          3            ..FV.....T. use median pixels
+
+colorize AVOptions:
+   hue               <float>      ..FV.....T. set the hue (from 0 to 360) (default 0)
+   saturation        <float>      ..FV.....T. set the saturation (from 0 to 1) (default 0.5)
+   lightness         <float>      ..FV.....T. set the lightness (from 0 to 1) (default 0.5)
+   mix               <float>      ..FV.....T. set the mix of source lightness (from 0 to 1) (default 1)
+
+colorkey AVOptions:
+   color             <color>      ..FV.....T. set the colorkey key color (default "black")
+   similarity        <float>      ..FV.....T. set the colorkey similarity value (from 1e-05 to 1) (default 0.01)
+   blend             <float>      ..FV.....T. set the colorkey key blend value (from 0 to 1) (default 0)
+
+colorkey_opencl AVOptions:
+   color             <color>      ..FV....... set the colorkey key color (default "black")
+   similarity        <float>      ..FV....... set the colorkey similarity value (from 0.01 to 1) (default 0.01)
+   blend             <float>      ..FV....... set the colorkey key blend value (from 0 to 1) (default 0)
+
+colorhold AVOptions:
+   color             <color>      ..FV.....T. set the colorhold key color (default "black")
+   similarity        <float>      ..FV.....T. set the colorhold similarity value (from 1e-05 to 1) (default 0.01)
+   blend             <float>      ..FV.....T. set the colorhold blend value (from 0 to 1) (default 0)
+
+colorlevels AVOptions:
+   rimin             <double>     ..FV.....T. set input red black point (from -1 to 1) (default 0)
+   gimin             <double>     ..FV.....T. set input green black point (from -1 to 1) (default 0)
+   bimin             <double>     ..FV.....T. set input blue black point (from -1 to 1) (default 0)
+   aimin             <double>     ..FV.....T. set input alpha black point (from -1 to 1) (default 0)
+   rimax             <double>     ..FV.....T. set input red white point (from -1 to 1) (default 1)
+   gimax             <double>     ..FV.....T. set input green white point (from -1 to 1) (default 1)
+   bimax             <double>     ..FV.....T. set input blue white point (from -1 to 1) (default 1)
+   aimax             <double>     ..FV.....T. set input alpha white point (from -1 to 1) (default 1)
+   romin             <double>     ..FV.....T. set output red black point (from 0 to 1) (default 0)
+   gomin             <double>     ..FV.....T. set output green black point (from 0 to 1) (default 0)
+   bomin             <double>     ..FV.....T. set output blue black point (from 0 to 1) (default 0)
+   aomin             <double>     ..FV.....T. set output alpha black point (from 0 to 1) (default 0)
+   romax             <double>     ..FV.....T. set output red white point (from 0 to 1) (default 1)
+   gomax             <double>     ..FV.....T. set output green white point (from 0 to 1) (default 1)
+   bomax             <double>     ..FV.....T. set output blue white point (from 0 to 1) (default 1)
+   aomax             <double>     ..FV.....T. set output alpha white point (from 0 to 1) (default 1)
+   preserve          <int>        ..FV.....T. set preserve color mode (from 0 to 6) (default none)
+     none            0            ..FV.....T. disabled
+     lum             1            ..FV.....T. luminance
+     max             2            ..FV.....T. max
+     avg             3            ..FV.....T. average
+     sum             4            ..FV.....T. sum
+     nrm             5            ..FV.....T. norm
+     pwr             6            ..FV.....T. power
+
+colormap AVOptions:
+   patch_size        <image_size> ..FV.....T. set patch size (default "64x64")
+   nb_patches        <int>        ..FV.....T. set number of patches (from 0 to 64) (default 0)
+   type              <int>        ..FV.....T. set the target type used (from 0 to 1) (default absolute)
+     relative        0            ..FV.....T. the target colors are relative
+     absolute        1            ..FV.....T. the target colors are absolute
+   kernel            <int>        ..FV.....T. set the kernel used for measuring color difference (from 0 to 1) (default euclidean)
+     euclidean       0            ..FV.....T. square root of sum of squared differences
+     weuclidean      1            ..FV.....T. weighted square root of sum of squared differences
+
+colormatrix AVOptions:
+   src               <int>        ..FV....... set source color matrix (from -1 to 4) (default -1)
+     bt709           0            ..FV....... set BT.709 colorspace
+     fcc             1            ..FV....... set FCC colorspace   
+     bt601           2            ..FV....... set BT.601 colorspace
+     bt470           2            ..FV....... set BT.470 colorspace
+     bt470bg         2            ..FV....... set BT.470 colorspace
+     smpte170m       2            ..FV....... set SMTPE-170M colorspace
+     smpte240m       3            ..FV....... set SMPTE-240M colorspace
+     bt2020          4            ..FV....... set BT.2020 colorspace
+   dst               <int>        ..FV....... set destination color matrix (from -1 to 4) (default -1)
+     bt709           0            ..FV....... set BT.709 colorspace
+     fcc             1            ..FV....... set FCC colorspace   
+     bt601           2            ..FV....... set BT.601 colorspace
+     bt470           2            ..FV....... set BT.470 colorspace
+     bt470bg         2            ..FV....... set BT.470 colorspace
+     smpte170m       2            ..FV....... set SMTPE-170M colorspace
+     smpte240m       3            ..FV....... set SMPTE-240M colorspace
+     bt2020          4            ..FV....... set BT.2020 colorspace
+
+colorspace AVOptions:
+   all               <int>        ..FV....... Set all color properties together (from 0 to 8) (default 0)
+     bt470m          1            ..FV....... 
+     bt470bg         2            ..FV....... 
+     bt601-6-525     3            ..FV....... 
+     bt601-6-625     4            ..FV....... 
+     bt709           5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     bt2020          8            ..FV....... 
+   space             <int>        ..FV....... Output colorspace (from 0 to 14) (default 2)
+     bt709           1            ..FV....... 
+     fcc             4            ..FV....... 
+     bt470bg         5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     ycgco           8            ..FV....... 
+     gbr             0            ..FV....... 
+     bt2020nc        9            ..FV....... 
+     bt2020ncl       9            ..FV....... 
+   range             <int>        ..FV....... Output color range (from 0 to 2) (default 0)
+     tv              1            ..FV....... 
+     mpeg            1            ..FV....... 
+     pc              2            ..FV....... 
+     jpeg            2            ..FV....... 
+   primaries         <int>        ..FV....... Output color primaries (from 0 to 22) (default 2)
+     bt709           1            ..FV....... 
+     bt470m          4            ..FV....... 
+     bt470bg         5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     smpte428        10           ..FV....... 
+     film            8            ..FV....... 
+     smpte431        11           ..FV....... 
+     smpte432        12           ..FV....... 
+     bt2020          9            ..FV....... 
+     jedec-p22       22           ..FV....... 
+     ebu3213         22           ..FV....... 
+   trc               <int>        ..FV....... Output transfer characteristics (from 0 to 18) (default 2)
+     bt709           1            ..FV....... 
+     bt470m          4            ..FV....... 
+     gamma22         4            ..FV....... 
+     bt470bg         5            ..FV....... 
+     gamma28         5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     linear          8            ..FV....... 
+     srgb            13           ..FV....... 
+     iec61966-2-1    13           ..FV....... 
+     xvycc           11           ..FV....... 
+     iec61966-2-4    11           ..FV....... 
+     bt2020-10       14           ..FV....... 
+     bt2020-12       15           ..FV....... 
+   format            <int>        ..FV....... Output pixel format (from -1 to 162) (default -1)
+     yuv420p         0            ..FV....... 
+     yuv420p10       62           ..FV....... 
+     yuv420p12       123          ..FV....... 
+     yuv422p         4            ..FV....... 
+     yuv422p10       64           ..FV....... 
+     yuv422p12       127          ..FV....... 
+     yuv444p         5            ..FV....... 
+     yuv444p10       68           ..FV....... 
+     yuv444p12       131          ..FV....... 
+   fast              <boolean>    ..FV....... Ignore primary chromaticity and gamma correction (default false)
+   dither            <int>        ..FV....... Dithering mode (from 0 to 1) (default none)
+     none            0            ..FV....... 
+     fsb             1            ..FV....... 
+   wpadapt           <int>        ..FV....... Whitepoint adaptation method (from 0 to 2) (default bradford)
+     bradford        0            ..FV....... 
+     vonkries        1            ..FV....... 
+     identity        2            ..FV....... 
+   iall              <int>        ..FV....... Set all input color properties together (from 0 to 8) (default 0)
+     bt470m          1            ..FV....... 
+     bt470bg         2            ..FV....... 
+     bt601-6-525     3            ..FV....... 
+     bt601-6-625     4            ..FV....... 
+     bt709           5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     bt2020          8            ..FV....... 
+   ispace            <int>        ..FV....... Input colorspace (from 0 to 22) (default 2)
+     bt709           1            ..FV....... 
+     fcc             4            ..FV....... 
+     bt470bg         5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     ycgco           8            ..FV....... 
+     gbr             0            ..FV....... 
+     bt2020nc        9            ..FV....... 
+     bt2020ncl       9            ..FV....... 
+   irange            <int>        ..FV....... Input color range (from 0 to 2) (default 0)
+     tv              1            ..FV....... 
+     mpeg            1            ..FV....... 
+     pc              2            ..FV....... 
+     jpeg            2            ..FV....... 
+   iprimaries        <int>        ..FV....... Input color primaries (from 0 to 22) (default 2)
+     bt709           1            ..FV....... 
+     bt470m          4            ..FV....... 
+     bt470bg         5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     smpte428        10           ..FV....... 
+     film            8            ..FV....... 
+     smpte431        11           ..FV....... 
+     smpte432        12           ..FV....... 
+     bt2020          9            ..FV....... 
+     jedec-p22       22           ..FV....... 
+     ebu3213         22           ..FV....... 
+   itrc              <int>        ..FV....... Input transfer characteristics (from 0 to 18) (default 2)
+     bt709           1            ..FV....... 
+     bt470m          4            ..FV....... 
+     gamma22         4            ..FV....... 
+     bt470bg         5            ..FV....... 
+     gamma28         5            ..FV....... 
+     smpte170m       6            ..FV....... 
+     smpte240m       7            ..FV....... 
+     linear          8            ..FV....... 
+     srgb            13           ..FV....... 
+     iec61966-2-1    13           ..FV....... 
+     xvycc           11           ..FV....... 
+     iec61966-2-4    11           ..FV....... 
+     bt2020-10       14           ..FV....... 
+     bt2020-12       15           ..FV....... 
+
+colorspace_cuda AVOptions:
+   range             <int>        ..FV....... Output video range (from 0 to 2) (default 0)
+     tv              1            ..FV....... Limited range
+     mpeg            1            ..FV....... Limited range
+     pc              2            ..FV....... Full range
+     jpeg            2            ..FV....... Full range
+
+colortemperature AVOptions:
+   temperature       <float>      ..FV.....T. set the temperature in Kelvin (from 1000 to 40000) (default 6500)
+   mix               <float>      ..FV.....T. set the mix with filtered output (from 0 to 1) (default 1)
+   pl                <float>      ..FV.....T. set the amount of preserving lightness (from 0 to 1) (default 0)
+
+convolution AVOptions:
+   0m                <string>     ..FV.....T. set matrix for 1st plane (default "0 0 0 0 1 0 0 0 0")
+   1m                <string>     ..FV.....T. set matrix for 2nd plane (default "0 0 0 0 1 0 0 0 0")
+   2m                <string>     ..FV.....T. set matrix for 3rd plane (default "0 0 0 0 1 0 0 0 0")
+   3m                <string>     ..FV.....T. set matrix for 4th plane (default "0 0 0 0 1 0 0 0 0")
+   0rdiv             <float>      ..FV.....T. set rdiv for 1st plane (from 0 to INT_MAX) (default 0)
+   1rdiv             <float>      ..FV.....T. set rdiv for 2nd plane (from 0 to INT_MAX) (default 0)
+   2rdiv             <float>      ..FV.....T. set rdiv for 3rd plane (from 0 to INT_MAX) (default 0)
+   3rdiv             <float>      ..FV.....T. set rdiv for 4th plane (from 0 to INT_MAX) (default 0)
+   0bias             <float>      ..FV.....T. set bias for 1st plane (from 0 to INT_MAX) (default 0)
+   1bias             <float>      ..FV.....T. set bias for 2nd plane (from 0 to INT_MAX) (default 0)
+   2bias             <float>      ..FV.....T. set bias for 3rd plane (from 0 to INT_MAX) (default 0)
+   3bias             <float>      ..FV.....T. set bias for 4th plane (from 0 to INT_MAX) (default 0)
+   0mode             <int>        ..FV.....T. set matrix mode for 1st plane (from 0 to 2) (default square)
+     square          0            ..FV.....T. square matrix
+     row             1            ..FV.....T. single row matrix
+     column          2            ..FV.....T. single column matrix
+   1mode             <int>        ..FV.....T. set matrix mode for 2nd plane (from 0 to 2) (default square)
+     square          0            ..FV.....T. square matrix
+     row             1            ..FV.....T. single row matrix
+     column          2            ..FV.....T. single column matrix
+   2mode             <int>        ..FV.....T. set matrix mode for 3rd plane (from 0 to 2) (default square)
+     square          0            ..FV.....T. square matrix
+     row             1            ..FV.....T. single row matrix
+     column          2            ..FV.....T. single column matrix
+   3mode             <int>        ..FV.....T. set matrix mode for 4th plane (from 0 to 2) (default square)
+     square          0            ..FV.....T. square matrix
+     row             1            ..FV.....T. single row matrix
+     column          2            ..FV.....T. single column matrix
+
+convolution_opencl AVOptions:
+   0m                <string>     ..FV....... set matrix for 2nd plane (default "0 0 0 0 1 0 0 0 0")
+   1m                <string>     ..FV....... set matrix for 2nd plane (default "0 0 0 0 1 0 0 0 0")
+   2m                <string>     ..FV....... set matrix for 3rd plane (default "0 0 0 0 1 0 0 0 0")
+   3m                <string>     ..FV....... set matrix for 4th plane (default "0 0 0 0 1 0 0 0 0")
+   0rdiv             <float>      ..FV....... set rdiv for 1nd plane (from 0 to INT_MAX) (default 1)
+   1rdiv             <float>      ..FV....... set rdiv for 2nd plane (from 0 to INT_MAX) (default 1)
+   2rdiv             <float>      ..FV....... set rdiv for 3rd plane (from 0 to INT_MAX) (default 1)
+   3rdiv             <float>      ..FV....... set rdiv for 4th plane (from 0 to INT_MAX) (default 1)
+   0bias             <float>      ..FV....... set bias for 1st plane (from 0 to INT_MAX) (default 0)
+   1bias             <float>      ..FV....... set bias for 2nd plane (from 0 to INT_MAX) (default 0)
+   2bias             <float>      ..FV....... set bias for 3rd plane (from 0 to INT_MAX) (default 0)
+   3bias             <float>      ..FV....... set bias for 4th plane (from 0 to INT_MAX) (default 0)
+
+convolve AVOptions:
+   planes            <int>        ..FV....... set planes to convolve (from 0 to 15) (default 7)
+   impulse           <int>        ..FV....... when to process impulses (from 0 to 1) (default all)
+     first           0            ..FV....... process only first impulse, ignore rest
+     all             1            ..FV....... process all impulses
+   noise             <float>      ..FV....... set noise (from 0 to 1) (default 1e-07)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+corr AVOptions:
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+cover_rect AVOptions:
+   cover             <string>     ..FV....... cover bitmap filename
+   mode              <int>        ..FV....... set removal mode (from 0 to 1) (default blur)
+     cover           0            ..FV....... cover area with bitmap
+     blur            1            ..FV....... blur area
+
+crop AVOptions:
+   out_w             <string>     ..FV.....T. set the width crop area expression (default "iw")
+   w                 <string>     ..FV.....T. set the width crop area expression (default "iw")
+   out_h             <string>     ..FV.....T. set the height crop area expression (default "ih")
+   h                 <string>     ..FV.....T. set the height crop area expression (default "ih")
+   x                 <string>     ..FV.....T. set the x crop area expression (default "(in_w-out_w)/2")
+   y                 <string>     ..FV.....T. set the y crop area expression (default "(in_h-out_h)/2")
+   keep_aspect       <boolean>    ..FV....... keep aspect ratio (default false)
+   exact             <boolean>    ..FV....... do exact cropping (default false)
+
+cropdetect AVOptions:
+   limit             <float>      ..FV.....T. Threshold below which the pixel is considered black (from 0 to 65535) (default 0.0941176)
+   round             <int>        ..FV....... Value by which the width/height should be divisible (from 0 to INT_MAX) (default 16)
+   reset             <int>        ..FV....... Recalculate the crop area after this many frames (from 0 to INT_MAX) (default 0)
+   skip              <int>        ..FV....... Number of initial frames to skip (from 0 to INT_MAX) (default 2)
+   reset_count       <int>        ..FV....... Recalculate the crop area after this many frames (from 0 to INT_MAX) (default 0)
+   max_outliers      <int>        ..FV....... Threshold count of outliers (from 0 to INT_MAX) (default 0)
+   mode              <int>        ..FV....... set mode (from 0 to 1) (default black)
+     black           0            ..FV....... detect black pixels surrounding the video
+     mvedges         1            ..FV....... detect motion and edged surrounding the video
+   high              <float>      ..FV....... Set high threshold for edge detection (from 0 to 1) (default 0.0980392)
+   low               <float>      ..FV....... Set low threshold for edge detection (from 0 to 1) (default 0.0588235)
+   mv_threshold      <int>        ..FV....... motion vector threshold when estimating video window size (from 0 to 100) (default 8)
+
+(a)cue AVOptions:
+   cue               <int64>      ..FVA...... cue unix timestamp in microseconds (from 0 to I64_MAX) (default 0)
+   preroll           <duration>   ..FVA...... preroll duration in seconds (default 0)
+   buffer            <duration>   ..FVA...... buffer duration in seconds (default 0)
+
+curves AVOptions:
+   preset            <int>        ..FV.....T. select a color curves preset (from 0 to 10) (default none)
+     none            0            ..FV.....T.
+     color_negative  1            ..FV.....T.
+     cross_process   2            ..FV.....T.
+     darker          3            ..FV.....T.
+     increase_contrast 4            ..FV.....T.
+     lighter         5            ..FV.....T.
+     linear_contrast 6            ..FV.....T.
+     medium_contrast 7            ..FV.....T.
+     negative        8            ..FV.....T.
+     strong_contrast 9            ..FV.....T.
+     vintage         10           ..FV.....T.
+   master            <string>     ..FV.....T. set master points coordinates
+   m                 <string>     ..FV.....T. set master points coordinates
+   red               <string>     ..FV.....T. set red points coordinates
+   r                 <string>     ..FV.....T. set red points coordinates
+   green             <string>     ..FV.....T. set green points coordinates
+   g                 <string>     ..FV.....T. set green points coordinates
+   blue              <string>     ..FV.....T. set blue points coordinates
+   b                 <string>     ..FV.....T. set blue points coordinates
+   all               <string>     ..FV.....T. set points coordinates for all components
+   psfile            <string>     ..FV.....T. set Photoshop curves file name
+   plot              <string>     ..FV.....T. save Gnuplot script of the curves in specified file
+   interp            <int>        ..FV.....T. specify the kind of interpolation (from 0 to 1) (default natural)
+     natural         0            ..FV.....T. natural cubic spline
+     pchip           1            ..FV.....T. monotonically cubic interpolation
+
+datascope AVOptions:
+   size              <image_size> ..FV....... set output size (default "hd720")
+   s                 <image_size> ..FV....... set output size (default "hd720")
+   x                 <int>        ..FV.....T. set x offset (from 0 to INT_MAX) (default 0)
+   y                 <int>        ..FV.....T. set y offset (from 0 to INT_MAX) (default 0)
+   mode              <int>        ..FV.....T. set scope mode (from 0 to 2) (default mono)
+     mono            0            ..FV.....T.
+     color           1            ..FV.....T.
+     color2          2            ..FV.....T.
+   axis              <boolean>    ..FV.....T. draw column/row numbers (default false)
+   opacity           <float>      ..FV.....T. set background opacity (from 0 to 1) (default 0.75)
+   format            <int>        ..FV.....T. set display number format (from 0 to 1) (default hex)
+     hex             0            ..FV.....T.
+     dec             1            ..FV.....T.
+   components        <int>        ..FV.....T. set components to display (from 1 to 15) (default 15)
+
+dblur AVOptions:
+   angle             <float>      ..FV.....T. set angle (from 0 to 360) (default 45)
+   radius            <float>      ..FV.....T. set radius (from 0 to 8192) (default 5)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+
+dctdnoiz AVOptions:
+   sigma             <float>      ..FV....... set noise sigma constant (from 0 to 999) (default 0)
+   s                 <float>      ..FV....... set noise sigma constant (from 0 to 999) (default 0)
+   overlap           <int>        ..FV....... set number of block overlapping pixels (from -1 to 15) (default -1)
+   expr              <string>     ..FV....... set coefficient factor expression
+   e                 <string>     ..FV....... set coefficient factor expression
+   n                 <int>        ..FV....... set the block size, expressed in bits (from 3 to 4) (default 3)
+
+deband AVOptions:
+   1thr              <float>      ..FV.....T. set 1st plane threshold (from 3e-05 to 0.5) (default 0.02)
+   2thr              <float>      ..FV.....T. set 2nd plane threshold (from 3e-05 to 0.5) (default 0.02)
+   3thr              <float>      ..FV.....T. set 3rd plane threshold (from 3e-05 to 0.5) (default 0.02)
+   4thr              <float>      ..FV.....T. set 4th plane threshold (from 3e-05 to 0.5) (default 0.02)
+   range             <int>        ..FV.....T. set range (from INT_MIN to INT_MAX) (default 16)
+   r                 <int>        ..FV.....T. set range (from INT_MIN to INT_MAX) (default 16)
+   direction         <float>      ..FV.....T. set direction (from -6.28319 to 6.28319) (default 6.28319)
+   d                 <float>      ..FV.....T. set direction (from -6.28319 to 6.28319) (default 6.28319)
+   blur              <boolean>    ..FV.....T. set blur (default true)
+   b                 <boolean>    ..FV.....T. set blur (default true)
+   coupling          <boolean>    ..FV.....T. set plane coupling (default false)
+   c                 <boolean>    ..FV.....T. set plane coupling (default false)
+
+deblock AVOptions:
+   filter            <int>        ..FV.....T. set type of filter (from 0 to 1) (default strong)
+     weak            0            ..FV.....T.
+     strong          1            ..FV.....T.
+   block             <int>        ..FV.....T. set size of block (from 4 to 512) (default 8)
+   alpha             <float>      ..FV.....T. set 1st detection threshold (from 0 to 1) (default 0.098)
+   beta              <float>      ..FV.....T. set 2nd detection threshold (from 0 to 1) (default 0.05)
+   gamma             <float>      ..FV.....T. set 3rd detection threshold (from 0 to 1) (default 0.05)
+   delta             <float>      ..FV.....T. set 4th detection threshold (from 0 to 1) (default 0.05)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+
+decimate AVOptions:
+   cycle             <int>        ..FV....... set the number of frame from which one will be dropped (from 2 to 25) (default 5)
+   dupthresh         <double>     ..FV....... set duplicate threshold (from 0 to 100) (default 1.1)
+   scthresh          <double>     ..FV....... set scene change threshold (from 0 to 100) (default 15)
+   blockx            <int>        ..FV....... set the size of the x-axis blocks used during metric calculations (from 4 to 512) (default 32)
+   blocky            <int>        ..FV....... set the size of the y-axis blocks used during metric calculations (from 4 to 512) (default 32)
+   ppsrc             <boolean>    ..FV....... mark main input as a pre-processed input and activate clean source input stream (default false)
+   chroma            <boolean>    ..FV....... set whether or not chroma is considered in the metric calculations (default true)
+   mixed             <boolean>    ..FV....... set whether or not the input only partially contains content to be decimated (default false)
+
+deconvolve AVOptions:
+   planes            <int>        ..FV....... set planes to deconvolve (from 0 to 15) (default 7)
+   impulse           <int>        ..FV....... when to process impulses (from 0 to 1) (default all)
+     first           0            ..FV....... process only first impulse, ignore rest
+     all             1            ..FV....... process all impulses
+   noise             <float>      ..FV....... set noise (from 0 to 1) (default 1e-07)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+dedot AVOptions:
+   m                 <flags>      ..FV....... set filtering mode (default dotcrawl+rainbows)
+     dotcrawl                     ..FV.......
+     rainbows                     ..FV.......
+   lt                <float>      ..FV....... set spatial luma threshold (from 0 to 1) (default 0.079)
+   tl                <float>      ..FV....... set tolerance for temporal luma (from 0 to 1) (default 0.079)
+   tc                <float>      ..FV....... set tolerance for chroma temporal variation (from 0 to 1) (default 0.058)
+   ct                <float>      ..FV....... set temporal chroma threshold (from 0 to 1) (default 0.019)
+
+deflate/inflate AVOptions:
+   threshold0        <int>        ..FV.....T. set threshold for 1st plane (from 0 to 65535) (default 65535)
+   threshold1        <int>        ..FV.....T. set threshold for 2nd plane (from 0 to 65535) (default 65535)
+   threshold2        <int>        ..FV.....T. set threshold for 3rd plane (from 0 to 65535) (default 65535)
+   threshold3        <int>        ..FV.....T. set threshold for 4th plane (from 0 to 65535) (default 65535)
+
+deflicker AVOptions:
+   size              <int>        ..FV....... set how many frames to use (from 2 to 129) (default 5)
+   s                 <int>        ..FV....... set how many frames to use (from 2 to 129) (default 5)
+   mode              <int>        ..FV....... set how to smooth luminance (from 0 to 6) (default am)
+     am              0            ..FV....... arithmetic mean
+     gm              1            ..FV....... geometric mean
+     hm              2            ..FV....... harmonic mean
+     qm              3            ..FV....... quadratic mean
+     cm              4            ..FV....... cubic mean
+     pm              5            ..FV....... power mean
+     median          6            ..FV....... median
+   m                 <int>        ..FV....... set how to smooth luminance (from 0 to 6) (default am)
+     am              0            ..FV....... arithmetic mean
+     gm              1            ..FV....... geometric mean
+     hm              2            ..FV....... harmonic mean
+     qm              3            ..FV....... quadratic mean
+     cm              4            ..FV....... cubic mean
+     pm              5            ..FV....... power mean
+     median          6            ..FV....... median
+   bypass            <boolean>    ..FV....... leave frames unchanged (default false)
+
+deinterlace_vaapi AVOptions:
+   mode              <int>        ..FV....... Deinterlacing mode (from 0 to 4) (default default)
+     default         0            ..FV....... Use the highest-numbered (and therefore possibly most advanced) deinterlacing algorithm
+     bob             1            ..FV....... Use the bob deinterlacing algorithm
+     weave           2            ..FV....... Use the weave deinterlacing algorithm
+     motion_adaptive 3            ..FV....... Use the motion adaptive deinterlacing algorithm
+     motion_compensated 4            ..FV....... Use the motion compensated deinterlacing algorithm
+   rate              <int>        ..FV....... Generate output at frame rate or field rate (from 1 to 2) (default frame)
+     frame           1            ..FV....... Output at frame rate (one frame of output for each field-pair)
+     field           2            ..FV....... Output at field rate (one frame of output for each field)
+   auto              <int>        ..FV....... Only deinterlace fields, passing frames through unchanged (from 0 to 1) (default 0)
+
+dejudder AVOptions:
+   cycle             <int>        ..FV....... set the length of the cycle to use for dejuddering (from 2 to 240) (default 4)
+
+delogo AVOptions:
+   x                 <string>     ..FV....... set logo x position (default "-1")
+   y                 <string>     ..FV....... set logo y position (default "-1")
+   w                 <string>     ..FV....... set logo width (default "-1")
+   h                 <string>     ..FV....... set logo height (default "-1")
+   show              <boolean>    ..FV....... show delogo area (default false)
+
+denoise_vaapi AVOptions:
+   denoise           <int>        ..FV....... denoise level (from 0 to 64) (default 0)
+
+derain AVOptions:
+   filter_type       <int>        ..FV....... filter type(derain/dehaze) (from 0 to 1) (default derain)
+     derain          0            ..FV....... derain filter flag
+     dehaze          1            ..FV....... dehaze filter flag
+   dnn_backend       <int>        ..FV....... DNN backend (from 0 to 1) (default 1)
+   model             <string>     ..FV....... path to model file
+   input             <string>     ..FV....... input name of the model (default "x")
+   output            <string>     ..FV....... output name of the model (default "y")
+
+deshake AVOptions:
+   x                 <int>        ..FV....... set x for the rectangular search area (from -1 to INT_MAX) (default -1)
+   y                 <int>        ..FV....... set y for the rectangular search area (from -1 to INT_MAX) (default -1)
+   w                 <int>        ..FV....... set width for the rectangular search area (from -1 to INT_MAX) (default -1)
+   h                 <int>        ..FV....... set height for the rectangular search area (from -1 to INT_MAX) (default -1)
+   rx                <int>        ..FV....... set x for the rectangular search area (from 0 to 64) (default 16)
+   ry                <int>        ..FV....... set y for the rectangular search area (from 0 to 64) (default 16)
+   edge              <int>        ..FV....... set edge mode (from 0 to 3) (default mirror)
+     blank           0            ..FV....... fill zeroes at blank locations
+     original        1            ..FV....... original image at blank locations
+     clamp           2            ..FV....... extruded edge value at blank locations
+     mirror          3            ..FV....... mirrored edge at blank locations
+   blocksize         <int>        ..FV....... set motion search blocksize (from 4 to 128) (default 8)
+   contrast          <int>        ..FV....... set contrast threshold for blocks (from 1 to 255) (default 125)
+   search            <int>        ..FV....... set search strategy (from 0 to 1) (default exhaustive)
+     exhaustive      0            ..FV....... exhaustive search
+     less            1            ..FV....... less exhaustive search
+   filename          <string>     ..FV....... set motion search detailed log file name
+   opencl            <boolean>    ..FV....... ignored (default false)
+
+deshake_opencl AVOptions:
+   tripod            <boolean>    ..FV....... simulates a tripod by preventing any camera movement whatsoever from the original frame (default false)
+   debug             <boolean>    ..FV....... turn on additional debugging information (default false)
+   adaptive_crop     <boolean>    ..FV....... attempt to subtly crop borders to reduce mirrored content (default true)
+   refine_features   <boolean>    ..FV....... refine feature point locations at a sub-pixel level (default true)
+   smooth_strength   <float>      ..FV....... smoothing strength (0 attempts to adaptively determine optimal strength) (from 0 to 1) (default 0)
+   smooth_window_multiplier <float>      ..FV....... multiplier for number of frames to buffer for motion data (from 0.1 to 10) (default 2)
+
+despill AVOptions:
+   type              <int>        ..FV.....T. set the screen type (from 0 to 1) (default green)
+     green           0            ..FV.....T. greenscreen
+     blue            1            ..FV.....T. bluescreen
+   mix               <float>      ..FV.....T. set the spillmap mix (from 0 to 1) (default 0.5)
+   expand            <float>      ..FV.....T. set the spillmap expand (from 0 to 1) (default 0)
+   red               <float>      ..FV.....T. set red scale (from -100 to 100) (default 0)
+   green             <float>      ..FV.....T. set green scale (from -100 to 100) (default -1)
+   blue              <float>      ..FV.....T. set blue scale (from -100 to 100) (default 0)
+   brightness        <float>      ..FV.....T. set brightness (from -10 to 10) (default 0)
+   alpha             <boolean>    ..FV.....T. change alpha component (default false)
+
+detelecine AVOptions:
+   first_field       <int>        ..FV....... select first field (from 0 to 1) (default top)
+     top             0            ..FV....... select top field first
+     t               0            ..FV....... select top field first
+     bottom          1            ..FV....... select bottom field first
+     b               1            ..FV....... select bottom field first
+   pattern           <string>     ..FV....... pattern that describe for how many fields a frame is to be displayed (default "23")
+   start_frame       <int>        ..FV....... position of first frame with respect to the pattern if stream is cut (from 0 to 13) (default 0)
+
+erosion/dilation AVOptions:
+   coordinates       <int>        ..FV.....T. set coordinates (from 0 to 255) (default 255)
+   threshold0        <int>        ..FV.....T. set threshold for 1st plane (from 0 to 65535) (default 65535)
+   threshold1        <int>        ..FV.....T. set threshold for 2nd plane (from 0 to 65535) (default 65535)
+   threshold2        <int>        ..FV.....T. set threshold for 3rd plane (from 0 to 65535) (default 65535)
+   threshold3        <int>        ..FV.....T. set threshold for 4th plane (from 0 to 65535) (default 65535)
+
+dilation_opencl AVOptions:
+   threshold0        <float>      ..FV....... set threshold for 1st plane (from 0 to 65535) (default 65535)
+   threshold1        <float>      ..FV....... set threshold for 2nd plane (from 0 to 65535) (default 65535)
+   threshold2        <float>      ..FV....... set threshold for 3rd plane (from 0 to 65535) (default 65535)
+   threshold3        <float>      ..FV....... set threshold for 4th plane (from 0 to 65535) (default 65535)
+   coordinates       <int>        ..FV....... set coordinates (from 0 to 255) (default 255)
+
+displace AVOptions:
+   edge              <int>        ..FV.....T. set edge mode (from 0 to 3) (default smear)
+     blank           0            ..FV.....T. 
+     smear           1            ..FV.....T. 
+     wrap            2            ..FV.....T. 
+     mirror          3            ..FV.....T. 
+
+dnn_classify AVOptions:
+   dnn_backend       <int>        ..FV....... DNN backend (from INT_MIN to INT_MAX) (default 2)
+   model             <string>     ..FV....... path to model file
+   input             <string>     ..FV....... input name of the model
+   output            <string>     ..FV....... output name of the model
+   backend_configs   <string>     ..FV....... backend configs
+   options           <string>     ..FV......P backend configs (deprecated, use backend_configs)
+   async             <boolean>    ..FV....... use DNN async inference (ignored, use backend_configs='async=1') (default true)
+   confidence        <float>      ..FV....... threshold of confidence (from 0 to 1) (default 0.5)
+   labels            <string>     ..FV....... path to labels file
+   target            <string>     ..FV....... which one to be classified
+
+dnn_detect AVOptions:
+   dnn_backend       <int>        ..FV....... DNN backend (from INT_MIN to INT_MAX) (default 2)
+   model             <string>     ..FV....... path to model file
+   input             <string>     ..FV....... input name of the model
+   output            <string>     ..FV....... output name of the model
+   backend_configs   <string>     ..FV....... backend configs
+   options           <string>     ..FV......P backend configs (deprecated, use backend_configs)
+   async             <boolean>    ..FV....... use DNN async inference (ignored, use backend_configs='async=1') (default true)
+   confidence        <float>      ..FV....... threshold of confidence (from 0 to 1) (default 0.5)
+   labels            <string>     ..FV....... path to labels file
+
+dnn_processing AVOptions:
+   dnn_backend       <int>        ..FV....... DNN backend (from INT_MIN to INT_MAX) (default 1)
+   model             <string>     ..FV....... path to model file
+   input             <string>     ..FV....... input name of the model
+   output            <string>     ..FV....... output name of the model
+   backend_configs   <string>     ..FV....... backend configs
+   options           <string>     ..FV......P backend configs (deprecated, use backend_configs)
+   async             <boolean>    ..FV....... use DNN async inference (ignored, use backend_configs='async=1') (default true)
+
+(double)weave AVOptions:
+   first_field       <int>        ..FV....... set first field (from 0 to 1) (default top)
+     top             0            ..FV....... set top field first
+     t               0            ..FV....... set top field first
+     bottom          1            ..FV....... set bottom field first
+     b               1            ..FV....... set bottom field first
+
+drawbox AVOptions:
+   x                 <string>     ..FV.....T. set horizontal position of the left box edge (default "0")
+   y                 <string>     ..FV.....T. set vertical position of the top box edge (default "0")
+   width             <string>     ..FV.....T. set width of the box (default "0")
+   w                 <string>     ..FV.....T. set width of the box (default "0")
+   height            <string>     ..FV.....T. set height of the box (default "0")
+   h                 <string>     ..FV.....T. set height of the box (default "0")
+   color             <string>     ..FV.....T. set color of the box (default "black")
+   c                 <string>     ..FV.....T. set color of the box (default "black")
+   thickness         <string>     ..FV.....T. set the box thickness (default "3")
+   t                 <string>     ..FV.....T. set the box thickness (default "3")
+   replace           <boolean>    ..FV.....T. replace color & alpha (default false)
+   box_source        <string>     ..FV.....T. use datas from bounding box in side data
+
+(a)drawgraph AVOptions:
+   m1                <string>     ..FV....... set 1st metadata key (default "")
+   fg1               <string>     ..FV....... set 1st foreground color expression (default "0xffff0000")
+   m2                <string>     ..FV....... set 2nd metadata key (default "")
+   fg2               <string>     ..FV....... set 2nd foreground color expression (default "0xff00ff00")
+   m3                <string>     ..FV....... set 3rd metadata key (default "")
+   fg3               <string>     ..FV....... set 3rd foreground color expression (default "0xffff00ff")
+   m4                <string>     ..FV....... set 4th metadata key (default "")
+   fg4               <string>     ..FV....... set 4th foreground color expression (default "0xffffff00")
+   bg                <color>      ..FV....... set background color (default "white")
+   min               <float>      ..FV....... set minimal value (from INT_MIN to INT_MAX) (default -1)
+   max               <float>      ..FV....... set maximal value (from INT_MIN to INT_MAX) (default 1)
+   mode              <int>        ..FV....... set graph mode (from 0 to 2) (default line)
+     bar             0            ..FV....... draw bars
+     dot             1            ..FV....... draw dots
+     line            2            ..FV....... draw lines
+   slide             <int>        ..FV....... set slide mode (from 0 to 4) (default frame)
+     frame           0            ..FV....... draw new frames
+     replace         1            ..FV....... replace old columns with new
+     scroll          2            ..FV....... scroll from right to left
+     rscroll         3            ..FV....... scroll from left to right
+     picture         4            ..FV....... display graph in single frame
+   size              <image_size> ..FV....... set graph size (default "900x256")
+   s                 <image_size> ..FV....... set graph size (default "900x256")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+
+drawgrid AVOptions:
+   x                 <string>     ..FV.....T. set horizontal offset (default "0")
+   y                 <string>     ..FV.....T. set vertical offset (default "0")
+   width             <string>     ..FV.....T. set width of grid cell (default "0")
+   w                 <string>     ..FV.....T. set width of grid cell (default "0")
+   height            <string>     ..FV.....T. set height of grid cell (default "0")
+   h                 <string>     ..FV.....T. set height of grid cell (default "0")
+   color             <string>     ..FV.....T. set color of the grid (default "black")
+   c                 <string>     ..FV.....T. set color of the grid (default "black")
+   thickness         <string>     ..FV.....T. set grid line thickness (default "1")
+   t                 <string>     ..FV.....T. set grid line thickness (default "1")
+   replace           <boolean>    ..FV.....T. replace color & alpha (default false)
+
+drawtext AVOptions:
+   fontfile          <string>     ..FV....... set font file
+   text              <string>     ..FV.....T. set text
+   textfile          <string>     ..FV....... set text file
+   fontcolor         <color>      ..FV.....T. set foreground color (default "black")
+   fontcolor_expr    <string>     ..FV....... set foreground color expression (default "")
+   boxcolor          <color>      ..FV.....T. set box color (default "white")
+   bordercolor       <color>      ..FV.....T. set border color (default "black")
+   shadowcolor       <color>      ..FV.....T. set shadow color (default "black")
+   box               <boolean>    ..FV.....T. set box (default false)
+   boxborderw        <string>     ..FV.....T. set box borders width (default "0")
+   line_spacing      <int>        ..FV.....T. set line spacing in pixels (from INT_MIN to INT_MAX) (default 0)
+   fontsize          <string>     ..FV.....T. set font size
+   text_align        <flags>      ..FV.....T. set text alignment (default 0)
+     left                         ..FV.....T.
+     L                            ..FV.....T.
+     right                        ..FV.....T.
+     R                            ..FV.....T.
+     center                       ..FV.....T.
+     C                            ..FV.....T.
+     top                          ..FV.....T.
+     T                            ..FV.....T.
+     bottom                       ..FV.....T.
+     B                            ..FV.....T.
+     middle                       ..FV.....T.
+     M                            ..FV.....T.
+   x                 <string>     ..FV.....T. set x expression (default "0")
+   y                 <string>     ..FV.....T. set y expression (default "0")
+   boxw              <int>        ..FV.....T. set box width (from 0 to INT_MAX) (default 0)
+   boxh              <int>        ..FV.....T. set box height (from 0 to INT_MAX) (default 0)
+   shadowx           <int>        ..FV.....T. set shadow x offset (from INT_MIN to INT_MAX) (default 0)
+   shadowy           <int>        ..FV.....T. set shadow y offset (from INT_MIN to INT_MAX) (default 0)
+   borderw           <int>        ..FV.....T. set border width (from INT_MIN to INT_MAX) (default 0)
+   tabsize           <int>        ..FV.....T. set tab size (from 0 to INT_MAX) (default 4)
+   basetime          <int64>      ..FV....... set base time (from I64_MIN to I64_MAX) (default I64_MIN)
+   font              <string>     ..FV....... Font name (default "Sans")
+   expansion         <int>        ..FV....... set the expansion mode (from 0 to 2) (default normal)
+     none            0            ..FV....... set no expansion
+     normal          1            ..FV....... set normal expansion
+     strftime        2            ..FV....... set strftime expansion (deprecated)
+   y_align           <int>        ..FV.....T. set the y alignment (from 0 to 2) (default text)
+     text            0            ..FV....... y is referred to the top of the first text line
+     baseline        1            ..FV....... y is referred to the baseline of the first line
+     font            2            ..FV....... y is referred to the font defined line metrics
+   timecode          <string>     ..FV....... set initial timecode
+   tc24hmax          <boolean>    ..FV....... set 24 hours max (timecode only) (default false)
+   timecode_rate     <rational>   ..FV....... set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
+   r                 <rational>   ..FV....... set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
+   rate              <rational>   ..FV....... set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
+   reload            <int>        ..FV....... reload text file at specified frame interval (from 0 to INT_MAX) (default 0)
+   alpha             <string>     ..FV.....T. apply alpha while rendering (default "1")
+   fix_bounds        <boolean>    ..FV....... check and fix text coords to avoid clipping (default false)
+   start_number      <int>        ..FV....... start frame number for n/frame_num variable (from 0 to INT_MAX) (default 0)
+   text_source       <string>     ..FV....... the source of text
+   text_shaping      <boolean>    ..FV....... attempt to shape text before drawing (default true)
+   ft_load_flags     <flags>      ..FV....... set font loading flags for libfreetype (default 0)
+     default                      ..FV.......
+     no_scale                     ..FV.......
+     no_hinting                   ..FV.......
+     render                       ..FV.......
+     no_bitmap                    ..FV.......
+     vertical_layout              ..FV.......
+     force_autohint               ..FV.......
+     crop_bitmap                  ..FV.......
+     pedantic                     ..FV.......
+     ignore_global_advance_width              ..FV.......
+     no_recurse                   ..FV.......
+     ignore_transform              ..FV.......
+     monochrome                   ..FV.......
+     linear_design                ..FV.......
+     no_autohint                  ..FV.......
+
+edgedetect AVOptions:
+   high              <double>     ..FV....... set high threshold (from 0 to 1) (default 0.196078)
+   low               <double>     ..FV....... set low threshold (from 0 to 1) (default 0.0784314)
+   mode              <int>        ..FV....... set mode (from 0 to 2) (default wires)
+     wires           0            ..FV....... white/gray wires on black
+     colormix        1            ..FV....... mix colors
+     canny           2            ..FV....... detect edges on planes
+   planes            <flags>      ..FV....... set planes to filter (default y+u+v+r+g+b)
+     y                            ..FV....... filter luma plane
+     u                            ..FV....... filter u plane
+     v                            ..FV....... filter v plane
+     r                            ..FV....... filter red plane
+     g                            ..FV....... filter green plane
+     b                            ..FV....... filter blue plane
+
+elbg AVOptions:
+   codebook_length   <int>        ..FV....... set codebook length (from 1 to INT_MAX) (default 256)
+   l                 <int>        ..FV....... set codebook length (from 1 to INT_MAX) (default 256)
+   nb_steps          <int>        ..FV....... set max number of steps used to compute the mapping (from 1 to INT_MAX) (default 1)
+   n                 <int>        ..FV....... set max number of steps used to compute the mapping (from 1 to INT_MAX) (default 1)
+   seed              <int64>      ..FV....... set the random seed (from -1 to UINT32_MAX) (default -1)
+   s                 <int64>      ..FV....... set the random seed (from -1 to UINT32_MAX) (default -1)
+   pal8              <boolean>    ..FV....... set the pal8 output (default false)
+   use_alpha         <boolean>    ..FV....... use alpha channel for mapping (default false)
+
+entropy AVOptions:
+   mode              <int>        ..FV....... set kind of histogram entropy measurement (from 0 to 1) (default normal)
+     normal          0            ..FV.......
+     diff            1            ..FV.......
+
+epx AVOptions:
+   n                 <int>        ..FV....... set scale factor (from 2 to 3) (default 3)
+
+eq AVOptions:
+   contrast          <string>     ..FV.....T. set the contrast adjustment, negative values give a negative image (default "1.0")
+   brightness        <string>     ..FV.....T. set the brightness adjustment (default "0.0")
+   saturation        <string>     ..FV.....T. set the saturation adjustment (default "1.0")
+   gamma             <string>     ..FV.....T. set the initial gamma value (default "1.0")
+   gamma_r           <string>     ..FV.....T. gamma value for red (default "1.0")
+   gamma_g           <string>     ..FV.....T. gamma value for green (default "1.0")
+   gamma_b           <string>     ..FV.....T. gamma value for blue (default "1.0")
+   gamma_weight      <string>     ..FV.....T. set the gamma weight which reduces the effect of gamma on bright areas (default "1.0")
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions per-frame
+
+erosion/dilation AVOptions:
+   coordinates       <int>        ..FV.....T. set coordinates (from 0 to 255) (default 255)
+   threshold0        <int>        ..FV.....T. set threshold for 1st plane (from 0 to 65535) (default 65535)
+   threshold1        <int>        ..FV.....T. set threshold for 2nd plane (from 0 to 65535) (default 65535)
+   threshold2        <int>        ..FV.....T. set threshold for 3rd plane (from 0 to 65535) (default 65535)
+   threshold3        <int>        ..FV.....T. set threshold for 4th plane (from 0 to 65535) (default 65535)
+
+erosion_opencl AVOptions:
+   threshold0        <float>      ..FV....... set threshold for 1st plane (from 0 to 65535) (default 65535)
+   threshold1        <float>      ..FV....... set threshold for 2nd plane (from 0 to 65535) (default 65535)
+   threshold2        <float>      ..FV....... set threshold for 3rd plane (from 0 to 65535) (default 65535)
+   threshold3        <float>      ..FV....... set threshold for 4th plane (from 0 to 65535) (default 65535)
+   coordinates       <int>        ..FV....... set coordinates (from 0 to 255) (default 255)
+
+estdif AVOptions:
+   mode              <int>        ..FV.....T. specify the mode (from 0 to 1) (default field)
+     frame           0            ..FV.....T. send one frame for each frame
+     field           1            ..FV.....T. send one frame for each field
+   parity            <int>        ..FV.....T. specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV.....T. assume top field first
+     bff             1            ..FV.....T. assume bottom field first
+     auto            -1           ..FV.....T. auto detect parity
+   deint             <int>        ..FV.....T. specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV.....T. deinterlace all frames
+     interlaced      1            ..FV.....T. only deinterlace frames marked as interlaced
+   rslope            <int>        ..FV.....T. specify the search radius for edge slope tracing (from 1 to 15) (default 1)
+   redge             <int>        ..FV.....T. specify the search radius for best edge matching (from 0 to 15) (default 2)
+   ecost             <int>        ..FV.....T. specify the edge cost for edge matching (from 0 to 50) (default 2)
+   mcost             <int>        ..FV.....T. specify the middle cost for edge matching (from 0 to 50) (default 1)
+   dcost             <int>        ..FV.....T. specify the distance cost for edge matching (from 0 to 50) (default 1)
+   interp            <int>        ..FV.....T. specify the type of interpolation (from 0 to 2) (default 4p)
+     2p              0            ..FV.....T. two-point interpolation
+     4p              1            ..FV.....T. four-point interpolation
+     6p              2            ..FV.....T. six-point interpolation
+
+exposure AVOptions:
+   exposure          <float>      ..FV.....T. set the exposure correction (from -3 to 3) (default 0)
+   black             <float>      ..FV.....T. set the black level correction (from -1 to 1) (default 0)
+
+extractplanes AVOptions:
+   planes            <flags>      ..FV....... set planes (default r)
+     y                            ..FV....... set luma plane
+     u                            ..FV....... set u plane
+     v                            ..FV....... set v plane
+     r                            ..FV....... set red plane
+     g                            ..FV....... set green plane
+     b                            ..FV....... set blue plane
+     a                            ..FV....... set alpha plane
+
+fade AVOptions:
+   type              <int>        ..FV....... set the fade direction (from 0 to 1) (default in)
+     in              0            ..FV....... fade-in
+     out             1            ..FV....... fade-out
+   t                 <int>        ..FV....... set the fade direction (from 0 to 1) (default in)
+     in              0            ..FV....... fade-in
+     out             1            ..FV....... fade-out
+   start_frame       <int>        ..FV....... Number of the first frame to which to apply the effect. (from 0 to INT_MAX) (default 0)
+   s                 <int>        ..FV....... Number of the first frame to which to apply the effect. (from 0 to INT_MAX) (default 0)
+   nb_frames         <int>        ..FV....... Number of frames to which the effect should be applied. (from 1 to INT_MAX) (default 25)
+   n                 <int>        ..FV....... Number of frames to which the effect should be applied. (from 1 to INT_MAX) (default 25)
+   alpha             <boolean>    ..FV....... fade alpha if it is available on the input (default false)
+   start_time        <duration>   ..FV....... Number of seconds of the beginning of the effect. (default 0)
+   st                <duration>   ..FV....... Number of seconds of the beginning of the effect. (default 0)
+   duration          <duration>   ..FV....... Duration of the effect in seconds. (default 0)
+   d                 <duration>   ..FV....... Duration of the effect in seconds. (default 0)
+   color             <color>      ..FV....... set color (default "black")
+   c                 <color>      ..FV....... set color (default "black")
+
+feedback AVOptions:
+   x                 <int>        ..FV.....T. set top left crop position (from 0 to INT_MAX) (default 0)
+   y                 <int>        ..FV.....T. set top left crop position (from 0 to INT_MAX) (default 0)
+   w                 <int>        ..FV....... set crop size (from 0 to INT_MAX) (default 0)
+   h                 <int>        ..FV....... set crop size (from 0 to INT_MAX) (default 0)
+
+fftdnoiz AVOptions:
+   sigma             <float>      ..FV.....T. set denoise strength (from 0 to 100) (default 1)
+   amount            <float>      ..FV.....T. set amount of denoising (from 0.01 to 1) (default 1)
+   block             <int>        ..FV....... set block size (from 8 to 256) (default 32)
+   overlap           <float>      ..FV....... set block overlap (from 0.2 to 0.8) (default 0.5)
+   method            <int>        ..FV.....T. set method of denoising (from 0 to 1) (default wiener)
+     wiener          0            ..FV.....T. wiener method
+     hard            1            ..FV.....T. hard thresholding
+   prev              <int>        ..FV....... set number of previous frames for temporal denoising (from 0 to 1) (default 0)
+   next              <int>        ..FV....... set number of next frames for temporal denoising (from 0 to 1) (default 0)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 7)
+   window            <int>        ..FV....... set window function (from 0 to 20) (default hann)
+     rect            0            ..FV....... Rectangular
+     bartlett        4            ..FV....... Bartlett
+     hann            1            ..FV....... Hann
+     hanning         1            ..FV....... Hanning
+     hamming         2            ..FV....... Hamming
+     blackman        3            ..FV....... Blackman
+     welch           5            ..FV....... Welch
+     flattop         6            ..FV....... Flat-top
+     bharris         7            ..FV....... Blackman-Harris
+     bnuttall        8            ..FV....... Blackman-Nuttall
+     bhann           11           ..FV....... Bartlett-Hann
+     sine            9            ..FV....... Sine
+     nuttall         10           ..FV....... Nuttall
+     lanczos         12           ..FV....... Lanczos
+     gauss           13           ..FV....... Gauss
+     tukey           14           ..FV....... Tukey
+     dolph           15           ..FV....... Dolph-Chebyshev
+     cauchy          16           ..FV....... Cauchy
+     parzen          17           ..FV....... Parzen
+     poisson         18           ..FV....... Poisson
+     bohman          19           ..FV....... Bohman
+     kaiser          20           ..FV....... Kaiser
+
+fftfilt AVOptions:
+   dc_Y              <int>        ..FV....... adjust gain in Y plane (from 0 to 1000) (default 0)
+   dc_U              <int>        ..FV....... adjust gain in U plane (from 0 to 1000) (default 0)
+   dc_V              <int>        ..FV....... adjust gain in V plane (from 0 to 1000) (default 0)
+   weight_Y          <string>     ..FV....... set luminance expression in Y plane (default "1")
+   weight_U          <string>     ..FV....... set chrominance expression in U plane
+   weight_V          <string>     ..FV....... set chrominance expression in V plane
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions per-frame
+
+field AVOptions:
+   type              <int>        ..FV....... set field type (top or bottom) (from 0 to 1) (default top)
+     top             0            ..FV....... select top field
+     bottom          1            ..FV....... select bottom field
+
+fieldhint AVOptions:
+   hint              <string>     ..FV....... set hint file
+   mode              <int>        ..FV....... set hint mode (from 0 to 2) (default absolute)
+     absolute        0            ..FV.......
+     relative        1            ..FV.......
+     pattern         2            ..FV.......
+
+fieldmatch AVOptions:
+   order             <int>        ..FV....... specify the assumed field order (from -1 to 1) (default auto)
+     auto            -1           ..FV....... auto detect parity
+     bff             0            ..FV....... assume bottom field first
+     tff             1            ..FV....... assume top field first
+   mode              <int>        ..FV....... set the matching mode or strategy to use (from 0 to 5) (default pc_n)
+     pc              0            ..FV....... 2-way match (p/c)
+     pc_n            1            ..FV....... 2-way match + 3rd match on combed (p/c + u)
+     pc_u            2            ..FV....... 2-way match + 3rd match (same order) on combed (p/c + u)
+     pc_n_ub         3            ..FV....... 2-way match + 3rd match on combed + 4th/5th matches if still combed (p/c + u + u/b)
+     pcn             4            ..FV....... 3-way match (p/c/n)
+     pcn_ub          5            ..FV....... 3-way match + 4th/5th matches on combed (p/c/n + u/b)
+   ppsrc             <boolean>    ..FV....... mark main input as a pre-processed input and activate clean source input stream (default false)
+   field             <int>        ..FV....... set the field to match from (from -1 to 1) (default auto)
+     auto            -1           ..FV....... automatic (same value as 'order')
+     bottom          0            ..FV....... bottom field
+     top             1            ..FV....... top field
+   mchroma           <boolean>    ..FV....... set whether or not chroma is included during the match comparisons (default true)
+   y0                <int>        ..FV....... define an exclusion band which excludes the lines between y0 and y1 from the field matching decision (from 0 to INT_MAX) (default 0)
+   y1                <int>        ..FV....... define an exclusion band which excludes the lines between y0 and y1 from the field matching decision (from 0 to INT_MAX) (default 0)
+   scthresh          <double>     ..FV....... set scene change detection threshold (from 0 to 100) (default 12)
+   combmatch         <int>        ..FV....... set combmatching mode (from 0 to 2) (default sc)
+     none            0            ..FV....... disable combmatching
+     sc              1            ..FV....... enable combmatching only on scene change
+     full            2            ..FV....... enable combmatching all the time
+   combdbg           <int>        ..FV....... enable comb debug (from 0 to 2) (default none)
+     none            0            ..FV....... no forced calculation
+     pcn             1            ..FV....... calculate p/c/n
+     pcnub           2            ..FV....... calculate p/c/n/u/b
+   cthresh           <int>        ..FV....... set the area combing threshold used for combed frame detection (from -1 to 255) (default 9)
+   chroma            <boolean>    ..FV....... set whether or not chroma is considered in the combed frame decision (default false)
+   blockx            <int>        ..FV....... set the x-axis size of the window used during combed frame detection (from 4 to 512) (default 16)
+   blocky            <int>        ..FV....... set the y-axis size of the window used during combed frame detection (from 4 to 512) (default 16)
+   combpel           <int>        ..FV....... set the number of combed pixels inside any of the blocky by blockx size blocks on the frame for the frame to be detected as combed (from 0 to INT_MAX) (default 80)
+
+fieldorder AVOptions:
+   order             <int>        ..FV....... output field order (from 0 to 1) (default tff)
+     bff             0            ..FV....... bottom field first
+     tff             1            ..FV....... top field first
+
+fillborders AVOptions:
+   left              <int>        ..FV.....T. set the left fill border (from 0 to INT_MAX) (default 0)
+   right             <int>        ..FV.....T. set the right fill border (from 0 to INT_MAX) (default 0)
+   top               <int>        ..FV.....T. set the top fill border (from 0 to INT_MAX) (default 0)
+   bottom            <int>        ..FV.....T. set the bottom fill border (from 0 to INT_MAX) (default 0)
+   mode              <int>        ..FV.....T. set the fill borders mode (from 0 to 6) (default smear)
+     smear           0            ..FV.....T.
+     mirror          1            ..FV.....T.
+     fixed           2            ..FV.....T.
+     reflect         3            ..FV.....T.
+     wrap            4            ..FV.....T.
+     fade            5            ..FV.....T.
+     margins         6            ..FV.....T.
+   color             <color>      ..FV.....T. set the color for the fixed/fade mode (default "black")
+
+find_rect AVOptions:
+   object            <string>     ..FV....... object bitmap filename
+   threshold         <float>      ..FV....... set threshold (from 0 to 1) (default 0.5)
+   mipmaps           <int>        ..FV....... set mipmaps (from 1 to 5) (default 3)
+   xmin              <int>        ..FV.......  (from 0 to INT_MAX) (default 0)
+   ymin              <int>        ..FV.......  (from 0 to INT_MAX) (default 0)
+   xmax              <int>        ..FV.......  (from 0 to INT_MAX) (default 0)
+   ymax              <int>        ..FV.......  (from 0 to INT_MAX) (default 0)
+   discard           <boolean>    ..FV.......  (default false)
+
+flip_vulkan AVOptions:
+
+floodfill AVOptions:
+   x                 <int>        ..FV....... set pixel x coordinate (from 0 to 65535) (default 0)
+   y                 <int>        ..FV....... set pixel y coordinate (from 0 to 65535) (default 0)
+   s0                <int>        ..FV....... set source #0 component value (from -1 to 65535) (default 0)
+   s1                <int>        ..FV....... set source #1 component value (from -1 to 65535) (default 0)
+   s2                <int>        ..FV....... set source #2 component value (from -1 to 65535) (default 0)
+   s3                <int>        ..FV....... set source #3 component value (from -1 to 65535) (default 0)
+   d0                <int>        ..FV....... set destination #0 component value (from 0 to 65535) (default 0)
+   d1                <int>        ..FV....... set destination #1 component value (from 0 to 65535) (default 0)
+   d2                <int>        ..FV....... set destination #2 component value (from 0 to 65535) (default 0)
+   d3                <int>        ..FV....... set destination #3 component value (from 0 to 65535) (default 0)
+
+(no)format AVOptions:
+   pix_fmts          <string>     ..FV....... A '|'-separated list of pixel formats
+
+fps AVOptions:
+   fps               <string>     ..FV....... A string describing desired output framerate (default "25")
+   start_time        <double>     ..FV....... Assume the first PTS should be this value. (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+   round             <int>        ..FV....... set rounding method for timestamps (from 0 to 5) (default near)
+     zero            0            ..FV....... round towards 0
+     inf             1            ..FV....... round away from 0
+     down            2            ..FV....... round towards -infty
+     up              3            ..FV....... round towards +infty
+     near            5            ..FV....... round to nearest
+   eof_action        <int>        ..FV....... action performed for last frame (from 0 to 1) (default round)
+     round           0            ..FV....... round similar to other frames
+     pass            1            ..FV....... pass through last frame
+
+framepack AVOptions:
+   format            <int>        ..FV....... Frame pack output format (from 0 to INT_MAX) (default sbs)
+     sbs             1            ..FV....... Views are packed next to each other
+     tab             2            ..FV....... Views are packed on top of each other
+     frameseq        3            ..FV....... Views are one after the other
+     lines           6            ..FV....... Views are interleaved by lines
+     columns         7            ..FV....... Views are interleaved by columns
+
+framerate AVOptions:
+   fps               <video_rate> ..FV....... required output frames per second rate (default "50")
+   interp_start      <int>        ..FV....... point to start linear interpolation (from 0 to 255) (default 15)
+   interp_end        <int>        ..FV....... point to end linear interpolation (from 0 to 255) (default 240)
+   scene             <double>     ..FV....... scene change level (from 0 to 100) (default 8.2)
+   flags             <flags>      ..FV....... set flags (default scene_change_detect+scd)
+     scene_change_detect              ..FV....... enable scene change detection
+     scd                          ..FV....... enable scene change detection
+
+framestep AVOptions:
+   step              <int>        ..FV....... set frame step (from 1 to INT_MAX) (default 1)
+
+freezedetect AVOptions:
+   n                 <double>     ..FV....... set noise tolerance (from 0 to 1) (default 0.001)
+   noise             <double>     ..FV....... set noise tolerance (from 0 to 1) (default 0.001)
+   d                 <duration>   ..FV....... set minimum duration in seconds (default 2)
+   duration          <duration>   ..FV....... set minimum duration in seconds (default 2)
+
+freezeframes AVOptions:
+   first             <int64>      ..FV....... set first frame to freeze (from 0 to I64_MAX) (default 0)
+   last              <int64>      ..FV....... set last frame to freeze (from 0 to I64_MAX) (default 0)
+   replace           <int64>      ..FV....... set frame to replace (from 0 to I64_MAX) (default 0)
+
+frei0r AVOptions:
+   filter_name       <string>     ..FV.......
+   filter_params     <string>     ..FV.....T.
+
+fspp AVOptions:
+   quality           <int>        ..FV....... set quality (from 4 to 5) (default 4)
+   qp                <int>        ..FV....... force a constant quantizer parameter (from 0 to 64) (default 0)
+   strength          <int>        ..FV....... set filter strength (from -15 to 32) (default 0)
+   use_bframe_qp     <boolean>    ..FV....... use B-frames' QP (default false)
+
+gblur AVOptions:
+   sigma             <float>      ..FV.....T. set sigma (from 0 to 1024) (default 0.5)
+   steps             <int>        ..FV.....T. set number of steps (from 1 to 6) (default 1)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   sigmaV            <float>      ..FV.....T. set vertical sigma (from -1 to 1024) (default -1)
+
+gblur_vulkan AVOptions:
+   sigma             <float>      ..FV....... Set sigma (from 0.01 to 1024) (default 0.5)
+   sigmaV            <float>      ..FV....... Set vertical sigma (from 0 to 1024) (default 0)
+   planes            <int>        ..FV....... Set planes to filter (from 0 to 15) (default 15)
+   size              <int>        ..FV....... Set kernel size (from 1 to 127) (default 19)
+   sizeV             <int>        ..FV....... Set vertical kernel size (from 0 to 127) (default 0)
+
+geq AVOptions:
+   lum_expr          <string>     ..FV....... set luminance expression
+   lum               <string>     ..FV....... set luminance expression
+   cb_expr           <string>     ..FV....... set chroma blue expression
+   cb                <string>     ..FV....... set chroma blue expression
+   cr_expr           <string>     ..FV....... set chroma red expression
+   cr                <string>     ..FV....... set chroma red expression
+   alpha_expr        <string>     ..FV....... set alpha expression
+   a                 <string>     ..FV....... set alpha expression
+   red_expr          <string>     ..FV....... set red expression
+   r                 <string>     ..FV....... set red expression
+   green_expr        <string>     ..FV....... set green expression
+   g                 <string>     ..FV....... set green expression
+   blue_expr         <string>     ..FV....... set blue expression
+   b                 <string>     ..FV....... set blue expression
+   interpolation     <int>        ..FV....... set interpolation method (from 0 to 1) (default bilinear)
+     nearest         0            ..FV....... nearest interpolation
+     n               0            ..FV....... nearest interpolation
+     bilinear        1            ..FV....... bilinear interpolation
+     b               1            ..FV....... bilinear interpolation
+   i                 <int>        ..FV....... set interpolation method (from 0 to 1) (default bilinear)
+     nearest         0            ..FV....... nearest interpolation
+     n               0            ..FV....... nearest interpolation
+     bilinear        1            ..FV....... bilinear interpolation
+     b               1            ..FV....... bilinear interpolation
+
+gradfun AVOptions:
+   strength          <float>      ..FV....... The maximum amount by which the filter will change any one pixel. (from 0.51 to 64) (default 1.2)
+   radius            <int>        ..FV....... The neighborhood to fit the gradient to. (from 4 to 32) (default 16)
+
+(a)graphmonitor AVOptions:
+   size              <image_size> ..FV....... set monitor size (default "hd720")
+   s                 <image_size> ..FV....... set monitor size (default "hd720")
+   opacity           <float>      ..FV.....T. set video opacity (from 0 to 1) (default 0.9)
+   o                 <float>      ..FV.....T. set video opacity (from 0 to 1) (default 0.9)
+   mode              <flags>      ..FV.....T. set mode (default 0)
+     full                         ..FV.....T.
+     compact                      ..FV.....T.
+     nozero                       ..FV.....T.
+     noeof                        ..FV.....T.
+     nodisabled                   ..FV.....T.
+   m                 <flags>      ..FV.....T. set mode (default 0)
+     full                         ..FV.....T.
+     compact                      ..FV.....T.
+     nozero                       ..FV.....T.
+     noeof                        ..FV.....T.
+     nodisabled                   ..FV.....T.
+   flags             <flags>      ..FV.....T. set flags (default all+queue)
+     none                         ..FV.....T.
+     all                          ..FV.....T.
+     queue                        ..FV.....T.
+     frame_count_in               ..FV.....T.
+     frame_count_out              ..FV.....T.
+     frame_count_delta              ..FV.....T.
+     pts                          ..FV.....T.
+     pts_delta                    ..FV.....T.
+     time                         ..FV.....T.
+     time_delta                   ..FV.....T.
+     timebase                     ..FV.....T.
+     format                       ..FV.....T.
+     size                         ..FV.....T.
+     rate                         ..FV.....T.
+     eof                          ..FV.....T.
+     sample_count_in              ..FV.....T.
+     sample_count_out              ..FV.....T.
+     sample_count_delta              ..FV.....T.
+     disabled                     ..FV.....T.
+   f                 <flags>      ..FV.....T. set flags (default all+queue)
+     none                         ..FV.....T.
+     all                          ..FV.....T.
+     queue                        ..FV.....T.
+     frame_count_in               ..FV.....T.
+     frame_count_out              ..FV.....T.
+     frame_count_delta              ..FV.....T.
+     pts                          ..FV.....T.
+     pts_delta                    ..FV.....T.
+     time                         ..FV.....T.
+     time_delta                   ..FV.....T.
+     timebase                     ..FV.....T.
+     format                       ..FV.....T.
+     size                         ..FV.....T.
+     rate                         ..FV.....T.
+     eof                          ..FV.....T.
+     sample_count_in              ..FV.....T.
+     sample_count_out              ..FV.....T.
+     sample_count_delta              ..FV.....T.
+     disabled                     ..FV.....T.
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+
+grayworld AVOptions:
+
+greyedge AVOptions:
+   difford           <int>        ..FV....... set differentiation order (from 0 to 2) (default 1)
+   minknorm          <int>        ..FV....... set Minkowski norm (from 0 to 20) (default 1)
+   sigma             <double>     ..FV....... set sigma (from 0 to 1024) (default 1)
+
+guided AVOptions:
+   radius            <int>        ..FV.....T. set the box radius (from 1 to 20) (default 3)
+   eps               <float>      ..FV.....T. set the regularization parameter (with square) (from 0 to 1) (default 0.01)
+   mode              <int>        ..FV.....T. set filtering mode (0: basic mode; 1: fast mode) (from 0 to 1) (default basic)
+     basic           0            ..FV.....T. basic guided filter
+     fast            1            ..FV.....T. fast guided filter
+   sub               <int>        ..FV.....T. subsampling ratio for fast mode (from 2 to 64) (default 4)
+   guidance          <int>        ..FV....... set guidance mode (0: off mode; 1: on mode) (from 0 to 1) (default off)
+     off             0            ..FV....... only one input is enabled
+     on              1            ..FV....... two inputs are required
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 1)
+
+haldclut AVOptions:
+   clut              <int>        ..FV.....T. when to process CLUT (from 0 to 1) (default all)
+     first           0            ..FV.....T. process only first CLUT, ignore rest
+     all             1            ..FV.....T. process all CLUTs
+   interp            <int>        ..FV.....T. select interpolation mode (from 0 to 4) (default tetrahedral)
+     nearest         0            ..FV.....T. use values from the nearest defined points
+     trilinear       1            ..FV.....T. interpolate values using the 8 points defining a cube
+     tetrahedral     2            ..FV.....T. interpolate values using a tetrahedron
+     pyramid         3            ..FV.....T. interpolate values using a pyramid
+     prism           4            ..FV.....T. interpolate values using a prism
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+hflip AVOptions:
+
+hflip_vulkan AVOptions:
+
+histeq AVOptions:
+   strength          <float>      ..FV....... set the strength (from 0 to 1) (default 0.2)
+   intensity         <float>      ..FV....... set the intensity (from 0 to 1) (default 0.21)
+   antibanding       <int>        ..FV....... set the antibanding level (from 0 to 2) (default none)
+     none            0            ..FV....... apply no antibanding
+     weak            1            ..FV....... apply weak antibanding
+     strong          2            ..FV....... apply strong antibanding
+
+histogram AVOptions:
+   level_height      <int>        ..FV....... set level height (from 50 to 2048) (default 200)
+   scale_height      <int>        ..FV....... set scale height (from 0 to 40) (default 12)
+   display_mode      <int>        ..FV....... set display mode (from 0 to 2) (default stack)
+     overlay         0            ..FV.......
+     parade          1            ..FV.......
+     stack           2            ..FV.......
+   d                 <int>        ..FV....... set display mode (from 0 to 2) (default stack)
+     overlay         0            ..FV.......
+     parade          1            ..FV.......
+     stack           2            ..FV.......
+   levels_mode       <int>        ..FV....... set levels mode (from 0 to 1) (default linear)
+     linear          0            ..FV.......
+     logarithmic     1            ..FV.......
+   m                 <int>        ..FV....... set levels mode (from 0 to 1) (default linear)
+     linear          0            ..FV.......
+     logarithmic     1            ..FV.......
+   components        <int>        ..FV....... set color components to display (from 1 to 15) (default 7)
+   c                 <int>        ..FV....... set color components to display (from 1 to 15) (default 7)
+   fgopacity         <float>      ..FV....... set foreground opacity (from 0 to 1) (default 0.7)
+   f                 <float>      ..FV....... set foreground opacity (from 0 to 1) (default 0.7)
+   bgopacity         <float>      ..FV....... set background opacity (from 0 to 1) (default 0.5)
+   b                 <float>      ..FV....... set background opacity (from 0 to 1) (default 0.5)
+   colors_mode       <int>        ..FV....... set colors mode (from 0 to 9) (default whiteonblack)
+     whiteonblack    0            ..FV.......
+     blackonwhite    1            ..FV.......
+     whiteongray     2            ..FV.......
+     blackongray     3            ..FV.......
+     coloronblack    4            ..FV.......
+     coloronwhite    5            ..FV.......
+     colorongray     6            ..FV.......
+     blackoncolor    7            ..FV.......
+     whiteoncolor    8            ..FV.......
+     grayoncolor     9            ..FV.......
+   l                 <int>        ..FV....... set colors mode (from 0 to 9) (default whiteonblack)
+     whiteonblack    0            ..FV.......
+     blackonwhite    1            ..FV.......
+     whiteongray     2            ..FV.......
+     blackongray     3            ..FV.......
+     coloronblack    4            ..FV.......
+     coloronwhite    5            ..FV.......
+     colorongray     6            ..FV.......
+     blackoncolor    7            ..FV.......
+     whiteoncolor    8            ..FV.......
+     grayoncolor     9            ..FV.......
+
+hqdn3d AVOptions:
+   luma_spatial      <double>     ..FV.....T. spatial luma strength (from 0 to DBL_MAX) (default 0)
+   chroma_spatial    <double>     ..FV.....T. spatial chroma strength (from 0 to DBL_MAX) (default 0)
+   luma_tmp          <double>     ..FV.....T. temporal luma strength (from 0 to DBL_MAX) (default 0)
+   chroma_tmp        <double>     ..FV.....T. temporal chroma strength (from 0 to DBL_MAX) (default 0)
+
+hqx AVOptions:
+   n                 <int>        ..FV....... set scale factor (from 2 to 4) (default 3)
+
+(h|v)stack AVOptions:
+   inputs            <int>        ..FV....... set number of inputs (from 2 to INT_MAX) (default 2)
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+
+hsvhold AVOptions:
+   hue               <float>      ..FV.....T. set the hue value (from -360 to 360) (default 0)
+   sat               <float>      ..FV.....T. set the saturation value (from -1 to 1) (default 0)
+   val               <float>      ..FV.....T. set the value value (from -1 to 1) (default 0)
+   similarity        <float>      ..FV.....T. set the hsvhold similarity value (from 1e-05 to 1) (default 0.01)
+   blend             <float>      ..FV.....T. set the hsvhold blend value (from 0 to 1) (default 0)
+
+hsvkey AVOptions:
+   hue               <float>      ..FV.....T. set the hue value (from -360 to 360) (default 0)
+   sat               <float>      ..FV.....T. set the saturation value (from -1 to 1) (default 0)
+   val               <float>      ..FV.....T. set the value value (from -1 to 1) (default 0)
+   similarity        <float>      ..FV.....T. set the hsvkey similarity value (from 1e-05 to 1) (default 0.01)
+   blend             <float>      ..FV.....T. set the hsvkey blend value (from 0 to 1) (default 0)
+
+hue AVOptions:
+   h                 <string>     ..FV.....T. set the hue angle degrees expression
+   s                 <string>     ..FV.....T. set the saturation expression (default "1")
+   H                 <string>     ..FV.....T. set the hue angle radians expression
+   b                 <string>     ..FV.....T. set the brightness expression (default "0")
+
+huesaturation AVOptions:
+   hue               <float>      ..FV.....T. set the hue shift (from -180 to 180) (default 0)
+   saturation        <float>      ..FV.....T. set the saturation shift (from -1 to 1) (default 0)
+   intensity         <float>      ..FV.....T. set the intensity shift (from -1 to 1) (default 0)
+   colors            <flags>      ..FV.....T. set colors range (default r+y+g+c+b+m+a)
+     r                            ..FV.....T. set reds
+     y                            ..FV.....T. set yellows
+     g                            ..FV.....T. set greens
+     c                            ..FV.....T. set cyans
+     b                            ..FV.....T. set blues
+     m                            ..FV.....T. set magentas
+     a                            ..FV.....T. set all colors
+   strength          <float>      ..FV.....T. set the filtering strength (from 0 to 100) (default 1)
+   rw                <float>      ..FV.....T. set the red weight (from 0 to 1) (default 0.333)
+   gw                <float>      ..FV.....T. set the green weight (from 0 to 1) (default 0.334)
+   bw                <float>      ..FV.....T. set the blue weight (from 0 to 1) (default 0.333)
+   lightness         <boolean>    ..FV.....T. set the preserve lightness (default false)
+
+hwmap AVOptions:
+   mode              <flags>      ..FV....... Frame mapping mode (default read+write)
+     read                         ..FV....... Mapping should be readable
+     write                        ..FV....... Mapping should be writeable
+     overwrite                    ..FV....... Mapping will always overwrite the entire frame
+     direct                       ..FV....... Mapping should not involve any copying
+   derive_device     <string>     ..FV....... Derive a new device of this type
+   reverse           <int>        ..FV....... Map in reverse (create and allocate in the sink) (from 0 to 1) (default 0)
+
+hwupload AVOptions:
+   derive_device     <string>     ..FV....... Derive a new device of this type
+
+cudaupload AVOptions:
+   device            <int>        ..FV....... Number of the device to use (from 0 to INT_MAX) (default 0)
+
+hysteresis AVOptions:
+   planes            <int>        ..FV....... set planes (from 0 to 15) (default 15)
+   threshold         <int>        ..FV....... set threshold (from 0 to 65535) (default 0)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+identity AVOptions:
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+idet AVOptions:
+   intl_thres        <float>      ..FV....... set interlacing threshold (from -1 to FLT_MAX) (default 1.04)
+   prog_thres        <float>      ..FV....... set progressive threshold (from -1 to FLT_MAX) (default 1.5)
+   rep_thres         <float>      ..FV....... set repeat threshold (from -1 to FLT_MAX) (default 3)
+   half_life         <float>      ..FV....... half life of cumulative statistics (from -1 to INT_MAX) (default 0)
+   analyze_interlaced_flag <int>        ..FV....... set number of frames to use to determine if the interlace flag is accurate (from 0 to INT_MAX) (default 0)
+
+il AVOptions:
+   luma_mode         <int>        ..FV.....T. select luma mode (from 0 to 2) (default none)
+     none            0            ..FV.....T.
+     interleave      1            ..FV.....T.
+     i               1            ..FV.....T.
+     deinterleave    2            ..FV.....T.
+     d               2            ..FV.....T.
+   l                 <int>        ..FV.....T. select luma mode (from 0 to 2) (default none)
+     none            0            ..FV.....T.
+     interleave      1            ..FV.....T.
+     i               1            ..FV.....T.
+     deinterleave    2            ..FV.....T.
+     d               2            ..FV.....T.
+   chroma_mode       <int>        ..FV.....T. select chroma mode (from 0 to 2) (default none)
+     none            0            ..FV.....T.
+     interleave      1            ..FV.....T.
+     i               1            ..FV.....T.
+     deinterleave    2            ..FV.....T.
+     d               2            ..FV.....T.
+   c                 <int>        ..FV.....T. select chroma mode (from 0 to 2) (default none)
+     none            0            ..FV.....T.
+     interleave      1            ..FV.....T.
+     i               1            ..FV.....T.
+     deinterleave    2            ..FV.....T.
+     d               2            ..FV.....T.
+   alpha_mode        <int>        ..FV.....T. select alpha mode (from 0 to 2) (default none)
+     none            0            ..FV.....T.
+     interleave      1            ..FV.....T.
+     i               1            ..FV.....T.
+     deinterleave    2            ..FV.....T.
+     d               2            ..FV.....T.
+   a                 <int>        ..FV.....T. select alpha mode (from 0 to 2) (default none)
+     none            0            ..FV.....T.
+     interleave      1            ..FV.....T.
+     i               1            ..FV.....T.
+     deinterleave    2            ..FV.....T.
+     d               2            ..FV.....T.
+   luma_swap         <boolean>    ..FV.....T. swap luma fields (default false)
+   ls                <boolean>    ..FV.....T. swap luma fields (default false)
+   chroma_swap       <boolean>    ..FV.....T. swap chroma fields (default false)
+   cs                <boolean>    ..FV.....T. swap chroma fields (default false)
+   alpha_swap        <boolean>    ..FV.....T. swap alpha fields (default false)
+   as                <boolean>    ..FV.....T. swap alpha fields (default false)
+
+deflate/inflate AVOptions:
+   threshold0        <int>        ..FV.....T. set threshold for 1st plane (from 0 to 65535) (default 65535)
+   threshold1        <int>        ..FV.....T. set threshold for 2nd plane (from 0 to 65535) (default 65535)
+   threshold2        <int>        ..FV.....T. set threshold for 3rd plane (from 0 to 65535) (default 65535)
+   threshold3        <int>        ..FV.....T. set threshold for 4th plane (from 0 to 65535) (default 65535)
+
+interlace AVOptions:
+   scan              <int>        ..FV....... scanning mode (from 0 to 1) (default tff)
+     tff             0            ..FV....... top field first
+     bff             1            ..FV....... bottom field first
+   lowpass           <int>        ..FV....... set vertical low-pass filter (from 0 to 2) (default linear)
+     off             0            ..FV....... disable vertical low-pass filter
+     linear          1            ..FV....... linear vertical low-pass filter
+     complex         2            ..FV....... complex vertical low-pass filter
+
+interleave AVOptions:
+   nb_inputs         <int>        ..FV....... set number of inputs (from 1 to INT_MAX) (default 2)
+   n                 <int>        ..FV....... set number of inputs (from 1 to INT_MAX) (default 2)
+   duration          <int>        ..FV....... how to determine the end-of-stream (from 0 to 2) (default longest)
+     longest         0            ..FV....... Duration of longest input
+     shortest        1            ..FV....... Duration of shortest input
+     first           2            ..FV....... Duration of first input
+
+kerndeint AVOptions:
+   thresh            <int>        ..FV....... set the threshold (from 0 to 255) (default 10)
+   map               <boolean>    ..FV....... set the map (default false)
+   order             <boolean>    ..FV....... set the order (default false)
+   sharp             <boolean>    ..FV....... set sharpening (default false)
+   twoway            <boolean>    ..FV....... set twoway (default false)
+
+kirsch/prewitt/roberts/scharr/sobel AVOptions:
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV.....T. set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV.....T. set delta (from -65535 to 65535) (default 0)
+
+lagfun AVOptions:
+   decay             <float>      ..FV.....T. set decay (from 0 to 1) (default 0.95)
+   planes            <flags>      ..FV.....T. set what planes to filter (default F)
+
+lenscorrection AVOptions:
+   cx                <double>     ..FV.....T. set relative center x (from 0 to 1) (default 0.5)
+   cy                <double>     ..FV.....T. set relative center y (from 0 to 1) (default 0.5)
+   k1                <double>     ..FV.....T. set quadratic distortion factor (from -1 to 1) (default 0)
+   k2                <double>     ..FV.....T. set double quadratic distortion factor (from -1 to 1) (default 0)
+   i                 <int>        ..FV.....T. set interpolation type (from 0 to 64) (default nearest)
+     nearest         0            ..FV.....T. nearest neighbour
+     bilinear        1            ..FV.....T. bilinear
+   fc                <color>      ..FV.....T. set the color of the unmapped pixels (default "black@0")
+
+libplacebo AVOptions:
+   inputs            <int>        ..FV....... Number of inputs (from 1 to INT_MAX) (default 1)
+   w                 <string>     ..FV....... Output video frame width (default "iw")
+   h                 <string>     ..FV....... Output video frame height (default "ih")
+   fps               <string>     ..FV....... Output video frame rate (default "none")
+   crop_x            <string>     ..FV.....T. Input video crop x (default "(iw-cw)/2")
+   crop_y            <string>     ..FV.....T. Input video crop y (default "(ih-ch)/2")
+   crop_w            <string>     ..FV.....T. Input video crop w (default "iw")
+   crop_h            <string>     ..FV.....T. Input video crop h (default "ih")
+   pos_x             <string>     ..FV.....T. Output video placement x (default "(ow-pw)/2")
+   pos_y             <string>     ..FV.....T. Output video placement y (default "(oh-ph)/2")
+   pos_w             <string>     ..FV.....T. Output video placement w (default "ow")
+   pos_h             <string>     ..FV.....T. Output video placement h (default "oh")
+   format            <string>     ..FV....... Output video format
+   force_original_aspect_ratio <int>        ..FV....... decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)
+     disable         0            ..FV.......
+     decrease        1            ..FV.......
+     increase        2            ..FV.......
+   force_divisible_by <int>        ..FV....... enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)
+   normalize_sar     <boolean>    ..FV....... force SAR normalization to 1:1 by adjusting pos_x/y/w/h (default false)
+   pad_crop_ratio    <float>      ..FV.....T. ratio between padding and cropping when normalizing SAR (0=pad, 1=crop) (from 0 to 1) (default 0)
+   fillcolor         <string>     ..FV.....T. Background fill color (default "black")
+   corner_rounding   <float>      ..FV.....T. Corner rounding radius (from 0 to 1) (default 0)
+   extra_opts        <dictionary> ..FV.....T. Pass extra libplacebo-specific options using a :-separated list of key=value pairs
+   colorspace        <int>        ..FV.....T. select colorspace (from -1 to 14) (default auto)
+     auto            -1           ..FV....... keep the same colorspace
+     gbr             0            ..FV.......
+     bt709           1            ..FV.......
+     unknown         2            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     ycgco           8            ..FV.......
+     bt2020nc        9            ..FV.......
+     bt2020c         10           ..FV.......
+     ictcp           14           ..FV.......
+   range             <int>        ..FV.....T. select color range (from -1 to 2) (default auto)
+     auto            -1           ..FV....... keep the same color range
+     unspecified     0            ..FV.......
+     unknown         0            ..FV.......
+     limited         1            ..FV.......
+     tv              1            ..FV.......
+     mpeg            1            ..FV.......
+     full            2            ..FV.......
+     pc              2            ..FV.......
+     jpeg            2            ..FV.......
+   color_primaries   <int>        ..FV.....T. select color primaries (from -1 to 22) (default auto)
+     auto            -1           ..FV....... keep the same color primaries
+     bt709           1            ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     film            8            ..FV.......
+     bt2020          9            ..FV.......
+     smpte428        10           ..FV.......
+     smpte431        11           ..FV.......
+     smpte432        12           ..FV.......
+     jedec-p22       22           ..FV.......
+     ebu3213         22           ..FV.......
+   color_trc         <int>        ..FV.....T. select color transfer (from -1 to 18) (default auto)
+     auto            -1           ..FV....... keep the same color transfer
+     bt709           1            ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     linear          8            ..FV.......
+     iec61966-2-4    11           ..FV.......
+     bt1361e         12           ..FV.......
+     iec61966-2-1    13           ..FV.......
+     bt2020-10       14           ..FV.......
+     bt2020-12       15           ..FV.......
+     smpte2084       16           ..FV.......
+     arib-std-b67    18           ..FV.......
+   upscaler          <string>     ..FV.....T. Upscaler function (default "spline36")
+   downscaler        <string>     ..FV.....T. Downscaler function (default "mitchell")
+   frame_mixer       <string>     ..FV.....T. Frame mixing function (default "none")
+   lut_entries       <int>        ..FV.....T. Number of scaler LUT entries (from 0 to 256) (default 0)
+   antiringing       <float>      ..FV.....T. Antiringing strength (for non-EWA filters) (from 0 to 1) (default 0)
+   sigmoid           <boolean>    ..FV.....T. Enable sigmoid upscaling (default true)
+   apply_filmgrain   <boolean>    ..FV.....T. Apply film grain metadata (default true)
+   apply_dolbyvision <boolean>    ..FV.....T. Apply Dolby Vision metadata (default true)
+   deband            <boolean>    ..FV.....T. Enable debanding (default false)
+   deband_iterations <int>        ..FV.....T. Deband iterations (from 0 to 16) (default 1)
+   deband_threshold  <float>      ..FV.....T. Deband threshold (from 0 to 1024) (default 4)
+   deband_radius     <float>      ..FV.....T. Deband radius (from 0 to 1024) (default 16)
+   deband_grain      <float>      ..FV.....T. Deband grain (from 0 to 1024) (default 6)
+   brightness        <float>      ..FV.....T. Brightness boost (from -1 to 1) (default 0)
+   contrast          <float>      ..FV.....T. Contrast gain (from 0 to 16) (default 1)
+   saturation        <float>      ..FV.....T. Saturation gain (from 0 to 16) (default 1)
+   hue               <float>      ..FV.....T. Hue shift (from -3.14159 to 3.14159) (default 0)
+   gamma             <float>      ..FV.....T. Gamma adjustment (from 0 to 16) (default 1)
+   peak_detect       <boolean>    ..FV.....T. Enable dynamic peak detection for HDR tone-mapping (default true)
+   smoothing_period  <float>      ..FV.....T. Peak detection smoothing period (from 0 to 1000) (default 100)
+   minimum_peak      <float>      ..FV.....T. Peak detection minimum peak (from 0 to 100) (default 1)
+   scene_threshold_low <float>      ..FV.....T. Scene change low threshold (from -1 to 100) (default 5.5)
+   scene_threshold_high <float>      ..FV.....T. Scene change high threshold (from -1 to 100) (default 10)
+   percentile        <float>      ..FV.....T. Peak detection percentile (from 0 to 100) (default 99.995)
+   gamut_mode        <int>        ..FV.....T. Gamut-mapping mode (from 0 to 8) (default perceptual)
+     clip            0            ..FV....... Hard-clip (RGB per-channel)
+     perceptual      1            ..FV....... Colorimetric soft clipping
+     relative        2            ..FV....... Relative colorimetric clipping
+     saturation      3            ..FV....... Saturation mapping (RGB -> RGB)
+     absolute        4            ..FV....... Absolute colorimetric clipping
+     desaturate      5            ..FV....... Colorimetrically desaturate colors towards white
+     darken          6            ..FV....... Colorimetric clip with bias towards darkening image to fit gamut
+     warn            7            ..FV....... Highlight out-of-gamut colors
+     linear          8            ..FV....... Linearly reduce chromaticity to fit gamut
+   tonemapping       <int>        ..FV.....T. Tone-mapping algorithm (from 0 to 11) (default auto)
+     auto            0            ..FV....... Automatic selection
+     clip            1            ..FV....... No tone mapping (clip
+     st2094-40       2            ..FV....... SMPTE ST 2094-40
+     st2094-10       3            ..FV....... SMPTE ST 2094-10
+     bt.2390         4            ..FV....... ITU-R BT.2390 EETF
+     bt.2446a        5            ..FV....... ITU-R BT.2446 Method A
+     spline          6            ..FV....... Single-pivot polynomial spline
+     reinhard        7            ..FV....... Reinhard
+     mobius          8            ..FV....... Mobius
+     hable           9            ..FV....... Filmic tone-mapping (Hable)
+     gamma           10           ..FV....... Gamma function with knee
+     linear          11           ..FV....... Perceptually linear stretch
+   tonemapping_param <float>      ..FV.....T. Tunable parameter for some tone-mapping functions (from 0 to 100) (default 0)
+   inverse_tonemapping <boolean>    ..FV.....T. Inverse tone mapping (range expansion) (default false)
+   tonemapping_lut_size <int>        ..FV.....T. Tone-mapping LUT size (from 2 to 1024) (default 256)
+   contrast_recovery <float>      ..FV.....T. HDR contrast recovery strength (from 0 to 3) (default 0.3)
+   contrast_smoothness <float>      ..FV.....T. HDR contrast recovery smoothness (from 1 to 32) (default 3.5)
+   desaturation_strength <float>      ..FV.....TP Desaturation strength (from -1 to 1) (default -1)
+   desaturation_exponent <float>      ..FV.....TP Desaturation exponent (from -1 to 10) (default -1)
+   gamut_warning     <boolean>    ..FV.....TP Highlight out-of-gamut colors (default false)
+   gamut_clipping    <boolean>    ..FV.....TP Enable desaturating colorimetric gamut clipping (default false)
+   intent            <int>        ..FV.....TP Rendering intent (from 0 to 3) (default perceptual)
+     perceptual      0            ..FV....... Perceptual
+     relative        1            ..FV....... Relative colorimetric
+     absolute        3            ..FV....... Absolute colorimetric
+     saturation      2            ..FV....... Saturation mapping
+   tonemapping_mode  <int>        ..FV.....TP Tone-mapping mode (from 0 to 4) (default auto)
+     auto            0            ..FV....... Automatic selection
+     rgb             1            ..FV....... Per-channel (RGB)
+     max             2            ..FV....... Maximum component
+     hybrid          3            ..FV....... Hybrid of Luma/RGB
+     luma            4            ..FV....... Luminance
+   tonemapping_crosstalk <float>      ..FV.....TP Crosstalk factor for tone-mapping (from 0 to 0.3) (default 0.04)
+   overshoot         <float>      ..FV.....TP Tone-mapping overshoot margin (from 0 to 1) (default 0.05)
+   hybrid_mix        <float>      ..FV.....T. Tone-mapping hybrid LMS mixing coefficient (from 0 to 1) (default 0.2)
+   dithering         <int>        ..FV.....T. Dither method to use (from -1 to 3) (default blue)
+     none            -1           ..FV....... Disable dithering
+     blue            0            ..FV....... Blue noise
+     ordered         1            ..FV....... Ordered LUT
+     ordered_fixed   2            ..FV....... Fixed function ordered
+     white           3            ..FV....... White noise
+   dither_lut_size   <int>        ..FV....... Dithering LUT size (from 1 to 8) (default 6)
+   dither_temporal   <boolean>    ..FV.....T. Enable temporal dithering (default false)
+   cones             <flags>      ..FV.....T. Colorblindness adaptation model (default 0)
+     l                            ..FV....... L cone
+     m                            ..FV....... M cone
+     s                            ..FV....... S cone
+   cone-strength     <float>      ..FV.....T. Colorblindness adaptation strength (from 0 to 10) (default 0)
+   custom_shader_path <string>     ..FV....... Path to custom user shader (mpv .hook format)
+   custom_shader_bin <binary>     ..FV....... Custom user shader as binary (mpv .hook format)
+   skip_aa           <boolean>    ..FV.....T. Skip anti-aliasing (default false)
+   polar_cutoff      <float>      ..FV.....T. Polar LUT cutoff (from 0 to 1) (default 0)
+   disable_linear    <boolean>    ..FV.....T. Disable linear scaling (default false)
+   disable_builtin   <boolean>    ..FV.....T. Disable built-in scalers (default false)
+   force_icc_lut     <boolean>    ..FV.....TP Deprecated, does nothing (default false)
+   force_dither      <boolean>    ..FV.....T. Force dithering (default false)
+   disable_fbos      <boolean>    ..FV.....T. Force-disable FBOs (default false)
+
+limitdiff AVOptions:
+   threshold         <float>      ..FV.....T. set the threshold (from 0 to 1) (default 0.00392157)
+   elasticity        <float>      ..FV.....T. set the elasticity (from 0 to 10) (default 2)
+   reference         <boolean>    ..FV....... enable reference stream (default false)
+   planes            <int>        ..FV.....T. set the planes to filter (from 0 to 15) (default 15)
+
+limiter AVOptions:
+   min               <int>        ..FV.....T. set min value (from 0 to 65535) (default 0)
+   max               <int>        ..FV.....T. set max value (from 0 to 65535) (default 65535)
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+
+loop AVOptions:
+   loop              <int>        ..FV....... number of loops (from -1 to INT_MAX) (default 0)
+   size              <int64>      ..FV....... max number of frames to loop (from 0 to 32767) (default 0)
+   start             <int64>      ..FV....... set the loop start frame (from -1 to I64_MAX) (default 0)
+   time              <duration>   ..FV....... set the loop start time (default INT64_MAX)
+
+lumakey AVOptions:
+   threshold         <double>     ..FV.....T. set the threshold value (from 0 to 1) (default 0)
+   tolerance         <double>     ..FV.....T. set the tolerance value (from 0 to 1) (default 0.01)
+   softness          <double>     ..FV.....T. set the softness value (from 0 to 1) (default 0)
+
+lut/lutyuv/lutrgb AVOptions:
+   c0                <string>     ..FV.....T. set component #0 expression (default "clipval")
+   c1                <string>     ..FV.....T. set component #1 expression (default "clipval")
+   c2                <string>     ..FV.....T. set component #2 expression (default "clipval")
+   c3                <string>     ..FV.....T. set component #3 expression (default "clipval")
+   y                 <string>     ..FV.....T. set Y expression (default "clipval")
+   u                 <string>     ..FV.....T. set U expression (default "clipval")
+   v                 <string>     ..FV.....T. set V expression (default "clipval")
+   r                 <string>     ..FV.....T. set R expression (default "clipval")
+   g                 <string>     ..FV.....T. set G expression (default "clipval")
+   b                 <string>     ..FV.....T. set B expression (default "clipval")
+   a                 <string>     ..FV.....T. set A expression (default "clipval")
+
+lut1d AVOptions:
+   file              <string>     ..FV.....T. set 1D LUT file name
+   interp            <int>        ..FV.....T. select interpolation mode (from 0 to 4) (default linear)
+     nearest         0            ..FV.....T. use values from the nearest defined points
+     linear          1            ..FV.....T. use values from the linear interpolation
+     cosine          3            ..FV.....T. use values from the cosine interpolation
+     cubic           2            ..FV.....T. use values from the cubic interpolation
+     spline          4            ..FV.....T. use values from the spline interpolation
+
+lut2 AVOptions:
+   c0                <string>     ..FV.....T. set component #0 expression (default "x")
+   c1                <string>     ..FV.....T. set component #1 expression (default "x")
+   c2                <string>     ..FV.....T. set component #2 expression (default "x")
+   c3                <string>     ..FV.....T. set component #3 expression (default "x")
+   d                 <int>        ..FV....... set output depth (from 0 to 16) (default 0)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+lut3d AVOptions:
+   file              <string>     ..FV....... set 3D LUT file name
+   clut              <int>        ..FV.....T. when to process CLUT (from 0 to 1) (default all)
+     first           0            ..FV.....T. process only first CLUT, ignore rest
+     all             1            ..FV.....T. process all CLUTs
+   interp            <int>        ..FV.....T. select interpolation mode (from 0 to 4) (default tetrahedral)
+     nearest         0            ..FV.....T. use values from the nearest defined points
+     trilinear       1            ..FV.....T. interpolate values using the 8 points defining a cube
+     tetrahedral     2            ..FV.....T. interpolate values using a tetrahedron
+     pyramid         3            ..FV.....T. interpolate values using a pyramid
+     prism           4            ..FV.....T. interpolate values using a prism
+
+lut/lutyuv/lutrgb AVOptions:
+   c0                <string>     ..FV.....T. set component #0 expression (default "clipval")
+   c1                <string>     ..FV.....T. set component #1 expression (default "clipval")
+   c2                <string>     ..FV.....T. set component #2 expression (default "clipval")
+   c3                <string>     ..FV.....T. set component #3 expression (default "clipval")
+   y                 <string>     ..FV.....T. set Y expression (default "clipval")
+   u                 <string>     ..FV.....T. set U expression (default "clipval")
+   v                 <string>     ..FV.....T. set V expression (default "clipval")
+   r                 <string>     ..FV.....T. set R expression (default "clipval")
+   g                 <string>     ..FV.....T. set G expression (default "clipval")
+   b                 <string>     ..FV.....T. set B expression (default "clipval")
+   a                 <string>     ..FV.....T. set A expression (default "clipval")
+
+lut/lutyuv/lutrgb AVOptions:
+   c0                <string>     ..FV.....T. set component #0 expression (default "clipval")
+   c1                <string>     ..FV.....T. set component #1 expression (default "clipval")
+   c2                <string>     ..FV.....T. set component #2 expression (default "clipval")
+   c3                <string>     ..FV.....T. set component #3 expression (default "clipval")
+   y                 <string>     ..FV.....T. set Y expression (default "clipval")
+   u                 <string>     ..FV.....T. set U expression (default "clipval")
+   v                 <string>     ..FV.....T. set V expression (default "clipval")
+   r                 <string>     ..FV.....T. set R expression (default "clipval")
+   g                 <string>     ..FV.....T. set G expression (default "clipval")
+   b                 <string>     ..FV.....T. set B expression (default "clipval")
+   a                 <string>     ..FV.....T. set A expression (default "clipval")
+
+maskedclamp AVOptions:
+   undershoot        <int>        ..FV.....T. set undershoot (from 0 to 65535) (default 0)
+   overshoot         <int>        ..FV.....T. set overshoot (from 0 to 65535) (default 0)
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+
+masked(min|max) AVOptions:
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+
+maskedmerge AVOptions:
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+
+masked(min|max) AVOptions:
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+
+maskedthreshold AVOptions:
+   threshold         <int>        ..FV.....T. set threshold (from 0 to 65535) (default 1)
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+   mode              <int>        ..FV....... set mode (from 0 to 1) (default abs)
+     abs             0            ..FV....... 
+     diff            1            ..FV....... 
+
+maskfun AVOptions:
+   low               <int>        ..FV.....T. set low threshold (from 0 to 65535) (default 10)
+   high              <int>        ..FV.....T. set high threshold (from 0 to 65535) (default 10)
+   planes            <int>        ..FV.....T. set planes (from 0 to 15) (default 15)
+   fill              <int>        ..FV.....T. set fill value (from 0 to 65535) (default 0)
+   sum               <int>        ..FV.....T. set sum value (from 0 to 65535) (default 10)
+
+mcdeint AVOptions:
+   mode              <int>        ..FV....... set mode (from 0 to 3) (default fast)
+     fast            0            ..FV.......
+     medium          1            ..FV.......
+     slow            2            ..FV.......
+     extra_slow      3            ..FV.......
+   parity            <int>        ..FV....... set the assumed picture field parity (from -1 to 1) (default bff)
+     tff             0            ..FV....... assume top field first
+     bff             1            ..FV....... assume bottom field first
+   qp                <int>        ..FV....... set qp (from INT_MIN to INT_MAX) (default 1)
+
+median AVOptions:
+   radius            <int>        ..FV.....T. set median radius (from 1 to 127) (default 1)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   radiusV           <int>        ..FV.....T. set median vertical radius (from 0 to 127) (default 0)
+   percentile        <float>      ..FV.....T. set median percentile (from 0 to 1) (default 0.5)
+
+mergeplanes AVOptions:
+   mapping           <int>        ..FV......P set input to output plane mapping (from -1 to 8.58993e+08) (default -1)
+   format            <pix_fmt>    ..FV....... set output pixel format (default yuva444p)
+   map0s             <int>        ..FV....... set 1st input to output stream mapping (from 0 to 3) (default 0)
+   map0p             <int>        ..FV....... set 1st input to output plane mapping (from 0 to 3) (default 0)
+   map1s             <int>        ..FV....... set 2nd input to output stream mapping (from 0 to 3) (default 0)
+   map1p             <int>        ..FV....... set 2nd input to output plane mapping (from 0 to 3) (default 0)
+   map2s             <int>        ..FV....... set 3rd input to output stream mapping (from 0 to 3) (default 0)
+   map2p             <int>        ..FV....... set 3rd input to output plane mapping (from 0 to 3) (default 0)
+   map3s             <int>        ..FV....... set 4th input to output stream mapping (from 0 to 3) (default 0)
+   map3p             <int>        ..FV....... set 4th input to output plane mapping (from 0 to 3) (default 0)
+
+mestimate AVOptions:
+   method            <int>        ..FV....... motion estimation method (from 1 to 9) (default esa)
+     esa             1            ..FV....... exhaustive search
+     tss             2            ..FV....... three step search
+     tdls            3            ..FV....... two dimensional logarithmic search
+     ntss            4            ..FV....... new three step search
+     fss             5            ..FV....... four step search
+     ds              6            ..FV....... diamond search
+     hexbs           7            ..FV....... hexagon-based search
+     epzs            8            ..FV....... enhanced predictive zonal search
+     umh             9            ..FV....... uneven multi-hexagon search
+   mb_size           <int>        ..FV....... macroblock size (from 8 to INT_MAX) (default 16)
+   search_param      <int>        ..FV....... search parameter (from 4 to INT_MAX) (default 7)
+
+metadata AVOptions:
+   mode              <int>        ..FV....... set a mode of operation (from 0 to 4) (default select)
+     select          0            ..FV....... select frame
+     add             1            ..FV....... add new metadata
+     modify          2            ..FV....... modify metadata
+     delete          3            ..FV....... delete metadata
+     print           4            ..FV....... print metadata
+   key               <string>     ..FV....... set metadata key
+   value             <string>     ..FV....... set metadata value
+   function          <int>        ..FV....... function for comparing values (from 0 to 6) (default same_str)
+     same_str        0            ..FV.......
+     starts_with     1            ..FV.......
+     less            2            ..FV.......
+     equal           3            ..FV.......
+     greater         4            ..FV.......
+     expr            5            ..FV.......
+     ends_with       6            ..FV.......
+   expr              <string>     ..FV....... set expression for expr function
+   file              <string>     ..FV....... set file where to print metadata information
+   direct            <boolean>    ..FV....... reduce buffering when printing to user-set file or pipe (default false)
+
+midequalizer AVOptions:
+   planes            <int>        ..FV....... set planes (from 0 to 15) (default 15)
+
+minterpolate AVOptions:
+   fps               <video_rate> ..FV....... output's frame rate (default "60")
+   mi_mode           <int>        ..FV....... motion interpolation mode (from 0 to 2) (default mci)
+     dup             0            ..FV....... duplicate frames
+     blend           1            ..FV....... blend frames
+     mci             2            ..FV....... motion compensated interpolation
+   mc_mode           <int>        ..FV....... motion compensation mode (from 0 to 1) (default obmc)
+     obmc            0            ..FV....... overlapped block motion compensation
+     aobmc           1            ..FV....... adaptive overlapped block motion compensation
+   me_mode           <int>        ..FV....... motion estimation mode (from 0 to 1) (default bilat)
+     bidir           0            ..FV....... bidirectional motion estimation
+     bilat           1            ..FV....... bilateral motion estimation
+   me                <int>        ..FV....... motion estimation method (from 1 to 9) (default epzs)
+     esa             1            ..FV....... exhaustive search
+     tss             2            ..FV....... three step search
+     tdls            3            ..FV....... two dimensional logarithmic search
+     ntss            4            ..FV....... new three step search
+     fss             5            ..FV....... four step search
+     ds              6            ..FV....... diamond search
+     hexbs           7            ..FV....... hexagon-based search
+     epzs            8            ..FV....... enhanced predictive zonal search
+     umh             9            ..FV....... uneven multi-hexagon search
+   mb_size           <int>        ..FV....... macroblock size (from 4 to 16) (default 16)
+   search_param      <int>        ..FV....... search parameter (from 4 to INT_MAX) (default 32)
+   vsbmc             <int>        ..FV....... variable-size block motion compensation (from 0 to 1) (default 0)
+   scd               <int>        ..FV....... scene change detection method (from 0 to 1) (default fdiff)
+     none            0            ..FV....... disable detection
+     fdiff           1            ..FV....... frame difference
+   scd_threshold     <double>     ..FV....... scene change threshold (from 0 to 100) (default 10)
+
+mix AVOptions:
+   inputs            <int>        ..FV....... set number of inputs (from 2 to 32767) (default 2)
+   weights           <string>     ..FV.....T. set weight for each input (default "1 1")
+   scale             <float>      ..FV.....T. set scale (from 0 to 32767) (default 0)
+   planes            <flags>      ..FV.....T. set what planes to filter (default F)
+   duration          <int>        ..FV....... how to determine end of stream (from 0 to 2) (default longest)
+     longest         0            ..FV....... Duration of longest input
+     shortest        1            ..FV....... Duration of shortest input
+     first           2            ..FV....... Duration of first input
+
+monochrome AVOptions:
+   cb                <float>      ..FV.....T. set the chroma blue spot (from -1 to 1) (default 0)
+   cr                <float>      ..FV.....T. set the chroma red spot (from -1 to 1) (default 0)
+   size              <float>      ..FV.....T. set the color filter size (from 0.1 to 10) (default 1)
+   high              <float>      ..FV.....T. set the highlights strength (from 0 to 1) (default 0)
+
+morpho AVOptions:
+   mode              <int>        ..FV.....T. set morphological transform (from 0 to 6) (default erode)
+     erode           0            ..FV.....T.
+     dilate          1            ..FV.....T.
+     open            2            ..FV.....T.
+     close           3            ..FV.....T.
+     gradient        4            ..FV.....T.
+     tophat          5            ..FV.....T.
+     blackhat        6            ..FV.....T.
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 7)
+   structure         <int>        ..FV.....T. when to process structures (from 0 to 1) (default all)
+     first           0            ..FV.....T. process only first structure, ignore rest
+     all             1            ..FV.....T. process all structure
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+mpdecimate AVOptions:
+   max               <int>        ..FV....... set the maximum number of consecutive dropped frames (positive), or the minimum interval between dropped frames (negative) (from INT_MIN to INT_MAX) (default 0)
+   keep              <int>        ..FV....... set the number of similar consecutive frames to be kept before starting to drop similar frames (from 0 to INT_MAX) (default 0)
+   hi                <int>        ..FV....... set high dropping threshold (from INT_MIN to INT_MAX) (default 768)
+   lo                <int>        ..FV....... set low dropping threshold (from INT_MIN to INT_MAX) (default 320)
+   frac              <float>      ..FV....... set fraction dropping threshold (from 0 to 1) (default 0.33)
+
+msad AVOptions:
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+multiply AVOptions:
+   scale             <float>      ..FV.....T. set scale (from 0 to 9) (default 1)
+   offset            <float>      ..FV.....T. set offset (from -1 to 1) (default 0.5)
+   planes            <flags>      ..FV.....T. set planes (default F)
+
+negate AVOptions:
+   components        <flags>      ..FV.....T. set components to negate (default y+u+v+r+g+b)
+     y                            ..FV.....T. set luma component
+     u                            ..FV.....T. set u component
+     v                            ..FV.....T. set v component
+     r                            ..FV.....T. set red component
+     g                            ..FV.....T. set green component
+     b                            ..FV.....T. set blue component
+     a                            ..FV.....T. set alpha component
+   negate_alpha      <boolean>    ..FV.....T. (default false)
+
+nlmeans AVOptions:
+   s                 <double>     ..FV....... denoising strength (from 1 to 30) (default 1)
+   p                 <int>        ..FV....... patch size (from 0 to 99) (default 7)
+   pc                <int>        ..FV....... patch size for chroma planes (from 0 to 99) (default 0)
+   r                 <int>        ..FV....... research window (from 0 to 99) (default 15)
+   rc                <int>        ..FV....... research window for chroma planes (from 0 to 99) (default 0)
+
+nlmeans_opencl AVOptions:
+   s                 <double>     ..FV....... denoising strength (from 1 to 30) (default 1)
+   p                 <int>        ..FV....... patch size (from 0 to 99) (default 7)
+   pc                <int>        ..FV....... patch size for chroma planes (from 0 to 99) (default 0)
+   r                 <int>        ..FV....... research window (from 0 to 99) (default 15)
+   rc                <int>        ..FV....... research window for chroma planes (from 0 to 99) (default 0)
+
+nlmeans_vulkan AVOptions:
+   s                 <double>     ..FV....... denoising strength for all components (from 1 to 100) (default 1)
+   p                 <int>        ..FV....... patch size for all components (from 0 to 99) (default 7)
+   r                 <int>        ..FV....... research window radius (from 0 to 99) (default 15)
+   t                 <int>        ..FV....... parallelism (from 1 to 168) (default 36)
+   s1                <double>     ..FV....... denoising strength for component 1 (from 1 to 100) (default 1)
+   s2                <double>     ..FV....... denoising strength for component 2 (from 1 to 100) (default 1)
+   s3                <double>     ..FV....... denoising strength for component 3 (from 1 to 100) (default 1)
+   s4                <double>     ..FV....... denoising strength for component 4 (from 1 to 100) (default 1)
+   p1                <int>        ..FV....... patch size for component 1 (from 0 to 99) (default 0)
+   p2                <int>        ..FV....... patch size for component 2 (from 0 to 99) (default 0)
+   p3                <int>        ..FV....... patch size for component 3 (from 0 to 99) (default 0)
+   p4                <int>        ..FV....... patch size for component 4 (from 0 to 99) (default 0)
+
+nnedi AVOptions:
+   weights           <string>     ..FV....... set weights file (default "nnedi3_weights.bin")
+   deint             <int>        ..FV.....T. set which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV.....T. deinterlace all frames
+     interlaced      1            ..FV.....T. only deinterlace frames marked as interlaced
+   field             <int>        ..FV.....T. set mode of operation (from -2 to 3) (default a)
+     af              -2           ..FV.....T. use frame flags, both fields
+     a               -1           ..FV.....T. use frame flags, single field
+     t               0            ..FV.....T. use top field only
+     b               1            ..FV.....T. use bottom field only
+     tf              2            ..FV.....T. use both fields, top first
+     bf              3            ..FV.....T. use both fields, bottom first
+   planes            <int>        ..FV.....T. set which planes to process (from 0 to 15) (default 7)
+   nsize             <int>        ..FV.....T. set size of local neighborhood around each pixel, used by the predictor neural network (from 0 to 6) (default s32x4)
+     s8x6            0            ..FV.....T.
+     s16x6           1            ..FV.....T.
+     s32x6           2            ..FV.....T.
+     s48x6           3            ..FV.....T.
+     s8x4            4            ..FV.....T.
+     s16x4           5            ..FV.....T.
+     s32x4           6            ..FV.....T.
+   nns               <int>        ..FV.....T. set number of neurons in predictor neural network (from 0 to 4) (default n32)
+     n16             0            ..FV.....T.
+     n32             1            ..FV.....T.
+     n64             2            ..FV.....T.
+     n128            3            ..FV.....T.
+     n256            4            ..FV.....T.
+   qual              <int>        ..FV.....T. set quality (from 1 to 2) (default fast)
+     fast            1            ..FV.....T.
+     slow            2            ..FV.....T.
+   etype             <int>        ..FV.....T. set which set of weights to use in the predictor (from 0 to 1) (default a)
+     a               0            ..FV.....T. weights trained to minimize absolute error
+     abs             0            ..FV.....T. weights trained to minimize absolute error
+     s               1            ..FV.....T. weights trained to minimize squared error
+     mse             1            ..FV.....T. weights trained to minimize squared error
+   pscrn             <int>        ..FV.....T. set prescreening (from 0 to 4) (default new)
+     none            0            ..FV.....T.
+     original        1            ..FV.....T.
+     new             2            ..FV.....T.
+     new2            3            ..FV.....T.
+     new3            4            ..FV.....T.
+
+(no)format AVOptions:
+   pix_fmts          <string>     ..FV....... A '|'-separated list of pixel formats
+
+noise AVOptions:
+   all_seed          <int>        ..FV....... set component #0 noise seed (from -1 to INT_MAX) (default -1)
+   all_strength      <int>        ..FV....... set component #0 strength (from 0 to 100) (default 0)
+   alls              <int>        ..FV....... set component #0 strength (from 0 to 100) (default 0)
+   all_flags         <flags>      ..FV....... set component #0 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   allf              <flags>      ..FV....... set component #0 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c0_seed           <int>        ..FV....... set component #0 noise seed (from -1 to INT_MAX) (default -1)
+   c0_strength       <int>        ..FV....... set component #0 strength (from 0 to 100) (default 0)
+   c0s               <int>        ..FV....... set component #0 strength (from 0 to 100) (default 0)
+   c0_flags          <flags>      ..FV....... set component #0 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c0f               <flags>      ..FV....... set component #0 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c1_seed           <int>        ..FV....... set component #1 noise seed (from -1 to INT_MAX) (default -1)
+   c1_strength       <int>        ..FV....... set component #1 strength (from 0 to 100) (default 0)
+   c1s               <int>        ..FV....... set component #1 strength (from 0 to 100) (default 0)
+   c1_flags          <flags>      ..FV....... set component #1 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c1f               <flags>      ..FV....... set component #1 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c2_seed           <int>        ..FV....... set component #2 noise seed (from -1 to INT_MAX) (default -1)
+   c2_strength       <int>        ..FV....... set component #2 strength (from 0 to 100) (default 0)
+   c2s               <int>        ..FV....... set component #2 strength (from 0 to 100) (default 0)
+   c2_flags          <flags>      ..FV....... set component #2 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c2f               <flags>      ..FV....... set component #2 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c3_seed           <int>        ..FV....... set component #3 noise seed (from -1 to INT_MAX) (default -1)
+   c3_strength       <int>        ..FV....... set component #3 strength (from 0 to 100) (default 0)
+   c3s               <int>        ..FV....... set component #3 strength (from 0 to 100) (default 0)
+   c3_flags          <flags>      ..FV....... set component #3 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+   c3f               <flags>      ..FV....... set component #3 flags (default 0)
+     a                            ..FV....... averaged noise
+     p                            ..FV....... (semi)regular pattern
+     t                            ..FV....... temporal noise
+     u                            ..FV....... uniform noise
+
+normalize AVOptions:
+   blackpt           <color>      ..FV.....T. output color to which darkest input color is mapped (default "black")
+   whitept           <color>      ..FV.....T. output color to which brightest input color is mapped (default "white")
+   smoothing         <int>        ..FV....... amount of temporal smoothing of the input range, to reduce flicker (from 0 to 2.68435e+08) (default 0)
+   independence      <float>      ..FV.....T. proportion of independent to linked channel normalization (from 0 to 1) (default 1)
+   strength          <float>      ..FV.....T. strength of filter, from no effect to full normalization (from 0 to 1) (default 1)
+
+oscilloscope AVOptions:
+   x                 <float>      ..FV.....T. set scope x position (from 0 to 1) (default 0.5)
+   y                 <float>      ..FV.....T. set scope y position (from 0 to 1) (default 0.5)
+   s                 <float>      ..FV.....T. set scope size (from 0 to 1) (default 0.8)
+   t                 <float>      ..FV.....T. set scope tilt (from 0 to 1) (default 0.5)
+   o                 <float>      ..FV.....T. set trace opacity (from 0 to 1) (default 0.8)
+   tx                <float>      ..FV.....T. set trace x position (from 0 to 1) (default 0.5)
+   ty                <float>      ..FV.....T. set trace y position (from 0 to 1) (default 0.9)
+   tw                <float>      ..FV.....T. set trace width (from 0.1 to 1) (default 0.8)
+   th                <float>      ..FV.....T. set trace height (from 0.1 to 1) (default 0.3)
+   c                 <int>        ..FV.....T. set components to trace (from 0 to 15) (default 7)
+   g                 <boolean>    ..FV.....T. draw trace grid (default true)
+   st                <boolean>    ..FV.....T. draw statistics (default true)
+   sc                <boolean>    ..FV.....T. draw scope (default true)
+
+overlay AVOptions:
+   x                 <string>     ..FV....... set the x expression (default "0")
+   y                 <string>     ..FV....... set the y expression (default "0")
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default frame)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions per-frame
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   format            <int>        ..FV....... set output format (from 0 to 8) (default yuv420)
+     yuv420          0            ..FV....... 
+     yuv420p10       1            ..FV....... 
+     yuv422          2            ..FV....... 
+     yuv422p10       3            ..FV....... 
+     yuv444          4            ..FV....... 
+     yuv444p10       5            ..FV....... 
+     rgb             6            ..FV....... 
+     gbrp            7            ..FV....... 
+     auto            8            ..FV....... 
+   repeatlast        <boolean>    ..FV....... repeat overlay of the last overlay frame (default true)
+   alpha             <int>        ..FV....... alpha format (from 0 to 1) (default straight)
+     straight        0            ..FV....... 
+     premultiplied   1            ..FV....... 
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+overlay_opencl AVOptions:
+   x                 <int>        ..FV....... Overlay x position (from 0 to INT_MAX) (default 0)
+   y                 <int>        ..FV....... Overlay y position (from 0 to INT_MAX) (default 0)
+
+overlay_vaapi AVOptions:
+   x                 <string>     ..FV....... Overlay x position (default "0")
+   y                 <string>     ..FV....... Overlay y position (default "0")
+   w                 <string>     ..FV....... Overlay width (default "overlay_iw")
+   h                 <string>     ..FV....... Overlay height (default "overlay_ih*w/overlay_iw")
+   alpha             <float>      ..FV....... Overlay global alpha (from 0 to 1) (default 1)
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... repeat overlay of the last overlay frame (default true)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+overlay_vulkan AVOptions:
+   x                 <int>        ..FV....... Set horizontal offset (from 0 to INT_MAX) (default 0)
+   y                 <int>        ..FV....... Set vertical offset (from 0 to INT_MAX) (default 0)
+
+overlay_cuda AVOptions:
+   x                 <string>     ..FV....... set the x expression of overlay (default "0")
+   y                 <string>     ..FV....... set the y expression of overlay (default "0")
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default frame)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions per-frame
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... repeat overlay of the last overlay frame (default true)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+owdenoise AVOptions:
+   depth             <int>        ..FV....... set depth (from 8 to 16) (default 8)
+   luma_strength     <double>     ..FV....... set luma strength (from 0 to 1000) (default 1)
+   ls                <double>     ..FV....... set luma strength (from 0 to 1000) (default 1)
+   chroma_strength   <double>     ..FV....... set chroma strength (from 0 to 1000) (default 1)
+   cs                <double>     ..FV....... set chroma strength (from 0 to 1000) (default 1)
+
+pad AVOptions:
+   width             <string>     ..FV....... set the pad area width expression (default "iw")
+   w                 <string>     ..FV....... set the pad area width expression (default "iw")
+   height            <string>     ..FV....... set the pad area height expression (default "ih")
+   h                 <string>     ..FV....... set the pad area height expression (default "ih")
+   x                 <string>     ..FV....... set the x offset expression for the input image position (default "0")
+   y                 <string>     ..FV....... set the y offset expression for the input image position (default "0")
+   color             <color>      ..FV....... set the color of the padded area border (default "black")
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions during initialization and per-frame
+   aspect            <rational>   ..FV....... pad to fit an aspect instead of a resolution (from 0 to DBL_MAX) (default 0/1)
+
+pad_opencl AVOptions:
+   width             <string>     ..FV....... set the pad area width (default "iw")
+   w                 <string>     ..FV....... set the pad area width (default "iw")
+   height            <string>     ..FV....... set the pad area height (default "ih")
+   h                 <string>     ..FV....... set the pad area height (default "ih")
+   x                 <string>     ..FV....... set the x offset for the input image position (default "0")
+   y                 <string>     ..FV....... set the y offset for the input image position (default "0")
+   color             <color>      ..FV....... set the color of the padded area border (default "black")
+   aspect            <rational>   ..FV....... pad to fit an aspect instead of a resolution (from 0 to 32767) (default 0/1)
+
+palettegen AVOptions:
+   max_colors        <int>        ..FV....... set the maximum number of colors to use in the palette (from 2 to 256) (default 256)
+   reserve_transparent <boolean>    ..FV....... reserve a palette entry for transparency (default true)
+   transparency_color <color>      ..FV....... set a background color for transparency (default "lime")
+   stats_mode        <int>        ..FV....... set statistics mode (from 0 to 2) (default full)
+     full            0            ..FV....... compute full frame histograms
+     diff            1            ..FV....... compute histograms only for the part that differs from previous frame
+     single          2            ..FV....... compute new histogram for each frame
+
+paletteuse AVOptions:
+   dither            <int>        ..FV....... select dithering mode (from 0 to 8) (default sierra2_4a)
+     bayer           1            ..FV....... ordered 8x8 bayer dithering (deterministic)
+     heckbert        2            ..FV....... dithering as defined by Paul Heckbert in 1982 (simple error diffusion)
+     floyd_steinberg 3            ..FV....... Floyd and Steingberg dithering (error diffusion)
+     sierra2         4            ..FV....... Frankie Sierra dithering v2 (error diffusion)
+     sierra2_4a      5            ..FV....... Frankie Sierra dithering v2 "Lite" (error diffusion)
+     sierra3         6            ..FV....... Frankie Sierra dithering v3 (error diffusion)
+     burkes          7            ..FV....... Burkes dithering (error diffusion)
+     atkinson        8            ..FV....... Atkinson dithering by Bill Atkinson at Apple Computer (error diffusion)
+   bayer_scale       <int>        ..FV....... set scale for bayer dithering (from 0 to 5) (default 2)
+   diff_mode         <int>        ..FV....... set frame difference mode (from 0 to 1) (default 0)
+     rectangle       1            ..FV....... process smallest different rectangle
+   new               <boolean>    ..FV....... take new palette for each output frame (default false)
+   alpha_threshold   <int>        ..FV....... set the alpha threshold for transparency (from 0 to 255) (default 128)
+   debug_kdtree      <string>     ..FV....... save Graphviz graph of the kdtree in specified file
+
+(a)perms AVOptions:
+   mode              <int>        ..FVA....T. select permissions mode (from 0 to 4) (default none)
+     none            0            ..FVA....T. do nothing
+     ro              1            ..FVA....T. set all output frames read-only
+     rw              2            ..FVA....T. set all output frames writable
+     toggle          3            ..FVA....T. switch permissions
+     random          4            ..FVA....T. set permissions randomly
+   seed              <int64>      ..FVA...... set the seed for the random mode (from -1 to UINT32_MAX) (default -1)
+
+perspective AVOptions:
+   x0                <string>     ..FV....... set top left x coordinate (default "0")
+   y0                <string>     ..FV....... set top left y coordinate (default "0")
+   x1                <string>     ..FV....... set top right x coordinate (default "W")
+   y1                <string>     ..FV....... set top right y coordinate (default "0")
+   x2                <string>     ..FV....... set bottom left x coordinate (default "0")
+   y2                <string>     ..FV....... set bottom left y coordinate (default "H")
+   x3                <string>     ..FV....... set bottom right x coordinate (default "W")
+   y3                <string>     ..FV....... set bottom right y coordinate (default "H")
+   interpolation     <int>        ..FV....... set interpolation (from 0 to 1) (default linear)
+     linear          0            ..FV....... 
+     cubic           1            ..FV....... 
+   sense             <int>        ..FV....... specify the sense of the coordinates (from 0 to 1) (default source)
+     source          0            ..FV....... specify locations in source to send to corners in destination
+     destination     1            ..FV....... specify locations in destination to send corners of source
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions per-frame
+
+phase AVOptions:
+   mode              <int>        ..FV.....T. set phase mode (from 0 to 8) (default A)
+     p               0            ..FV.....T. progressive
+     t               1            ..FV.....T. top first
+     b               2            ..FV.....T. bottom first
+     T               3            ..FV.....T. top first analyze
+     B               4            ..FV.....T. bottom first analyze
+     u               5            ..FV.....T. analyze
+     U               6            ..FV.....T. full analyze
+     a               7            ..FV.....T. auto
+     A               8            ..FV.....T. auto analyze
+
+photosensitivity AVOptions:
+   frames            <int>        ..FV....... set how many frames to use (from 2 to 240) (default 30)
+   f                 <int>        ..FV....... set how many frames to use (from 2 to 240) (default 30)
+   threshold         <float>      ..FV....... set detection threshold factor (lower is stricter) (from 0.1 to FLT_MAX) (default 1)
+   t                 <float>      ..FV....... set detection threshold factor (lower is stricter) (from 0.1 to FLT_MAX) (default 1)
+   skip              <int>        ..FV....... set pixels to skip when sampling frames (from 1 to 1024) (default 1)
+   bypass            <boolean>    ..FV....... leave frames unchanged (default false)
+
+pixelize AVOptions:
+   width             <int>        ..FV.....T. set block width (from 1 to 1024) (default 16)
+   w                 <int>        ..FV.....T. set block width (from 1 to 1024) (default 16)
+   height            <int>        ..FV.....T. set block height (from 1 to 1024) (default 16)
+   h                 <int>        ..FV.....T. set block height (from 1 to 1024) (default 16)
+   mode              <int>        ..FV.....T. set the pixelize mode (from 0 to 2) (default avg)
+     avg             0            ..FV.....T. average
+     min             1            ..FV.....T. minimum
+     max             2            ..FV.....T. maximum
+   m                 <int>        ..FV.....T. set the pixelize mode (from 0 to 2) (default avg)
+     avg             0            ..FV.....T. average
+     min             1            ..FV.....T. minimum
+     max             2            ..FV.....T. maximum
+   planes            <flags>      ..FV.....T. set what planes to filter (default F)
+   p                 <flags>      ..FV.....T. set what planes to filter (default F)
+
+pixscope AVOptions:
+   x                 <float>      ..FV.....T. set scope x offset (from 0 to 1) (default 0.5)
+   y                 <float>      ..FV.....T. set scope y offset (from 0 to 1) (default 0.5)
+   w                 <int>        ..FV.....T. set scope width (from 1 to 80) (default 7)
+   h                 <int>        ..FV.....T. set scope height (from 1 to 80) (default 7)
+   o                 <float>      ..FV.....T. set window opacity (from 0 to 1) (default 0.5)
+   wx                <float>      ..FV.....T. set window x offset (from -1 to 1) (default -1)
+   wy                <float>      ..FV.....T. set window y offset (from -1 to 1) (default -1)
+
+pp AVOptions:
+   subfilters        <string>     ..FV....... set postprocess subfilters (default "de")
+
+pp7 AVOptions:
+   qp                <int>        ..FV....... force a constant quantizer parameter (from 0 to 64) (default 0)
+   mode              <int>        ..FV....... set thresholding mode (from 0 to 2) (default medium)
+     hard            0            ..FV....... hard thresholding
+     soft            1            ..FV....... soft thresholding
+     medium          2            ..FV....... medium thresholding
+
+(un)premultiply AVOptions:
+   planes            <int>        ..FV....... set planes (from 0 to 15) (default 15)
+   inplace           <boolean>    ..FV....... enable inplace mode (default false)
+
+kirsch/prewitt/roberts/scharr/sobel AVOptions:
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV.....T. set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV.....T. set delta (from -65535 to 65535) (default 0)
+
+prewitt_opencl AVOptions:
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV....... set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV....... set delta (from -65535 to 65535) (default 0)
+
+procamp_vaapi AVOptions:
+   b                 <float>      ..FV....... Output video brightness (from -100 to 100) (default 0)
+   brightness        <float>      ..FV....... Output video brightness (from -100 to 100) (default 0)
+   s                 <float>      ..FV....... Output video saturation (from 0 to 10) (default 1)
+   saturatio         <float>      ..FV....... Output video saturation (from 0 to 10) (default 1)
+   c                 <float>      ..FV....... Output video contrast (from 0 to 10) (default 1)
+   contrast          <float>      ..FV....... Output video contrast (from 0 to 10) (default 1)
+   h                 <float>      ..FV....... Output video hue (from -180 to 180) (default 0)
+   hue               <float>      ..FV....... Output video hue (from -180 to 180) (default 0)
+
+program_opencl AVOptions:
+   source            <string>     ..FV....... OpenCL program source file
+   kernel            <string>     ..FV....... Kernel name in program
+   inputs            <int>        ..FV....... Number of inputs (from 1 to INT_MAX) (default 1)
+   size              <image_size> ..FV....... Video size
+   s                 <image_size> ..FV....... Video size
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+pseudocolor AVOptions:
+   c0                <string>     ..FV.....T. set component #0 expression (default "val")
+   c1                <string>     ..FV.....T. set component #1 expression (default "val")
+   c2                <string>     ..FV.....T. set component #2 expression (default "val")
+   c3                <string>     ..FV.....T. set component #3 expression (default "val")
+   index             <int>        ..FV.....T. set component as base (from 0 to 3) (default 0)
+   i                 <int>        ..FV.....T. set component as base (from 0 to 3) (default 0)
+   preset            <int>        ..FV.....T. set preset (from -1 to 20) (default none)
+     none            -1           ..FV.....T.
+     magma           0            ..FV.....T.
+     inferno         1            ..FV.....T.
+     plasma          2            ..FV.....T.
+     viridis         3            ..FV.....T.
+     turbo           4            ..FV.....T.
+     cividis         5            ..FV.....T.
+     range1          6            ..FV.....T.
+     range2          7            ..FV.....T.
+     shadows         8            ..FV.....T.
+     highlights      9            ..FV.....T.
+     solar           10           ..FV.....T.
+     nominal         11           ..FV.....T.
+     preferred       12           ..FV.....T.
+     total           13           ..FV.....T.
+     spectral        14           ..FV.....T.
+     cool            15           ..FV.....T.
+     heat            16           ..FV.....T.
+     fiery           17           ..FV.....T.
+     blues           18           ..FV.....T.
+     green           19           ..FV.....T.
+     helix           20           ..FV.....T.
+   p                 <int>        ..FV.....T. set preset (from -1 to 20) (default none)
+     none            -1           ..FV.....T.
+     magma           0            ..FV.....T.
+     inferno         1            ..FV.....T.
+     plasma          2            ..FV.....T.
+     viridis         3            ..FV.....T.
+     turbo           4            ..FV.....T.
+     cividis         5            ..FV.....T.
+     range1          6            ..FV.....T.
+     range2          7            ..FV.....T.
+     shadows         8            ..FV.....T.
+     highlights      9            ..FV.....T.
+     solar           10           ..FV.....T.
+     nominal         11           ..FV.....T.
+     preferred       12           ..FV.....T.
+     total           13           ..FV.....T.
+     spectral        14           ..FV.....T.
+     cool            15           ..FV.....T.
+     heat            16           ..FV.....T.
+     fiery           17           ..FV.....T.
+     blues           18           ..FV.....T.
+     green           19           ..FV.....T.
+     helix           20           ..FV.....T.
+   opacity           <float>      ..FV.....T. set pseudocolor opacity (from 0 to 1) (default 1)
+
+psnr AVOptions:
+   stats_file        <string>     ..FV....... Set file where to store per-frame difference information
+   f                 <string>     ..FV....... Set file where to store per-frame difference information
+   stats_version     <int>        ..FV....... Set the format version for the stats file. (from 1 to 2) (default 1)
+   output_max        <boolean>    ..FV....... Add raw stats (max values) to the output log. (default false)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+pullup AVOptions:
+   jl                <int>        ..FV....... set left junk size (from 0 to INT_MAX) (default 1)
+   jr                <int>        ..FV....... set right junk size (from 0 to INT_MAX) (default 1)
+   jt                <int>        ..FV....... set top junk size (from 1 to INT_MAX) (default 4)
+   jb                <int>        ..FV....... set bottom junk size (from 1 to INT_MAX) (default 4)
+   sb                <boolean>    ..FV....... set strict breaks (default false)
+   mp                <int>        ..FV....... set metric plane (from 0 to 2) (default y)
+     y               0            ..FV....... luma
+     u               1            ..FV....... chroma blue
+     v               2            ..FV....... chroma red
+
+qp AVOptions:
+   qp                <string>     ..FV....... set qp expression
+
+random AVOptions:
+   frames            <int>        ..FV....... set number of frames in cache (from 2 to 512) (default 30)
+   seed              <int64>      ..FV....... set the seed (from -1 to UINT32_MAX) (default -1)
+
+readeia608 AVOptions:
+   scan_min          <int>        ..FV.....T. set from which line to scan for codes (from 0 to INT_MAX) (default 0)
+   scan_max          <int>        ..FV.....T. set to which line to scan for codes (from 0 to INT_MAX) (default 29)
+   spw               <float>      ..FV.....T. set ratio of width reserved for sync code detection (from 0.1 to 0.7) (default 0.27)
+   chp               <boolean>    ..FV.....T. check and apply parity bit (default false)
+   lp                <boolean>    ..FV.....T. lowpass line prior to processing (default true)
+
+readvitc AVOptions:
+   scan_max          <int>        ..FV....... maximum line numbers to scan for VITC data (from -1 to INT_MAX) (default 45)
+   thr_b             <double>     ..FV....... black color threshold (from 0 to 1) (default 0.2)
+   thr_w             <double>     ..FV....... white color threshold (from 0 to 1) (default 0.6)
+
+(a)realtime AVOptions:
+   limit             <duration>   ..FVA....T. sleep time limit (default 2)
+   speed             <double>     ..FVA....T. speed factor (from DBL_MIN to DBL_MAX) (default 1)
+
+remap AVOptions:
+   format            <int>        ..FV....... set output format (from 0 to 1) (default color)
+     color           0            ..FV....... 
+     gray            1            ..FV....... 
+   fill              <color>      ..FV....... set the color of the unmapped pixels (default "black")
+
+remap_opencl AVOptions:
+   interp            <int>        ..FV....... set interpolation method (from 0 to 1) (default linear)
+     near            0            ..FV.......
+     linear          1            ..FV.......
+   fill              <color>      ..FV....... set the color of the unmapped pixels (default "black")
+
+removegrain AVOptions:
+   m0                <int>        ..FV....... set mode for 1st plane (from 0 to 24) (default 0)
+   m1                <int>        ..FV....... set mode for 2nd plane (from 0 to 24) (default 0)
+   m2                <int>        ..FV....... set mode for 3rd plane (from 0 to 24) (default 0)
+   m3                <int>        ..FV....... set mode for 4th plane (from 0 to 24) (default 0)
+
+removelogo AVOptions:
+   filename          <string>     ..FV....... set bitmap filename
+   f                 <string>     ..FV....... set bitmap filename
+
+rgbashift AVOptions:
+   rh                <int>        ..FV.....T. shift red horizontally (from -255 to 255) (default 0)
+   rv                <int>        ..FV.....T. shift red vertically (from -255 to 255) (default 0)
+   gh                <int>        ..FV.....T. shift green horizontally (from -255 to 255) (default 0)
+   gv                <int>        ..FV.....T. shift green vertically (from -255 to 255) (default 0)
+   bh                <int>        ..FV.....T. shift blue horizontally (from -255 to 255) (default 0)
+   bv                <int>        ..FV.....T. shift blue vertically (from -255 to 255) (default 0)
+   ah                <int>        ..FV.....T. shift alpha horizontally (from -255 to 255) (default 0)
+   av                <int>        ..FV.....T. shift alpha vertically (from -255 to 255) (default 0)
+   edge              <int>        ..FV.....T. set edge operation (from 0 to 1) (default smear)
+     smear           0            ..FV.....T.
+     wrap            1            ..FV.....T.
+
+kirsch/prewitt/roberts/scharr/sobel AVOptions:
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV.....T. set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV.....T. set delta (from -65535 to 65535) (default 0)
+
+roberts_opencl AVOptions:
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV....... set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV....... set delta (from -65535 to 65535) (default 0)
+
+rotate AVOptions:
+   angle             <string>     ..FV.....T. set angle (in radians) (default "0")
+   a                 <string>     ..FV.....T. set angle (in radians) (default "0")
+   out_w             <string>     ..FV....... set output width expression (default "iw")
+   ow                <string>     ..FV....... set output width expression (default "iw")
+   out_h             <string>     ..FV....... set output height expression (default "ih")
+   oh                <string>     ..FV....... set output height expression (default "ih")
+   fillcolor         <string>     ..FV....... set background fill color (default "black")
+   c                 <string>     ..FV....... set background fill color (default "black")
+   bilinear          <boolean>    ..FV....... use bilinear interpolation (default true)
+
+sab AVOptions:
+   luma_radius       <float>      ..FV....... set luma radius (from 0.1 to 4) (default 1)
+   lr                <float>      ..FV....... set luma radius (from 0.1 to 4) (default 1)
+   luma_pre_filter_radius <float>      ..FV....... set luma pre-filter radius (from 0.1 to 2) (default 1)
+   lpfr              <float>      ..FV....... set luma pre-filter radius (from 0.1 to 2) (default 1)
+   luma_strength     <float>      ..FV....... set luma strength (from 0.1 to 100) (default 1)
+   ls                <float>      ..FV....... set luma strength (from 0.1 to 100) (default 1)
+   chroma_radius     <float>      ..FV....... set chroma radius (from -0.9 to 4) (default -0.9)
+   cr                <float>      ..FV....... set chroma radius (from -0.9 to 4) (default -0.9)
+   chroma_pre_filter_radius <float>      ..FV....... set chroma pre-filter radius (from -0.9 to 2) (default -0.9)
+   cpfr              <float>      ..FV....... set chroma pre-filter radius (from -0.9 to 2) (default -0.9)
+   chroma_strength   <float>      ..FV....... set chroma strength (from -0.9 to 100) (default -0.9)
+   cs                <float>      ..FV....... set chroma strength (from -0.9 to 100) (default -0.9)
+
+scale(2ref) AVOptions:
+   w                 <string>     ..FV.....T. Output video width
+   width             <string>     ..FV.....T. Output video width
+   h                 <string>     ..FV.....T. Output video height
+   height            <string>     ..FV.....T. Output video height
+   flags             <string>     ..FV....... Flags to pass to libswscale (default "")
+   interl            <boolean>    ..FV....... set interlacing (default false)
+   in_color_matrix   <string>     ..FV....... set input YCbCr type (default "auto")
+     auto                         ..FV.......
+     bt601                        ..FV.......
+     bt470                        ..FV.......
+     smpte170m                    ..FV.......
+     bt709                        ..FV.......
+     fcc                          ..FV.......
+     smpte240m                    ..FV.......
+     bt2020                       ..FV.......
+   out_color_matrix  <string>     ..FV....... set output YCbCr type
+     auto                         ..FV.......
+     bt601                        ..FV.......
+     bt470                        ..FV.......
+     smpte170m                    ..FV.......
+     bt709                        ..FV.......
+     fcc                          ..FV.......
+     smpte240m                    ..FV.......
+     bt2020                       ..FV.......
+   in_range          <int>        ..FV....... set input color range (from 0 to 2) (default auto)
+     auto            0            ..FV.......
+     unknown         0            ..FV.......
+     full            2            ..FV.......
+     limited         1            ..FV.......
+     jpeg            2            ..FV.......
+     mpeg            1            ..FV.......
+     tv              1            ..FV.......
+     pc              2            ..FV.......
+   out_range         <int>        ..FV....... set output color range (from 0 to 2) (default auto)
+     auto            0            ..FV.......
+     unknown         0            ..FV.......
+     full            2            ..FV.......
+     limited         1            ..FV.......
+     jpeg            2            ..FV.......
+     mpeg            1            ..FV.......
+     tv              1            ..FV.......
+     pc              2            ..FV.......
+   in_v_chr_pos      <int>        ..FV....... input vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
+   in_h_chr_pos      <int>        ..FV....... input horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
+   out_v_chr_pos     <int>        ..FV....... output vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
+   out_h_chr_pos     <int>        ..FV....... output horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
+   force_original_aspect_ratio <int>        ..FV....... decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)
+     disable         0            ..FV.......
+     decrease        1            ..FV.......
+     increase        2            ..FV.......
+   force_divisible_by <int>        ..FV....... enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)
+   param0            <double>     ..FV....... Scaler param 0 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+   param1            <double>     ..FV....... Scaler param 1 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions during initialization and per-frame
+
+SWScaler AVOptions:
+
+cudascale AVOptions:
+   w                 <string>     ..FV....... Output video width (default "iw")
+   h                 <string>     ..FV....... Output video height (default "ih")
+   interp_algo       <int>        ..FV....... Interpolation algorithm used for resizing (from 0 to 4) (default 0)
+     nearest         1            ..FV....... nearest neighbour
+     bilinear        2            ..FV....... bilinear
+     bicubic         3            ..FV....... bicubic
+     lanczos         4            ..FV....... lanczos
+   format            <pix_fmt>    ..FV....... Output video pixel format (default none)
+   passthrough       <boolean>    ..FV....... Do not process frames at all if parameters match (default true)
+   param             <float>      ..FV....... Algorithm-Specific parameter (from -FLT_MAX to FLT_MAX) (default 999999)
+   force_original_aspect_ratio <int>        ..FV....... decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)
+     disable         0            ..FV.......
+     decrease        1            ..FV.......
+     increase        2            ..FV.......
+   force_divisible_by <int>        ..FV....... enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)
+
+scale_vaapi AVOptions:
+   w                 <string>     ..FV....... Output video width (default "iw")
+   h                 <string>     ..FV....... Output video height (default "ih")
+   format            <string>     ..FV....... Output video format (software format of hardware frames)
+   mode              <int>        ..FV....... Scaling mode (from 0 to 768) (default hq)
+     default         0            ..FV....... Use the default (depend on the driver) scaling algorithm
+     fast            256          ..FV....... Use fast scaling algorithm
+     hq              512          ..FV....... Use high quality scaling algorithm
+     nl_anamorphic   768          ..FV....... Use nolinear anamorphic scaling algorithm
+   out_color_matrix  <string>     ..FV....... Output colour matrix coefficient set
+   out_range         <int>        ..FV....... Output colour range (from 0 to 2) (default 0)
+     full            2            ..FV....... Full range
+     limited         1            ..FV....... Limited range
+     jpeg            2            ..FV....... Full range
+     mpeg            1            ..FV....... Limited range
+     tv              1            ..FV....... Limited range
+     pc              2            ..FV....... Full range
+   out_color_primaries <string>     ..FV....... Output colour primaries
+   out_color_transfer <string>     ..FV....... Output colour transfer characteristics
+   out_chroma_location <string>     ..FV....... Output chroma sample location
+   force_original_aspect_ratio <int>        ..FV....... decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)
+     disable         0            ..FV.......
+     decrease        1            ..FV.......
+     increase        2            ..FV.......
+   force_divisible_by <int>        ..FV....... enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)
+
+scale_vulkan AVOptions:
+   w                 <string>     ..FV....... Output video width (default "iw")
+   h                 <string>     ..FV....... Output video height (default "ih")
+   scaler            <int>        ..FV....... Scaler function (from 0 to 2) (default bilinear)
+     bilinear        0            ..FV....... Bilinear interpolation (fastest)
+     nearest         1            ..FV....... Nearest (useful for pixel art)
+   format            <string>     ..FV....... Output video format (software format of hardware frames)
+   out_range         <int>        ..FV....... Output colour range (from 0 to 2) (default 0) (from 0 to 2) (default 0)
+     full            2            ..FV....... Full range
+     limited         1            ..FV....... Limited range
+     jpeg            2            ..FV....... Full range
+     mpeg            1            ..FV....... Limited range
+     tv              1            ..FV....... Limited range
+     pc              2            ..FV....... Full range
+
+scale(2ref) AVOptions:
+   w                 <string>     ..FV.....T. Output video width
+   width             <string>     ..FV.....T. Output video width
+   h                 <string>     ..FV.....T. Output video height
+   height            <string>     ..FV.....T. Output video height
+   flags             <string>     ..FV....... Flags to pass to libswscale (default "")
+   interl            <boolean>    ..FV....... set interlacing (default false)
+   in_color_matrix   <string>     ..FV....... set input YCbCr type (default "auto")
+     auto                         ..FV.......
+     bt601                        ..FV.......
+     bt470                        ..FV.......
+     smpte170m                    ..FV.......
+     bt709                        ..FV.......
+     fcc                          ..FV.......
+     smpte240m                    ..FV.......
+     bt2020                       ..FV.......
+   out_color_matrix  <string>     ..FV....... set output YCbCr type
+     auto                         ..FV.......
+     bt601                        ..FV.......
+     bt470                        ..FV.......
+     smpte170m                    ..FV.......
+     bt709                        ..FV.......
+     fcc                          ..FV.......
+     smpte240m                    ..FV.......
+     bt2020                       ..FV.......
+   in_range          <int>        ..FV....... set input color range (from 0 to 2) (default auto)
+     auto            0            ..FV.......
+     unknown         0            ..FV.......
+     full            2            ..FV.......
+     limited         1            ..FV.......
+     jpeg            2            ..FV.......
+     mpeg            1            ..FV.......
+     tv              1            ..FV.......
+     pc              2            ..FV.......
+   out_range         <int>        ..FV....... set output color range (from 0 to 2) (default auto)
+     auto            0            ..FV.......
+     unknown         0            ..FV.......
+     full            2            ..FV.......
+     limited         1            ..FV.......
+     jpeg            2            ..FV.......
+     mpeg            1            ..FV.......
+     tv              1            ..FV.......
+     pc              2            ..FV.......
+   in_v_chr_pos      <int>        ..FV....... input vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
+   in_h_chr_pos      <int>        ..FV....... input horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
+   out_v_chr_pos     <int>        ..FV....... output vertical chroma position in luma grid/256 (from -513 to 512) (default -513)
+   out_h_chr_pos     <int>        ..FV....... output horizontal chroma position in luma grid/256 (from -513 to 512) (default -513)
+   force_original_aspect_ratio <int>        ..FV....... decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)
+     disable         0            ..FV.......
+     decrease        1            ..FV.......
+     increase        2            ..FV.......
+   force_divisible_by <int>        ..FV....... enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)
+   param0            <double>     ..FV....... Scaler param 0 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+   param1            <double>     ..FV....... Scaler param 1 (from -DBL_MAX to DBL_MAX) (default DBL_MAX)
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions during initialization and per-frame
+
+SWScaler AVOptions:
+
+scdet AVOptions:
+   threshold         <double>     ..FV....... set scene change detect threshold (from 0 to 100) (default 10)
+   t                 <double>     ..FV....... set scene change detect threshold (from 0 to 100) (default 10)
+   sc_pass           <boolean>    ..FV....... Set the flag to pass scene change frames (default false)
+   s                 <boolean>    ..FV....... Set the flag to pass scene change frames (default false)
+
+kirsch/prewitt/roberts/scharr/sobel AVOptions:
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV.....T. set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV.....T. set delta (from -65535 to 65535) (default 0)
+
+scroll AVOptions:
+   horizontal        <float>      ..FV.....T. set the horizontal scrolling speed (from -1 to 1) (default 0)
+   h                 <float>      ..FV.....T. set the horizontal scrolling speed (from -1 to 1) (default 0)
+   vertical          <float>      ..FV.....T. set the vertical scrolling speed (from -1 to 1) (default 0)
+   v                 <float>      ..FV.....T. set the vertical scrolling speed (from -1 to 1) (default 0)
+   hpos              <float>      ..FV....... set initial horizontal position (from 0 to 1) (default 0)
+   vpos              <float>      ..FV....... set initial vertical position (from 0 to 1) (default 0)
+
+segment AVOptions:
+   timestamps        <string>     ..FV....... timestamps of input at which to split input
+   frames            <string>     ..FV....... frames at which to split input
+
+select AVOptions:
+   expr              <string>     ..FV....... set an expression to use for selecting frames (default "1")
+   e                 <string>     ..FV....... set an expression to use for selecting frames (default "1")
+   outputs           <int>        ..FV....... set the number of outputs (from 1 to INT_MAX) (default 1)
+   n                 <int>        ..FV....... set the number of outputs (from 1 to INT_MAX) (default 1)
+
+selectivecolor AVOptions:
+   correction_method <int>        ..FV....... select correction method (from 0 to 1) (default absolute)
+     absolute        0            ..FV.......
+     relative        1            ..FV.......
+   reds              <string>     ..FV....... adjust red regions
+   yellows           <string>     ..FV....... adjust yellow regions
+   greens            <string>     ..FV....... adjust green regions
+   cyans             <string>     ..FV....... adjust cyan regions
+   blues             <string>     ..FV....... adjust blue regions
+   magentas          <string>     ..FV....... adjust magenta regions
+   whites            <string>     ..FV....... adjust white regions
+   neutrals          <string>     ..FV....... adjust neutral regions
+   blacks            <string>     ..FV....... adjust black regions
+   psfile            <string>     ..FV....... set Photoshop selectivecolor file name
+
+(a)sendcmd AVOptions:
+   commands          <string>     ..FVA...... set commands
+   c                 <string>     ..FVA...... set commands
+   filename          <string>     ..FVA...... set commands file
+   f                 <string>     ..FVA...... set commands file
+
+setdar AVOptions:
+   dar               <string>     ..FV....... set display aspect ratio (default "0")
+   ratio             <string>     ..FV....... set display aspect ratio (default "0")
+   r                 <string>     ..FV....... set display aspect ratio (default "0")
+   max               <int>        ..FV....... set max value for nominator or denominator in the ratio (from 1 to INT_MAX) (default 100)
+
+setfield AVOptions:
+   mode              <int>        ..FV....... select interlace mode (from -1 to 2) (default auto)
+     auto            -1           ..FV....... keep the same input field
+     bff             0            ..FV....... mark as bottom-field-first
+     tff             1            ..FV....... mark as top-field-first
+     prog            2            ..FV....... mark as progressive
+
+setparams AVOptions:
+   field_mode        <int>        ..FV....... select interlace mode (from -1 to 2) (default auto)
+     auto            -1           ..FV....... keep the same input field
+     bff             0            ..FV....... mark as bottom-field-first
+     tff             1            ..FV....... mark as top-field-first
+     prog            2            ..FV....... mark as progressive
+   range             <int>        ..FV....... select color range (from -1 to 2) (default auto)
+     auto            -1           ..FV....... keep the same color range
+     unspecified     0            ..FV.......
+     unknown         0            ..FV.......
+     limited         1            ..FV.......
+     tv              1            ..FV.......
+     mpeg            1            ..FV.......
+     full            2            ..FV.......
+     pc              2            ..FV.......
+     jpeg            2            ..FV.......
+   color_primaries   <int>        ..FV....... select color primaries (from -1 to 22) (default auto)
+     auto            -1           ..FV....... keep the same color primaries
+     bt709           1            ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     film            8            ..FV.......
+     bt2020          9            ..FV.......
+     smpte428        10           ..FV.......
+     smpte431        11           ..FV.......
+     smpte432        12           ..FV.......
+     jedec-p22       22           ..FV.......
+     ebu3213         22           ..FV.......
+   color_trc         <int>        ..FV....... select color transfer (from -1 to 18) (default auto)
+     auto            -1           ..FV....... keep the same color transfer
+     bt709           1            ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     linear          8            ..FV.......
+     log100          9            ..FV.......
+     log316          10           ..FV.......
+     iec61966-2-4    11           ..FV.......
+     bt1361e         12           ..FV.......
+     iec61966-2-1    13           ..FV.......
+     bt2020-10       14           ..FV.......
+     bt2020-12       15           ..FV.......
+     smpte2084       16           ..FV.......
+     smpte428        17           ..FV.......
+     arib-std-b67    18           ..FV.......
+   colorspace        <int>        ..FV....... select colorspace (from -1 to 14) (default auto)
+     auto            -1           ..FV....... keep the same colorspace
+     gbr             0            ..FV.......
+     bt709           1            ..FV.......
+     unknown         2            ..FV.......
+     fcc             4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     ycgco           8            ..FV.......
+     bt2020nc        9            ..FV.......
+     bt2020c         10           ..FV.......
+     smpte2085       11           ..FV.......
+     chroma-derived-nc 12           ..FV.......
+     chroma-derived-c 13           ..FV.......
+     ictcp           14           ..FV.......
+
+setpts AVOptions:
+   expr              <string>     ..FV.....T. Expression determining the frame timestamp (default "PTS")
+
+setrange AVOptions:
+   range             <int>        ..FV....... select color range (from -1 to 2) (default auto)
+     auto            -1           ..FV....... keep the same color range
+     unspecified     0            ..FV.......
+     unknown         0            ..FV.......
+     limited         1            ..FV.......
+     tv              1            ..FV.......
+     mpeg            1            ..FV.......
+     full            2            ..FV.......
+     pc              2            ..FV.......
+     jpeg            2            ..FV.......
+
+setsar AVOptions:
+   sar               <string>     ..FV....... set sample (pixel) aspect ratio (default "0")
+   ratio             <string>     ..FV....... set sample (pixel) aspect ratio (default "0")
+   r                 <string>     ..FV....... set sample (pixel) aspect ratio (default "0")
+   max               <int>        ..FV....... set max value for nominator or denominator in the ratio (from 1 to INT_MAX) (default 100)
+
+settb AVOptions:
+   expr              <string>     ..FV....... set expression determining the output timebase (default "intb")
+   tb                <string>     ..FV....... set expression determining the output timebase (default "intb")
+
+sharpness_vaapi AVOptions:
+   sharpness         <int>        ..FV....... sharpness level (from 0 to 64) (default 44)
+
+shear AVOptions:
+   shx               <float>      ..FV.....T. set x shear factor (from -2 to 2) (default 0)
+   shy               <float>      ..FV.....T. set y shear factor (from -2 to 2) (default 0)
+   fillcolor         <string>     ..FV.....T. set background fill color (default "black")
+   c                 <string>     ..FV.....T. set background fill color (default "black")
+   interp            <int>        ..FV.....T. set interpolation (from 0 to 1) (default bilinear)
+     nearest         0            ..FV.....T. nearest neighbour
+     bilinear        1            ..FV.....T. bilinear
+
+showinfo AVOptions:
+   checksum          <boolean>    ..FV....... calculate checksums (default true)
+
+showpalette AVOptions:
+   s                 <int>        ..FV....... set pixel box size (from 1 to 100) (default 30)
+
+shuffleframes AVOptions:
+   mapping           <string>     ..FV....... set destination indexes of input frames (default "0")
+
+shufflepixels AVOptions:
+   direction         <int>        ..FV....... set shuffle direction (from 0 to 1) (default forward)
+     forward         0            ..FV.......
+     inverse         1            ..FV.......
+   d                 <int>        ..FV....... set shuffle direction (from 0 to 1) (default forward)
+     forward         0            ..FV.......
+     inverse         1            ..FV.......
+   mode              <int>        ..FV....... set shuffle mode (from 0 to 2) (default horizontal)
+     horizontal      0            ..FV.......
+     vertical        1            ..FV.......
+     block           2            ..FV.......
+   m                 <int>        ..FV....... set shuffle mode (from 0 to 2) (default horizontal)
+     horizontal      0            ..FV.......
+     vertical        1            ..FV.......
+     block           2            ..FV.......
+   width             <int>        ..FV....... set block width (from 1 to 8000) (default 10)
+   w                 <int>        ..FV....... set block width (from 1 to 8000) (default 10)
+   height            <int>        ..FV....... set block height (from 1 to 8000) (default 10)
+   h                 <int>        ..FV....... set block height (from 1 to 8000) (default 10)
+   seed              <int64>      ..FV....... set random seed (from -1 to UINT32_MAX) (default -1)
+   s                 <int64>      ..FV....... set random seed (from -1 to UINT32_MAX) (default -1)
+
+shuffleplanes AVOptions:
+   map0              <int>        ..FV....... Index of the input plane to be used as the first output plane  (from 0 to 3) (default 0)
+   map1              <int>        ..FV....... Index of the input plane to be used as the second output plane  (from 0 to 3) (default 1)
+   map2              <int>        ..FV....... Index of the input plane to be used as the third output plane  (from 0 to 3) (default 2)
+   map3              <int>        ..FV....... Index of the input plane to be used as the fourth output plane  (from 0 to 3) (default 3)
+
+sidedata AVOptions:
+   mode              <int>        ..FV....... set a mode of operation (from 0 to 1) (default select)
+     select          0            ..FV....... select frame
+     delete          1            ..FV....... delete side data
+   type              <int>        ..FV....... set side data type (from -1 to INT_MAX) (default -1)
+     PANSCAN         0            ..FV....... 
+     A53_CC          1            ..FV....... 
+     STEREO3D        2            ..FV....... 
+     MATRIXENCODING  3            ..FV....... 
+     DOWNMIX_INFO    4            ..FV....... 
+     REPLAYGAIN      5            ..FV....... 
+     DISPLAYMATRIX   6            ..FV....... 
+     AFD             7            ..FV....... 
+     MOTION_VECTORS  8            ..FV....... 
+     SKIP_SAMPLES    9            ..FV....... 
+     AUDIO_SERVICE_TYPE 10           ..FV....... 
+     MASTERING_DISPLAY_METADATA 11           ..FV....... 
+     GOP_TIMECODE    12           ..FV....... 
+     SPHERICAL       13           ..FV....... 
+     CONTENT_LIGHT_LEVEL 14           ..FV....... 
+     ICC_PROFILE     15           ..FV....... 
+     S12M_TIMECOD    16           ..FV....... 
+     DYNAMIC_HDR_PLUS 17           ..FV....... 
+     REGIONS_OF_INTEREST 18           ..FV....... 
+     DETECTION_BOUNDING_BOXES 22           ..FV....... 
+     SEI_UNREGISTERED 20           ..FV....... 
+
+signalstats AVOptions:
+   stat              <flags>      ..FV....... set statistics filters (default 0)
+     tout                         ..FV....... analyze pixels for temporal outliers
+     vrep                         ..FV....... analyze video lines for vertical line repetition
+     brng                         ..FV....... analyze for pixels outside of broadcast range
+   out               <int>        ..FV....... set video filter (from -1 to 2) (default -1)
+     tout            0            ..FV....... highlight pixels that depict temporal outliers
+     vrep            1            ..FV....... highlight video lines that depict vertical line repetition
+     brng            2            ..FV....... highlight pixels that are outside of broadcast range
+   c                 <color>      ..FV....... set highlight color (default "yellow")
+   color             <color>      ..FV....... set highlight color (default "yellow")
+
+signature AVOptions:
+   detectmode        <int>        ..FV....... set the detectmode (from 0 to 2) (default off)
+     off             0            ..FV.......
+     full            1            ..FV.......
+     fast            2            ..FV.......
+   nb_inputs         <int>        ..FV....... number of inputs (from 1 to INT_MAX) (default 1)
+   filename          <string>     ..FV....... filename for output files (default "")
+   format            <int>        ..FV....... set output format (from 0 to 1) (default binary)
+     binary          0            ..FV.......
+     xml             1            ..FV.......
+   th_d              <int>        ..FV....... threshold to detect one word as similar (from 1 to INT_MAX) (default 9000)
+   th_dc             <int>        ..FV....... threshold to detect all words as similar (from 1 to INT_MAX) (default 60000)
+   th_xh             <int>        ..FV....... threshold to detect frames as similar (from 1 to INT_MAX) (default 116)
+   th_di             <int>        ..FV....... minimum length of matching sequence in frames (from 0 to INT_MAX) (default 0)
+   th_it             <double>     ..FV....... threshold for relation of good to all frames (from 0 to 1) (default 0.5)
+
+siti AVOptions:
+   print_summary     <boolean>    ..FV....... Print summary showing average values (default false)
+
+smartblur AVOptions:
+   luma_radius       <float>      ..FV....... set luma radius (from 0.1 to 5) (default 1)
+   lr                <float>      ..FV....... set luma radius (from 0.1 to 5) (default 1)
+   luma_strength     <float>      ..FV....... set luma strength (from -1 to 1) (default 1)
+   ls                <float>      ..FV....... set luma strength (from -1 to 1) (default 1)
+   luma_threshold    <int>        ..FV....... set luma threshold (from -30 to 30) (default 0)
+   lt                <int>        ..FV....... set luma threshold (from -30 to 30) (default 0)
+   chroma_radius     <float>      ..FV....... set chroma radius (from -0.9 to 5) (default -0.9)
+   cr                <float>      ..FV....... set chroma radius (from -0.9 to 5) (default -0.9)
+   chroma_strength   <float>      ..FV....... set chroma strength (from -2 to 1) (default -2)
+   cs                <float>      ..FV....... set chroma strength (from -2 to 1) (default -2)
+   chroma_threshold  <int>        ..FV....... set chroma threshold (from -31 to 30) (default -31)
+   ct                <int>        ..FV....... set chroma threshold (from -31 to 30) (default -31)
+
+kirsch/prewitt/roberts/scharr/sobel AVOptions:
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV.....T. set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV.....T. set delta (from -65535 to 65535) (default 0)
+
+sobel_opencl AVOptions:
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 15)
+   scale             <float>      ..FV....... set scale (from 0 to 65535) (default 1)
+   delta             <float>      ..FV....... set delta (from -65535 to 65535) (default 0)
+
+(a)split AVOptions:
+   outputs           <int>        ..FVA...... set number of outputs (from 1 to INT_MAX) (default 2)
+
+spp AVOptions:
+   quality           <int>        ..FV.....T. set quality (from 0 to 6) (default 3)
+   qp                <int>        ..FV....... force a constant quantizer parameter (from 0 to 63) (default 0)
+   mode              <int>        ..FV....... set thresholding mode (from 0 to 1) (default hard)
+     hard            0            ..FV....... hard thresholding
+     soft            1            ..FV....... soft thresholding
+   use_bframe_qp     <boolean>    ..FV....... use B-frames' QP (default false)
+
+AVDCT AVOptions:
+
+sr AVOptions:
+   dnn_backend       <int>        ..FV....... DNN backend used for model execution (from 0 to 1) (default 1)
+   scale_factor      <int>        ..FV....... scale factor for SRCNN model (from 2 to 4) (default 2)
+   model             <string>     ..FV....... path to model file specifying network architecture and its parameters
+   input             <string>     ..FV....... input name of the model (default "x")
+   output            <string>     ..FV....... output name of the model (default "y")
+
+ssim AVOptions:
+   stats_file        <string>     ..FV....... Set file where to store per-frame difference information
+   f                 <string>     ..FV....... Set file where to store per-frame difference information
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+ssim360 AVOptions:
+   stats_file        <string>     ..FV....... Set file where to store per-frame difference information
+   f                 <string>     ..FV....... Set file where to store per-frame difference information
+   compute_chroma    <int>        ..FV....... Specifies if non-luma channels must be computed (from 0 to 1) (default 1)
+   frame_skip_ratio  <int>        ..FV....... Specifies the number of frames to be skipped from evaluation, for every evaluated frame (from 0 to 1e+06) (default 0)
+   ref_projection    <int>        ..FV....... projection of the reference video (from 0 to 4) (default e)
+     e               4            ..FV....... equirectangular
+     equirect        4            ..FV....... equirectangular
+     c3x2            0            ..FV....... cubemap 3x2
+     c2x3            1            ..FV....... cubemap 2x3
+     barrel          2            ..FV....... barrel facebook's 360 format
+     barrelsplit     3            ..FV....... barrel split facebook's 360 format
+   main_projection   <int>        ..FV....... projection of the main video (from 0 to 5) (default 5)
+     e               4            ..FV....... equirectangular
+     equirect        4            ..FV....... equirectangular
+     c3x2            0            ..FV....... cubemap 3x2
+     c2x3            1            ..FV....... cubemap 2x3
+     barrel          2            ..FV....... barrel facebook's 360 format
+     barrelsplit     3            ..FV....... barrel split facebook's 360 format
+   ref_stereo        <int>        ..FV....... stereo format of the reference video (from 0 to 2) (default mono)
+     mono            2            ..FV.......
+     tb              0            ..FV.......
+     lr              1            ..FV.......
+   main_stereo       <int>        ..FV....... stereo format of main video (from 0 to 3) (default 3)
+     mono            2            ..FV.......
+     tb              0            ..FV.......
+     lr              1            ..FV.......
+   ref_pad           <float>      ..FV....... Expansion (padding) coefficient for each cube face of the reference video (from 0 to 10) (default 0)
+   main_pad          <float>      ..FV....... Expansion (padding) coeffiecient for each cube face of the main video (from 0 to 10) (default 0)
+   use_tape          <int>        ..FV....... Specifies if the tape based SSIM 360 algorithm must be used independent of the input video types (from 0 to 1) (default 0)
+   heatmap_str       <string>     ..FV....... Heatmap data for view-based evaluation. For heatmap file format, please refer to EntSphericalVideoHeatmapData.
+   default_heatmap_width <int>        ..FV....... Default heatmap dimension. Will be used when dimension is not specified in heatmap data. (from 1 to 4096) (default 32)
+   default_heatmap_height <int>        ..FV....... Default heatmap dimension. Will be used when dimension is not specified in heatmap data. (from 1 to 4096) (default 16)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+stereo3d AVOptions:
+   in                <int>        ..FV....... set input format (from 16 to 32) (default sbsl)
+     ab2l            24           ..FV....... above below half height left first
+     tb2l            24           ..FV....... above below half height left first
+     ab2r            25           ..FV....... above below half height right first
+     tb2r            25           ..FV....... above below half height right first
+     abl             22           ..FV....... above below left first
+     tbl             22           ..FV....... above below left first
+     abr             23           ..FV....... above below right first
+     tbr             23           ..FV....... above below right first
+     al              26           ..FV....... alternating frames left first
+     ar              27           ..FV....... alternating frames right first
+     sbs2l           20           ..FV....... side by side half width left first
+     sbs2r           21           ..FV....... side by side half width right first
+     sbsl            18           ..FV....... side by side left first
+     sbsr            19           ..FV....... side by side right first
+     irl             16           ..FV....... interleave rows left first
+     irr             17           ..FV....... interleave rows right first
+     icl             30           ..FV....... interleave columns left first
+     icr             31           ..FV....... interleave columns right first
+   out               <int>        ..FV....... set output format (from 0 to 32) (default arcd)
+     ab2l            24           ..FV....... above below half height left first
+     tb2l            24           ..FV....... above below half height left first
+     ab2r            25           ..FV....... above below half height right first
+     tb2r            25           ..FV....... above below half height right first
+     abl             22           ..FV....... above below left first
+     tbl             22           ..FV....... above below left first
+     abr             23           ..FV....... above below right first
+     tbr             23           ..FV....... above below right first
+     agmc            6            ..FV....... anaglyph green magenta color
+     agmd            7            ..FV....... anaglyph green magenta dubois
+     agmg            4            ..FV....... anaglyph green magenta gray
+     agmh            5            ..FV....... anaglyph green magenta half color
+     al              26           ..FV....... alternating frames left first
+     ar              27           ..FV....... alternating frames right first
+     arbg            12           ..FV....... anaglyph red blue gray
+     arcc            2            ..FV....... anaglyph red cyan color
+     arcd            3            ..FV....... anaglyph red cyan dubois
+     arcg            0            ..FV....... anaglyph red cyan gray
+     arch            1            ..FV....... anaglyph red cyan half color
+     argg            13           ..FV....... anaglyph red green gray
+     aybc            10           ..FV....... anaglyph yellow blue color
+     aybd            11           ..FV....... anaglyph yellow blue dubois
+     aybg            8            ..FV....... anaglyph yellow blue gray
+     aybh            9            ..FV....... anaglyph yellow blue half color
+     irl             16           ..FV....... interleave rows left first
+     irr             17           ..FV....... interleave rows right first
+     ml              14           ..FV....... mono left
+     mr              15           ..FV....... mono right
+     sbs2l           20           ..FV....... side by side half width left first
+     sbs2r           21           ..FV....... side by side half width right first
+     sbsl            18           ..FV....... side by side left first
+     sbsr            19           ..FV....... side by side right first
+     chl             28           ..FV....... checkerboard left first
+     chr             29           ..FV....... checkerboard right first
+     icl             30           ..FV....... interleave columns left first
+     icr             31           ..FV....... interleave columns right first
+     hdmi            32           ..FV....... HDMI frame pack
+
+(a)streamselect AVOptions:
+   inputs            <int>        ..FVA...... number of input streams (from 2 to INT_MAX) (default 2)
+   map               <string>     ..FVA....T. input indexes to remap to outputs
+
+subtitles AVOptions:
+   filename          <string>     ..FV....... set the filename of file to read
+   f                 <string>     ..FV....... set the filename of file to read
+   original_size     <image_size> ..FV....... set the size of the original video (used to scale fonts)
+   fontsdir          <string>     ..FV....... set the directory containing the fonts to read
+   alpha             <boolean>    ..FV....... enable processing of alpha channel (default false)
+   charenc           <string>     ..FV....... set input character encoding
+   stream_index      <int>        ..FV....... set stream index (from -1 to INT_MAX) (default -1)
+   si                <int>        ..FV....... set stream index (from -1 to INT_MAX) (default -1)
+   force_style       <string>     ..FV....... force subtitle style
+   wrap_unicode      <boolean>    ..FV....... break lines according to the Unicode Line Breaking Algorithm (default auto)
+
+swaprect AVOptions:
+   w                 <string>     ..FV.....T. set rect width (default "w/2")
+   h                 <string>     ..FV.....T. set rect height (default "h/2")
+   x1                <string>     ..FV.....T. set 1st rect x top left coordinate (default "w/2")
+   y1                <string>     ..FV.....T. set 1st rect y top left coordinate (default "h/2")
+   x2                <string>     ..FV.....T. set 2nd rect x top left coordinate (default "0")
+   y2                <string>     ..FV.....T. set 2nd rect y top left coordinate (default "0")
+
+swapuv AVOptions:
+
+tblend AVOptions:
+   c0_mode           <int>        ..FV.....T. set component #0 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c1_mode           <int>        ..FV.....T. set component #1 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c2_mode           <int>        ..FV.....T. set component #2 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c3_mode           <int>        ..FV.....T. set component #3 blend mode (from 0 to 39) (default normal)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   all_mode          <int>        ..FV.....T. set blend mode for all components (from -1 to 39) (default -1)
+     addition        1            ..FV.....T. 
+     addition128     28           ..FV.....T. 
+     grainmerge      28           ..FV.....T. 
+     and             2            ..FV.....T. 
+     average         3            ..FV.....T. 
+     burn            4            ..FV.....T. 
+     darken          5            ..FV.....T. 
+     difference      6            ..FV.....T. 
+     difference128   7            ..FV.....T. 
+     grainextract    7            ..FV.....T. 
+     divide          8            ..FV.....T. 
+     dodge           9            ..FV.....T. 
+     exclusion       10           ..FV.....T. 
+     extremity       32           ..FV.....T. 
+     freeze          31           ..FV.....T. 
+     glow            27           ..FV.....T. 
+     hardlight       11           ..FV.....T. 
+     hardmix         25           ..FV.....T. 
+     heat            30           ..FV.....T. 
+     lighten         12           ..FV.....T. 
+     linearlight     26           ..FV.....T. 
+     multiply        13           ..FV.....T. 
+     multiply128     29           ..FV.....T. 
+     negation        14           ..FV.....T. 
+     normal          0            ..FV.....T. 
+     or              15           ..FV.....T. 
+     overlay         16           ..FV.....T. 
+     phoenix         17           ..FV.....T. 
+     pinlight        18           ..FV.....T. 
+     reflect         19           ..FV.....T. 
+     screen          20           ..FV.....T. 
+     softlight       21           ..FV.....T. 
+     subtract        22           ..FV.....T. 
+     vividlight      23           ..FV.....T. 
+     xor             24           ..FV.....T. 
+     softdifference  33           ..FV.....T. 
+     geometric       34           ..FV.....T. 
+     harmonic        35           ..FV.....T. 
+     bleach          36           ..FV.....T. 
+     stain           37           ..FV.....T. 
+     interpolate     38           ..FV.....T. 
+     hardoverlay     39           ..FV.....T. 
+   c0_expr           <string>     ..FV.....T. set color component #0 expression
+   c1_expr           <string>     ..FV.....T. set color component #1 expression
+   c2_expr           <string>     ..FV.....T. set color component #2 expression
+   c3_expr           <string>     ..FV.....T. set color component #3 expression
+   all_expr          <string>     ..FV.....T. set expression for all color components
+   c0_opacity        <double>     ..FV.....T. set color component #0 opacity (from 0 to 1) (default 1)
+   c1_opacity        <double>     ..FV.....T. set color component #1 opacity (from 0 to 1) (default 1)
+   c2_opacity        <double>     ..FV.....T. set color component #2 opacity (from 0 to 1) (default 1)
+   c3_opacity        <double>     ..FV.....T. set color component #3 opacity (from 0 to 1) (default 1)
+   all_opacity       <double>     ..FV.....T. set opacity for all color components (from 0 to 1) (default 1)
+
+telecine AVOptions:
+   first_field       <int>        ..FV....... select first field (from 0 to 1) (default top)
+     top             0            ..FV....... select top field first
+     t               0            ..FV....... select top field first
+     bottom          1            ..FV....... select bottom field first
+     b               1            ..FV....... select bottom field first
+   pattern           <string>     ..FV....... pattern that describe for how many fields a frame is to be displayed (default "23")
+
+thistogram AVOptions:
+   width             <int>        ..FV....... set width (from 0 to 8192) (default 0)
+   w                 <int>        ..FV....... set width (from 0 to 8192) (default 0)
+   display_mode      <int>        ..FV....... set display mode (from 0 to 2) (default stack)
+     overlay         0            ..FV.......
+     parade          1            ..FV.......
+     stack           2            ..FV.......
+   d                 <int>        ..FV....... set display mode (from 0 to 2) (default stack)
+     overlay         0            ..FV.......
+     parade          1            ..FV.......
+     stack           2            ..FV.......
+   levels_mode       <int>        ..FV....... set levels mode (from 0 to 1) (default linear)
+     linear          0            ..FV.......
+     logarithmic     1            ..FV.......
+   m                 <int>        ..FV....... set levels mode (from 0 to 1) (default linear)
+     linear          0            ..FV.......
+     logarithmic     1            ..FV.......
+   components        <int>        ..FV....... set color components to display (from 1 to 15) (default 7)
+   c                 <int>        ..FV....... set color components to display (from 1 to 15) (default 7)
+   bgopacity         <float>      ..FV....... set background opacity (from 0 to 1) (default 0.9)
+   b                 <float>      ..FV....... set background opacity (from 0 to 1) (default 0.9)
+   envelope          <boolean>    ..FV....... display envelope (default false)
+   e                 <boolean>    ..FV....... display envelope (default false)
+   ecolor            <color>      ..FV....... set envelope color (default "gold")
+   ec                <color>      ..FV....... set envelope color (default "gold")
+   slide             <int>        ..FV....... set slide mode (from 0 to 4) (default replace)
+     frame           0            ..FV....... draw new frames
+     replace         1            ..FV....... replace old columns with new
+     scroll          2            ..FV....... scroll from right to left
+     rscroll         3            ..FV....... scroll from left to right
+     picture         4            ..FV....... display graph in single frame
+
+threshold AVOptions:
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+
+thumbnail AVOptions:
+   n                 <int>        ..FV....... set the frames batch size (from 2 to INT_MAX) (default 100)
+   log               <int>        ..FV....... force stats logging level (from INT_MIN to INT_MAX) (default info)
+     quiet           -8           ..FV....... logging disabled
+     info            32           ..FV....... information logging level
+     verbose         40           ..FV....... verbose logging level
+
+thumbnail_cuda AVOptions:
+   n                 <int>        ..FV....... set the frames batch size (from 2 to INT_MAX) (default 100)
+
+tile AVOptions:
+   layout            <image_size> ..FV....... set grid size (default "6x5")
+   nb_frames         <int>        ..FV....... set maximum number of frame to render (from 0 to INT_MAX) (default 0)
+   margin            <int>        ..FV....... set outer border margin in pixels (from 0 to 1024) (default 0)
+   padding           <int>        ..FV....... set inner border thickness in pixels (from 0 to 1024) (default 0)
+   color             <color>      ..FV....... set the color of the unused area (default "black")
+   overlap           <int>        ..FV....... set how many frames to overlap for each render (from 0 to INT_MAX) (default 0)
+   init_padding      <int>        ..FV....... set how many frames to initially pad (from 0 to INT_MAX) (default 0)
+
+tinterlace AVOptions:
+   mode              <int>        ..FV....... select interlace mode (from 0 to 7) (default merge)
+     merge           0            ..FV....... merge fields
+     drop_even       1            ..FV....... drop even fields
+     drop_odd        2            ..FV....... drop odd fields
+     pad             3            ..FV....... pad alternate lines with black
+     interleave_top  4            ..FV....... interleave top and bottom fields
+     interleave_bottom 5            ..FV....... interleave bottom and top fields
+     interlacex2     6            ..FV....... interlace fields from two consecutive frames
+     mergex2         7            ..FV....... merge fields keeping same frame rate
+
+tlut2 AVOptions:
+   c0                <string>     ..FV.....T. set component #0 expression (default "x")
+   c1                <string>     ..FV.....T. set component #1 expression (default "x")
+   c2                <string>     ..FV.....T. set component #2 expression (default "x")
+   c3                <string>     ..FV.....T. set component #3 expression (default "x")
+
+tmedian AVOptions:
+   radius            <int>        ..FV....... set median filter radius (from 1 to 127) (default 1)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   percentile        <float>      ..FV.....T. set percentile (from 0 to 1) (default 0.5)
+
+tmidequalizer AVOptions:
+   radius            <int>        ..FV....... set radius (from 1 to 127) (default 5)
+   sigma             <float>      ..FV....... set sigma (from 0 to 1) (default 0.5)
+   planes            <int>        ..FV....... set planes (from 0 to 15) (default 15)
+
+tmix AVOptions:
+   frames            <int>        ..FV....... set number of successive frames to mix (from 1 to 1024) (default 3)
+   weights           <string>     ..FV.....T. set weight for each frame (default "1 1 1")
+   scale             <float>      ..FV.....T. set scale (from 0 to 32767) (default 0)
+   planes            <flags>      ..FV.....T. set what planes to filter (default F)
+
+tonemap AVOptions:
+   tonemap           <int>        ..FV....... tonemap algorithm selection (from 0 to 6) (default none)
+     none            0            ..FV.......
+     linear          1            ..FV.......
+     gamma           2            ..FV.......
+     clip            3            ..FV.......
+     reinhard        4            ..FV.......
+     hable           5            ..FV.......
+     mobius          6            ..FV.......
+   param             <double>     ..FV....... tonemap parameter (from DBL_MIN to DBL_MAX) (default nan)
+   desat             <double>     ..FV....... desaturation strength (from 0 to DBL_MAX) (default 2)
+   peak              <double>     ..FV....... signal peak override (from 0 to DBL_MAX) (default 0)
+
+tonemap_opencl AVOptions:
+   tonemap           <int>        ..FV....... tonemap algorithm selection (from 0 to 6) (default none)
+     none            0            ..FV.......
+     linear          1            ..FV.......
+     gamma           2            ..FV.......
+     clip            3            ..FV.......
+     reinhard        4            ..FV.......
+     hable           5            ..FV.......
+     mobius          6            ..FV.......
+   transfer          <int>        ..FV....... set transfer characteristic (from -1 to INT_MAX) (default bt709)
+     bt709           1            ..FV.......
+     bt2020          14           ..FV.......
+   t                 <int>        ..FV....... set transfer characteristic (from -1 to INT_MAX) (default bt709)
+     bt709           1            ..FV.......
+     bt2020          14           ..FV.......
+   matrix            <int>        ..FV....... set colorspace matrix (from -1 to INT_MAX) (default -1)
+     bt709           1            ..FV.......
+     bt2020          9            ..FV.......
+   m                 <int>        ..FV....... set colorspace matrix (from -1 to INT_MAX) (default -1)
+     bt709           1            ..FV.......
+     bt2020          9            ..FV.......
+   primaries         <int>        ..FV....... set color primaries (from -1 to INT_MAX) (default -1)
+     bt709           1            ..FV.......
+     bt2020          9            ..FV.......
+   p                 <int>        ..FV....... set color primaries (from -1 to INT_MAX) (default -1)
+     bt709           1            ..FV.......
+     bt2020          9            ..FV.......
+   range             <int>        ..FV....... set color range (from -1 to INT_MAX) (default -1)
+     tv              1            ..FV.......
+     pc              2            ..FV.......
+     limited         1            ..FV.......
+     full            2            ..FV.......
+   r                 <int>        ..FV....... set color range (from -1 to INT_MAX) (default -1)
+     tv              1            ..FV.......
+     pc              2            ..FV.......
+     limited         1            ..FV.......
+     full            2            ..FV.......
+   format            <pix_fmt>    ..FV....... output pixel format (default none)
+   peak              <double>     ..FV....... signal peak override (from 0 to DBL_MAX) (default 0)
+   param             <double>     ..FV....... tonemap parameter (from DBL_MIN to DBL_MAX) (default nan)
+   desat             <double>     ..FV....... desaturation parameter (from 0 to DBL_MAX) (default 0.5)
+   threshold         <double>     ..FV....... scene detection threshold (from 0 to DBL_MAX) (default 0.2)
+
+tonemap_vaapi AVOptions:
+   format            <string>     ..FV....... Output pixel format set
+   matrix            <string>     ..FV....... Output color matrix coefficient set
+   m                 <string>     ..FV....... Output color matrix coefficient set
+   primaries         <string>     ..FV....... Output color primaries set
+   p                 <string>     ..FV....... Output color primaries set
+   transfer          <string>     ..FV....... Output color transfer characteristics set
+   t                 <string>     ..FV....... Output color transfer characteristics set
+
+tpad AVOptions:
+   start             <int>        ..FV....... set the number of frames to delay input (from 0 to INT_MAX) (default 0)
+   stop              <int>        ..FV....... set the number of frames to add after input finished (from -1 to INT_MAX) (default 0)
+   start_mode        <int>        ..FV....... set the mode of added frames to start (from 0 to 1) (default add)
+     add             0            ..FV....... add solid-color frames
+     clone           1            ..FV....... clone first/last frame
+   stop_mode         <int>        ..FV....... set the mode of added frames to end (from 0 to 1) (default add)
+     add             0            ..FV....... add solid-color frames
+     clone           1            ..FV....... clone first/last frame
+   start_duration    <duration>   ..FV....... set the duration to delay input (default 0)
+   stop_duration     <duration>   ..FV....... set the duration to pad input (default 0)
+   color             <color>      ..FV....... set the color of the added frames (default "black")
+
+transpose AVOptions:
+   dir               <int>        ..FV....... set transpose direction (from 0 to 7) (default cclock_flip)
+     cclock_flip     0            ..FV....... rotate counter-clockwise with vertical flip
+     clock           1            ..FV....... rotate clockwise
+     cclock          2            ..FV....... rotate counter-clockwise
+     clock_flip      3            ..FV....... rotate clockwise with vertical flip
+   passthrough       <int>        ..FV....... do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)
+     none            0            ..FV....... always apply transposition
+     portrait        2            ..FV....... preserve portrait geometry
+     landscape       1            ..FV....... preserve landscape geometry
+
+transpose_opencl AVOptions:
+   dir               <int>        ..FV....... set transpose direction (from 0 to 3) (default cclock_flip)
+     cclock_flip     0            ..FV....... rotate counter-clockwise with vertical flip
+     clock           1            ..FV....... rotate clockwise
+     cclock          2            ..FV....... rotate counter-clockwise
+     clock_flip      3            ..FV....... rotate clockwise with vertical flip
+   passthrough       <int>        ..FV....... do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)
+     none            0            ..FV....... always apply transposition
+     portrait        2            ..FV....... preserve portrait geometry
+     landscape       1            ..FV....... preserve landscape geometry
+
+transpose_vaapi AVOptions:
+   dir               <int>        ..FV....... set transpose direction (from 0 to 6) (default cclock_flip)
+     cclock_flip     0            ..FV....... rotate counter-clockwise with vertical flip
+     clock           1            ..FV....... rotate clockwise
+     cclock          2            ..FV....... rotate counter-clockwise
+     clock_flip      3            ..FV....... rotate clockwise with vertical flip
+     reversal        4            ..FV....... rotate by half-turn
+     hflip           5            ..FV....... flip horizontally
+     vflip           6            ..FV....... flip vertically
+   passthrough       <int>        ..FV....... do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)
+     none            0            ..FV....... always apply transposition
+     portrait        2            ..FV....... preserve portrait geometry
+     landscape       1            ..FV....... preserve landscape geometry
+
+transpose_vulkan AVOptions:
+   dir               <int>        ..FV....... set transpose direction (from 0 to 7) (default cclock_flip)
+     cclock_flip     0            ..FV....... rotate counter-clockwise with vertical flip
+     clock           1            ..FV....... rotate clockwise
+     cclock          2            ..FV....... rotate counter-clockwise
+     clock_flip      3            ..FV....... rotate clockwise with vertical flip
+   passthrough       <int>        ..FV....... do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)
+     none            0            ..FV....... always apply transposition
+     portrait        2            ..FV....... preserve portrait geometry
+     landscape       1            ..FV....... preserve landscape geometry
+
+trim AVOptions:
+   start             <duration>   ..FV....... Timestamp of the first frame that should be passed (default INT64_MAX)
+   starti            <duration>   ..FV....... Timestamp of the first frame that should be passed (default INT64_MAX)
+   end               <duration>   ..FV....... Timestamp of the first frame that should be dropped again (default INT64_MAX)
+   endi              <duration>   ..FV....... Timestamp of the first frame that should be dropped again (default INT64_MAX)
+   start_pts         <int64>      ..FV....... Timestamp of the first frame that should be  passed (from I64_MIN to I64_MAX) (default I64_MIN)
+   end_pts           <int64>      ..FV....... Timestamp of the first frame that should be dropped again (from I64_MIN to I64_MAX) (default I64_MIN)
+   duration          <duration>   ..FV....... Maximum duration of the output (default 0)
+   durationi         <duration>   ..FV....... Maximum duration of the output (default 0)
+   start_frame       <int64>      ..FV....... Number of the first frame that should be passed to the output (from -1 to I64_MAX) (default -1)
+   end_frame         <int64>      ..FV....... Number of the first frame that should be dropped again (from 0 to I64_MAX) (default I64_MAX)
+
+(un)premultiply AVOptions:
+   planes            <int>        ..FV....... set planes (from 0 to 15) (default 15)
+   inplace           <boolean>    ..FV....... enable inplace mode (default false)
+
+unsharp AVOptions:
+   luma_msize_x      <int>        ..FV....... set luma matrix horizontal size (from 3 to 23) (default 5)
+   lx                <int>        ..FV....... set luma matrix horizontal size (from 3 to 23) (default 5)
+   luma_msize_y      <int>        ..FV....... set luma matrix vertical size (from 3 to 23) (default 5)
+   ly                <int>        ..FV....... set luma matrix vertical size (from 3 to 23) (default 5)
+   luma_amount       <float>      ..FV....... set luma effect strength (from -2 to 5) (default 1)
+   la                <float>      ..FV....... set luma effect strength (from -2 to 5) (default 1)
+   chroma_msize_x    <int>        ..FV....... set chroma matrix horizontal size (from 3 to 23) (default 5)
+   cx                <int>        ..FV....... set chroma matrix horizontal size (from 3 to 23) (default 5)
+   chroma_msize_y    <int>        ..FV....... set chroma matrix vertical size (from 3 to 23) (default 5)
+   cy                <int>        ..FV....... set chroma matrix vertical size (from 3 to 23) (default 5)
+   chroma_amount     <float>      ..FV....... set chroma effect strength (from -2 to 5) (default 0)
+   ca                <float>      ..FV....... set chroma effect strength (from -2 to 5) (default 0)
+   alpha_msize_x     <int>        ..FV....... set alpha matrix horizontal size (from 3 to 23) (default 5)
+   ax                <int>        ..FV....... set alpha matrix horizontal size (from 3 to 23) (default 5)
+   alpha_msize_y     <int>        ..FV....... set alpha matrix vertical size (from 3 to 23) (default 5)
+   ay                <int>        ..FV....... set alpha matrix vertical size (from 3 to 23) (default 5)
+   alpha_amount      <float>      ..FV....... set alpha effect strength (from -2 to 5) (default 0)
+   aa                <float>      ..FV....... set alpha effect strength (from -2 to 5) (default 0)
+
+unsharp_opencl AVOptions:
+   luma_msize_x      <float>      ..FV....... Set luma mask horizontal diameter (pixels) (from 1 to 23) (default 5)
+   lx                <float>      ..FV....... Set luma mask horizontal diameter (pixels) (from 1 to 23) (default 5)
+   luma_msize_y      <float>      ..FV....... Set luma mask vertical diameter (pixels) (from 1 to 23) (default 5)
+   ly                <float>      ..FV....... Set luma mask vertical diameter (pixels) (from 1 to 23) (default 5)
+   luma_amount       <float>      ..FV....... Set luma amount (multiplier) (from -10 to 10) (default 1)
+   la                <float>      ..FV....... Set luma amount (multiplier) (from -10 to 10) (default 1)
+   chroma_msize_x    <float>      ..FV....... Set chroma mask horizontal diameter (pixels after subsampling) (from 1 to 23) (default 5)
+   cx                <float>      ..FV....... Set chroma mask horizontal diameter (pixels after subsampling) (from 1 to 23) (default 5)
+   chroma_msize_y    <float>      ..FV....... Set chroma mask vertical diameter (pixels after subsampling) (from 1 to 23) (default 5)
+   cy                <float>      ..FV....... Set chroma mask vertical diameter (pixels after subsampling) (from 1 to 23) (default 5)
+   chroma_amount     <float>      ..FV....... Set chroma amount (multiplier) (from -10 to 10) (default 0)
+   ca                <float>      ..FV....... Set chroma amount (multiplier) (from -10 to 10) (default 0)
+
+untile AVOptions:
+   layout            <image_size> ..FV....... set grid size (default "6x5")
+
+uspp AVOptions:
+   quality           <int>        ..FV....... set quality (from 0 to 8) (default 3)
+   qp                <int>        ..FV....... force a constant quantizer parameter (from 0 to 63) (default 0)
+   use_bframe_qp     <boolean>    ..FV....... use B-frames' QP (default false)
+   codec             <string>     ..FV....... Codec name (default "snow")
+
+v360 AVOptions:
+   input             <int>        ..FV....... set input projection (from 0 to 24) (default e)
+     e               0            ..FV....... equirectangular
+     equirect        0            ..FV....... equirectangular
+     c3x2            1            ..FV....... cubemap 3x2
+     c6x1            2            ..FV....... cubemap 6x1
+     eac             3            ..FV....... equi-angular cubemap
+     dfisheye        5            ..FV....... dual fisheye
+     flat            4            ..FV....... regular video
+     rectilinear     4            ..FV....... regular video
+     gnomonic        4            ..FV....... regular video
+     barrel          6            ..FV....... barrel facebook's 360 format
+     fb              6            ..FV....... barrel facebook's 360 format
+     c1x6            7            ..FV....... cubemap 1x6
+     sg              8            ..FV....... stereographic
+     mercator        9            ..FV....... mercator
+     ball            10           ..FV....... ball
+     hammer          11           ..FV....... hammer
+     sinusoidal      12           ..FV....... sinusoidal
+     fisheye         13           ..FV....... fisheye
+     pannini         14           ..FV....... pannini
+     cylindrical     15           ..FV....... cylindrical
+     tetrahedron     17           ..FV....... tetrahedron
+     barrelsplit     18           ..FV....... barrel split facebook's 360 format
+     tsp             19           ..FV....... truncated square pyramid
+     hequirect       20           ..FV....... half equirectangular
+     he              20           ..FV....... half equirectangular
+     equisolid       21           ..FV....... equisolid
+     og              22           ..FV....... orthographic
+     octahedron      23           ..FV....... octahedron
+     cylindricalea   24           ..FV....... cylindrical equal area
+   output            <int>        ..FV....... set output projection (from 0 to 24) (default c3x2)
+     e               0            ..FV....... equirectangular
+     equirect        0            ..FV....... equirectangular
+     c3x2            1            ..FV....... cubemap 3x2
+     c6x1            2            ..FV....... cubemap 6x1
+     eac             3            ..FV....... equi-angular cubemap
+     dfisheye        5            ..FV....... dual fisheye
+     flat            4            ..FV....... regular video
+     rectilinear     4            ..FV....... regular video
+     gnomonic        4            ..FV....... regular video
+     barrel          6            ..FV....... barrel facebook's 360 format
+     fb              6            ..FV....... barrel facebook's 360 format
+     c1x6            7            ..FV....... cubemap 1x6
+     sg              8            ..FV....... stereographic
+     mercator        9            ..FV....... mercator
+     ball            10           ..FV....... ball
+     hammer          11           ..FV....... hammer
+     sinusoidal      12           ..FV....... sinusoidal
+     fisheye         13           ..FV....... fisheye
+     pannini         14           ..FV....... pannini
+     cylindrical     15           ..FV....... cylindrical
+     perspective     16           ..FV....... perspective
+     tetrahedron     17           ..FV....... tetrahedron
+     barrelsplit     18           ..FV....... barrel split facebook's 360 format
+     tsp             19           ..FV....... truncated square pyramid
+     hequirect       20           ..FV....... half equirectangular
+     he              20           ..FV....... half equirectangular
+     equisolid       21           ..FV....... equisolid
+     og              22           ..FV....... orthographic
+     octahedron      23           ..FV....... octahedron
+     cylindricalea   24           ..FV....... cylindrical equal area
+   interp            <int>        ..FV....... set interpolation method (from 0 to 7) (default line)
+     near            0            ..FV....... nearest neighbour
+     nearest         0            ..FV....... nearest neighbour
+     line            1            ..FV....... bilinear interpolation
+     linear          1            ..FV....... bilinear interpolation
+     lagrange9       2            ..FV....... lagrange9 interpolation
+     cube            3            ..FV....... bicubic interpolation
+     cubic           3            ..FV....... bicubic interpolation
+     lanc            4            ..FV....... lanczos interpolation
+     lanczos         4            ..FV....... lanczos interpolation
+     sp16            5            ..FV....... spline16 interpolation
+     spline16        5            ..FV....... spline16 interpolation
+     gauss           6            ..FV....... gaussian interpolation
+     gaussian        6            ..FV....... gaussian interpolation
+     mitchell        7            ..FV....... mitchell interpolation
+   w                 <int>        ..FV....... output width (from 0 to 32767) (default 0)
+   h                 <int>        ..FV....... output height (from 0 to 32767) (default 0)
+   in_stereo         <int>        ..FV....... input stereo format (from 0 to 2) (default 2d)
+     2d              0            ..FV....... 2d mono
+     sbs             1            ..FV....... side by side
+     tb              2            ..FV....... top bottom
+   out_stereo        <int>        ..FV....... output stereo format (from 0 to 2) (default 2d)
+     2d              0            ..FV....... 2d mono
+     sbs             1            ..FV....... side by side
+     tb              2            ..FV....... top bottom
+   in_forder         <string>     ..FV....... input cubemap face order (default "rludfb")
+   out_forder        <string>     ..FV....... output cubemap face order (default "rludfb")
+   in_frot           <string>     ..FV....... input cubemap face rotation (default "000000")
+   out_frot          <string>     ..FV....... output cubemap face rotation (default "000000")
+   in_pad            <float>      ..FV.....T. percent input cubemap pads (from 0 to 0.1) (default 0)
+   out_pad           <float>      ..FV.....T. percent output cubemap pads (from 0 to 0.1) (default 0)
+   fin_pad           <int>        ..FV.....T. fixed input cubemap pads (from 0 to 100) (default 0)
+   fout_pad          <int>        ..FV.....T. fixed output cubemap pads (from 0 to 100) (default 0)
+   yaw               <float>      ..FV.....T. yaw rotation (from -180 to 180) (default 0)
+   pitch             <float>      ..FV.....T. pitch rotation (from -180 to 180) (default 0)
+   roll              <float>      ..FV.....T. roll rotation (from -180 to 180) (default 0)
+   rorder            <string>     ..FV.....T. rotation order (default "ypr")
+   h_fov             <float>      ..FV.....T. output horizontal field of view (from 0 to 360) (default 0)
+   v_fov             <float>      ..FV.....T. output vertical field of view (from 0 to 360) (default 0)
+   d_fov             <float>      ..FV.....T. output diagonal field of view (from 0 to 360) (default 0)
+   h_flip            <boolean>    ..FV.....T. flip out video horizontally (default false)
+   v_flip            <boolean>    ..FV.....T. flip out video vertically (default false)
+   d_flip            <boolean>    ..FV.....T. flip out video indepth (default false)
+   ih_flip           <boolean>    ..FV.....T. flip in video horizontally (default false)
+   iv_flip           <boolean>    ..FV.....T. flip in video vertically (default false)
+   in_trans          <boolean>    ..FV....... transpose video input (default false)
+   out_trans         <boolean>    ..FV....... transpose video output (default false)
+   ih_fov            <float>      ..FV.....T. input horizontal field of view (from 0 to 360) (default 0)
+   iv_fov            <float>      ..FV.....T. input vertical field of view (from 0 to 360) (default 0)
+   id_fov            <float>      ..FV.....T. input diagonal field of view (from 0 to 360) (default 0)
+   h_offset          <float>      ..FV.....T. output horizontal off-axis offset (from -1 to 1) (default 0)
+   v_offset          <float>      ..FV.....T. output vertical off-axis offset (from -1 to 1) (default 0)
+   alpha_mask        <boolean>    ..FV....... build mask in alpha plane (default false)
+   reset_rot         <boolean>    ..FV.....T. reset rotation (default false)
+
+vaguedenoiser AVOptions:
+   threshold         <float>      ..FV....... set filtering strength (from 0 to DBL_MAX) (default 2)
+   method            <int>        ..FV....... set filtering method (from 0 to 2) (default garrote)
+     hard            0            ..FV....... hard thresholding
+     soft            1            ..FV....... soft thresholding
+     garrote         2            ..FV....... garrote thresholding
+   nsteps            <int>        ..FV....... set number of steps (from 1 to 32) (default 6)
+   percent           <float>      ..FV....... set percent of full denoising (from 0 to 100) (default 85)
+   planes            <int>        ..FV....... set planes to filter (from 0 to 15) (default 15)
+   type              <int>        ..FV....... set threshold type (from 0 to 1) (default universal)
+     universal       0            ..FV....... universal (VisuShrink)
+     bayes           1            ..FV....... bayes (BayesShrink)
+
+varblur AVOptions:
+   min_r             <int>        ..FV.....T. set min blur radius (from 0 to 254) (default 0)
+   max_r             <int>        ..FV.....T. set max blur radius (from 1 to 255) (default 8)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+vectorscope AVOptions:
+   mode              <int>        ..FV....... set vectorscope mode (from 0 to 5) (default gray)
+     gray            0            ..FV.......
+     tint            0            ..FV.......
+     color           1            ..FV.......
+     color2          2            ..FV.......
+     color3          3            ..FV.......
+     color4          4            ..FV.......
+     color5          5            ..FV.......
+   m                 <int>        ..FV....... set vectorscope mode (from 0 to 5) (default gray)
+     gray            0            ..FV.......
+     tint            0            ..FV.......
+     color           1            ..FV.......
+     color2          2            ..FV.......
+     color3          3            ..FV.......
+     color4          4            ..FV.......
+     color5          5            ..FV.......
+   x                 <int>        ..FV....... set color component on X axis (from 0 to 2) (default 1)
+   y                 <int>        ..FV....... set color component on Y axis (from 0 to 2) (default 2)
+   intensity         <float>      ..FV.....T. set intensity (from 0 to 1) (default 0.004)
+   i                 <float>      ..FV.....T. set intensity (from 0 to 1) (default 0.004)
+   envelope          <int>        ..FV.....T. set envelope (from 0 to 3) (default none)
+     none            0            ..FV.....T.
+     instant         1            ..FV.....T.
+     peak            2            ..FV.....T.
+     peak+instant    3            ..FV.....T.
+   e                 <int>        ..FV.....T. set envelope (from 0 to 3) (default none)
+     none            0            ..FV.....T.
+     instant         1            ..FV.....T.
+     peak            2            ..FV.....T.
+     peak+instant    3            ..FV.....T.
+   graticule         <int>        ..FV....... set graticule (from 0 to 3) (default none)
+     none            0            ..FV.......
+     green           1            ..FV.......
+     color           2            ..FV.......
+     invert          3            ..FV.......
+   g                 <int>        ..FV....... set graticule (from 0 to 3) (default none)
+     none            0            ..FV.......
+     green           1            ..FV.......
+     color           2            ..FV.......
+     invert          3            ..FV.......
+   opacity           <float>      ..FV.....T. set graticule opacity (from 0 to 1) (default 0.75)
+   o                 <float>      ..FV.....T. set graticule opacity (from 0 to 1) (default 0.75)
+   flags             <flags>      ..FV.....T. set graticule flags (default name)
+     white                        ..FV.....T. draw white point
+     black                        ..FV.....T. draw black point
+     name                         ..FV.....T. draw point name
+   f                 <flags>      ..FV.....T. set graticule flags (default name)
+     white                        ..FV.....T. draw white point
+     black                        ..FV.....T. draw black point
+     name                         ..FV.....T. draw point name
+   bgopacity         <float>      ..FV.....T. set background opacity (from 0 to 1) (default 0.3)
+   b                 <float>      ..FV.....T. set background opacity (from 0 to 1) (default 0.3)
+   lthreshold        <float>      ..FV....... set low threshold (from 0 to 1) (default 0)
+   l                 <float>      ..FV....... set low threshold (from 0 to 1) (default 0)
+   hthreshold        <float>      ..FV....... set high threshold (from 0 to 1) (default 1)
+   h                 <float>      ..FV....... set high threshold (from 0 to 1) (default 1)
+   colorspace        <int>        ..FV....... set colorspace (from 0 to 2) (default auto)
+     auto            0            ..FV.......
+     601             1            ..FV.......
+     709             2            ..FV.......
+   c                 <int>        ..FV....... set colorspace (from 0 to 2) (default auto)
+     auto            0            ..FV.......
+     601             1            ..FV.......
+     709             2            ..FV.......
+   tint0             <float>      ..FV.....T. set 1st tint (from -1 to 1) (default 0)
+   t0                <float>      ..FV.....T. set 1st tint (from -1 to 1) (default 0)
+   tint1             <float>      ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
+   t1                <float>      ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
+
+vflip AVOptions:
+
+vflip_vulkan AVOptions:
+
+vibrance AVOptions:
+   intensity         <float>      ..FV.....T. set the intensity value (from -2 to 2) (default 0)
+   rbal              <float>      ..FV.....T. set the red balance value (from -10 to 10) (default 1)
+   gbal              <float>      ..FV.....T. set the green balance value (from -10 to 10) (default 1)
+   bbal              <float>      ..FV.....T. set the blue balance value (from -10 to 10) (default 1)
+   rlum              <float>      ..FV.....T. set the red luma coefficient (from 0 to 1) (default 0.072186)
+   glum              <float>      ..FV.....T. set the green luma coefficient (from 0 to 1) (default 0.715158)
+   blum              <float>      ..FV.....T. set the blue luma coefficient (from 0 to 1) (default 0.212656)
+   alternate         <boolean>    ..FV.....T. use alternate colors (default false)
+
+vidstabdetect AVOptions:
+   result            <string>     ..FV....... path to the file used to write the transforms (default "transforms.trf")
+   shakiness         <int>        ..FV....... how shaky is the video and how quick is the camera? 1: little (fast) 10: very strong/quick (slow) (from 1 to 10) (default 5)
+   accuracy          <int>        ..FV....... (>=shakiness) 1: low 15: high (slow) (from 1 to 15) (default 15)
+   stepsize          <int>        ..FV....... region around minimum is scanned with 1 pixel resolution (from 1 to 32) (default 6)
+   mincontrast       <double>     ..FV....... below this contrast a field is discarded (0-1) (from 0 to 1) (default 0.25)
+   show              <int>        ..FV....... 0: draw nothing; 1,2: show fields and transforms (from 0 to 2) (default 0)
+   tripod            <int>        ..FV....... virtual tripod mode (if >0): motion is compared to a reference reference frame (frame # is the value) (from 0 to INT_MAX) (default 0)
+
+vidstabtransform AVOptions:
+   input             <string>     ..FV....... set path to the file storing the transforms (default "transforms.trf")
+   smoothing         <int>        ..FV....... set number of frames*2 + 1 used for lowpass filtering (from 0 to 1000) (default 15)
+   optalgo           <int>        ..FV....... set camera path optimization algo (from 0 to 2) (default opt)
+     opt             0            ..FV....... global optimization
+     gauss           1            ..FV....... gaussian kernel
+     avg             2            ..FV....... simple averaging on motion
+   maxshift          <int>        ..FV....... set maximal number of pixels to translate image (from -1 to 500) (default -1)
+   maxangle          <double>     ..FV....... set maximal angle in rad to rotate image (from -1 to 3.14) (default -1)
+   crop              <int>        ..FV....... set cropping mode (from 0 to 1) (default keep)
+     keep            0            ..FV....... keep border
+     black           1            ..FV....... black border
+   invert            <int>        ..FV....... invert transforms (from 0 to 1) (default 0)
+   relative          <int>        ..FV....... consider transforms as relative (from 0 to 1) (default 1)
+   zoom              <double>     ..FV....... set percentage to zoom (>0: zoom in, <0: zoom out (from -100 to 100) (default 0)
+   optzoom           <int>        ..FV....... set optimal zoom (0: nothing, 1: optimal static zoom, 2: optimal dynamic zoom) (from 0 to 2) (default 1)
+   zoomspeed         <double>     ..FV....... for adative zoom: percent to zoom maximally each frame (from 0 to 5) (default 0.25)
+   interpol          <int>        ..FV....... set type of interpolation (from 0 to 3) (default bilinear)
+     no              0            ..FV....... no interpolation
+     linear          1            ..FV....... linear (horizontal)
+     bilinear        2            ..FV....... bi-linear
+     bicubic         3            ..FV....... bi-cubic
+   tripod            <boolean>    ..FV....... enable virtual tripod mode (same as relative=0:smoothing=0) (default false)
+   debug             <boolean>    ..FV....... enable debug mode and writer global motions information to file (default false)
+
+vif AVOptions:
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+vignette AVOptions:
+   angle             <string>     ..FV....... set lens angle (default "PI/5")
+   a                 <string>     ..FV....... set lens angle (default "PI/5")
+   x0                <string>     ..FV....... set circle center position on x-axis (default "w/2")
+   y0                <string>     ..FV....... set circle center position on y-axis (default "h/2")
+   mode              <int>        ..FV....... set forward/backward mode (from 0 to 1) (default forward)
+     forward         0            ..FV.......
+     backward        1            ..FV.......
+   eval              <int>        ..FV....... specify when to evaluate expressions (from 0 to 1) (default init)
+     init            0            ..FV....... eval expressions once during initialization
+     frame           1            ..FV....... eval expressions for each frame
+   dither            <boolean>    ..FV....... set dithering (default true)
+   aspect            <rational>   ..FV....... set aspect ratio (from 0 to DBL_MAX) (default 1/1)
+
+vmafmotion AVOptions:
+   stats_file        <string>     ..FV....... Set file where to store per-frame difference information
+
+(h|v)stack AVOptions:
+   inputs            <int>        ..FV....... set number of inputs (from 2 to INT_MAX) (default 2)
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+
+w3fdif AVOptions:
+   filter            <int>        ..FV.....T. specify the filter (from 0 to 1) (default complex)
+     simple          0            ..FV.....T.
+     complex         1            ..FV.....T.
+   mode              <int>        ..FV.....T. specify the interlacing mode (from 0 to 1) (default field)
+     frame           0            ..FV.....T. send one frame for each frame
+     field           1            ..FV.....T. send one frame for each field
+   parity            <int>        ..FV.....T. specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV.....T. assume top field first
+     bff             1            ..FV.....T. assume bottom field first
+     auto            -1           ..FV.....T. auto detect parity
+   deint             <int>        ..FV.....T. specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV.....T. deinterlace all frames
+     interlaced      1            ..FV.....T. only deinterlace frames marked as interlaced
+
+waveform AVOptions:
+   mode              <int>        ..FV....... set mode (from 0 to 1) (default column)
+     row             0            ..FV.......
+     column          1            ..FV.......
+   m                 <int>        ..FV....... set mode (from 0 to 1) (default column)
+     row             0            ..FV.......
+     column          1            ..FV.......
+   intensity         <float>      ..FV.....T. set intensity (from 0 to 1) (default 0.04)
+   i                 <float>      ..FV.....T. set intensity (from 0 to 1) (default 0.04)
+   mirror            <boolean>    ..FV....... set mirroring (default true)
+   r                 <boolean>    ..FV....... set mirroring (default true)
+   display           <int>        ..FV....... set display mode (from 0 to 2) (default stack)
+     overlay         0            ..FV.......
+     stack           1            ..FV.......
+     parade          2            ..FV.......
+   d                 <int>        ..FV....... set display mode (from 0 to 2) (default stack)
+     overlay         0            ..FV.......
+     stack           1            ..FV.......
+     parade          2            ..FV.......
+   components        <int>        ..FV....... set components to display (from 1 to 15) (default 1)
+   c                 <int>        ..FV....... set components to display (from 1 to 15) (default 1)
+   envelope          <int>        ..FV.....T. set envelope to display (from 0 to 3) (default none)
+     none            0            ..FV.....T.
+     instant         1            ..FV.....T.
+     peak            2            ..FV.....T.
+     peak+instant    3            ..FV.....T.
+   e                 <int>        ..FV.....T. set envelope to display (from 0 to 3) (default none)
+     none            0            ..FV.....T.
+     instant         1            ..FV.....T.
+     peak            2            ..FV.....T.
+     peak+instant    3            ..FV.....T.
+   filter            <int>        ..FV....... set filter (from 0 to 7) (default lowpass)
+     lowpass         0            ..FV.......
+     flat            1            ..FV.......
+     aflat           2            ..FV.......
+     chroma          3            ..FV.......
+     color           4            ..FV.......
+     acolor          5            ..FV.......
+     xflat           6            ..FV.......
+     yflat           7            ..FV.......
+   f                 <int>        ..FV....... set filter (from 0 to 7) (default lowpass)
+     lowpass         0            ..FV.......
+     flat            1            ..FV.......
+     aflat           2            ..FV.......
+     chroma          3            ..FV.......
+     color           4            ..FV.......
+     acolor          5            ..FV.......
+     xflat           6            ..FV.......
+     yflat           7            ..FV.......
+   graticule         <int>        ..FV....... set graticule (from 0 to 3) (default none)
+     none            0            ..FV.......
+     green           1            ..FV.......
+     orange          2            ..FV.......
+     invert          3            ..FV.......
+   g                 <int>        ..FV....... set graticule (from 0 to 3) (default none)
+     none            0            ..FV.......
+     green           1            ..FV.......
+     orange          2            ..FV.......
+     invert          3            ..FV.......
+   opacity           <float>      ..FV.....T. set graticule opacity (from 0 to 1) (default 0.75)
+   o                 <float>      ..FV.....T. set graticule opacity (from 0 to 1) (default 0.75)
+   flags             <flags>      ..FV.....T. set graticule flags (default numbers)
+     numbers                      ..FV.....T. draw numbers
+     dots                         ..FV.....T. draw dots instead of lines
+   fl                <flags>      ..FV.....T. set graticule flags (default numbers)
+     numbers                      ..FV.....T. draw numbers
+     dots                         ..FV.....T. draw dots instead of lines
+   scale             <int>        ..FV....... set scale (from 0 to 2) (default digital)
+     digital         0            ..FV.......
+     millivolts      1            ..FV.......
+     ire             2            ..FV.......
+   s                 <int>        ..FV....... set scale (from 0 to 2) (default digital)
+     digital         0            ..FV.......
+     millivolts      1            ..FV.......
+     ire             2            ..FV.......
+   bgopacity         <float>      ..FV.....T. set background opacity (from 0 to 1) (default 0.75)
+   b                 <float>      ..FV.....T. set background opacity (from 0 to 1) (default 0.75)
+   tint0             <float>      ..FV.....T. set 1st tint (from -1 to 1) (default 0)
+   t0                <float>      ..FV.....T. set 1st tint (from -1 to 1) (default 0)
+   tint1             <float>      ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
+   t1                <float>      ..FV.....T. set 2nd tint (from -1 to 1) (default 0)
+   fitmode           <int>        ..FV....... set fit mode (from 0 to 1) (default none)
+     none            0            ..FV.......
+     size            1            ..FV.......
+   fm                <int>        ..FV....... set fit mode (from 0 to 1) (default none)
+     none            0            ..FV.......
+     size            1            ..FV.......
+   input             <int>        ..FV....... set input formats selection (from 0 to 1) (default first)
+     all             0            ..FV....... try to select from all available formats
+     first           1            ..FV....... pick first available format
+
+(double)weave AVOptions:
+   first_field       <int>        ..FV....... set first field (from 0 to 1) (default top)
+     top             0            ..FV....... set top field first
+     t               0            ..FV....... set top field first
+     bottom          1            ..FV....... set bottom field first
+     b               1            ..FV....... set bottom field first
+
+xbr AVOptions:
+   n                 <int>        ..FV....... set scale factor (from 2 to 4) (default 3)
+
+xcorrelate AVOptions:
+   planes            <int>        ..FV....... set planes to cross-correlate (from 0 to 15) (default 7)
+   secondary         <int>        ..FV....... when to process secondary frame (from 0 to 1) (default all)
+     first           0            ..FV....... process only first secondary frame, ignore rest
+     all             1            ..FV....... process all secondary frames
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+xfade AVOptions:
+   transition        <int>        ..FV....... set cross fade transition (from -1 to 57) (default fade)
+     custom          -1           ..FV....... custom transition
+     fade            0            ..FV....... fade transition
+     wipeleft        1            ..FV....... wipe left transition
+     wiperight       2            ..FV....... wipe right transition
+     wipeup          3            ..FV....... wipe up transition
+     wipedown        4            ..FV....... wipe down transition
+     slideleft       5            ..FV....... slide left transition
+     slideright      6            ..FV....... slide right transition
+     slideup         7            ..FV....... slide up transition
+     slidedown       8            ..FV....... slide down transition
+     circlecrop      9            ..FV....... circle crop transition
+     rectcrop        10           ..FV....... rect crop transition
+     distance        11           ..FV....... distance transition
+     fadeblack       12           ..FV....... fadeblack transition
+     fadewhite       13           ..FV....... fadewhite transition
+     radial          14           ..FV....... radial transition
+     smoothleft      15           ..FV....... smoothleft transition
+     smoothright     16           ..FV....... smoothright transition
+     smoothup        17           ..FV....... smoothup transition
+     smoothdown      18           ..FV....... smoothdown transition
+     circleopen      19           ..FV....... circleopen transition
+     circleclose     20           ..FV....... circleclose transition
+     vertopen        21           ..FV....... vert open transition
+     vertclose       22           ..FV....... vert close transition
+     horzopen        23           ..FV....... horz open transition
+     horzclose       24           ..FV....... horz close transition
+     dissolve        25           ..FV....... dissolve transition
+     pixelize        26           ..FV....... pixelize transition
+     diagtl          27           ..FV....... diag tl transition
+     diagtr          28           ..FV....... diag tr transition
+     diagbl          29           ..FV....... diag bl transition
+     diagbr          30           ..FV....... diag br transition
+     hlslice         31           ..FV....... hl slice transition
+     hrslice         32           ..FV....... hr slice transition
+     vuslice         33           ..FV....... vu slice transition
+     vdslice         34           ..FV....... vd slice transition
+     hblur           35           ..FV....... hblur transition
+     fadegrays       36           ..FV....... fadegrays transition
+     wipetl          37           ..FV....... wipe tl transition
+     wipetr          38           ..FV....... wipe tr transition
+     wipebl          39           ..FV....... wipe bl transition
+     wipebr          40           ..FV....... wipe br transition
+     squeezeh        41           ..FV....... squeeze h transition
+     squeezev        42           ..FV....... squeeze v transition
+     zoomin          43           ..FV....... zoom in transition
+     fadefast        44           ..FV....... fast fade transition
+     fadeslow        45           ..FV....... slow fade transition
+     hlwind          46           ..FV....... hl wind transition
+     hrwind          47           ..FV....... hr wind transition
+     vuwind          48           ..FV....... vu wind transition
+     vdwind          49           ..FV....... vd wind transition
+     coverleft       50           ..FV....... cover left transition
+     coverright      51           ..FV....... cover right transition
+     coverup         52           ..FV....... cover up transition
+     coverdown       53           ..FV....... cover down transition
+     revealleft      54           ..FV....... reveal left transition
+     revealright     55           ..FV....... reveal right transition
+     revealup        56           ..FV....... reveal up transition
+     revealdown      57           ..FV....... reveal down transition
+   duration          <duration>   ..FV....... set cross fade duration (default 1)
+   offset            <duration>   ..FV....... set cross fade start relative to first input stream (default 0)
+   expr              <string>     ..FV....... set expression for custom transition
+
+xfade_opencl AVOptions:
+   transition        <int>        ..FV....... set cross fade transition (from 0 to 9) (default fade)
+     custom          0            ..FV....... custom transition
+     fade            1            ..FV....... fade transition
+     wipeleft        2            ..FV....... wipe left transition
+     wiperight       3            ..FV....... wipe right transition
+     wipeup          4            ..FV....... wipe up transition
+     wipedown        5            ..FV....... wipe down transition
+     slideleft       6            ..FV....... slide left transition
+     slideright      7            ..FV....... slide right transition
+     slideup         8            ..FV....... slide up transition
+     slidedown       9            ..FV....... slide down transition
+   source            <string>     ..FV....... set OpenCL program source file for custom transition
+   kernel            <string>     ..FV....... set kernel name in program file for custom transition
+   duration          <duration>   ..FV....... set cross fade duration (default 1)
+   offset            <duration>   ..FV....... set cross fade start relative to first input stream (default 0)
+
+xfade_vulkan AVOptions:
+   transition        <int>        ..FV....... set cross fade transition (from 0 to 16) (default fade)
+     fade            0            ..FV....... fade transition
+     wipeleft        1            ..FV....... wipe left transition
+     wiperight       2            ..FV....... wipe right transition
+     wipeup          3            ..FV....... wipe up transition
+     wipedown        4            ..FV....... wipe down transition
+     slidedown       5            ..FV....... slide down transition
+     slideup         6            ..FV....... slide up transition
+     slideleft       7            ..FV....... slide left transition
+     slideright      8            ..FV....... slide right transition
+     circleopen      9            ..FV....... circleopen transition
+     circleclose     10           ..FV....... circleclose transition
+     dissolve        11           ..FV....... dissolve transition
+     pixelize        12           ..FV....... pixelize transition
+     wipetl          13           ..FV....... wipe top left transition
+     wipetr          14           ..FV....... wipe top right transition
+     wipebl          15           ..FV....... wipe bottom left transition
+     wipebr          16           ..FV....... wipe bottom right transition
+   duration          <duration>   ..FV....... set cross fade duration (default 1)
+   offset            <duration>   ..FV....... set cross fade start relative to first input stream (default 0)
+
+xmedian AVOptions:
+   inputs            <int>        ..FV....... set number of inputs (from 3 to 255) (default 3)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 15)
+   percentile        <float>      ..FV.....T. set percentile (from 0 to 1) (default 0.5)
+
+framesync AVOptions:
+   eof_action        <int>        ..FV....... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
+     repeat          0            ..FV....... Repeat the previous frame.
+     endall          1            ..FV....... End both streams.
+     pass            2            ..FV....... Pass through the main input.
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   repeatlast        <boolean>    ..FV....... extend last frame of secondary streams beyond EOF (default true)
+   ts_sync_mode      <int>        ..FV....... How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+     default         0            ..FV....... Frame from secondary input with the nearest lower or equal timestamp to the primary input frame
+     nearest         1            ..FV....... Frame from secondary input with the absolute nearest timestamp to the primary input frame
+
+xstack AVOptions:
+   inputs            <int>        ..FV....... set number of inputs (from 2 to INT_MAX) (default 2)
+   layout            <string>     ..FV....... set custom layout
+   grid              <image_size> ..FV....... set fixed size grid layout
+   shortest          <boolean>    ..FV....... force termination when the shortest input terminates (default false)
+   fill              <string>     ..FV....... set the color for unused pixels (default "none")
+
+yadif AVOptions:
+   mode              <int>        ..FV....... specify the interlacing mode (from 0 to 3) (default send_frame)
+     send_frame      0            ..FV....... send one frame for each frame
+     send_field      1            ..FV....... send one frame for each field
+     send_frame_nospatial 2            ..FV....... send one frame for each frame, but skip spatial interlacing check
+     send_field_nospatial 3            ..FV....... send one frame for each field, but skip spatial interlacing check
+   parity            <int>        ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV....... assume top field first
+     bff             1            ..FV....... assume bottom field first
+     auto            -1           ..FV....... auto detect parity
+   deint             <int>        ..FV....... specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV....... deinterlace all frames
+     interlaced      1            ..FV....... only deinterlace frames marked as interlaced
+
+yadif_cuda AVOptions:
+   mode              <int>        ..FV....... specify the interlacing mode (from 0 to 3) (default send_frame)
+     send_frame      0            ..FV....... send one frame for each frame
+     send_field      1            ..FV....... send one frame for each field
+     send_frame_nospatial 2            ..FV....... send one frame for each frame, but skip spatial interlacing check
+     send_field_nospatial 3            ..FV....... send one frame for each field, but skip spatial interlacing check
+   parity            <int>        ..FV....... specify the assumed picture field parity (from -1 to 1) (default auto)
+     tff             0            ..FV....... assume top field first
+     bff             1            ..FV....... assume bottom field first
+     auto            -1           ..FV....... auto detect parity
+   deint             <int>        ..FV....... specify which frames to deinterlace (from 0 to 1) (default all)
+     all             0            ..FV....... deinterlace all frames
+     interlaced      1            ..FV....... only deinterlace frames marked as interlaced
+
+yaepblur AVOptions:
+   radius            <int>        ..FV.....T. set window radius (from 0 to INT_MAX) (default 3)
+   r                 <int>        ..FV.....T. set window radius (from 0 to INT_MAX) (default 3)
+   planes            <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 1)
+   p                 <int>        ..FV.....T. set planes to filter (from 0 to 15) (default 1)
+   sigma             <int>        ..FV.....T. set blur strength (from 1 to INT_MAX) (default 128)
+   s                 <int>        ..FV.....T. set blur strength (from 1 to INT_MAX) (default 128)
+
+(a)zmq AVOptions:
+   bind_address      <string>     ..FVA...... set bind address (default "tcp://*:5555")
+   b                 <string>     ..FVA...... set bind address (default "tcp://*:5555")
+
+zoompan AVOptions:
+   zoom              <string>     ..FV....... set the zoom expression (default "1")
+   z                 <string>     ..FV....... set the zoom expression (default "1")
+   x                 <string>     ..FV....... set the x expression (default "0")
+   y                 <string>     ..FV....... set the y expression (default "0")
+   d                 <string>     ..FV....... set the duration expression (default "90")
+   s                 <image_size> ..FV....... set the output image size (default "hd720")
+   fps               <video_rate> ..FV....... set the output framerate (default "25")
+
+zscale AVOptions:
+   w                 <string>     ..FV.....T. Output video width
+   width             <string>     ..FV.....T. Output video width
+   h                 <string>     ..FV.....T. Output video height
+   height            <string>     ..FV.....T. Output video height
+   size              <string>     ..FV....... set video size
+   s                 <string>     ..FV....... set video size
+   dither            <int>        ..FV....... set dither type (from 0 to 3) (default none)
+     none            0            ..FV.......
+     ordered         1            ..FV.......
+     random          2            ..FV.......
+     error_diffusion 3            ..FV.......
+   d                 <int>        ..FV....... set dither type (from 0 to 3) (default none)
+     none            0            ..FV.......
+     ordered         1            ..FV.......
+     random          2            ..FV.......
+     error_diffusion 3            ..FV.......
+   filter            <int>        ..FV....... set filter type (from 0 to 5) (default bilinear)
+     point           0            ..FV.......
+     bilinear        1            ..FV.......
+     bicubic         2            ..FV.......
+     spline16        3            ..FV.......
+     spline36        4            ..FV.......
+     lanczos         5            ..FV.......
+   f                 <int>        ..FV....... set filter type (from 0 to 5) (default bilinear)
+     point           0            ..FV.......
+     bilinear        1            ..FV.......
+     bicubic         2            ..FV.......
+     spline16        3            ..FV.......
+     spline36        4            ..FV.......
+     lanczos         5            ..FV.......
+   out_range         <int>        ..FV....... set color range (from -1 to 1) (default input)
+     input           -1           ..FV.......
+     limited         0            ..FV.......
+     full            1            ..FV.......
+     unknown         -1           ..FV.......
+     tv              0            ..FV.......
+     pc              1            ..FV.......
+   range             <int>        ..FV....... set color range (from -1 to 1) (default input)
+     input           -1           ..FV.......
+     limited         0            ..FV.......
+     full            1            ..FV.......
+     unknown         -1           ..FV.......
+     tv              0            ..FV.......
+     pc              1            ..FV.......
+   r                 <int>        ..FV....... set color range (from -1 to 1) (default input)
+     input           -1           ..FV.......
+     limited         0            ..FV.......
+     full            1            ..FV.......
+     unknown         -1           ..FV.......
+     tv              0            ..FV.......
+     pc              1            ..FV.......
+   primaries         <int>        ..FV....... set color primaries (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     170m            6            ..FV.......
+     240m            7            ..FV.......
+     2020            9            ..FV.......
+     unknown         2            ..FV.......
+     bt709           1            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     film            8            ..FV.......
+     bt2020          9            ..FV.......
+     smpte428        10           ..FV.......
+     smpte431        11           ..FV.......
+     smpte432        12           ..FV.......
+     jedec-p22       22           ..FV.......
+     ebu3213         22           ..FV.......
+   p                 <int>        ..FV....... set color primaries (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     170m            6            ..FV.......
+     240m            7            ..FV.......
+     2020            9            ..FV.......
+     unknown         2            ..FV.......
+     bt709           1            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     film            8            ..FV.......
+     bt2020          9            ..FV.......
+     smpte428        10           ..FV.......
+     smpte431        11           ..FV.......
+     smpte432        12           ..FV.......
+     jedec-p22       22           ..FV.......
+     ebu3213         22           ..FV.......
+   transfer          <int>        ..FV....... set transfer characteristic (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     601             6            ..FV.......
+     linear          8            ..FV.......
+     2020_10         14           ..FV.......
+     2020_12         15           ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     bt709           1            ..FV.......
+     linear          8            ..FV.......
+     log100          9            ..FV.......
+     log316          10           ..FV.......
+     bt2020-10       14           ..FV.......
+     bt2020-12       15           ..FV.......
+     smpte2084       16           ..FV.......
+     iec61966-2-4    11           ..FV.......
+     iec61966-2-1    13           ..FV.......
+     arib-std-b67    18           ..FV.......
+   t                 <int>        ..FV....... set transfer characteristic (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     601             6            ..FV.......
+     linear          8            ..FV.......
+     2020_10         14           ..FV.......
+     2020_12         15           ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     bt709           1            ..FV.......
+     linear          8            ..FV.......
+     log100          9            ..FV.......
+     log316          10           ..FV.......
+     bt2020-10       14           ..FV.......
+     bt2020-12       15           ..FV.......
+     smpte2084       16           ..FV.......
+     iec61966-2-4    11           ..FV.......
+     iec61966-2-1    13           ..FV.......
+     arib-std-b67    18           ..FV.......
+   matrix            <int>        ..FV....... set colorspace matrix (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     470bg           5            ..FV.......
+     170m            6            ..FV.......
+     2020_ncl        9            ..FV.......
+     2020_cl         10           ..FV.......
+     unknown         2            ..FV.......
+     gbr             0            ..FV.......
+     bt709           1            ..FV.......
+     fcc             4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     ycgco           8            ..FV.......
+     bt2020nc        9            ..FV.......
+     bt2020c         10           ..FV.......
+     chroma-derived-nc 12           ..FV.......
+     chroma-derived-c 13           ..FV.......
+     ictcp           14           ..FV.......
+   m                 <int>        ..FV....... set colorspace matrix (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     470bg           5            ..FV.......
+     170m            6            ..FV.......
+     2020_ncl        9            ..FV.......
+     2020_cl         10           ..FV.......
+     unknown         2            ..FV.......
+     gbr             0            ..FV.......
+     bt709           1            ..FV.......
+     fcc             4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     ycgco           8            ..FV.......
+     bt2020nc        9            ..FV.......
+     bt2020c         10           ..FV.......
+     chroma-derived-nc 12           ..FV.......
+     chroma-derived-c 13           ..FV.......
+     ictcp           14           ..FV.......
+   in_range          <int>        ..FV....... set input color range (from -1 to 1) (default input)
+     input           -1           ..FV.......
+     limited         0            ..FV.......
+     full            1            ..FV.......
+     unknown         -1           ..FV.......
+     tv              0            ..FV.......
+     pc              1            ..FV.......
+   rangein           <int>        ..FV....... set input color range (from -1 to 1) (default input)
+     input           -1           ..FV.......
+     limited         0            ..FV.......
+     full            1            ..FV.......
+     unknown         -1           ..FV.......
+     tv              0            ..FV.......
+     pc              1            ..FV.......
+   rin               <int>        ..FV....... set input color range (from -1 to 1) (default input)
+     input           -1           ..FV.......
+     limited         0            ..FV.......
+     full            1            ..FV.......
+     unknown         -1           ..FV.......
+     tv              0            ..FV.......
+     pc              1            ..FV.......
+   primariesin       <int>        ..FV....... set input color primaries (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     170m            6            ..FV.......
+     240m            7            ..FV.......
+     2020            9            ..FV.......
+     unknown         2            ..FV.......
+     bt709           1            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     film            8            ..FV.......
+     bt2020          9            ..FV.......
+     smpte428        10           ..FV.......
+     smpte431        11           ..FV.......
+     smpte432        12           ..FV.......
+     jedec-p22       22           ..FV.......
+     ebu3213         22           ..FV.......
+   pin               <int>        ..FV....... set input color primaries (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     170m            6            ..FV.......
+     240m            7            ..FV.......
+     2020            9            ..FV.......
+     unknown         2            ..FV.......
+     bt709           1            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     film            8            ..FV.......
+     bt2020          9            ..FV.......
+     smpte428        10           ..FV.......
+     smpte431        11           ..FV.......
+     smpte432        12           ..FV.......
+     jedec-p22       22           ..FV.......
+     ebu3213         22           ..FV.......
+   transferin        <int>        ..FV....... set input transfer characteristic (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     601             6            ..FV.......
+     linear          8            ..FV.......
+     2020_10         14           ..FV.......
+     2020_12         15           ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     bt709           1            ..FV.......
+     linear          8            ..FV.......
+     log100          9            ..FV.......
+     log316          10           ..FV.......
+     bt2020-10       14           ..FV.......
+     bt2020-12       15           ..FV.......
+     smpte2084       16           ..FV.......
+     iec61966-2-4    11           ..FV.......
+     iec61966-2-1    13           ..FV.......
+     arib-std-b67    18           ..FV.......
+   tin               <int>        ..FV....... set input transfer characteristic (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     601             6            ..FV.......
+     linear          8            ..FV.......
+     2020_10         14           ..FV.......
+     2020_12         15           ..FV.......
+     unknown         2            ..FV.......
+     bt470m          4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     bt709           1            ..FV.......
+     linear          8            ..FV.......
+     log100          9            ..FV.......
+     log316          10           ..FV.......
+     bt2020-10       14           ..FV.......
+     bt2020-12       15           ..FV.......
+     smpte2084       16           ..FV.......
+     iec61966-2-4    11           ..FV.......
+     iec61966-2-1    13           ..FV.......
+     arib-std-b67    18           ..FV.......
+   matrixin          <int>        ..FV....... set input colorspace matrix (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     470bg           5            ..FV.......
+     170m            6            ..FV.......
+     2020_ncl        9            ..FV.......
+     2020_cl         10           ..FV.......
+     unknown         2            ..FV.......
+     gbr             0            ..FV.......
+     bt709           1            ..FV.......
+     fcc             4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     ycgco           8            ..FV.......
+     bt2020nc        9            ..FV.......
+     bt2020c         10           ..FV.......
+     chroma-derived-nc 12           ..FV.......
+     chroma-derived-c 13           ..FV.......
+     ictcp           14           ..FV.......
+   min               <int>        ..FV....... set input colorspace matrix (from -1 to INT_MAX) (default input)
+     input           -1           ..FV.......
+     709             1            ..FV.......
+     unspecified     2            ..FV.......
+     470bg           5            ..FV.......
+     170m            6            ..FV.......
+     2020_ncl        9            ..FV.......
+     2020_cl         10           ..FV.......
+     unknown         2            ..FV.......
+     gbr             0            ..FV.......
+     bt709           1            ..FV.......
+     fcc             4            ..FV.......
+     bt470bg         5            ..FV.......
+     smpte170m       6            ..FV.......
+     smpte240m       7            ..FV.......
+     ycgco           8            ..FV.......
+     bt2020nc        9            ..FV.......
+     bt2020c         10           ..FV.......
+     chroma-derived-nc 12           ..FV.......
+     chroma-derived-c 13           ..FV.......
+     ictcp           14           ..FV.......
+   chromal           <int>        ..FV....... set output chroma location (from -1 to 5) (default input)
+     input           -1           ..FV.......
+     left            0            ..FV.......
+     center          1            ..FV.......
+     topleft         2            ..FV.......
+     top             3            ..FV.......
+     bottomleft      4            ..FV.......
+     bottom          5            ..FV.......
+   c                 <int>        ..FV....... set output chroma location (from -1 to 5) (default input)
+     input           -1           ..FV.......
+     left            0            ..FV.......
+     center          1            ..FV.......
+     topleft         2            ..FV.......
+     top             3            ..FV.......
+     bottomleft      4            ..FV.......
+     bottom          5            ..FV.......
+   chromalin         <int>        ..FV....... set input chroma location (from -1 to 5) (default input)
+     input           -1           ..FV.......
+     left            0            ..FV.......
+     center          1            ..FV.......
+     topleft         2            ..FV.......
+     top             3            ..FV.......
+     bottomleft      4            ..FV.......
+     bottom          5            ..FV.......
+   cin               <int>        ..FV....... set input chroma location (from -1 to 5) (default input)
+     input           -1           ..FV.......
+     left            0            ..FV.......
+     center          1            ..FV.......
+     topleft         2            ..FV.......
+     top             3            ..FV.......
+     bottomleft      4            ..FV.......
+     bottom          5            ..FV.......
+   npl               <double>     ..FV....... set nominal peak luminance (from 0 to DBL_MAX) (default nan)
+   agamma            <boolean>    ..FV....... allow approximate gamma (default true)
+   param_a           <double>     ..FV....... parameter A, which is parameter "b" for bicubic, and the number of filter taps for lanczos (from -DBL_MAX to DBL_MAX) (default nan)
+   param_b           <double>     ..FV....... parameter B, which is parameter "c" for bicubic (from -DBL_MAX to DBL_MAX) (default nan)
+
+hstack_vaapi AVOptions:
+   inputs            <int>        ..FV....... Set number of inputs (from 2 to 65535) (default 2)
+   shortest          <boolean>    ..FV....... Force termination when the shortest input terminates (default false)
+   height            <int>        ..FV....... Set output height (0 to use the height of input 0) (from 0 to 65535) (default 0)
+
+vstack_vaapi AVOptions:
+   inputs            <int>        ..FV....... Set number of inputs (from 2 to 65535) (default 2)
+   shortest          <boolean>    ..FV....... Force termination when the shortest input terminates (default false)
+   width             <int>        ..FV....... Set output width (0 to use the width of input 0) (from 0 to 65535) (default 0)
+
+xstack_vaapi AVOptions:
+   inputs            <int>        ..FV....... Set number of inputs (from 2 to 65535) (default 2)
+   shortest          <boolean>    ..FV....... Force termination when the shortest input terminates (default false)
+   layout            <string>     ..FV....... Set custom layout
+   grid              <image_size> ..FV....... set fixed size grid layout
+   grid_tile_size    <image_size> ..FV....... set tile size in grid layout
+   fill              <string>     ..FV....... Set the color for unused pixels (default "none")
+
+allyuv/allrgb AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+allyuv/allrgb AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+cellauto AVOptions:
+   filename          <string>     ..FV....... read initial pattern from file
+   f                 <string>     ..FV....... read initial pattern from file
+   pattern           <string>     ..FV....... set initial pattern
+   p                 <string>     ..FV....... set initial pattern
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   size              <image_size> ..FV....... set video size
+   s                 <image_size> ..FV....... set video size
+   rule              <int>        ..FV....... set rule (from 0 to 255) (default 110)
+   random_fill_ratio <double>     ..FV....... set fill ratio for filling initial grid randomly (from 0 to 1) (default 0.618034)
+   ratio             <double>     ..FV....... set fill ratio for filling initial grid randomly (from 0 to 1) (default 0.618034)
+   random_seed       <int64>      ..FV....... set the seed for filling the initial grid randomly (from -1 to UINT32_MAX) (default -1)
+   seed              <int64>      ..FV....... set the seed for filling the initial grid randomly (from -1 to UINT32_MAX) (default -1)
+   scroll            <boolean>    ..FV....... scroll pattern downward (default true)
+   start_full        <boolean>    ..FV....... start filling the whole video (default false)
+   full              <boolean>    ..FV....... start filling the whole video (default true)
+   stitch            <boolean>    ..FV....... stitch boundaries (default true)
+
+color AVOptions:
+   color             <color>      ..FV.....T. set color (default "black")
+   c                 <color>      ..FV.....T. set color (default "black")
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+color_vulkan AVOptions:
+   color             <color>      ..FV....... set color (default "black")
+   c                 <color>      ..FV....... set color (default "black")
+   size              <image_size> ..FV....... set video size (default "1920x1080")
+   s                 <image_size> ..FV....... set video size (default "1920x1080")
+   rate              <video_rate> ..FV....... set video rate (default "60")
+   r                 <video_rate> ..FV....... set video rate (default "60")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   format            <string>     ..FV....... Output video format (software format of hardware frames)
+   out_range         <int>        ..FV....... Output colour range (from 0 to 2) (default 0) (from 0 to 2) (default 0)
+     full            2            ..FV....... Full range
+     limited         1            ..FV....... Limited range
+     jpeg            2            ..FV....... Full range
+     mpeg            1            ..FV....... Limited range
+     tv              1            ..FV....... Limited range
+     pc              2            ..FV....... Full range
+
+colorchart AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   patch_size        <image_size> ..FV....... set the single patch size (default "64x64")
+   preset            <int>        ..FV....... set the color checker chart preset (from 0 to 1) (default reference)
+     reference       0            ..FV....... reference
+     skintones       1            ..FV....... skintones
+
+colorspectrum AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   type              <int>        ..FV....... set the color spectrum type (from 0 to 2) (default black)
+     black           0            ..FV....... fade to black
+     white           1            ..FV....... fade to white
+     all             2            ..FV....... white to black
+
+frei0r_src AVOptions:
+   size              <image_size> ..FV....... Dimensions of the generated video. (default "320x240")
+   framerate         <video_rate> ..FV....... (default "25")
+   filter_name       <string>     ..FV.......
+   filter_params     <string>     ..FV.......
+
+gradients AVOptions:
+   size              <image_size> ..FV....... set frame size (default "640x480")
+   s                 <image_size> ..FV....... set frame size (default "640x480")
+   rate              <video_rate> ..FV....... set frame rate (default "25")
+   r                 <video_rate> ..FV....... set frame rate (default "25")
+   c0                <color>      ..FV....... set 1st color (default "random")
+   c1                <color>      ..FV....... set 2nd color (default "random")
+   c2                <color>      ..FV....... set 3rd color (default "random")
+   c3                <color>      ..FV....... set 4th color (default "random")
+   c4                <color>      ..FV....... set 5th color (default "random")
+   c5                <color>      ..FV....... set 6th color (default "random")
+   c6                <color>      ..FV....... set 7th color (default "random")
+   c7                <color>      ..FV....... set 8th color (default "random")
+   x0                <int>        ..FV....... set gradient line source x0 (from -1 to INT_MAX) (default -1)
+   y0                <int>        ..FV....... set gradient line source y0 (from -1 to INT_MAX) (default -1)
+   x1                <int>        ..FV....... set gradient line destination x1 (from -1 to INT_MAX) (default -1)
+   y1                <int>        ..FV....... set gradient line destination y1 (from -1 to INT_MAX) (default -1)
+   nb_colors         <int>        ..FV....... set the number of colors (from 2 to 8) (default 2)
+   n                 <int>        ..FV....... set the number of colors (from 2 to 8) (default 2)
+   seed              <int64>      ..FV....... set the seed (from -1 to UINT32_MAX) (default -1)
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   speed             <float>      ..FV....... set gradients rotation speed (from 1e-05 to 1) (default 0.01)
+   type              <int>        ..FV....... set gradient type (from 0 to 3) (default linear)
+     linear          0            ..FV....... set gradient type
+     radial          1            ..FV....... set gradient type
+     circular        2            ..FV....... set gradient type
+     spiral          3            ..FV....... set gradient type
+   t                 <int>        ..FV....... set gradient type (from 0 to 3) (default linear)
+     linear          0            ..FV....... set gradient type
+     radial          1            ..FV....... set gradient type
+     circular        2            ..FV....... set gradient type
+     spiral          3            ..FV....... set gradient type
+
+haldclutsrc AVOptions:
+   level             <int>        ..FV....... set level (from 2 to 16) (default 6)
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+life AVOptions:
+   filename          <string>     ..FV....... set source file
+   f                 <string>     ..FV....... set source file
+   size              <image_size> ..FV....... set video size
+   s                 <image_size> ..FV....... set video size
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   rule              <string>     ..FV....... set rule (default "B3/S23")
+   random_fill_ratio <double>     ..FV....... set fill ratio for filling initial grid randomly (from 0 to 1) (default 0.618034)
+   ratio             <double>     ..FV....... set fill ratio for filling initial grid randomly (from 0 to 1) (default 0.618034)
+   random_seed       <int64>      ..FV....... set the seed for filling the initial grid randomly (from -1 to UINT32_MAX) (default -1)
+   seed              <int64>      ..FV....... set the seed for filling the initial grid randomly (from -1 to UINT32_MAX) (default -1)
+   stitch            <boolean>    ..FV....... stitch boundaries (default true)
+   mold              <int>        ..FV....... set mold speed for dead cells (from 0 to 255) (default 0)
+   life_color        <color>      ..FV....... set life color (default "white")
+   death_color       <color>      ..FV....... set death color (default "black")
+   mold_color        <color>      ..FV....... set mold color (default "black")
+
+mandelbrot AVOptions:
+   size              <image_size> ..FV....... set frame size (default "640x480")
+   s                 <image_size> ..FV....... set frame size (default "640x480")
+   rate              <video_rate> ..FV....... set frame rate (default "25")
+   r                 <video_rate> ..FV....... set frame rate (default "25")
+   maxiter           <int>        ..FV....... set max iterations number (from 1 to INT_MAX) (default 7189)
+   start_x           <double>     ..FV....... set the initial x position (from -100 to 100) (default -0.743644)
+   start_y           <double>     ..FV....... set the initial y position (from -100 to 100) (default -0.131826)
+   start_scale       <double>     ..FV....... set the initial scale value (from 0 to FLT_MAX) (default 3)
+   end_scale         <double>     ..FV....... set the terminal scale value (from 0 to FLT_MAX) (default 0.3)
+   end_pts           <double>     ..FV....... set the terminal pts value (from 0 to I64_MAX) (default 400)
+   bailout           <double>     ..FV....... set the bailout value (from 0 to FLT_MAX) (default 10)
+   morphxf           <double>     ..FV....... set morph x frequency (from -FLT_MAX to FLT_MAX) (default 0.01)
+   morphyf           <double>     ..FV....... set morph y frequency (from -FLT_MAX to FLT_MAX) (default 0.0123)
+   morphamp          <double>     ..FV....... set morph amplitude (from -FLT_MAX to FLT_MAX) (default 0)
+   outer             <int>        ..FV....... set outer coloring mode (from 0 to INT_MAX) (default normalized_iteration_count)
+     iteration_count 0            ..FV....... set iteration count mode
+     normalized_iteration_count 1            ..FV....... set normalized iteration count mode
+     white           2            ..FV....... set white mode
+     outz            3            ..FV....... set outz mode
+   inner             <int>        ..FV....... set inner coloring mode (from 0 to INT_MAX) (default mincol)
+     black           0            ..FV....... set black mode
+     period          1            ..FV....... set period mode
+     convergence     2            ..FV....... show time until convergence
+     mincol          3            ..FV....... color based on point closest to the origin of the iterations
+
+mptestsrc AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   test              <int>        ..FV....... set test to perform (from 0 to INT_MAX) (default all)
+     dc_luma         0            ..FV....... 
+     dc_chroma       1            ..FV....... 
+     freq_luma       2            ..FV....... 
+     freq_chroma     3            ..FV....... 
+     amp_luma        4            ..FV....... 
+     amp_chroma      5            ..FV....... 
+     cbp             6            ..FV....... 
+     mv              7            ..FV....... 
+     ring1           8            ..FV....... 
+     ring2           9            ..FV....... 
+     all             10           ..FV....... 
+   t                 <int>        ..FV....... set test to perform (from 0 to INT_MAX) (default all)
+     dc_luma         0            ..FV....... 
+     dc_chroma       1            ..FV....... 
+     freq_luma       2            ..FV....... 
+     freq_chroma     3            ..FV....... 
+     amp_luma        4            ..FV....... 
+     amp_chroma      5            ..FV....... 
+     cbp             6            ..FV....... 
+     mv              7            ..FV....... 
+     ring1           8            ..FV....... 
+     ring2           9            ..FV....... 
+     all             10           ..FV....... 
+   max_frames        <int64>      ..FV....... Set the maximum number of frames generated for each test (from 1 to I64_MAX) (default 30)
+   m                 <int64>      ..FV....... Set the maximum number of frames generated for each test (from 1 to I64_MAX) (default 30)
+
+nullsrc/yuvtestsrc AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+openclsrc AVOptions:
+   source            <string>     ..FV....... OpenCL program source file
+   kernel            <string>     ..FV....... Kernel name in program
+   size              <image_size> ..FV....... Video size
+   s                 <image_size> ..FV....... Video size
+   format            <pix_fmt>    ..FV....... Video format (default none)
+   rate              <video_rate> ..FV....... Video frame rate (default "25")
+   r                 <video_rate> ..FV....... Video frame rate (default "25")
+
+pal(75|100)bars AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+pal(75|100)bars AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+rgbtestsrc AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   complement        <boolean>    ..FV....... set complement colors (default false)
+   co                <boolean>    ..FV....... set complement colors (default false)
+
+sierpinski AVOptions:
+   size              <image_size> ..FV....... set frame size (default "640x480")
+   s                 <image_size> ..FV....... set frame size (default "640x480")
+   rate              <video_rate> ..FV....... set frame rate (default "25")
+   r                 <video_rate> ..FV....... set frame rate (default "25")
+   seed              <int64>      ..FV....... set the seed (from -1 to UINT32_MAX) (default -1)
+   jump              <int>        ..FV....... set the jump (from 1 to 10000) (default 100)
+   type              <int>        ..FV....... set fractal type (from 0 to 1) (default carpet)
+     carpet          0            ..FV....... sierpinski carpet
+     triangle        1            ..FV....... sierpinski triangle
+
+smpte(hd)bars AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+smpte(hd)bars AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+testsrc AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   decimals          <int>        ..FV....... set number of decimals to show (from 0 to 17) (default 0)
+   n                 <int>        ..FV....... set number of decimals to show (from 0 to 17) (default 0)
+
+testsrc2 AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   alpha             <int>        ..FV....... set global alpha (opacity) (from 0 to 255) (default 255)
+
+nullsrc/yuvtestsrc AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+
+zoneplate AVOptions:
+   size              <image_size> ..FV....... set video size (default "320x240")
+   s                 <image_size> ..FV....... set video size (default "320x240")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   duration          <duration>   ..FV....... set video duration (default -0.000001)
+   d                 <duration>   ..FV....... set video duration (default -0.000001)
+   sar               <rational>   ..FV....... set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)
+   precision         <int>        ..FV....... set LUT precision (from 4 to 16) (default 10)
+   xo                <int>        ..FV.....T. set X-axis offset (from INT_MIN to INT_MAX) (default 0)
+   yo                <int>        ..FV.....T. set Y-axis offset (from INT_MIN to INT_MAX) (default 0)
+   to                <int>        ..FV.....T. set T-axis offset (from INT_MIN to INT_MAX) (default 0)
+   k0                <int>        ..FV.....T. set 0-order phase (from INT_MIN to INT_MAX) (default 0)
+   kx                <int>        ..FV.....T. set 1-order X-axis phase (from INT_MIN to INT_MAX) (default 0)
+   ky                <int>        ..FV.....T. set 1-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)
+   kt                <int>        ..FV.....T. set 1-order T-axis phase (from INT_MIN to INT_MAX) (default 0)
+   kxt               <int>        ..FV.....T. set X-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)
+   kyt               <int>        ..FV.....T. set Y-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)
+   kxy               <int>        ..FV.....T. set X-axis*Y-axis product phase (from INT_MIN to INT_MAX) (default 0)
+   kx2               <int>        ..FV.....T. set 2-order X-axis phase (from INT_MIN to INT_MAX) (default 0)
+   ky2               <int>        ..FV.....T. set 2-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)
+   kt2               <int>        ..FV.....T. set 2-order T-axis phase (from INT_MIN to INT_MAX) (default 0)
+   ku                <int>        ..FV.....T. set 0-order U-color phase (from INT_MIN to INT_MAX) (default 0)
+   kv                <int>        ..FV.....T. set 0-order V-color phase (from INT_MIN to INT_MAX) (default 0)
+
+a3dscope AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   size              <image_size> ..FV....... set video size (default "hd720")
+   s                 <image_size> ..FV....... set video size (default "hd720")
+   fov               <float>      ..FV.....T. set camera FoV (from 40 to 150) (default 90)
+   roll              <float>      ..FV.....T. set camera roll (from -180 to 180) (default 0)
+   pitch             <float>      ..FV.....T. set camera pitch (from -180 to 180) (default 0)
+   yaw               <float>      ..FV.....T. set camera yaw (from -180 to 180) (default 0)
+   xzoom             <float>      ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
+   yzoom             <float>      ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
+   zzoom             <float>      ..FV.....T. set camera zoom (from 0.01 to 10) (default 1)
+   xpos              <float>      ..FV.....T. set camera position (from -60 to 60) (default 0)
+   ypos              <float>      ..FV.....T. set camera position (from -60 to 60) (default 0)
+   zpos              <float>      ..FV.....T. set camera position (from -60 to 60) (default 0)
+   length            <int>        ..FV....... set length (from 1 to 60) (default 15)
+
+abitscope AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   size              <image_size> ..FV....... set video size (default "1024x256")
+   s                 <image_size> ..FV....... set video size (default "1024x256")
+   colors            <string>     ..FV....... set channels colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+   mode              <int>        ..FV....... set output mode (from 0 to 1) (default bars)
+     bars            0            ..FV.......
+     trace           1            ..FV.......
+   m                 <int>        ..FV....... set output mode (from 0 to 1) (default bars)
+     bars            0            ..FV.......
+     trace           1            ..FV.......
+
+(a)drawgraph AVOptions:
+   m1                <string>     ..FV....... set 1st metadata key (default "")
+   fg1               <string>     ..FV....... set 1st foreground color expression (default "0xffff0000")
+   m2                <string>     ..FV....... set 2nd metadata key (default "")
+   fg2               <string>     ..FV....... set 2nd foreground color expression (default "0xff00ff00")
+   m3                <string>     ..FV....... set 3rd metadata key (default "")
+   fg3               <string>     ..FV....... set 3rd foreground color expression (default "0xffff00ff")
+   m4                <string>     ..FV....... set 4th metadata key (default "")
+   fg4               <string>     ..FV....... set 4th foreground color expression (default "0xffffff00")
+   bg                <color>      ..FV....... set background color (default "white")
+   min               <float>      ..FV....... set minimal value (from INT_MIN to INT_MAX) (default -1)
+   max               <float>      ..FV....... set maximal value (from INT_MIN to INT_MAX) (default 1)
+   mode              <int>        ..FV....... set graph mode (from 0 to 2) (default line)
+     bar             0            ..FV....... draw bars
+     dot             1            ..FV....... draw dots
+     line            2            ..FV....... draw lines
+   slide             <int>        ..FV....... set slide mode (from 0 to 4) (default frame)
+     frame           0            ..FV....... draw new frames
+     replace         1            ..FV....... replace old columns with new
+     scroll          2            ..FV....... scroll from right to left
+     rscroll         3            ..FV....... scroll from left to right
+     picture         4            ..FV....... display graph in single frame
+   size              <image_size> ..FV....... set graph size (default "900x256")
+   s                 <image_size> ..FV....... set graph size (default "900x256")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+
+(a)graphmonitor AVOptions:
+   size              <image_size> ..FV....... set monitor size (default "hd720")
+   s                 <image_size> ..FV....... set monitor size (default "hd720")
+   opacity           <float>      ..FV.....T. set video opacity (from 0 to 1) (default 0.9)
+   o                 <float>      ..FV.....T. set video opacity (from 0 to 1) (default 0.9)
+   mode              <flags>      ..FV.....T. set mode (default 0)
+     full                         ..FV.....T.
+     compact                      ..FV.....T.
+     nozero                       ..FV.....T.
+     noeof                        ..FV.....T.
+     nodisabled                   ..FV.....T.
+   m                 <flags>      ..FV.....T. set mode (default 0)
+     full                         ..FV.....T.
+     compact                      ..FV.....T.
+     nozero                       ..FV.....T.
+     noeof                        ..FV.....T.
+     nodisabled                   ..FV.....T.
+   flags             <flags>      ..FV.....T. set flags (default all+queue)
+     none                         ..FV.....T.
+     all                          ..FV.....T.
+     queue                        ..FV.....T.
+     frame_count_in               ..FV.....T.
+     frame_count_out              ..FV.....T.
+     frame_count_delta              ..FV.....T.
+     pts                          ..FV.....T.
+     pts_delta                    ..FV.....T.
+     time                         ..FV.....T.
+     time_delta                   ..FV.....T.
+     timebase                     ..FV.....T.
+     format                       ..FV.....T.
+     size                         ..FV.....T.
+     rate                         ..FV.....T.
+     eof                          ..FV.....T.
+     sample_count_in              ..FV.....T.
+     sample_count_out              ..FV.....T.
+     sample_count_delta              ..FV.....T.
+     disabled                     ..FV.....T.
+   f                 <flags>      ..FV.....T. set flags (default all+queue)
+     none                         ..FV.....T.
+     all                          ..FV.....T.
+     queue                        ..FV.....T.
+     frame_count_in               ..FV.....T.
+     frame_count_out              ..FV.....T.
+     frame_count_delta              ..FV.....T.
+     pts                          ..FV.....T.
+     pts_delta                    ..FV.....T.
+     time                         ..FV.....T.
+     time_delta                   ..FV.....T.
+     timebase                     ..FV.....T.
+     format                       ..FV.....T.
+     size                         ..FV.....T.
+     rate                         ..FV.....T.
+     eof                          ..FV.....T.
+     sample_count_in              ..FV.....T.
+     sample_count_out              ..FV.....T.
+     sample_count_delta              ..FV.....T.
+     disabled                     ..FV.....T.
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+
+ahistogram AVOptions:
+   dmode             <int>        ..FV....... set method to display channels (from 0 to 1) (default single)
+     single          0            ..FV....... all channels use single histogram
+     separate        1            ..FV....... each channel have own histogram
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   size              <image_size> ..FV....... set video size (default "hd720")
+   s                 <image_size> ..FV....... set video size (default "hd720")
+   scale             <int>        ..FV....... set display scale (from 0 to 4) (default log)
+     log             3            ..FV....... logarithmic
+     sqrt            1            ..FV....... square root
+     cbrt            2            ..FV....... cubic root
+     lin             0            ..FV....... linear
+     rlog            4            ..FV....... reverse logarithmic
+   ascale            <int>        ..FV....... set amplitude scale (from 0 to 1) (default log)
+     log             1            ..FV....... logarithmic
+     lin             0            ..FV....... linear
+   acount            <int>        ..FV....... how much frames to accumulate (from -1 to 100) (default 1)
+   rheight           <float>      ..FV....... set histogram ratio of window height (from 0 to 1) (default 0.1)
+   slide             <int>        ..FV....... set sonogram sliding (from 0 to 1) (default replace)
+     replace         0            ..FV....... replace old rows with new
+     scroll          1            ..FV....... scroll from top to bottom
+   hmode             <int>        ..FV....... set histograms mode (from 0 to 1) (default abs)
+     abs             0            ..FV....... use absolute samples
+     sign            1            ..FV....... use unchanged samples
+
+aphasemeter AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   size              <image_size> ..FV....... set video size (default "800x400")
+   s                 <image_size> ..FV....... set video size (default "800x400")
+   rc                <int>        ..FV....... set red contrast (from 0 to 255) (default 2)
+   gc                <int>        ..FV....... set green contrast (from 0 to 255) (default 7)
+   bc                <int>        ..FV....... set blue contrast (from 0 to 255) (default 1)
+   mpc               <string>     ..FV....... set median phase color (default "none")
+   video             <boolean>    ..FV....... set video output (default true)
+   phasing           <boolean>    ..FV....... set mono and out-of-phase detection output (default false)
+   tolerance         <float>      ..FV....... set phase tolerance for mono detection (from 0 to 1) (default 0)
+   t                 <float>      ..FV....... set phase tolerance for mono detection (from 0 to 1) (default 0)
+   angle             <float>      ..FV....... set angle threshold for out-of-phase detection (from 90 to 180) (default 170)
+   a                 <float>      ..FV....... set angle threshold for out-of-phase detection (from 90 to 180) (default 170)
+   duration          <duration>   ..FV....... set minimum mono or out-of-phase duration in seconds (default 2)
+   d                 <duration>   ..FV....... set minimum mono or out-of-phase duration in seconds (default 2)
+
+avectorscope AVOptions:
+   mode              <int>        ..FV.....T. set mode (from 0 to 2) (default lissajous)
+     lissajous       0            ..FV.....T. 
+     lissajous_xy    1            ..FV.....T. 
+     polar           2            ..FV.....T. 
+   m                 <int>        ..FV.....T. set mode (from 0 to 2) (default lissajous)
+     lissajous       0            ..FV.....T. 
+     lissajous_xy    1            ..FV.....T. 
+     polar           2            ..FV.....T. 
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   size              <image_size> ..FV....... set video size (default "400x400")
+   s                 <image_size> ..FV....... set video size (default "400x400")
+   rc                <int>        ..FV.....T. set red contrast (from 0 to 255) (default 40)
+   gc                <int>        ..FV.....T. set green contrast (from 0 to 255) (default 160)
+   bc                <int>        ..FV.....T. set blue contrast (from 0 to 255) (default 80)
+   ac                <int>        ..FV.....T. set alpha contrast (from 0 to 255) (default 255)
+   rf                <int>        ..FV.....T. set red fade (from 0 to 255) (default 15)
+   gf                <int>        ..FV.....T. set green fade (from 0 to 255) (default 10)
+   bf                <int>        ..FV.....T. set blue fade (from 0 to 255) (default 5)
+   af                <int>        ..FV.....T. set alpha fade (from 0 to 255) (default 5)
+   zoom              <double>     ..FV.....T. set zoom factor (from 0 to 10) (default 1)
+   draw              <int>        ..FV.....T. set draw mode (from 0 to 2) (default dot)
+     dot             0            ..FV.....T. draw dots
+     line            1            ..FV.....T. draw lines
+     aaline          2            ..FV.....T. draw anti-aliased lines
+   scale             <int>        ..FV.....T. set amplitude scale mode (from 0 to 3) (default lin)
+     lin             0            ..FV.....T. linear
+     sqrt            1            ..FV.....T. square root
+     cbrt            2            ..FV.....T. cube root
+     log             3            ..FV.....T. logarithmic
+   swap              <boolean>    ..FV.....T. swap x axis with y axis (default true)
+   mirror            <int>        ..FV.....T. mirror axis (from 0 to 3) (default none)
+     none            0            ..FV.....T. no mirror
+     x               1            ..FV.....T. mirror x
+     y               2            ..FV.....T. mirror y
+     xy              3            ..FV.....T. mirror both
+
+concat AVOptions:
+   n                 <int>        ..FVA...... specify the number of segments (from 1 to INT_MAX) (default 2)
+   v                 <int>        ..FV....... specify the number of video streams (from 0 to INT_MAX) (default 1)
+   a                 <int>        ..F.A...... specify the number of audio streams (from 0 to INT_MAX) (default 0)
+   unsafe            <boolean>    ..FVA...... enable unsafe mode (default false)
+
+showcqt AVOptions:
+   size              <image_size> ..FV....... set video size (default "1920x1080")
+   s                 <image_size> ..FV....... set video size (default "1920x1080")
+   fps               <video_rate> ..FV....... set video rate (default "25")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   bar_h             <int>        ..FV....... set bargraph height (from -1 to INT_MAX) (default -1)
+   axis_h            <int>        ..FV....... set axis height (from -1 to INT_MAX) (default -1)
+   sono_h            <int>        ..FV....... set sonogram height (from -1 to INT_MAX) (default -1)
+   fullhd            <boolean>    ..FV....... set fullhd size (default true)
+   sono_v            <string>     ..FV....... set sonogram volume (default "16")
+   volume            <string>     ..FV....... set sonogram volume (default "16")
+   bar_v             <string>     ..FV....... set bargraph volume (default "sono_v")
+   volume2           <string>     ..FV....... set bargraph volume (default "sono_v")
+   sono_g            <float>      ..FV....... set sonogram gamma (from 1 to 7) (default 3)
+   gamma             <float>      ..FV....... set sonogram gamma (from 1 to 7) (default 3)
+   bar_g             <float>      ..FV....... set bargraph gamma (from 1 to 7) (default 1)
+   gamma2            <float>      ..FV....... set bargraph gamma (from 1 to 7) (default 1)
+   bar_t             <float>      ..FV....... set bar transparency (from 0 to 1) (default 1)
+   timeclamp         <double>     ..FV....... set timeclamp (from 0.002 to 1) (default 0.17)
+   tc                <double>     ..FV....... set timeclamp (from 0.002 to 1) (default 0.17)
+   attack            <double>     ..FV....... set attack time (from 0 to 1) (default 0)
+   basefreq          <double>     ..FV....... set base frequency (from 10 to 100000) (default 20.0152)
+   endfreq           <double>     ..FV....... set end frequency (from 10 to 100000) (default 20495.6)
+   coeffclamp        <float>      ..FV....... set coeffclamp (from 0.1 to 10) (default 1)
+   tlength           <string>     ..FV....... set tlength (default "384*tc/(384+tc*f)")
+   count             <int>        ..FV....... set transform count (from 1 to 30) (default 6)
+   fcount            <int>        ..FV....... set frequency count (from 0 to 10) (default 0)
+   fontfile          <string>     ..FV....... set axis font file
+   font              <string>     ..FV....... set axis font
+   fontcolor         <string>     ..FV....... set font color (default "st(0, (midi(f)-59.5)/12);st(1, if(between(ld(0),0,1), 0.5-0.5*cos(2*PI*ld(0)), 0));r(1-ld(1)) + b(ld(1))")
+   axisfile          <string>     ..FV....... set axis image
+   axis              <boolean>    ..FV....... draw axis (default true)
+   text              <boolean>    ..FV....... draw axis (default true)
+   csp               <int>        ..FV....... set color space (from 0 to INT_MAX) (default unspecified)
+     unspecified     2            ..FV....... unspecified
+     bt709           1            ..FV....... bt709
+     fcc             4            ..FV....... fcc
+     bt470bg         5            ..FV....... bt470bg
+     smpte170m       6            ..FV....... smpte170m
+     smpte240m       7            ..FV....... smpte240m
+     bt2020ncl       9            ..FV....... bt2020ncl
+   cscheme           <string>     ..FV....... set color scheme (default "1|0.5|0|0|0.5|1")
+
+showcwt AVOptions:
+   size              <image_size> ..FV....... set video size (default "640x512")
+   s                 <image_size> ..FV....... set video size (default "640x512")
+   rate              <string>     ..FV....... set video rate (default "25")
+   r                 <string>     ..FV....... set video rate (default "25")
+   scale             <int>        ..FV....... set frequency scale (from 0 to 7) (default linear)
+     linear          0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+     bark            2            ..FV....... bark
+     mel             3            ..FV....... mel
+     erbs            4            ..FV....... erbs
+     sqrt            5            ..FV....... sqrt
+     cbrt            6            ..FV....... cbrt
+     qdrt            7            ..FV....... qdrt
+   iscale            <int>        ..FV....... set intensity scale (from 0 to 4) (default log)
+     linear          1            ..FV....... linear
+     log             0            ..FV....... logarithmic
+     sqrt            2            ..FV....... sqrt
+     cbrt            3            ..FV....... cbrt
+     qdrt            4            ..FV....... qdrt
+   min               <float>      ..FV....... set minimum frequency (from 1 to 192000) (default 20)
+   max               <float>      ..FV....... set maximum frequency (from 1 to 192000) (default 20000)
+   imin              <float>      ..FV....... set minimum intensity (from 0 to 1) (default 0)
+   imax              <float>      ..FV....... set maximum intensity (from 0 to 1) (default 1)
+   logb              <float>      ..FV....... set logarithmic basis (from 0 to 1) (default 0.0001)
+   deviation         <float>      ..FV....... set frequency deviation (from 0 to 100) (default 1)
+   pps               <int>        ..FV....... set pixels per second (from 1 to 1024) (default 64)
+   mode              <int>        ..FV....... set output mode (from 0 to 4) (default magnitude)
+     magnitude       0            ..FV....... magnitude
+     phase           1            ..FV....... phase
+     magphase        2            ..FV....... magnitude+phase
+     channel         3            ..FV....... color per channel
+     stereo          4            ..FV....... stereo difference
+   slide             <int>        ..FV....... set slide mode (from 0 to 2) (default replace)
+     replace         0            ..FV....... replace
+     scroll          1            ..FV....... scroll
+     frame           2            ..FV....... frame
+   direction         <int>        ..FV....... set direction mode (from 0 to 3) (default lr)
+     lr              0            ..FV....... left to right
+     rl              1            ..FV....... right to left
+     ud              2            ..FV....... up to down
+     du              3            ..FV....... down to up
+   bar               <float>      ..FV....... set bar ratio (from 0 to 1) (default 0)
+   rotation          <float>      ..FV....... set color rotation (from -1 to 1) (default 0)
+
+showfreqs AVOptions:
+   size              <image_size> ..FV....... set video size (default "1024x512")
+   s                 <image_size> ..FV....... set video size (default "1024x512")
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   mode              <int>        ..FV....... set display mode (from 0 to 2) (default bar)
+     line            0            ..FV....... show lines
+     bar             1            ..FV....... show bars
+     dot             2            ..FV....... show dots
+   ascale            <int>        ..FV....... set amplitude scale (from 0 to 3) (default log)
+     lin             0            ..FV....... linear
+     sqrt            1            ..FV....... square root
+     cbrt            2            ..FV....... cubic root
+     log             3            ..FV....... logarithmic
+   fscale            <int>        ..FV....... set frequency scale (from 0 to 2) (default lin)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+     rlog            2            ..FV....... reverse logarithmic
+   win_size          <int>        ..FV....... set window size (from 16 to 65536) (default 2048)
+   win_func          <int>        ..FV....... set window function (from 0 to 20) (default hann)
+     rect            0            ..FV....... Rectangular
+     bartlett        4            ..FV....... Bartlett
+     hann            1            ..FV....... Hann
+     hanning         1            ..FV....... Hanning
+     hamming         2            ..FV....... Hamming
+     blackman        3            ..FV....... Blackman
+     welch           5            ..FV....... Welch
+     flattop         6            ..FV....... Flat-top
+     bharris         7            ..FV....... Blackman-Harris
+     bnuttall        8            ..FV....... Blackman-Nuttall
+     bhann           11           ..FV....... Bartlett-Hann
+     sine            9            ..FV....... Sine
+     nuttall         10           ..FV....... Nuttall
+     lanczos         12           ..FV....... Lanczos
+     gauss           13           ..FV....... Gauss
+     tukey           14           ..FV....... Tukey
+     dolph           15           ..FV....... Dolph-Chebyshev
+     cauchy          16           ..FV....... Cauchy
+     parzen          17           ..FV....... Parzen
+     poisson         18           ..FV....... Poisson
+     bohman          19           ..FV....... Bohman
+     kaiser          20           ..FV....... Kaiser
+   overlap           <float>      ..FV....... set window overlap (from 0 to 1) (default 1)
+   averaging         <int>        ..FV....... set time averaging (from 0 to INT_MAX) (default 1)
+   colors            <string>     ..FV....... set channels colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+   cmode             <int>        ..FV....... set channel mode (from 0 to 1) (default combined)
+     combined        0            ..FV....... show all channels in same window
+     separate        1            ..FV....... show each channel in own window
+   minamp            <float>      ..FV....... set minimum amplitude (from FLT_MIN to 1e-06) (default 1e-06)
+   data              <int>        ..FV....... set data mode (from 0 to 2) (default magnitude)
+     magnitude       0            ..FV....... show magnitude
+     phase           1            ..FV....... show phase
+     delay           2            ..FV....... show group delay
+   channels          <string>     ..FV....... set channels to draw (default "all")
+
+showspatial AVOptions:
+   size              <image_size> ..FV....... set video size (default "512x512")
+   s                 <image_size> ..FV....... set video size (default "512x512")
+   win_size          <int>        ..FV....... set window size (from 1024 to 65536) (default 4096)
+   win_func          <int>        ..FV....... set window function (from 0 to 20) (default hann)
+     rect            0            ..FV....... Rectangular
+     bartlett        4            ..FV....... Bartlett
+     hann            1            ..FV....... Hann
+     hanning         1            ..FV....... Hanning
+     hamming         2            ..FV....... Hamming
+     blackman        3            ..FV....... Blackman
+     welch           5            ..FV....... Welch
+     flattop         6            ..FV....... Flat-top
+     bharris         7            ..FV....... Blackman-Harris
+     bnuttall        8            ..FV....... Blackman-Nuttall
+     bhann           11           ..FV....... Bartlett-Hann
+     sine            9            ..FV....... Sine
+     nuttall         10           ..FV....... Nuttall
+     lanczos         12           ..FV....... Lanczos
+     gauss           13           ..FV....... Gauss
+     tukey           14           ..FV....... Tukey
+     dolph           15           ..FV....... Dolph-Chebyshev
+     cauchy          16           ..FV....... Cauchy
+     parzen          17           ..FV....... Parzen
+     poisson         18           ..FV....... Poisson
+     bohman          19           ..FV....... Bohman
+     kaiser          20           ..FV....... Kaiser
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+
+showspectrum AVOptions:
+   size              <image_size> ..FV....... set video size (default "640x512")
+   s                 <image_size> ..FV....... set video size (default "640x512")
+   slide             <int>        ..FV....... set sliding mode (from 0 to 4) (default replace)
+     replace         0            ..FV....... replace old columns with new
+     scroll          1            ..FV....... scroll from right to left
+     fullframe       2            ..FV....... return full frames
+     rscroll         3            ..FV....... scroll from left to right
+     lreplace        4            ..FV....... replace from right to left
+   mode              <int>        ..FV....... set channel display mode (from 0 to 1) (default combined)
+     combined        0            ..FV....... combined mode
+     separate        1            ..FV....... separate mode
+   color             <int>        ..FV....... set channel coloring (from 0 to 14) (default channel)
+     channel         0            ..FV....... separate color for each channel
+     intensity       1            ..FV....... intensity based coloring
+     rainbow         2            ..FV....... rainbow based coloring
+     moreland        3            ..FV....... moreland based coloring
+     nebulae         4            ..FV....... nebulae based coloring
+     fire            5            ..FV....... fire based coloring
+     fiery           6            ..FV....... fiery based coloring
+     fruit           7            ..FV....... fruit based coloring
+     cool            8            ..FV....... cool based coloring
+     magma           9            ..FV....... magma based coloring
+     green           10           ..FV....... green based coloring
+     viridis         11           ..FV....... viridis based coloring
+     plasma          12           ..FV....... plasma based coloring
+     cividis         13           ..FV....... cividis based coloring
+     terrain         14           ..FV....... terrain based coloring
+   scale             <int>        ..FV....... set display scale (from 0 to 5) (default sqrt)
+     lin             0            ..FV....... linear
+     sqrt            1            ..FV....... square root
+     cbrt            2            ..FV....... cubic root
+     log             3            ..FV....... logarithmic
+     4thrt           4            ..FV....... 4th root
+     5thrt           5            ..FV....... 5th root
+   fscale            <int>        ..FV....... set frequency scale (from 0 to 1) (default lin)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+   saturation        <float>      ..FV....... color saturation multiplier (from -10 to 10) (default 1)
+   win_func          <int>        ..FV....... set window function (from 0 to 20) (default hann)
+     rect            0            ..FV....... Rectangular
+     bartlett        4            ..FV....... Bartlett
+     hann            1            ..FV....... Hann
+     hanning         1            ..FV....... Hanning
+     hamming         2            ..FV....... Hamming
+     blackman        3            ..FV....... Blackman
+     welch           5            ..FV....... Welch
+     flattop         6            ..FV....... Flat-top
+     bharris         7            ..FV....... Blackman-Harris
+     bnuttall        8            ..FV....... Blackman-Nuttall
+     bhann           11           ..FV....... Bartlett-Hann
+     sine            9            ..FV....... Sine
+     nuttall         10           ..FV....... Nuttall
+     lanczos         12           ..FV....... Lanczos
+     gauss           13           ..FV....... Gauss
+     tukey           14           ..FV....... Tukey
+     dolph           15           ..FV....... Dolph-Chebyshev
+     cauchy          16           ..FV....... Cauchy
+     parzen          17           ..FV....... Parzen
+     poisson         18           ..FV....... Poisson
+     bohman          19           ..FV....... Bohman
+     kaiser          20           ..FV....... Kaiser
+   orientation       <int>        ..FV....... set orientation (from 0 to 1) (default vertical)
+     vertical        0            ..FV.......
+     horizontal      1            ..FV.......
+   overlap           <float>      ..FV....... set window overlap (from 0 to 1) (default 0)
+   gain              <float>      ..FV....... set scale gain (from 0 to 128) (default 1)
+   data              <int>        ..FV....... set data mode (from 0 to 2) (default magnitude)
+     magnitude       0            ..FV.......
+     phase           1            ..FV.......
+     uphase          2            ..FV.......
+   rotation          <float>      ..FV....... color rotation (from -1 to 1) (default 0)
+   start             <int>        ..FV....... start frequency (from 0 to INT_MAX) (default 0)
+   stop              <int>        ..FV....... stop frequency (from 0 to INT_MAX) (default 0)
+   fps               <string>     ..FV....... set video rate (default "auto")
+   legend            <boolean>    ..FV....... draw legend (default false)
+   drange            <float>      ..FV....... set dynamic range in dBFS (from 10 to 200) (default 120)
+   limit             <float>      ..FV....... set upper limit in dBFS (from -100 to 100) (default 0)
+   opacity           <float>      ..FV....... set opacity strength (from 0 to 10) (default 1)
+
+showspectrumpic AVOptions:
+   size              <image_size> ..FV....... set video size (default "4096x2048")
+   s                 <image_size> ..FV....... set video size (default "4096x2048")
+   mode              <int>        ..FV....... set channel display mode (from 0 to 1) (default combined)
+     combined        0            ..FV....... combined mode
+     separate        1            ..FV....... separate mode
+   color             <int>        ..FV....... set channel coloring (from 0 to 14) (default intensity)
+     channel         0            ..FV....... separate color for each channel
+     intensity       1            ..FV....... intensity based coloring
+     rainbow         2            ..FV....... rainbow based coloring
+     moreland        3            ..FV....... moreland based coloring
+     nebulae         4            ..FV....... nebulae based coloring
+     fire            5            ..FV....... fire based coloring
+     fiery           6            ..FV....... fiery based coloring
+     fruit           7            ..FV....... fruit based coloring
+     cool            8            ..FV....... cool based coloring
+     magma           9            ..FV....... magma based coloring
+     green           10           ..FV....... green based coloring
+     viridis         11           ..FV....... viridis based coloring
+     plasma          12           ..FV....... plasma based coloring
+     cividis         13           ..FV....... cividis based coloring
+     terrain         14           ..FV....... terrain based coloring
+   scale             <int>        ..FV....... set display scale (from 0 to 5) (default log)
+     lin             0            ..FV....... linear
+     sqrt            1            ..FV....... square root
+     cbrt            2            ..FV....... cubic root
+     log             3            ..FV....... logarithmic
+     4thrt           4            ..FV....... 4th root
+     5thrt           5            ..FV....... 5th root
+   fscale            <int>        ..FV....... set frequency scale (from 0 to 1) (default lin)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+   saturation        <float>      ..FV....... color saturation multiplier (from -10 to 10) (default 1)
+   win_func          <int>        ..FV....... set window function (from 0 to 20) (default hann)
+     rect            0            ..FV....... Rectangular
+     bartlett        4            ..FV....... Bartlett
+     hann            1            ..FV....... Hann
+     hanning         1            ..FV....... Hanning
+     hamming         2            ..FV....... Hamming
+     blackman        3            ..FV....... Blackman
+     welch           5            ..FV....... Welch
+     flattop         6            ..FV....... Flat-top
+     bharris         7            ..FV....... Blackman-Harris
+     bnuttall        8            ..FV....... Blackman-Nuttall
+     bhann           11           ..FV....... Bartlett-Hann
+     sine            9            ..FV....... Sine
+     nuttall         10           ..FV....... Nuttall
+     lanczos         12           ..FV....... Lanczos
+     gauss           13           ..FV....... Gauss
+     tukey           14           ..FV....... Tukey
+     dolph           15           ..FV....... Dolph-Chebyshev
+     cauchy          16           ..FV....... Cauchy
+     parzen          17           ..FV....... Parzen
+     poisson         18           ..FV....... Poisson
+     bohman          19           ..FV....... Bohman
+     kaiser          20           ..FV....... Kaiser
+   orientation       <int>        ..FV....... set orientation (from 0 to 1) (default vertical)
+     vertical        0            ..FV.......
+     horizontal      1            ..FV.......
+   gain              <float>      ..FV....... set scale gain (from 0 to 128) (default 1)
+   legend            <boolean>    ..FV....... draw legend (default true)
+   rotation          <float>      ..FV....... color rotation (from -1 to 1) (default 0)
+   start             <int>        ..FV....... start frequency (from 0 to INT_MAX) (default 0)
+   stop              <int>        ..FV....... stop frequency (from 0 to INT_MAX) (default 0)
+   drange            <float>      ..FV....... set dynamic range in dBFS (from 10 to 200) (default 120)
+   limit             <float>      ..FV....... set upper limit in dBFS (from -100 to 100) (default 0)
+   opacity           <float>      ..FV....... set opacity strength (from 0 to 10) (default 1)
+
+showvolume AVOptions:
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   b                 <int>        ..FV....... set border width (from 0 to 5) (default 1)
+   w                 <int>        ..FV....... set channel width (from 80 to 8192) (default 400)
+   h                 <int>        ..FV....... set channel height (from 1 to 900) (default 20)
+   f                 <double>     ..FV....... set fade (from 0 to 1) (default 0.95)
+   c                 <string>     ..FV....... set volume color expression (default "PEAK*255+floor((1-PEAK)*255)*256+0xff000000")
+   t                 <boolean>    ..FV....... display channel names (default true)
+   v                 <boolean>    ..FV....... display volume value (default true)
+   dm                <double>     ..FV....... duration for max value display (from 0 to 9000) (default 0)
+   dmc               <color>      ..FV....... set color of the max value line (default "orange")
+   o                 <int>        ..FV....... set orientation (from 0 to 1) (default h)
+     h               0            ..FV....... horizontal
+     v               1            ..FV....... vertical
+   s                 <int>        ..FV....... set step size (from 0 to 5) (default 0)
+   p                 <float>      ..FV....... set background opacity (from 0 to 1) (default 0)
+   m                 <int>        ..FV....... set mode (from 0 to 1) (default p)
+     p               0            ..FV....... peak
+     r               1            ..FV....... rms
+   ds                <int>        ..FV....... set display scale (from 0 to 1) (default lin)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... log
+
+showwaves AVOptions:
+   size              <image_size> ..FV....... set video size (default "600x240")
+   s                 <image_size> ..FV....... set video size (default "600x240")
+   mode              <int>        ..FV....... select display mode (from 0 to 3) (default point)
+     point           0            ..FV....... draw a point for each sample
+     line            1            ..FV....... draw a line for each sample
+     p2p             2            ..FV....... draw a line between samples
+     cline           3            ..FV....... draw a centered line for each sample
+   n                 <rational>   ..FV....... set how many samples to show in the same point (from 0 to INT_MAX) (default 0/1)
+   rate              <video_rate> ..FV....... set video rate (default "25")
+   r                 <video_rate> ..FV....... set video rate (default "25")
+   split_channels    <boolean>    ..FV....... draw channels separately (default false)
+   colors            <string>     ..FV....... set channels colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+   scale             <int>        ..FV....... set amplitude scale (from 0 to 3) (default lin)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+     sqrt            2            ..FV....... square root
+     cbrt            3            ..FV....... cubic root
+   draw              <int>        ..FV....... set draw mode (from 0 to 1) (default scale)
+     scale           0            ..FV....... scale pixel values for each drawn sample
+     full            1            ..FV....... draw every pixel for sample directly
+
+showwavespic AVOptions:
+   size              <image_size> ..FV....... set video size (default "600x240")
+   s                 <image_size> ..FV....... set video size (default "600x240")
+   split_channels    <boolean>    ..FV....... draw channels separately (default false)
+   colors            <string>     ..FV....... set channels colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+   scale             <int>        ..FV....... set amplitude scale (from 0 to 3) (default lin)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+     sqrt            2            ..FV....... square root
+     cbrt            3            ..FV....... cubic root
+   draw              <int>        ..FV....... set draw mode (from 0 to 1) (default scale)
+     scale           0            ..FV....... scale pixel values for each drawn sample
+     full            1            ..FV....... draw every pixel for sample directly
+   filter            <int>        ..FV....... set filter mode (from 0 to 1) (default average)
+     average         0            ..FV....... use average samples
+     peak            1            ..FV....... use peak samples
+
+spectrumsynth AVOptions:
+   sample_rate       <int>        ..F.A...... set sample rate (from 15 to INT_MAX) (default 44100)
+   channels          <int>        ..F.A...... set channels (from 1 to 8) (default 1)
+   scale             <int>        ..FV....... set input amplitude scale (from 0 to 1) (default log)
+     lin             0            ..FV....... linear
+     log             1            ..FV....... logarithmic
+   slide             <int>        ..FV....... set input sliding mode (from 0 to 3) (default fullframe)
+     replace         0            ..FV....... consume old columns with new
+     scroll          1            ..FV....... consume only most right column
+     fullframe       2            ..FV....... consume full frames
+     rscroll         3            ..FV....... consume only most left column
+   win_func          <int>        ..F.A...... set window function (from 0 to 20) (default rect)
+     rect            0            ..F.A...... Rectangular
+     bartlett        4            ..F.A...... Bartlett
+     hann            1            ..F.A...... Hann
+     hanning         1            ..F.A...... Hanning
+     hamming         2            ..F.A...... Hamming
+     blackman        3            ..F.A...... Blackman
+     welch           5            ..F.A...... Welch
+     flattop         6            ..F.A...... Flat-top
+     bharris         7            ..F.A...... Blackman-Harris
+     bnuttall        8            ..F.A...... Blackman-Nuttall
+     bhann           11           ..F.A...... Bartlett-Hann
+     sine            9            ..F.A...... Sine
+     nuttall         10           ..F.A...... Nuttall
+     lanczos         12           ..F.A...... Lanczos
+     gauss           13           ..F.A...... Gauss
+     tukey           14           ..F.A...... Tukey
+     dolph           15           ..F.A...... Dolph-Chebyshev
+     cauchy          16           ..F.A...... Cauchy
+     parzen          17           ..F.A...... Parzen
+     poisson         18           ..F.A...... Poisson
+     bohman          19           ..F.A...... Bohman
+     kaiser          20           ..F.A...... Kaiser
+   overlap           <float>      ..F.A...... set window overlap (from 0 to 1) (default 1)
+   orientation       <int>        ..FV....... set orientation (from 0 to 1) (default vertical)
+     vertical        0            ..FV.......
+     horizontal      1            ..FV.......
+
+avsynctest AVOptions:
+   size              <image_size> ..FV....... set frame size (default "hd720")
+   s                 <image_size> ..FV....... set frame size (default "hd720")
+   framerate         <video_rate> ..FV....... set frame rate (default "30")
+   fr                <video_rate> ..FV....... set frame rate (default "30")
+   samplerate        <int>        ..F.A...... set sample rate (from 8000 to 384000) (default 44100)
+   sr                <int>        ..F.A...... set sample rate (from 8000 to 384000) (default 44100)
+   amplitude         <float>      ..F.A....T. set beep amplitude (from 0 to 1) (default 0.7)
+   a                 <float>      ..F.A....T. set beep amplitude (from 0 to 1) (default 0.7)
+   period            <int>        ..F.A...... set beep period (from 1 to 99) (default 3)
+   p                 <int>        ..F.A...... set beep period (from 1 to 99) (default 3)
+   delay             <int>        ..FV.....T. set flash delay (from -30 to 30) (default 0)
+   dl                <int>        ..FV.....T. set flash delay (from -30 to 30) (default 0)
+   cycle             <boolean>    ..FV.....T. set delay cycle (default false)
+   c                 <boolean>    ..FV.....T. set delay cycle (default false)
+   duration          <duration>   ..FVA...... set duration (default 0)
+   d                 <duration>   ..FVA...... set duration (default 0)
+   fg                <color>      ..FV....... set foreground color (default "white")
+   bg                <color>      ..FV....... set background color (default "black")
+   ag                <color>      ..FV....... set additional color (default "gray")
+
+(a)movie AVOptions:
+   filename          <string>     ..FVA......
+   format_name       <string>     ..FVA...... set format name
+   f                 <string>     ..FVA...... set format name
+   stream_index      <int>        ..FVA...... set stream index (from -1 to INT_MAX) (default -1)
+   si                <int>        ..FVA...... set stream index (from -1 to INT_MAX) (default -1)
+   seek_point        <double>     ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
+   sp                <double>     ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
+   streams           <string>     ..FVA...... set streams
+   s                 <string>     ..FVA...... set streams
+   loop              <int>        ..FVA...... set loop count (from 0 to INT_MAX) (default 1)
+   discontinuity     <duration>   ..FVA...... set discontinuity threshold (default 0)
+   dec_threads       <int>        ..FVA...... set the number of threads for decoding (from 0 to INT_MAX) (default 0)
+   format_opts       <dictionary> ..FVA...... set format options for the opened file
+
+(a)movie AVOptions:
+   filename          <string>     ..FVA......
+   format_name       <string>     ..FVA...... set format name
+   f                 <string>     ..FVA...... set format name
+   stream_index      <int>        ..FVA...... set stream index (from -1 to INT_MAX) (default -1)
+   si                <int>        ..FVA...... set stream index (from -1 to INT_MAX) (default -1)
+   seek_point        <double>     ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
+   sp                <double>     ..FVA...... set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
+   streams           <string>     ..FVA...... set streams
+   s                 <string>     ..FVA...... set streams
+   loop              <int>        ..FVA...... set loop count (from 0 to INT_MAX) (default 1)
+   discontinuity     <duration>   ..FVA...... set discontinuity threshold (default 0)
+   dec_threads       <int>        ..FVA...... set the number of threads for decoding (from 0 to INT_MAX) (default 0)
+   format_opts       <dictionary> ..FVA...... set format options for the opened file
+
+abuffer AVOptions:
+   time_base         <rational>   ..F.A...... (from 0 to INT_MAX) (default 0/1)
+   sample_rate       <int>        ..F.A...... (from 0 to INT_MAX) (default 0)
+   sample_fmt        <sample_fmt> ..F.A...... (default none)
+   channel_layout    <string>     ..F.A......
+   channels          <int>        ..F.A...... (from 0 to INT_MAX) (default 0)
+
+buffer AVOptions:
+   width             <int>        ..FV....... (from 0 to INT_MAX) (default 0)
+   video_size        <image_size> ..FV.......
+   height            <int>        ..FV....... (from 0 to INT_MAX) (default 0)
+   pix_fmt           <pix_fmt>    ..FV....... (default none)
+   sar               <rational>   ..FV....... sample aspect ratio (from 0 to DBL_MAX) (default 0/1)
+   pixel_aspect      <rational>   ..FV....... sample aspect ratio (from 0 to DBL_MAX) (default 0/1)
+   time_base         <rational>   ..FV....... (from 0 to DBL_MAX) (default 0/1)
+   frame_rate        <rational>   ..FV....... (from 0 to DBL_MAX) (default 0/1)
+
+abuffersink AVOptions:
+   sample_fmts       <binary>     ..F.A...... set the supported sample formats
+   sample_rates      <binary>     ..F.A...... set the supported sample rates
+   channel_layouts   <binary>     ..F.A.....P set the supported channel layouts (deprecated, use ch_layouts)
+   channel_counts    <binary>     ..F.A.....P set the supported channel counts (deprecated, use ch_layouts)
+   ch_layouts        <string>     ..F.A...... set a '|'-separated list of supported channel layouts
+   all_channel_counts <boolean>    ..F.A...... accept all channel counts (default false)
+
+buffersink AVOptions:
+   pix_fmts          <binary>     ..FV....... set the supported pixel formats
+
+
+While playing:
+q, ESC              quit
+f                   toggle full screen
+p, SPC              pause
+m                   toggle mute
+9, 0                decrease and increase volume respectively
+/, *                decrease and increase volume respectively
+a                   cycle audio channel in the current program
+v                   cycle video channel
+t                   cycle subtitle channel in the current program
+c                   cycle program
+w                   cycle video filters or show modes
+s                   activate frame-step mode
+left/right          seek backward/forward 10 seconds or to custom interval if -seek_interval is set
+down/up             seek backward/forward 1 minute
+page down/page up   seek backward/forward 10 minutes
+right mouse click   seek to percentage in file corresponding to fraction of width
+left double-click   toggle full screen

--- a/corpus/ffplay/6.1.1-3ubuntu5/meta.toml
+++ b/corpus/ffplay/6.1.1-3ubuntu5/meta.toml
@@ -1,0 +1,19 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "ffplay"
+version = "6.1.1-3ubuntu5"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.5.0"
+
+[[capture]]
+argv = ["ffplay", "--help"]
+stdout = "help.txt"
+stderr = "help.stderr.txt"
+exit_code = 0
+
+[contract]
+expected_framework = "generic"
+min_status = "ok"
+must_contain_flags = ["--flags", "--flags2"]

--- a/corpus/tar/1.35/expected.snap
+++ b/corpus/tar/1.35/expected.snap
@@ -756,12 +756,18 @@ flags:
   value_name: FORMAT
   value_kind: Required
   choices:
-  - gnu
-  - oldgnu
-  - pax
-  - posix
-  - ustar
-  - v7
+  - name: gnu
+    description: GNU tar 1.13.x format
+  - name: oldgnu
+    description: GNU format as per tar <= 1.12
+  - name: pax
+    description: POSIX 1003.1-2001 (pax) format
+  - name: posix
+    description: same as pax
+  - name: ustar
+    description: POSIX 1003.1-1988 (ustar) format
+  - name: v7
+    description: old V7 tar format
   group: 'Archive format selection:'
   description: create archive of the given format
   provenance:
@@ -870,14 +876,22 @@ flags:
   value_name: CONTROL
   value_kind: Optional
   choices:
-  - none
-  - off
-  - t
-  - numbered
-  - nil
-  - existing
-  - never
-  - simple
+  - name: none
+    description: never make backups
+  - name: off
+    description: never make backups
+  - name: t
+    description: make numbered backups
+  - name: numbered
+    description: make numbered backups
+  - name: nil
+    description: numbered if numbered backups exist, simple otherwise
+  - name: existing
+    description: numbered if numbered backups exist, simple otherwise
+  - name: never
+    description: always make simple backups
+  - name: simple
+    description: always make simple backups
   group: 'Local file selection:'
   description: backup before removal, choose version CONTROL
   provenance:

--- a/mandible-core/src/entity.rs
+++ b/mandible-core/src/entity.rs
@@ -126,6 +126,52 @@ impl Spelling {
     }
 }
 
+/// One enumerated value an [`Entity`] may take, e.g. one row of ffmpeg's
+/// AVOption sub-table under `-flags`:
+///
+/// ```text
+/// -flags             <flags>      ED.VAS..... (default 0)
+///      unaligned                    .D.V....... allow decoders to produce unaligned output
+/// ```
+///
+/// Most tools document choices as a bare list of names with no per-value
+/// explanation (`tar --quoting-style`'s `literal`/`shell`/`c`/...) — those
+/// carry `description: None`. A tool whose choice rows carry their own text
+/// (ffmpeg's AVOption constants, `tar --format`'s `FORMAT is one of the
+/// following:` enum) keeps it here rather than smeared into the owning
+/// entity's own `description` (spec §7 Tier B rule 4, §9.3's `values:`
+/// line). `description` is `Text` because it originates in the tool's own
+/// help output and must pass through the same sanitization boundary as any
+/// other prose the IR carries (spec §4.1) — `name` stays a bare `String`,
+/// the same choice `Spelling::name` makes for an identifier that is
+/// searched and compared rather than displayed as prose.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Choice {
+    /// The enumerated value's own name, e.g. `"unaligned"`, `"gnu"`.
+    pub name: String,
+    /// The value's own documentation, when the tool writes one per choice.
+    /// `None` for the common bare-list case.
+    pub description: Option<Text>,
+}
+
+impl Choice {
+    /// A choice with no documented description — the common case.
+    pub fn bare(name: impl Into<String>) -> Choice {
+        Choice {
+            name: name.into(),
+            description: None,
+        }
+    }
+
+    /// A choice whose own row carries a description.
+    pub fn described(name: impl Into<String>, description: Text) -> Choice {
+        Choice {
+            name: name.into(),
+            description: Some(description),
+        }
+    }
+}
+
 /// Which kind of documented item an [`Entity`] is. Decides which detail
 /// pane section it renders under (spec §9.3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -161,8 +207,10 @@ pub struct Entity {
     /// Whether this entity takes no value, a required one, or an optional
     /// one.
     pub value_kind: ValueKind,
-    /// Enumerated choices, e.g. `{json|yaml|table}` for `--format`.
-    pub choices: Vec<Text>,
+    /// Enumerated choices, e.g. `{json|yaml|table}` for `--format`. Each
+    /// [`Choice`] carries its own description when the tool documents one
+    /// per value (spec §7 Tier B rule 4, §9.3).
+    pub choices: Vec<Choice>,
     /// True if this entity may be given more than once: a flag the tool
     /// accepts repeatedly (`-v -v -v`), and a positional written with an
     /// ellipsis (`<pathspec>...`) — the pre-0.5.0 `Positional::variadic`.
@@ -570,7 +618,14 @@ impl From<Flag> for Entity {
             spellings,
             value_name: f.value_name,
             value_kind: f.value_kind,
-            choices: f.choices,
+            // The pre-0.5.0 `Flag` never had per-choice descriptions, so
+            // every converted choice is bare — the lossless direction for
+            // this one-way parity conversion.
+            choices: f
+                .choices
+                .into_iter()
+                .map(|t| Choice::bare(t.as_str()))
+                .collect(),
             repeatable: f.repeatable,
             required: f.required,
             hidden: f.hidden,

--- a/mandible-core/src/lib.rs
+++ b/mandible-core/src/lib.rs
@@ -20,7 +20,7 @@ mod provenance;
 mod snapshot;
 mod text;
 
-pub use entity::{Dashes, Entity, EntityKind, Spelling};
+pub use entity::{Choice, Dashes, Entity, EntityKind, Spelling};
 pub use merge::{
     merge_entity_lists, merge_nodes, merge_subcommand_lists, pair_aliases, MergeError,
 };
@@ -28,7 +28,7 @@ pub use node::{is_command_name_shaped, CommandNode, Confession, Example, ValueKi
 pub use noderef::{resolve, resolve_flag, resolve_mut, FlagKey, NodeRef};
 pub use provenance::{Authority, Axis, ManFormat, Provenance, Source};
 pub use snapshot::{
-    to_snapshot, ConfessionSnapshot, EnvVarSnapshot, ExampleSnapshot, FlagSnapshot,
+    to_snapshot, ChoiceSnapshot, ConfessionSnapshot, EnvVarSnapshot, ExampleSnapshot, FlagSnapshot,
     ModifierSnapshot, NodeSnapshot, PositionalSnapshot, ProvenanceSnapshot,
 };
 pub use text::{strip_escapes, Text, MAX_TEXT_CHARS};

--- a/mandible-core/src/snapshot.rs
+++ b/mandible-core/src/snapshot.rs
@@ -74,7 +74,7 @@
 //! strip — elapsed time lives on `mandible-extract::ExtractionResult`, one
 //! layer above the IR this module snapshots, so it never reaches here.
 
-use crate::entity::Entity;
+use crate::entity::{Choice, Entity};
 use crate::node::{CommandNode, Example, ValueKind};
 use crate::provenance::{Provenance, Source};
 use serde::Serialize;
@@ -140,6 +140,39 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
+/// Snapshot form of one [`Choice`] — `#[serde(untagged)]` so the near-
+/// universal bare case (no per-value description) writes as a plain YAML
+/// string, exactly as the pre-choice-description `Vec<String>` shape did,
+/// and only a tool that documents per-choice text (ffmpeg's AVOption
+/// constants) pays for the `name`/`description` mapping shape. Keeps 105
+/// fixtures' bare `choices: [a, b, c]` lists byte-identical while still
+/// letting a described list read cleanly.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ChoiceSnapshot {
+    /// A choice with no documented description — the common case.
+    Bare(String),
+    /// A choice whose own row carries a description.
+    Described {
+        /// The choice's own name.
+        name: String,
+        /// The choice's own documentation.
+        description: String,
+    },
+}
+
+impl From<&Choice> for ChoiceSnapshot {
+    fn from(c: &Choice) -> Self {
+        match &c.description {
+            Some(d) => ChoiceSnapshot::Described {
+                name: c.name.clone(),
+                description: d.as_str().to_string(),
+            },
+            None => ChoiceSnapshot::Bare(c.name.clone()),
+        }
+    }
+}
+
 /// Snapshot form of a flag [`Entity`]. Field order matches the pre-0.5.0
 /// `Flag`'s own declaration, and must keep matching it —
 /// see the `From` impl below. Every `Option`/`Vec` field is omitted when
@@ -161,7 +194,7 @@ pub struct FlagSnapshot {
     pub value_kind: ValueKind,
     /// Enumerated choices, e.g. `{json|yaml|table}` for `--format`.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub choices: Vec<String>,
+    pub choices: Vec<ChoiceSnapshot>,
     /// True if this flag may be given more than once.
     #[serde(skip_serializing_if = "is_false")]
     pub repeatable: bool,
@@ -222,7 +255,7 @@ impl From<&Entity> for FlagSnapshot {
             long: e.long().map(str::to_string),
             value_name: e.value_name.clone(),
             value_kind: e.value_kind,
-            choices: e.choices.iter().map(|t| t.as_str().to_string()).collect(),
+            choices: e.choices.iter().map(ChoiceSnapshot::from).collect(),
             repeatable: e.repeatable,
             required: e.required,
             negatable: e.negatable(),

--- a/mandible-extract/src/help_text/sections/emit.rs
+++ b/mandible-extract/src/help_text/sections/emit.rs
@@ -436,6 +436,22 @@ pub(super) fn split_heading_inline_row(line: &str) -> Option<(&str, &str)> {
 /// a fix may move text to its right place, never delete it). A row with no
 /// separate description (`tar --quoting-style`'s bare `literal`/`shell`/…
 /// list) still produces a bare [`Choice`] with `description: None`.
+/// **Still open, pending the maintainer's ruling on unproven blocks**: does
+/// an unproven block (no name match, no value_name word match —
+/// `find_owning_flag_index` returns `None`) attach bare names to the
+/// fallback flag exactly as base (988170a) did, or attach nothing at all?
+/// `true` reproduces base's own behavior byte-for-byte (bare names attach
+/// to the last-emitted flag, descriptions never do — base's `emit_choices`
+/// always discarded `_desc_text`); `false` attaches nothing, so an
+/// unproven block never touches any flag's `choices`. Deliberately one
+/// line so the two readings differ by flipping this constant, not by
+/// re-deriving the logic below — see the round's PR discussion for the
+/// two readings and why they diverge (byte-for-byte-base still lets a
+/// wrong flag carry bare-but-real names, e.g. `cp`'s `--version`;
+/// attach-nothing loses that pre-existing, already-wrong data instead of
+/// preserving it).
+const UNPROVEN_BLOCKS_ATTACH_BARE_NAMES: bool = true;
+
 pub(super) fn emit_choices(
     heading: &str,
     entries: Vec<(&str, String)>,
@@ -472,6 +488,8 @@ pub(super) fn emit_choices(
     }
     match find_owning_flag_index(heading, &out.flags) {
         Some(idx) => {
+            // Proven ownership (a literal `--name` match or a value_name
+            // word match) — full names and descriptions, both trustworthy.
             for (name, desc) in candidates {
                 if out.flags[idx].choices.iter().any(|c| c.name == name) {
                     continue;
@@ -480,6 +498,23 @@ pub(super) fn emit_choices(
                     name,
                     description: desc.map(|d| Text::sanitize(&d)),
                 });
+            }
+        }
+        None if UNPROVEN_BLOCKS_ATTACH_BARE_NAMES && !out.flags.is_empty() => {
+            // Unproven: no name match, no value_name match. Base
+            // (988170a) attached a bare name to the last-emitted flag
+            // regardless — see `UNPROVEN_BLOCKS_ATTACH_BARE_NAMES`'s own
+            // doc comment for why that byte-for-byte reproduction is still
+            // here pending the maintainer's ruling. Descriptions never
+            // attach here even when the toggle is on: an unproven owner
+            // gets no new information riding along with it, proven or not.
+            let idx = out.flags.len() - 1;
+            out.saw_unattributable_content = true;
+            for (name, _desc) in candidates {
+                if out.flags[idx].choices.iter().any(|c| c.name == name) {
+                    continue;
+                }
+                out.flags[idx].choices.push(Choice::bare(name));
             }
         }
         None => {
@@ -969,5 +1004,170 @@ mod tests {
                 node.summary
             );
         }
+    }
+
+    /// `--format`'s own value_name is `FORMAT`, and the enum heading
+    /// (`"FORMAT is one of the following:"`) contains that exact word —
+    /// `find_owning_flag_index`'s second proof, not the deleted proximity
+    /// fallback. This is the "proven" pin: full names *and* descriptions
+    /// attach, byte-exact against the real capture.
+    #[test]
+    fn tar_format_choices_carry_descriptions_via_the_value_name_proof() {
+        let parsed = parse(TAR_HELP);
+        let format = parsed
+            .flags
+            .iter()
+            .find(|f| f.long() == Some("format"))
+            .expect("--format flag recovered");
+        let got: Vec<(&str, &str)> = format
+            .choices
+            .iter()
+            .map(|c| {
+                (
+                    c.name.as_str(),
+                    c.description.as_ref().map_or("", |d| d.as_str()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                ("gnu", "GNU tar 1.13.x format"),
+                ("oldgnu", "GNU format as per tar <= 1.12"),
+                ("pax", "POSIX 1003.1-2001 (pax) format"),
+                ("posix", "same as pax"),
+                ("ustar", "POSIX 1003.1-1988 (ustar) format"),
+                ("v7", "old V7 tar format"),
+            ],
+            "proven ownership must carry every description, verbatim: {got:?}"
+        );
+    }
+
+    /// `automake --help`'s real shape (the STOP-worthy find): the
+    /// `"Warning categories include:"` block documents `-W,
+    /// --warnings=CATEGORY`, several rows earlier — but the heading names
+    /// no flag literally, and `"categories"` is not an exact word match
+    /// for the value_name `CATEGORY` (plural vs. singular — deliberately
+    /// refused, see `heading_contains_word`'s doc comment). Ownership is
+    /// therefore unproven, and `-f, --force-missing` (the actual last flag
+    /// before the block) must never receive a description for text that
+    /// is not its own — the regression this pins is "a confident wrong
+    /// answer never ships." `UNPROVEN_BLOCKS_ATTACH_BARE_NAMES` still
+    /// attaches the bare names to it (base's own byte-for-byte behavior,
+    /// pending the maintainer's ruling), but never a description.
+    #[test]
+    fn automake_style_unproven_block_never_attaches_a_description() {
+        let raw = "Usage: widget [OPTION]... [FILE]...\n\nOperation modes:\n  \
+                   -W, --warnings=CATEGORY  report the warnings falling in CATEGORY\n  \
+                   -f, --force-missing    force update of standard files\n\n\
+                   Warning categories include:\n  \
+                   cross                  cross compilation issues\n  \
+                   gnu                    GNU coding standards\n  \
+                   obsolete               obsolete features or constructions\n";
+        let parsed = parse(raw);
+        let warnings = flag_named(&parsed, "warnings");
+        assert!(
+            warnings.choices.is_empty(),
+            "the true owner must never receive a fuzzy/stem-matched attachment: {:?}",
+            warnings.choices
+        );
+        let force_missing = flag_named(&parsed, "force-missing");
+        let names: Vec<&str> = force_missing
+            .choices
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["cross", "gnu", "obsolete"],
+            "base's own byte-for-byte behavior: bare names still attach to the fallback flag"
+        );
+        assert!(
+            force_missing
+                .choices
+                .iter()
+                .all(|c| c.description.is_none()),
+            "an unproven owner must never carry a description, right or wrong: {:?}",
+            force_missing.choices
+        );
+    }
+
+    /// `cp --help`'s real shape: the trailing `VERSION_CONTROL` enum
+    /// documents `--backup`, but several unrelated prose paragraphs sit
+    /// between the flags table ending and this block, so `--version` (the
+    /// actual last flag) is not provably the owner either — same
+    /// unproven-fallback pin as the automake case, different failure
+    /// shape (distance rather than a competing named flag).
+    #[test]
+    fn cp_style_trailing_prose_block_never_attaches_a_description() {
+        let raw = "Usage: widget [OPTION]... SOURCE DEST\n\nOptions:\n  \
+                   --backup[=CONTROL]     make a backup of each existing destination file\n  \
+                   --version              output version information and exit\n\n\
+                   Some unrelated prose paragraph about attributes that has nothing to\n\
+                   do with any flag above it, spanning a couple of sentences so it reads\n\
+                   like real documentation rather than a table.\n\n\
+                   The version control method may be selected via the VERSION_CONTROL\n\
+                   environment variable.  Here are the values:\n\n  \
+                   none, off       never make backups\n  \
+                   numbered, t     make numbered backups\n";
+        let parsed = parse(raw);
+        let backup = flag_named(&parsed, "backup");
+        assert!(
+            backup.choices.is_empty(),
+            "the true owner must never receive an unproven attachment: {:?}",
+            backup.choices
+        );
+        let version = flag_named(&parsed, "version");
+        let names: Vec<&str> = version.choices.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["none", "off", "numbered", "t"],
+            "base's own byte-for-byte behavior: bare names still attach to the fallback flag"
+        );
+        assert!(
+            version.choices.iter().all(|c| c.description.is_none()),
+            "an unproven owner must never carry a description: {:?}",
+            version.choices
+        );
+    }
+
+    /// ffplay's own AVOption sub-table (`-flags`, the round's motivating
+    /// case) never reaches `find_owning_flag_index`/`emit_choices` at all
+    /// — it is recognized entirely inside `scan_flags_block`'s own
+    /// continuation handling (`choice_description_sub_row`), one indent
+    /// level under the flag's own row, with no heading of any kind
+    /// governing it. Proven by construction: strip every heading from the
+    /// input (just the flag row and its sub-rows, nothing else) and the
+    /// descriptions still attach, which the heading-block matcher could
+    /// never do since it has no heading text to match against.
+    #[test]
+    fn ffplay_choices_never_route_through_the_heading_block_matcher() {
+        let raw = "-flags             <flags>      ED.VAS..... (default 0)\n\
+                   \x20    unaligned                    .D.V....... allow decoders to produce unaligned output\n\
+                   \x20    gray                         ED.V....... only decode/encode grayscale\n";
+        let parsed = parse(raw);
+        let flags = flag_named(&parsed, "flags");
+        let got: Vec<(&str, &str)> = flags
+            .choices
+            .iter()
+            .map(|c| {
+                (
+                    c.name.as_str(),
+                    c.description.as_ref().map_or("", |d| d.as_str()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                (
+                    "unaligned",
+                    ".D.V....... allow decoders to produce unaligned output"
+                ),
+                ("gray", "ED.V....... only decode/encode grayscale"),
+            ],
+            "no heading governs this input at all, so this can only have come from \
+             scan_flags_block's own continuation handling: {got:?}"
+        );
     }
 }

--- a/mandible-extract/src/help_text/sections/emit.rs
+++ b/mandible-extract/src/help_text/sections/emit.rs
@@ -36,14 +36,18 @@ pub(super) fn emit_flags(
         flag.value_kind = spec.value_kind;
         flag.group = group.clone();
         flag.description = non_empty_text(&desc_text);
-        // `llvm-ar`'s own `=default`/`=gnu`/… sub-rows, nested directly
-        // under this flag's own row — see `choices_sub_row_value`'s doc
-        // comment. Per-value descriptions have no home in the IR and are
-        // dropped; only the bare value names survive, into the same
+        // Sub-rows nested directly under this flag's own row: llvm-ar's
+        // bare `=default`/`=gnu`/… shape (no per-value text) and ffmpeg/
+        // ffplay's AVOption shape (each carrying its own description) both
+        // land here — see `choices_sub_row_value`'s and
+        // `choice_description_sub_row`'s own doc comments. The same
         // `choices` field clap's `[possible values: …]` already fills.
         flag.choices = choice_names
             .into_iter()
-            .map(|c| Text::sanitize(&c))
+            .map(|(name, desc)| Choice {
+                name,
+                description: desc.map(|d| Text::sanitize(&d)),
+            })
             .collect();
         out.flags.push(flag);
     }
@@ -424,6 +428,14 @@ pub(super) fn split_heading_inline_row(line: &str) -> Option<(&str, &str)> {
 /// plausible owning flag exists — fabricated structure is worse than
 /// missing structure either way, so an unattributable block is simply
 /// discarded rather than becoming subcommands by default.
+///
+/// **Per-value descriptions are kept, not dropped.** `tar`'s own
+/// `FORMAT is one of the following:` enum documents each value
+/// (`gnu   GNU tar 1.13.x format`) — earlier this function kept only the
+/// bare name and threw the description away (the no-information-loss rule:
+/// a fix may move text to its right place, never delete it). A row with no
+/// separate description (`tar --quoting-style`'s bare `literal`/`shell`/…
+/// list) still produces a bare [`Choice`] with `description: None`.
 pub(super) fn emit_choices(
     heading: &str,
     entries: Vec<(&str, String)>,
@@ -431,14 +443,16 @@ pub(super) fn emit_choices(
 ) -> (usize, usize) {
     let mut seen = 0usize;
     let mut clean = 0usize;
-    let mut candidates: Vec<String> = Vec::new();
-    for (spec_text, _desc_text) in &entries {
+    let mut candidates: Vec<(String, Option<String>)> = Vec::new();
+    for (spec_text, desc_text) in &entries {
         if candidates.len() >= MAX_RECOVERED_ENTRIES {
             break;
         }
+        let desc = non_empty_string(desc_text);
         // Real listings sometimes alias several values on one line
         // (`"none, off       never make backups"`); each comma-separated
-        // fragment is its own candidate choice.
+        // fragment is its own candidate choice, and the row's one
+        // description belongs to every alias on it.
         for fragment in spec_text.split(',') {
             let name = fragment.trim();
             if name.is_empty() {
@@ -450,7 +464,7 @@ pub(super) fn emit_choices(
                 continue;
             }
             clean += 1;
-            candidates.push(name.to_string());
+            candidates.push((name.to_string(), desc.clone()));
         }
     }
     if candidates.is_empty() {
@@ -458,11 +472,14 @@ pub(super) fn emit_choices(
     }
     match find_owning_flag_index(heading, &out.flags) {
         Some(idx) => {
-            for name in candidates {
-                let text = Text::sanitize(&name);
-                if !out.flags[idx].choices.contains(&text) {
-                    out.flags[idx].choices.push(text);
+            for (name, desc) in candidates {
+                if out.flags[idx].choices.iter().any(|c| c.name == name) {
+                    continue;
                 }
+                out.flags[idx].choices.push(Choice {
+                    name,
+                    description: desc.map(|d| Text::sanitize(&d)),
+                });
             }
         }
         None => {
@@ -473,6 +490,13 @@ pub(super) fn emit_choices(
         }
     }
     (seen, clean)
+}
+
+/// `desc_text.trim()`, as `None` when empty — the shared "is there really a
+/// description here" check [`emit_choices`] uses before sanitizing one.
+fn non_empty_string(desc_text: &str) -> Option<String> {
+    let trimmed = desc_text.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 /// The bare name a positional-block row or a usage-synopsis token carries,
@@ -613,7 +637,7 @@ mod tests {
             .iter()
             .find(|f| f.long() == Some("format"))
             .expect("--format flag recovered");
-        let choice_strs: Vec<&str> = format.choices.iter().map(|t| t.as_str()).collect();
+        let choice_strs: Vec<&str> = format.choices.iter().map(|c| c.name.as_str()).collect();
         for want in ["gnu", "oldgnu", "pax", "posix", "ustar", "v7"] {
             assert!(choice_strs.contains(&want), "{choice_strs:?}");
         }
@@ -676,7 +700,11 @@ mod tests {
             .iter()
             .find(|f| f.long() == Some("quoting-style"))
             .expect("--quoting-style flag recovered");
-        let choice_strs: Vec<&str> = quoting_style.choices.iter().map(|t| t.as_str()).collect();
+        let choice_strs: Vec<&str> = quoting_style
+            .choices
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
         assert!(choice_strs.contains(&"literal"), "{choice_strs:?}");
         assert!(
             choice_strs.contains(&"shell-escape-always"),

--- a/mandible-extract/src/help_text/sections/emit.rs
+++ b/mandible-extract/src/help_text/sections/emit.rs
@@ -436,22 +436,6 @@ pub(super) fn split_heading_inline_row(line: &str) -> Option<(&str, &str)> {
 /// a fix may move text to its right place, never delete it). A row with no
 /// separate description (`tar --quoting-style`'s bare `literal`/`shell`/…
 /// list) still produces a bare [`Choice`] with `description: None`.
-/// **Still open, pending the maintainer's ruling on unproven blocks**: does
-/// an unproven block (no name match, no value_name word match —
-/// `find_owning_flag_index` returns `None`) attach bare names to the
-/// fallback flag exactly as base (988170a) did, or attach nothing at all?
-/// `true` reproduces base's own behavior byte-for-byte (bare names attach
-/// to the last-emitted flag, descriptions never do — base's `emit_choices`
-/// always discarded `_desc_text`); `false` attaches nothing, so an
-/// unproven block never touches any flag's `choices`. Deliberately one
-/// line so the two readings differ by flipping this constant, not by
-/// re-deriving the logic below — see the round's PR discussion for the
-/// two readings and why they diverge (byte-for-byte-base still lets a
-/// wrong flag carry bare-but-real names, e.g. `cp`'s `--version`;
-/// attach-nothing loses that pre-existing, already-wrong data instead of
-/// preserving it).
-const UNPROVEN_BLOCKS_ATTACH_BARE_NAMES: bool = true;
-
 pub(super) fn emit_choices(
     heading: &str,
     entries: Vec<(&str, String)>,
@@ -500,14 +484,17 @@ pub(super) fn emit_choices(
                 });
             }
         }
-        None if UNPROVEN_BLOCKS_ATTACH_BARE_NAMES && !out.flags.is_empty() => {
+        None if !out.flags.is_empty() => {
             // Unproven: no name match, no value_name match. Base
             // (988170a) attached a bare name to the last-emitted flag
-            // regardless — see `UNPROVEN_BLOCKS_ATTACH_BARE_NAMES`'s own
-            // doc comment for why that byte-for-byte reproduction is still
-            // here pending the maintainer's ruling. Descriptions never
-            // attach here even when the toggle is on: an unproven owner
-            // gets no new information riding along with it, proven or not.
+            // regardless, and that byte-for-byte behavior stays —
+            // dropping it would lose the pre-existing (already-imperfect)
+            // data rather than improve it. What changed is descriptions:
+            // they never attach here. An unproven owner gets no new
+            // information riding along with it, only the same bare name
+            // base always gave it. Attaching bare names more broadly once
+            // ownership can be proven for more shapes is a follow-up, not
+            // a runtime toggle — see the round's PR body.
             let idx = out.flags.len() - 1;
             out.saw_unattributable_content = true;
             for (name, _desc) in candidates {
@@ -1052,9 +1039,8 @@ mod tests {
     /// therefore unproven, and `-f, --force-missing` (the actual last flag
     /// before the block) must never receive a description for text that
     /// is not its own — the regression this pins is "a confident wrong
-    /// answer never ships." `UNPROVEN_BLOCKS_ATTACH_BARE_NAMES` still
-    /// attaches the bare names to it (base's own byte-for-byte behavior,
-    /// pending the maintainer's ruling), but never a description.
+    /// answer never ships." The bare names still attach to it (base's own
+    /// byte-for-byte behavior), but never a description.
     #[test]
     fn automake_style_unproven_block_never_attaches_a_description() {
         let raw = "Usage: widget [OPTION]... [FILE]...\n\nOperation modes:\n  \

--- a/mandible-extract/src/help_text/sections/flag_rows.rs
+++ b/mandible-extract/src/help_text/sections/flag_rows.rs
@@ -534,11 +534,15 @@ pub(super) enum FlagsBlockRow<'a> {
 }
 
 /// One recovered flag-table row: its spec text, its description, and any
-/// enumerated values nested directly under it (`llvm-ar`'s own `=default`/
-/// `=gnu`/… sub-rows under `--format` — see [`choices_sub_row_value`]).
-/// Kept as a named alias rather than a bare tuple purely so the three
-/// positions don't have to be remembered at every call site.
-pub(super) type FlagRowEntry = (String, String, Vec<String>);
+/// enumerated values nested directly under it — `llvm-ar`'s own `=default`/
+/// `=gnu`/… sub-rows under `--format` (see [`choices_sub_row_value`]), or
+/// ffmpeg/ffplay's AVOption sub-table rows, each carrying its own
+/// description (see [`choice_description_sub_row`]). A choice entry's
+/// second element is `None` for the bare-name shape, `Some(description)`
+/// for the described one. Kept as a named alias rather than a bare tuple
+/// purely so the three positions don't have to be remembered at every call
+/// site.
+pub(super) type FlagRowEntry = (String, String, Vec<(String, Option<String>)>);
 
 /// True when `trimmed` is an "argfile" row — `jmod`'s `@<filename>`,
 /// `llvm-ar`'s and `ar`'s `@<file>` — the GNU-family convention for "read
@@ -635,6 +639,54 @@ pub(super) fn choices_sub_row_value(trimmed: &str) -> Option<&str> {
     }
     find_description_gap(trimmed)?;
     Some(&rest[..end])
+}
+
+/// True when `trimmed` is ffmpeg/ffplay's own AVOption sub-table shape — a
+/// bare constant name, a real column gap, then that value's scope flags and
+/// explanation, kept together and verbatim as the choice's own description
+/// (spec §7 recognition rule):
+///
+/// ```text
+///   -flags             <flags>      ED.VAS..... (default 0)
+///      unaligned                    .D.V....... allow decoders to produce unaligned output
+///      gray                         ED.V....... only decode/encode grayscale
+/// ```
+///
+/// Returns `(name, description)` when the row matches, `None` otherwise.
+/// Two conditions, both required, so an ordinary wrapped-prose continuation
+/// line is never misread as a described choice: the row opens with a bare,
+/// [`is_command_name_shaped`] token (no `=` prefix — that shape belongs to
+/// [`choices_sub_row_value`] instead, and this function is only ever tried
+/// after that one has already refused), and a genuine aligned column gap
+/// ([`find_multi_space_gap`] — deliberately not the full
+/// [`find_description_gap`] fallback chain, whose colon/equals/sentence
+/// heuristics exist for *flag* rows and would happily fire on an ordinary
+/// sentence that merely contains a colon) separates it from the rest of the
+/// row. Ordinary prose almost never opens with one identifier-shaped word
+/// immediately followed by two or more spaces — that shape is what a
+/// column-aligned table draws, not what a wrapped sentence does — which is
+/// what keeps this from firing on the `--strip`/`--guesswork`-style
+/// colon- or single-space-separated continuation prose
+/// [`nested_entry_table_starts_at`]'s own tests pin.
+///
+/// The scope columns (`ED.VAS.....`) and any numeric value column
+/// (`-strict`'s `very            2            ED.VA...... ...`) are the
+/// tool's own text and stay verbatim inside the returned description — no
+/// parser for them, exactly as the round brief requires.
+pub(super) fn choice_description_sub_row(trimmed: &str) -> Option<(&str, &str)> {
+    if trimmed.starts_with('=') {
+        return None;
+    }
+    let gap = find_multi_space_gap(trimmed)?;
+    let name = &trimmed[..gap];
+    if !is_command_name_shaped(name) {
+        return None;
+    }
+    let desc = trimmed[gap..].trim();
+    if desc.is_empty() {
+        return None;
+    }
+    Some((name, desc))
 }
 
 pub(super) fn scan_flags_block<'a>(
@@ -871,16 +923,27 @@ pub(super) fn scan_flags_block<'a>(
                     // actually observed.
                     if placeholder_left_open(&last.0) {
                         last.0.push_str(text);
+                    } else if let Some((name, desc)) = choice_description_sub_row(text) {
+                        // ffmpeg/ffplay's AVOption sub-table rows: the
+                        // flag's enumerated values, each with its own
+                        // description — see `choice_description_sub_row`'s
+                        // own doc comment. Tried before the bare `=name`
+                        // shape below since that one only ever matches an
+                        // `=`-prefixed row this one already refuses.
+                        let name = name.to_string();
+                        if !last.2.iter().any(|(n, _)| n == &name) {
+                            last.2.push((name, Some(desc.to_string())));
+                        }
                     } else if let Some(choice) = choices_sub_row_value(text) {
                         // llvm-ar's own `=default`/`=gnu`/… sub-rows: the
                         // flag's enumerated values, not more description —
                         // see `choices_sub_row_value`'s own doc comment.
-                        // Per-value descriptions have no home in the IR and
-                        // are intentionally dropped here (recorded as a
-                        // known limitation, not solved by inventing one).
+                        // llvm-ar never documents a per-value explanation on
+                        // this shape (measured against the full corpus), so
+                        // there is nothing to attach here.
                         let choice = choice.to_string();
-                        if !last.2.contains(&choice) {
-                            last.2.push(choice);
+                        if !last.2.iter().any(|(n, _)| n == &choice) {
+                            last.2.push((choice, None));
                         }
                     } else {
                         last.1.push(' ');
@@ -1609,7 +1672,7 @@ Options:
     fn llvm_ar_format_sub_rows_become_choices_not_description_text() {
         let parsed = parse_named(LLVM_AR_HELP, "llvm-ar-18");
         let format = flag_named(&parsed, "format");
-        let choice_strs: Vec<&str> = format.choices.iter().map(|t| t.as_str()).collect();
+        let choice_strs: Vec<&str> = format.choices.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(
             choice_strs,
             vec!["default", "gnu", "darwin", "bsd", "bigarchive"]
@@ -1619,6 +1682,171 @@ Options:
             Some("- archive format to create"),
             "the =value sub-rows must not remain in the description: {:?}",
             format.description
+        );
+    }
+
+    /// `ffplay -help`'s real `-flags` row (`corpus/ffplay/6.1.1-3ubuntu5/help.txt`,
+    /// lines 85-90): six AVOption constants, each with its own scope-flags-
+    /// plus-explanation text, nested one indent deeper than the flag row
+    /// itself. Byte-exact from the real capture. Before this recognizer,
+    /// every one of these six lines fell through to the default
+    /// continuation rule and was appended, space-joined, into `-flags`'s
+    /// own `description` — this is the smear the round brief names.
+    #[test]
+    fn ffplay_flags_sub_rows_become_described_choices() {
+        let raw = "AVCodecContext AVOptions:\n\
+                    \x20 -flags             <flags>      ED.VAS..... (default 0)\n\
+                    \x20    unaligned                    .D.V....... allow decoders to produce unaligned output\n\
+                    \x20    gray                         ED.V....... only decode/encode grayscale\n\
+                    \x20    low_delay                    ED.V....... force low delay\n\
+                    \x20    bitexact                     ED.VAS..... use only bitexact functions (except (I)DCT)\n\
+                    \x20    output_corrupt               .D.V....... Output even potentially corrupted frames\n\
+                    \x20    drop_changed                 .D.VA.....P Drop frames whose parameters differ from first decoded frame\n\
+                    \x20 -ar                <int>        ED..A...... set audio sampling rate (in Hz) (from 0 to INT_MAX) (default 0)\n";
+        let parsed = parse(raw);
+        let flags = flag_named(&parsed, "flags");
+
+        let want: Vec<(&str, &str)> = vec![
+            (
+                "unaligned",
+                ".D.V....... allow decoders to produce unaligned output",
+            ),
+            ("gray", "ED.V....... only decode/encode grayscale"),
+            ("low_delay", "ED.V....... force low delay"),
+            (
+                "bitexact",
+                "ED.VAS..... use only bitexact functions (except (I)DCT)",
+            ),
+            (
+                "output_corrupt",
+                ".D.V....... Output even potentially corrupted frames",
+            ),
+            (
+                "drop_changed",
+                ".D.VA.....P Drop frames whose parameters differ from first decoded frame",
+            ),
+        ];
+        let got: Vec<(&str, &str)> = flags
+            .choices
+            .iter()
+            .map(|c| {
+                (
+                    c.name.as_str(),
+                    c.description.as_ref().map_or("", |d| d.as_str()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            got, want,
+            "every constant name and description byte must survive, verbatim, in order"
+        );
+
+        // The flag's own description shrinks to what actually belongs to
+        // it — the constants are gone, not merely duplicated.
+        let desc = flags.description.as_ref().map_or("", |t| t.as_str());
+        assert!(
+            desc.contains("ED.VAS....."),
+            "the flag's own scope/default text must survive: {desc:?}"
+        );
+        for (name, text) in &want {
+            assert!(
+                !desc.contains(name) && !desc.contains(text),
+                "choice {name:?}'s text must leave the flag's own description, not just be duplicated into choices: {desc:?}"
+            );
+        }
+
+        // The flag row directly after the sub-table must survive untouched
+        // — a wrong break here would re-route it into `-flags`'s choices or
+        // drop it outright. (Its own spelling is a pre-existing, unrelated
+        // parser gap — GNU-style two-letter single-dash options like `-ar`
+        // read as short `-a` plus a value named `r` — so this checks the
+        // row's *content* landed somewhere rather than pinning that name.)
+        assert!(
+            parsed.flags.iter().any(|f| f
+                .description
+                .as_ref()
+                .is_some_and(|d| d.as_str().contains("set audio sampling rate"))),
+            "the row after the choices sub-table must not be dropped or absorbed: {:?}",
+            parsed
+                .flags
+                .iter()
+                .map(|f| f.description.as_ref().map(|d| d.as_str()))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !flags.choices.iter().any(|c| c.name == "ar"
+                || c.description
+                    .as_ref()
+                    .is_some_and(|d| d.as_str().contains("sampling rate"))),
+            "the next flag row must never be absorbed into -flags's own choices: {:?}",
+            flags.choices
+        );
+    }
+
+    /// The same recognizer against the real, full `ffplay --help` capture
+    /// (`corpus/ffplay/6.1.1-3ubuntu5/help.txt`) rather than a hand-typed
+    /// excerpt — pins the shape against the tool's actual byte stream, not
+    /// just a minimal reproduction of it.
+    #[test]
+    fn ffplay_help_real_capture_describes_flags_choices() {
+        let parsed = parse_named(FFPLAY_HELP, "ffplay");
+        let flags = flag_named(&parsed, "flags");
+        let names: Vec<&str> = flags.choices.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "unaligned",
+                "gray",
+                "low_delay",
+                "bitexact",
+                "output_corrupt",
+                "drop_changed"
+            ]
+        );
+        for choice in &flags.choices {
+            assert!(
+                choice.description.is_some(),
+                "every -flags constant in the real capture documents itself: {:?}",
+                choice.name
+            );
+        }
+        let unaligned = flags
+            .choices
+            .iter()
+            .find(|c| c.name == "unaligned")
+            .unwrap();
+        assert_eq!(
+            unaligned.description.as_ref().map(|d| d.as_str()),
+            Some(".D.V....... allow decoders to produce unaligned output")
+        );
+    }
+
+    /// A wrapped-description continuation that merely *starts* with a
+    /// lowercase word must never be misread as a described choice: real
+    /// prose reflows at a single space, it does not draw a genuine 2+-space
+    /// aligned column the way ffmpeg's AVOption table does. This is the
+    /// negative case `choice_description_sub_row` exists to refuse —
+    /// distinct from `guesswork_style_keyword_list_is_not_read_as_a_nested_table`
+    /// above (a bare-word-only continuation with its explanation on a
+    /// still-deeper line), this one puts the explanation on the *same*
+    /// line, single-spaced, which is the shape a described choice must not
+    /// be confused with.
+    #[test]
+    fn a_single_spaced_prose_continuation_is_never_read_as_a_described_choice() {
+        let raw = "Usage: widget [options]\n\nOptions:\n    \
+                   --relaxed  a somewhat informal mode that widget falls back to\n        \
+                   when strict parsing fails and the input still looks plausible enough to run\n";
+        let parsed = parse(raw);
+        let relaxed = flag_named(&parsed, "relaxed");
+        assert!(
+            relaxed.choices.is_empty(),
+            "single-spaced prose must never become a choice: {:?}",
+            relaxed.choices
+        );
+        let desc = relaxed.description.as_ref().map_or("", |t| t.as_str());
+        assert!(
+            desc.contains("strict parsing fails"),
+            "the wrapped continuation must still land in the description: {desc:?}"
         );
     }
 }

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -853,14 +853,53 @@ pub(super) fn command_mode_seed(text: &str, profile: Option<&FrameworkProfile>) 
     mentions_commands_word(text)
 }
 
-/// Find the index of the flag in `flags` that `heading` is most plausibly
-/// "nested under" (spec §7 Tier B rule 4): first, a flag whose long or
-/// short spelling is literally mentioned in the heading text (`"Valid
-/// arguments for the --quoting-style option are:"` names `--quoting-style`
-/// directly); failing that, the most recently emitted flag, since an
-/// unlabeled enum list in `--help` output conventionally follows the flag
-/// it enumerates with no other heading in between (tar's `--format=FORMAT`
-/// immediately followed by `"FORMAT is one of the following:"`).
+/// Find the index of the flag in `flags` that `heading` is **provably**
+/// "nested under" (spec §7 Tier B rule 4) — two literal proofs, nothing
+/// else. `None` means ownership is unproven, and the caller attaches
+/// **nothing**: no names, no descriptions.
+///
+/// **This function used to guess.** A third branch fell back to
+/// `flags.len() - 1` — "the most recently emitted flag" — whenever neither
+/// proof fired, on the theory that an unlabeled enum list conventionally
+/// follows the flag it enumerates with nothing else in between (tar's
+/// `--format=FORMAT` immediately followed by `"FORMAT is one of the
+/// following:"`). Measured directly, twice, that theory does not hold:
+///
+/// - `cp`'s trailing `VERSION_CONTROL` enum (which documents `--backup`)
+///   attached to `--version` instead, because several unrelated prose
+///   paragraphs sit between the flags table ending and the block — the
+///   "most recently emitted flag" was simply whatever printed last, not
+///   the block's owner. A proximity check (was this block the very next
+///   thing scanned after a flags block ended) fixes this specific case.
+/// - `automake`'s `"Warning categories include:"` block documents its own
+///   `-W, --warnings=CATEGORY`, ten lines earlier — but attached to
+///   `-f, --force-missing`, the *actual* last flag before the block, with
+///   only a blank line between them. That is the same tight adjacency
+///   shape as tar's correct case, so a proximity check approves it too —
+///   confidently, and wrongly. Proximity cannot tell these two shapes
+///   apart, because the true axis isn't distance, it's whether the
+///   fallback's candidate is the real owner at all.
+///
+/// No adjacency signal separates "confidently right" (tar) from
+/// "confidently wrong" (automake), so the fallback is gone. Ownership is
+/// proven exactly two ways:
+///
+/// 1. The heading names the flag's long spelling literally
+///    (`"Valid arguments for the --quoting-style option are:"` names
+///    `--quoting-style` directly).
+/// 2. The heading contains one candidate flag's `value_name`, verbatim, as
+///    a whole word (case-insensitive) — tar's `FORMAT is one of the
+///    following:` names `--format=FORMAT`'s own placeholder. This is
+///    deliberately a literal word match, not a stem/plural/morphological
+///    one: `automake`'s heading says "categories" against a `CATEGORY`
+///    value_name, and admitting that match is exactly the false positive
+///    that would reproduce the `-f`/`-W` misattribution one level up the
+///    stack (see the follow-up issue for what a real fix needs).
+///
+/// Neither proof favors a "most recent" or "closest" candidate over
+/// another that also matches — both scan every flag in `flags`, in order,
+/// and take the first hit, same as the original name-match branch always
+/// did.
 pub(super) fn find_owning_flag_index(heading: &str, flags: &[Entity]) -> Option<usize> {
     let lower = heading.to_lowercase();
     if let Some(idx) = flags.iter().position(|f| {
@@ -869,11 +908,42 @@ pub(super) fn find_owning_flag_index(heading: &str, flags: &[Entity]) -> Option<
     }) {
         return Some(idx);
     }
-    if flags.is_empty() {
-        None
-    } else {
-        Some(flags.len() - 1)
-    }
+    flags.iter().position(|f| {
+        f.value_name.as_ref().is_some_and(|vn| {
+            // A one-character value_name is never a real placeholder — no
+            // tool author writes a single-letter metavar, since it would
+            // be indistinguishable from a short flag on the same row. It
+            // is always the signature of an unrelated parser artifact:
+            // ffplay's own `-fs` (force full screen) misreads as short
+            // `-f` plus value_name `"s"` (a pre-existing, separate
+            // single-dash-multi-character defect, spec Appendix A's
+            // `as`/`-fdump-*` family — see AGENTS.md's "GCC's single-dash
+            // multi-character convention" entry), and across an
+            // 1100-flag document a bare one-letter token like `"s"`
+            // coincidentally appears as its own word in unrelated
+            // headings dozens of times. Measured directly: without this
+            // guard, `ffplay`'s corpus fixture moved a described choices
+            // block onto `-fs` from a heading that has nothing to do with
+            // it. Excluding length-1 value_names costs nothing real —
+            // every genuine GNU-style placeholder (`FORMAT`, `CATEGORY`,
+            // `CONTROL`, `MODE`) is a whole word already.
+            vn.chars().count() > 1 && heading_contains_word(&lower, vn)
+        })
+    })
+}
+
+/// True when `word` (any case) appears in `lower_haystack` (already
+/// lowercased) as a whole token — split on any non-alphanumeric byte, so
+/// `FORMAT` matches `" FORMAT is one of the following:"` but does not
+/// match inside `FORMATS` or `REFORMAT`. Case-insensitive because a
+/// heading's own capitalization of a placeholder word is not guaranteed to
+/// match the value_name's (both are typically all-caps in practice, but
+/// nothing enforces it).
+fn heading_contains_word(lower_haystack: &str, word: &str) -> bool {
+    let word_lower = word.to_lowercase();
+    lower_haystack
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|token| token == word_lower)
 }
 
 /// Turn a word-grid block into subcommand stubs (if `treat_as_commands`)

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -49,8 +49,8 @@ use super::grammar::{
 };
 use super::profile::{heading_matches_markers, FrameworkProfile};
 use mandible_core::{
-    is_command_name_shaped, strip_escapes, CommandNode, Entity, Provenance, Source, Spelling, Text,
-    ValueKind,
+    is_command_name_shaped, strip_escapes, Choice, CommandNode, Entity, Provenance, Source,
+    Spelling, Text, ValueKind,
 };
 
 mod backfill;

--- a/mandible-extract/src/help_text/sections/test_support.rs
+++ b/mandible-extract/src/help_text/sections/test_support.rs
@@ -33,6 +33,8 @@ pub(super) const UNZIP_HELP: &str = include_str!("../../../../corpus/unzip/6.00/
 pub(super) const ZOXIDE_HELP: &str = include_str!("../../../../corpus/zoxide/0.9.9/help.txt");
 pub(super) const JMOD_HELP: &str = include_str!("../../../../corpus/jmod/17.0.20/help.txt");
 pub(super) const LLVM_AR_HELP: &str = include_str!("../../../../corpus/llvm-ar-18/18.1.3/help.txt");
+pub(super) const FFPLAY_HELP: &str =
+    include_str!("../../../../corpus/ffplay/6.1.1-3ubuntu5/help.txt");
 
 pub(super) const OPENSSL_HELP: &str =
     include_str!("../../../tests/fixtures/help_text/openssl_help.stderr");

--- a/mandible-extract/tests/snapshots/corpus_snapshot_format__tar_help_through_the_real_pipeline_snapshots_readably.snap
+++ b/mandible-extract/tests/snapshots/corpus_snapshot_format__tar_help_through_the_real_pipeline_snapshots_readably.snap
@@ -1,5 +1,6 @@
 ---
 source: mandible-extract/tests/corpus_snapshot_format.rs
+assertion_line: 127
 expression: "mandible_core::to_snapshot(&node)"
 ---
 name: tar
@@ -760,12 +761,18 @@ flags:
     value_name: FORMAT
     value_kind: Required
     choices:
-      - gnu
-      - oldgnu
-      - pax
-      - posix
-      - ustar
-      - v7
+      - name: gnu
+        description: GNU tar 1.13.x format
+      - name: oldgnu
+        description: GNU format as per tar <= 1.12
+      - name: pax
+        description: POSIX 1003.1-2001 (pax) format
+      - name: posix
+        description: same as pax
+      - name: ustar
+        description: POSIX 1003.1-1988 (ustar) format
+      - name: v7
+        description: old V7 tar format
     group: "Archive format selection:"
     description: create archive of the given format
     provenance:
@@ -874,14 +881,22 @@ flags:
     value_name: CONTROL
     value_kind: Optional
     choices:
-      - none
-      - "off"
-      - t
-      - numbered
-      - nil
-      - existing
-      - never
-      - simple
+      - name: none
+        description: never make backups
+      - name: "off"
+        description: never make backups
+      - name: t
+        description: make numbered backups
+      - name: numbered
+        description: make numbered backups
+      - name: nil
+        description: "numbered if numbered backups exist, simple otherwise"
+      - name: existing
+        description: "numbered if numbered backups exist, simple otherwise"
+      - name: never
+        description: always make simple backups
+      - name: simple
+        description: always make simple backups
     group: "Local file selection:"
     description: "backup before removal, choose version CONTROL"
     provenance:

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -1877,17 +1877,24 @@ fn entity_line(
     // into either would corrupt it. A derived enumeration gets its own
     // labeled line instead, indented two columns past the description
     // column, in the section's derived-metadata style.
-    let values_line = (!flag.choices.is_empty()).then(|| {
+    // A flag whose choices carry no per-value description (the common
+    // case — `tar --quoting-style`'s bare `literal`/`shell`/`c`/...) still
+    // gets the round-6 single summary line. A flag whose choices carry
+    // their own text (ffmpeg/ffplay's AVOption constants, spec §7
+    // recognition rule) render one indented `name  description` line per
+    // choice instead — see `choice_detail_lines` below.
+    let has_choice_descriptions = flag.choices.iter().any(|c| c.description.is_some());
+    let values_line = (!flag.choices.is_empty() && !has_choice_descriptions).then(|| {
         let joined = flag
             .choices
             .iter()
-            .map(|c| c.as_str().to_string())
+            .map(|c| c.name.as_str())
             .collect::<Vec<_>>()
             .join(", ");
         format!("values: {joined}")
     });
 
-    if description_text.is_none() && values_line.is_none() {
+    if description_text.is_none() && values_line.is_none() && !has_choice_descriptions {
         if !head.is_empty() {
             return head;
         }
@@ -1965,6 +1972,91 @@ fn entity_line(
                 format!("{values_indent}{chunk}"),
                 values_style,
             )));
+        }
+    } else if has_choice_descriptions {
+        lines.extend(choice_detail_lines(flag, column, width, color_enabled));
+    }
+
+    lines
+}
+
+/// Render a flag's choices as a `values:` header followed by one indented
+/// `name  description` row per choice (spec §9.3/§4.1's render note),
+/// dim/derived style matching the bare `values:` line this replaces.
+///
+/// Only called when at least one choice carries a description — the mixed
+/// case (some choices described, some bare, e.g. ffmpeg's `-bug`, whose
+/// `autodetect` value has no text of its own) still renders every choice
+/// through this path so the list stays one table rather than splitting
+/// into two.
+fn choice_detail_lines(
+    flag: &Entity,
+    column: usize,
+    width: usize,
+    color_enabled: bool,
+) -> Vec<Line<'static>> {
+    let values_column = column + 2;
+    let values_indent = " ".repeat(values_column);
+    let values_style = style::muted(color_enabled);
+
+    let choice_column = values_column + 2;
+    let choice_indent = " ".repeat(choice_column);
+    let choice_width = width.saturating_sub(choice_column).max(1);
+    let name_width = flag
+        .choices
+        .iter()
+        .map(|c| display_width(&c.name))
+        .max()
+        .unwrap_or(0);
+
+    let mut lines = vec![Line::from(Span::styled(
+        format!("{values_indent}values:"),
+        values_style,
+    ))];
+
+    for choice in &flag.choices {
+        let desc = choice
+            .description
+            .as_ref()
+            .map(|d| d.single_line())
+            .filter(|d| !d.is_empty());
+        let Some(desc) = desc else {
+            lines.push(Line::from(Span::styled(
+                format!("{choice_indent}{}", choice.name),
+                values_style,
+            )));
+            continue;
+        };
+        let head = format!("{:<name_width$}  ", choice.name);
+        let head_width = display_width(&head);
+        let first_room = choice_width.saturating_sub(head_width);
+        match leading_words(&desc, first_room) {
+            Some((first_chunk, rest)) => {
+                lines.push(Line::from(Span::styled(
+                    format!("{choice_indent}{head}{first_chunk}"),
+                    values_style,
+                )));
+                let cont_indent = " ".repeat(choice_column + head_width);
+                let cont_width = width.saturating_sub(choice_column + head_width).max(1);
+                for chunk in wrap_words(&rest, cont_width) {
+                    lines.push(Line::from(Span::styled(
+                        format!("{cont_indent}{chunk}"),
+                        values_style,
+                    )));
+                }
+            }
+            None => {
+                lines.push(Line::from(Span::styled(
+                    format!("{choice_indent}{}", choice.name),
+                    values_style,
+                )));
+                for chunk in wrap_words(&desc, choice_width) {
+                    lines.push(Line::from(Span::styled(
+                        format!("{choice_indent}{chunk}"),
+                        values_style,
+                    )));
+                }
+            }
         }
     }
 
@@ -2127,7 +2219,7 @@ pub fn provenance_caveat(node: &CommandNode, glyphs: Glyphs) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mandible_core::{Provenance, Source, Text};
+    use mandible_core::{Choice, Provenance, Source, Text};
 
     fn node_with_flags() -> CommandNode {
         let mut n = CommandNode::new(
@@ -2861,11 +2953,11 @@ mod tests {
         let mut flag = Entity::flag_long("format", Provenance::single(Source::HelpText));
         flag.description = Some(Text::sanitize("archive format to create"));
         flag.choices = vec![
-            Text::sanitize("default"),
-            Text::sanitize("gnu"),
-            Text::sanitize("darwin"),
-            Text::sanitize("bsd"),
-            Text::sanitize("bigarchive"),
+            Choice::bare("default"),
+            Choice::bare("gnu"),
+            Choice::bare("darwin"),
+            Choice::bare("bsd"),
+            Choice::bare("bigarchive"),
         ];
         let layout = SectionLayout {
             description: 20,
@@ -2912,7 +3004,7 @@ mod tests {
     #[test]
     fn choices_render_even_when_the_flag_has_no_description() {
         let mut flag = Entity::flag_long("format", Provenance::single(Source::HelpText));
-        flag.choices = vec![Text::sanitize("posix"), Text::sanitize("windows")];
+        flag.choices = vec![Choice::bare("posix"), Choice::bare("windows")];
         let layout = SectionLayout {
             description: 20,
             indent: 0,
@@ -2935,6 +3027,93 @@ mod tests {
         assert_eq!(indent_len, layout.description + 2, "{text:?}");
     }
 
+    /// A flag whose choices carry their own text — ffplay/ffmpeg's AVOption
+    /// constants (spec §7 recognition rule) — render `values:` alone as a
+    /// header, then one indented `name  description` row per choice,
+    /// instead of the single comma-joined summary line a bare-choices flag
+    /// gets. Folding the constants back into one line would just relocate
+    /// the smear this round's recognizer exists to fix.
+    #[test]
+    fn described_choices_render_as_a_name_description_list() {
+        let mut flag = Entity::flag_long("flags", Provenance::single(Source::HelpText));
+        flag.value_name = Some("<flags>".to_string());
+        flag.description = Some(Text::sanitize("ED.VAS..... (default 0)"));
+        flag.choices = vec![
+            Choice::described(
+                "unaligned",
+                Text::sanitize(".D.V....... allow decoders to produce unaligned output"),
+            ),
+            Choice::described(
+                "gray",
+                Text::sanitize("ED.V....... only decode/encode grayscale"),
+            ),
+        ];
+        let layout = SectionLayout {
+            description: 20,
+            indent: 0,
+        };
+        // A wide pane, deliberately: this test is about the choice list's
+        // *shape* (a header line, then one row per choice), not about
+        // word-wrap, which `a_narrow_pane_clamps_the_column_rather_than_shredding_prose`
+        // and friends already cover for the description column this
+        // section reuses.
+        let lines = entity_line(&flag, false, 200, true, layout);
+        let joined: String = lines.iter().map(text_of).collect::<Vec<_>>().join("\n");
+
+        assert!(
+            joined.contains("ED.VAS..... (default 0)"),
+            "the flag's own description must stay put: {joined:?}"
+        );
+        assert!(
+            !joined.contains("unaligned, gray"),
+            "described choices must never fall back to the comma-joined line: {joined:?}"
+        );
+
+        let header = lines
+            .iter()
+            .find(|l| text_of(l).trim() == "values:")
+            .expect("a bare 'values:' header line");
+        let header_indent = {
+            let t = text_of(header);
+            t.len() - t.trim_start().len()
+        };
+        assert_eq!(
+            header_indent,
+            layout.description + 2,
+            "the header sits two columns past the description column, exactly like the bare case"
+        );
+        assert_eq!(
+            header.spans[0].style,
+            style::muted(true),
+            "the header must use the pane's derived-metadata style"
+        );
+
+        let unaligned = lines
+            .iter()
+            .find(|l| text_of(l).contains("unaligned"))
+            .expect("the unaligned choice row");
+        let unaligned_text = text_of(unaligned);
+        assert!(
+            unaligned_text.contains("allow decoders to produce unaligned output"),
+            "{unaligned_text:?}"
+        );
+        let unaligned_indent = unaligned_text.len() - unaligned_text.trim_start().len();
+        assert!(
+            unaligned_indent > header_indent,
+            "each choice row sits deeper than the 'values:' header: {unaligned_indent} vs {header_indent}"
+        );
+
+        let gray = lines
+            .iter()
+            .find(|l| text_of(l).contains("gray"))
+            .expect("the gray choice row");
+        assert!(
+            text_of(gray).contains("only decode/encode grayscale"),
+            "{:?}",
+            text_of(gray)
+        );
+    }
+
     /// `tar --format` carries both a `FORMAT` placeholder in the spelling
     /// column and `choices` (spec §7 Tier B rule 4). The placeholder must
     /// render verbatim, on the head line, exactly as before — the values
@@ -2946,10 +3125,10 @@ mod tests {
         flag.value_kind = ValueKind::Required;
         flag.description = Some(Text::sanitize("archive format to create"));
         flag.choices = vec![
-            Text::sanitize("gnu"),
-            Text::sanitize("oldgnu"),
-            Text::sanitize("pax"),
-            Text::sanitize("posix"),
+            Choice::bare("gnu"),
+            Choice::bare("oldgnu"),
+            Choice::bare("pax"),
+            Choice::bare("posix"),
         ];
         let layout = SectionLayout {
             description: 20,

--- a/mandible-tui/src/render/detail_pane.rs
+++ b/mandible-tui/src/render/detail_pane.rs
@@ -2036,13 +2036,26 @@ fn choice_detail_lines(
                     format!("{choice_indent}{head}{first_chunk}"),
                     values_style,
                 )));
-                let cont_indent = " ".repeat(choice_column + head_width);
-                let cont_width = width.saturating_sub(choice_column + head_width).max(1);
-                for chunk in wrap_words(&rest, cont_width) {
-                    lines.push(Line::from(Span::styled(
-                        format!("{cont_indent}{chunk}"),
-                        values_style,
-                    )));
+                // `leading_words` returns `rest == ""` when the whole
+                // description fit on the first line — `wrap_words` always
+                // returns at least one (possibly empty) chunk for callers
+                // that need one, which is exactly wrong here: an empty
+                // `rest` means there is no continuation to render, not one
+                // blank line's worth. Skipping the call entirely (rather
+                // than filtering its output) is what keeps a choice whose
+                // description merely happens to be blank-after-wrapping
+                // indistinguishable from one that never had a remainder —
+                // there is no such case, `rest` is only ever the literal
+                // empty string when nothing is left.
+                if !rest.is_empty() {
+                    let cont_indent = " ".repeat(choice_column + head_width);
+                    let cont_width = width.saturating_sub(choice_column + head_width).max(1);
+                    for chunk in wrap_words(&rest, cont_width) {
+                        lines.push(Line::from(Span::styled(
+                            format!("{cont_indent}{chunk}"),
+                            values_style,
+                        )));
+                    }
                 }
             }
             None => {
@@ -3111,6 +3124,60 @@ mod tests {
             text_of(gray).contains("only decode/encode grayscale"),
             "{:?}",
             text_of(gray)
+        );
+    }
+
+    /// A choice whose description fits on the row's first line must never
+    /// be followed by a blank line. `wrap_words` always returns at least
+    /// one (possibly empty) chunk — a documented guarantee useful to most
+    /// of its callers, wrong for a continuation that may legitimately not
+    /// exist — so calling it unconditionally on `leading_words`'s `rest`
+    /// rendered one spurious blank `Line` per choice whose text fit
+    /// entirely on its own row. At a width where `-flags`' real `unaligned`
+    /// wraps and its real `gray` does not, this pins both shapes at once:
+    /// the render must show exactly six lines (the header, one wrapped
+    /// choice across two rows, one single-line choice), never eight.
+    #[test]
+    fn a_choice_that_fits_on_one_line_is_never_followed_by_a_blank_line() {
+        let mut flag = Entity::flag_long("flags", Provenance::single(Source::HelpText));
+        flag.value_name = Some("<flags>".to_string());
+        flag.description = Some(Text::sanitize("ED.VAS..... (default 0)"));
+        flag.choices = vec![
+            Choice::described(
+                "unaligned",
+                Text::sanitize(".D.V....... allow decoders to produce unaligned output"),
+            ),
+            Choice::described(
+                "gray",
+                Text::sanitize("ED.V....... only decode/encode grayscale"),
+            ),
+        ];
+        let layout = SectionLayout {
+            description: 20,
+            indent: 0,
+        };
+        // Narrow enough that "unaligned"'s longer description wraps, wide
+        // enough that "gray"'s shorter one fits on a single line — the
+        // exact split the real ffplay pane showed the defect on.
+        let lines = entity_line(&flag, false, 82, true, layout);
+        let texts: Vec<String> = lines.iter().map(text_of).collect();
+
+        assert!(
+            texts.iter().all(|t| !t.trim().is_empty()),
+            "no rendered line may be blank: {texts:?}"
+        );
+        assert_eq!(
+            texts,
+            vec![
+                "    --flags         ED.VAS..... (default 0)".to_string(),
+                "                      values:".to_string(),
+                "                        unaligned  .D.V....... allow decoders to produce unaligned"
+                    .to_string(),
+                "                                   output".to_string(),
+                "                        gray       ED.V....... only decode/encode grayscale"
+                    .to_string(),
+            ],
+            "{texts:#?}"
         );
     }
 

--- a/spec.md
+++ b/spec.md
@@ -291,7 +291,7 @@ pub struct Entity {
     pub spellings: Vec<Spelling>,
     pub value_name: Option<String>,
     pub value_kind: ValueKind,
-    pub choices: Vec<Text>,
+    pub choices: Vec<Choice>,
     pub description: Option<Text>,
     pub group: Option<String>,
     pub see_also: Vec<Text>,
@@ -307,6 +307,15 @@ pub struct Entity {
 }
 
 pub enum EntityKind { Flag, Positional, Modifier, EnvVar }
+
+/// One enumerated value an entity may take. `name` is a bare identifier —
+/// searched and compared, the same convention `Spelling::name` follows —
+/// and never carries the tool's scope-flag decoration. `description` is
+/// `Text`, sanitized through the same §4.1 boundary as every other string
+/// the IR carries from tool output; it is `None` for the common bare-list
+/// case (`tar --quoting-style`'s `literal`/`shell`/`c`/...) and `Some` when
+/// the tool documents one per value (ffmpeg/ffplay's AVOption constants).
+pub struct Choice { pub name: String, pub description: Option<Text> }
 ```
 
 `short()`, `long()`, `negatable()` and `single_dash()` are **derived from
@@ -456,7 +465,11 @@ Each of the three is handed one already-line-split string at a time: a
 raw-help line, one logical usage entry (whose wrapped continuations Tier
 B's parser has already joined), or one line of the unparsed document.
 Everything else that feeds the IR — descriptions above all — goes through
-`Text::sanitize`. The rule that decides between them is ownership of the
+`Text::sanitize`. This includes a `Choice`'s own `description` (§4.5): a
+per-value explanation is exactly as external as the entity's own
+description, and passes the same boundary — there is no second, laxer path
+for text that happens to arrive nested one level deeper in the document.
+The rule that decides between them is ownership of the
 layout, never the field: mandible sets prose, the author sets everything
 shown as drawn. The two constructors are verified apart: diffing the raw
 pane against independently captured `--help` output for `du` (column
@@ -1773,7 +1786,42 @@ The generic fallback parser (step 2) is built with `winnow`:
      whitespace. *"treat them as errors"* fails; `commit` passes.
   4. An indented list nested under a flag is that flag's **`choices`**, not
      subcommands — `gnu`/`oldgnu`/`pax`/`posix` under `tar --format=` are enum
-     values, and the IR already has a field for them.
+     values, and the IR already has a field for them. A per-value
+     description, when the source documents one, is kept rather than
+     dropped: `tar`'s own `FORMAT is one of the following:` and
+     `VERSION_CONTROL` enums name each value's meaning
+     (`gnu   GNU tar 1.13.x format`), and an earlier version of this rule
+     kept only the bare name — exactly the information-loss the recognizer
+     below exists to stop happening a second time.
+  5. **A row strictly deeper-indented than a flag row directly under it,
+     whose name column is a bare, dashless word** (`is_command_name_shaped`
+     — internal `-`/`_`/digits allowed, no leading dash, no leading digit),
+     **separated from the rest of the row by a genuine aligned column gap**
+     (two or more spaces, or a tab — never a single space, which is
+     ordinary prose wrapping, not a table), attaches to that flag's
+     `choices` as one **described** value: the name becomes `Choice::name`,
+     everything from the gap to the end of the line becomes
+     `Choice::description`, verbatim. ffmpeg/ffplay's AVOption sub-table is
+     the source of this rule:
+
+     ```text
+     -flags             <flags>      ED.VAS..... (default 0)
+          unaligned                    .D.V....... allow decoders to produce unaligned output
+          gray                         ED.V....... only decode/encode grayscale
+     ```
+
+     The scope-flag columns (`ED.VAS.....`) and any numeric value column
+     (`-strict`'s `very  2  ED.VA...... ...`) are the tool's own text and
+     stay inside the description unparsed — mandible does not model what
+     the columns mean. Distinct from rule 4's plain bare-word block (no
+     gap, no per-row description — the whole block is one flat name list)
+     and from an ordinary wrapped-description continuation line (single-
+     spaced prose, no aligned column): both keep folding into the owning
+     entity's own `description` exactly as before. A flag whose choices are
+     already populated by other means, and whose immediately-following
+     block also looks like this shape, is not resolved by this rule — that
+     ambiguity belongs to the still-unscheduled structure-aware description
+     work, not to shape-based recognition.
 - **Confidence must fall when the grammar is guessing.** The same bug was
   reported as `ok` at `100% described`, because invented nodes inflate the
   metric rather than depressing it. Any block that yields names failing rule 3,
@@ -2692,6 +2740,19 @@ Rules:
   in the section's derived-metadata style** — never folded into the
   description text or the spelling column, both of which stay verbatim
   (`tar --format` carries a `FORMAT` placeholder and `choices` together).
+  **A choice's own description, when the tool documents one per value**
+  (ffmpeg/ffplay's AVOption constants — `-flags`' `unaligned`, `gray`, ...,
+  each with its own scope-flags-and-explanation text), renders one further
+  indent past the `values:` line, one `name  description` row per choice,
+  in the same derived-metadata style as the bare case — never the single
+  comma-joined line, which would just relocate the smear rather than fix
+  it. A flag whose choices all lack a per-value description keeps the
+  single-line `values: a, b, c` summary; the two shapes are decided per
+  flag, by whether any choice carries a description, and a flag may mix
+  described and undescribed choices in the same list (`-bug`'s `autodetect`
+  has none of the others' text). ffmpeg's own scope-flag columns
+  (`ED.VAS.....`) are the tool's text, kept verbatim inside the
+  description — mandible parses no meaning out of them.
 - **Capped shared column, per section.** Every list section (POSITIONALS,
   FLAGS, MODIFIERS, ENVIRONMENT) computes its own column, fitted to
   roughly the p90 row width — the majority, not the outliers — measured

--- a/spec.md
+++ b/spec.md
@@ -1790,9 +1790,8 @@ The generic fallback parser (step 2) is built with `winnow`:
      description, when the source documents one, is kept rather than
      dropped: `tar`'s own `FORMAT is one of the following:` and
      `VERSION_CONTROL` enums name each value's meaning
-     (`gnu   GNU tar 1.13.x format`), and an earlier version of this rule
-     kept only the bare name — exactly the information-loss the recognizer
-     below exists to stop happening a second time.
+     (`gnu   GNU tar 1.13.x format`), and that text belongs on the value it
+     describes, never discarded.
   5. **A row strictly deeper-indented than a flag row directly under it,
      whose name column is a bare, dashless word** (`is_command_name_shaped`
      — internal `-`/`_`/digits allowed, no leading dash, no leading digit),
@@ -1819,9 +1818,7 @@ The generic fallback parser (step 2) is built with `winnow`:
      spaced prose, no aligned column): both keep folding into the owning
      entity's own `description` exactly as before. A flag whose choices are
      already populated by other means, and whose immediately-following
-     block also looks like this shape, is not resolved by this rule — that
-     ambiguity belongs to the still-unscheduled structure-aware description
-     work, not to shape-based recognition.
+     block also looks like this shape, is not resolved by this recognizer.
 - **Confidence must fall when the grammar is guessing.** The same bug was
   reported as `ok` at `100% described`, because invented nodes inflate the
   metric rather than depressing it. Any block that yields names failing rule 3,

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -375,10 +375,18 @@ fn build_fingerprint(root: Option<&mandible_core::CommandNode>) -> ToolFingerpri
             let choices_hash = if entity.choices.is_empty() {
                 None
             } else {
+                // Name and description (when the tool documents one per
+                // choice — ffmpeg's AVOption constants) both feed the hash,
+                // separated by a distinct control character from the outer
+                // per-choice join, so a description-only edit still moves
+                // the fingerprint the same way a name-only one always did.
                 let joined = entity
                     .choices
                     .iter()
-                    .map(mandible_core::Text::as_str)
+                    .map(|c| match &c.description {
+                        Some(d) => format!("{}\u{1e}{}", c.name, d.as_str()),
+                        None => c.name.clone(),
+                    })
                     .collect::<Vec<_>>()
                     .join("\u{1f}");
                 Some(fnv1a(joined.as_bytes()))
@@ -2792,7 +2800,7 @@ mod tests {
     /// with no process spawned at all.
     #[test]
     fn fingerprint_footer_round_trips_a_synthetic_tree() {
-        use mandible_core::{CommandNode, Entity, Provenance, Source, Text, ValueKind};
+        use mandible_core::{Choice, CommandNode, Entity, Provenance, Source, Text, ValueKind};
 
         let mut root = CommandNode::new("demo", Provenance::single(Source::HelpText));
         let mut flag = Entity::flag_spelled(
@@ -2803,7 +2811,7 @@ mod tests {
             Provenance::single(Source::HelpText),
         );
         flag.description = Some(Text::sanitize("increase verbosity"));
-        flag.choices = vec![Text::sanitize("low"), Text::sanitize("high")];
+        flag.choices = vec![Choice::bare("low"), Choice::bare("high")];
         flag.value_name = Some("LEVEL".to_string());
         flag.value_kind = ValueKind::Required;
         root.entities.push(flag);

--- a/xtask/src/residue.rs
+++ b/xtask/src/residue.rs
@@ -434,7 +434,7 @@ impl Vocabulary {
             // *consumed* — counting those rows as residue would report
             // the rule working as if it had failed.
             for choice in &entity.choices {
-                self.names.insert(choice.as_str().to_string());
+                self.names.insert(choice.name.clone());
             }
         }
         for child in &node.subcommands {
@@ -1059,7 +1059,7 @@ mod tests {
         let mut f = flag(None, Some("quoting-style"));
         f.choices = ["literal", "shell", "c"]
             .iter()
-            .map(|c| mandible_core::Text::sanitize(c))
+            .map(|c| mandible_core::Choice::bare(*c))
             .collect();
         root.entities.push(f);
         assert_eq!(analyze(raw, &root).unaccounted, 0);


### PR DESCRIPTION
Extends #95's values line: `Choice` gains an optional description, and a flag whose choices carry descriptions renders them as an indented sub-table under `values:` (bare-name choices keep the single line). Motivating case: ffplay/ffmpeg AVOption families (`-flags`' constants were smeared whole into the flag description).

Ownership of a separate choices-block is attached only on proof — the heading literally names the flag, or contains the flag's `value_name` as an exact case-insensitive word (tar's `FORMAT is one of:` → `--format`). The proximity fallback is removed: `automake`'s warning-category block sits adjacent to `--force-missing` but belongs to `-W, --warnings`, so adjacency is evidence of nothing. Unproven blocks render exactly as before, byte-for-byte.

Also fixed while measuring: a one-character `value_name` (artifact of an unrelated misparse) coincidence-matched headings across ffplay's 11k-line help (length guard), which surfaced and fixed a pre-existing `--framerate` cross-attachment.

Fleet sweep vs base: 2259 tools, 0 status transitions, 0 flag-count changes, 35 field-level movers — constants moving from descriptions into `choices`, spot-verified against live `--help` (m4, cp, libtool, od). Tests 1470/1470; corpus 0 failed; revert-plants watched red per AGENTS §3.4; pty screenshots at 100/180 columns.