### PR TITLE
release: 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-09-01
+
 ### Fixed
 
 - `cargo install mandible` can reach 0.6.x again: the `mandible` binary crate failed to publish at 0.6.0 (the four library crates went through) because its `--shell-init` snippets lived under the repo's `packaging/shell/`, outside the crate root, and `cargo publish` verifies the build from the packaged tarball, which can only carry files under the crate — the snippets now live in `mandible/shell/` inside the crate, and CI packages the whole workspace on every PR so a file referenced from outside its crate fails there rather than at the registry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "base64",
@@ -2365,7 +2365,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.6.0" }
-mandible-extract = { path = "mandible-extract", version = "0.6.0" }
-mandible-search = { path = "mandible-search", version = "0.6.0" }
-mandible-tui = { path = "mandible-tui", version = "0.6.0" }
+mandible-core = { path = "mandible-core", version = "0.6.1" }
+mandible-extract = { path = "mandible-extract", version = "0.6.1" }
+mandible-search = { path = "mandible-search", version = "0.6.1" }
+mandible-tui = { path = "mandible-tui", version = "0.6.1" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Patch release: the `mandible` binary crate failed to publish at 0.6.0 (#105 explains and fixes it); 0.6.1 republishes all five crates so `cargo install mandible` reaches 0.6.x. No other change since 0.6.0.