### PR TITLE
release: 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-01
+
 ### Added
 
 - `mandible llvm-ar` now shows its `OPERATIONS:` table (`d`, `m`, `p`, `q`, `r`, `s`, `t`, `x`) as subcommands instead of dropping it: the heading says "operations" rather than "commands", which spec §7 Tier B rule 1's recognized-heading vocabulary is extended to accept as the same kind of evidence, since an operation letter is an invocation verb exactly the way a subcommand name is — `ar`'s own equivalent table was unaffected because its heading already says "commands".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "directories",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arboard",
  "base64",
@@ -2365,7 +2365,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.5.0" }
-mandible-extract = { path = "mandible-extract", version = "0.5.0" }
-mandible-search = { path = "mandible-search", version = "0.5.0" }
-mandible-tui = { path = "mandible-tui", version = "0.5.0" }
+mandible-core = { path = "mandible-core", version = "0.6.0" }
+mandible-extract = { path = "mandible-extract", version = "0.6.0" }
+mandible-search = { path = "mandible-search", version = "0.6.0" }
+mandible-tui = { path = "mandible-tui", version = "0.6.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Cuts 0.6.0: workspace version bump and the CHANGELOG section for everything merged since 0.5.0 — multi-spelling emission (#97), search over every entity kind (#96), the values line and per-choice descriptions (#95, #99), the argfile sigil flag and ar's recovered descriptions (#100), the CI baseline refresh (#98), and the post-merge fixes (#101, #103). Minor bump per cargo's 0.y compatibility boundary: the public IR changed (spellings, Choice, FlagKey::Name, snapshot format). Tag v0.6.0 follows the merge.