### PR TITLE
Split parse_body into named passes

### DIFF
--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -639,12 +639,24 @@ fn extract_description(
 /// subcommands, modifiers, positionals and environment variables as
 /// each recognized section shape is met. Returns the entry counts
 /// `compute_confidence` scores. See docs/shapes.md S-013 and S-019.
+/// The mutable state the body scan threads through every branch.
+/// Bundled so a branch can be lifted into its own function without a
+/// ten-argument signature.
+struct BodyScan<'a> {
+    result: &'a mut ParsedHelp,
+    command_mode: bool,
+    in_ignorable_section: bool,
+    obscured_ignorable_indent: Option<(usize, bool)>,
+    total_entries: usize,
+    clean_entries: usize,
+}
+
 fn scan_entries(
     raw: &str,
     lines: &[&str],
     usage_lines: &[String],
     mut i: usize,
-    mut result: &mut ParsedHelp,
+    result: &mut ParsedHelp,
     profile: Option<&FrameworkProfile>,
     tool_name: Option<&str>,
     bnf_row_lines: &std::collections::HashSet<usize>,
@@ -656,11 +668,11 @@ fn scan_entries(
     // only, not the whole document, keeps this from lighting up on tar's
     // `--occurrence` description, which mentions "subcommands" in prose
     // describing something else. Deliberately not also seeded from
-    // `result.usage`: containerd and ctr both write a docopt-style
+    // `st.result.usage`: containerd and ctr both write a docopt-style
     // `USAGE: <tool> ... command ...` synopsis, and seeding from that
     // alone turned their unrelated `VERSION:` block into a fabricated
     // subcommand named their own version string. See S-070.
-    let mut command_mode = result
+    let command_mode = result
         .description
         .as_deref()
         .is_some_and(|d| command_mode_seed(d, profile));
@@ -673,17 +685,17 @@ fn scan_entries(
     // generic bare-block fallback the example lines actually take —
     // resetting there would clear the flag on the first example line and
     // reopen the fabrication on the second. See S-071.
-    let mut in_ignorable_section = false;
+    let in_ignorable_section = false;
     // Some hand-written help indents `Examples:` beneath the prose
     // sentence immediately before it, which would otherwise be promoted
     // to a heading and hide the marker from `is_ignorable_heading`
     // entirely. While this is `Some((indent, _))`, the whole region is
     // fenced before any emission path can see its rows; a physical
     // dedent, or an independently attested flag section at the marker's
-    // indent or deeper, closes it. Separate from `in_ignorable_section`
+    // indent or deeper, closes it. Separate from `st.in_ignorable_section`
     // so a fence opened inside an already-suppressed section restores
     // that suppression rather than clearing it. See S-071.
-    let mut obscured_ignorable_indent: Option<(usize, bool)> = None;
+    let obscured_ignorable_indent: Option<(usize, bool)> = None;
 
     // 3. Section blocks: scan the rest of the output for a heading line
     // followed by more-indented content — or, if the first content already
@@ -691,18 +703,24 @@ fn scan_entries(
     // "Heading" is relative, not "column 0": tar indents its own headings
     // by one space while entries sit at two, so a block is recognized
     // whenever a line is followed by content indented more than it.
-    let mut total_entries = 0usize;
-    let mut clean_entries = 0usize;
+    let mut st = BodyScan {
+        result,
+        command_mode,
+        in_ignorable_section,
+        obscured_ignorable_indent,
+        total_entries: 0usize,
+        clean_entries: 0usize,
+    };
     while i < lines.len() {
         let line = lines[i];
         if line.trim().is_empty() {
             i += 1;
             continue;
         }
-        if let Some((marker_indent, prior_ignorable)) = obscured_ignorable_indent {
+        if let Some((marker_indent, prior_ignorable)) = st.obscured_ignorable_indent {
             if obscured_fence_reopens(&lines, i, marker_indent) {
-                obscured_ignorable_indent = None;
-                in_ignorable_section = prior_ignorable;
+                st.obscured_ignorable_indent = None;
+                st.in_ignorable_section = prior_ignorable;
             } else {
                 i += 1;
                 continue;
@@ -724,21 +742,21 @@ fn scan_entries(
                 emit_packed_flags(
                     None,
                     entries.into_iter().map(|(s, d, _)| (s, d)).collect(),
-                    &mut result,
+                    st.result,
                 );
-                total_entries += seen;
-                clean_entries += seen;
+                st.total_entries += seen;
+                st.clean_entries += seen;
             } else {
-                let (seen, clean) = emit_flags(None, entries, &mut result);
-                total_entries += seen;
-                clean_entries += clean;
+                let (seen, clean) = emit_flags(None, entries, st.result);
+                st.total_entries += seen;
+                st.clean_entries += clean;
             }
             if let Some(entry) = argfile_entry {
-                total_entries += 1;
-                clean_entries += 1;
-                emit_argfile_flag(None, entry, &mut result);
+                st.total_entries += 1;
+                st.clean_entries += 1;
+                emit_argfile_flag(None, entry, st.result);
             }
-            command_mode = false;
+            st.command_mode = false;
             continue;
         }
 
@@ -753,12 +771,12 @@ fn scan_entries(
                     scan_headingless_invocation_table(&lines, i, tool_name, raw)
                 {
                     i = end;
-                    total_entries += seen;
-                    clean_entries += clean;
+                    st.total_entries += seen;
+                    st.clean_entries += clean;
                     for node in nodes {
-                        result.try_push_subcommand(node);
+                        st.result.try_push_subcommand(node);
                     }
-                    command_mode = false;
+                    st.command_mode = false;
                     continue;
                 }
             }
@@ -776,16 +794,18 @@ fn scan_entries(
                 && leading_whitespace(lines[marker_idx]) > heading_indent
                 && is_obscured_fence_marker(lines[marker_idx].trim())
             {
-                obscured_ignorable_indent =
-                    Some((leading_whitespace(lines[marker_idx]), in_ignorable_section));
-                in_ignorable_section = true;
-                command_mode = false;
+                st.obscured_ignorable_indent = Some((
+                    leading_whitespace(lines[marker_idx]),
+                    st.in_ignorable_section,
+                ));
+                st.in_ignorable_section = true;
+                st.command_mode = false;
                 i = marker_idx + 1;
                 continue;
             }
         }
         if is_ignorable_heading(&heading) {
-            in_ignorable_section = true;
+            st.in_ignorable_section = true;
         }
         // A hard-wrapped prose sentence, whose second physical line the
         // indentation-alone heading rule would otherwise hand to the
@@ -812,12 +832,12 @@ fn scan_entries(
             {
                 if let Some((end, rows)) = scan_env_var_table(&lines, i) {
                     i = end;
-                    in_ignorable_section = false;
-                    command_mode = false;
+                    st.in_ignorable_section = false;
+                    st.command_mode = false;
                     let (seen, clean) =
-                        emit_env_vars(meaningful_flag_group(heading.clone()), rows, &mut result);
-                    total_entries += seen;
-                    clean_entries += clean;
+                        emit_env_vars(meaningful_flag_group(heading.clone()), rows, st.result);
+                    st.total_entries += seen;
+                    st.clean_entries += clean;
                     continue;
                 }
             }
@@ -847,19 +867,19 @@ fn scan_entries(
                     i += 1;
                 }
                 if !is_ignorable_heading(&heading) {
-                    in_ignorable_section = false;
+                    st.in_ignorable_section = false;
                     let recognized = is_recognized_command_heading(&heading, profile);
                     if recognized {
-                        command_mode = true;
+                        st.command_mode = true;
                     }
                     let (seen, clean) = process_word_grid(
                         &heading,
                         &lines[grid_start..i],
-                        recognized || command_mode,
-                        &mut result,
+                        recognized || st.command_mode,
+                        st.result,
                     );
-                    total_entries += seen;
-                    clean_entries += clean;
+                    st.total_entries += seen;
+                    st.clean_entries += clean;
                 }
                 continue;
             }
@@ -894,11 +914,11 @@ fn scan_entries(
                     scan_same_indent_entry_table(&lines, i, heading_indent)
                 {
                     i = end;
-                    command_mode = true;
-                    in_ignorable_section = false;
-                    let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
-                    total_entries += seen;
-                    clean_entries += clean;
+                    st.command_mode = true;
+                    st.in_ignorable_section = false;
+                    let (seen, clean) = emit_subcommands(&heading, entries, st.result);
+                    st.total_entries += seen;
+                    st.clean_entries += clean;
                     continue;
                 }
             }
@@ -908,7 +928,7 @@ fn scan_entries(
             // whose group headings say nothing about "commands"
             // themselves), remember that. See S-070.
             if command_mode_seed(&heading, profile) {
-                command_mode = true;
+                st.command_mode = true;
             }
             // Rewind to just past the original line and continue scanning
             // it as its own candidate.
@@ -923,7 +943,7 @@ fn scan_entries(
         // this runs once per heading rather than folded into any later
         // branch.
         //
-        // Gated on `!in_ignorable_section`: bpftrace's own `EXAMPLES:`
+        // Gated on `!st.in_ignorable_section`: bpftrace's own `EXAMPLES:`
         // block writes each example in the identical shape to a real
         // stanza head, and without this guard it fabricated `-e`/`-l`
         // rows that displaced the real, described ones. See S-071.
@@ -931,7 +951,7 @@ fn scan_entries(
         // A stanza with its own description sentence above its head line
         // labels its group with that sentence instead ([`stanza_description_above`]).
         // The head line is not lost: it becomes a usage form
-        // (`result.usage`, spec §4.5). Pushed here because this is the
+        // (`st.result.usage`, spec §4.5). Pushed here because this is the
         // one place that knows the head line is about to stop being the
         // group label; `extract_positionals` has already run, so nothing
         // is mined out of the added line. See S-012.
@@ -941,21 +961,21 @@ fn scan_entries(
         // mean the tool printed the stanza twice. A scan of `usage` per
         // heading would be the quadratic shape `MAX_RECOVERED_ENTRIES`
         // exists for (instmodsh's repeated banner, S-072).
-        let stanza_label = if in_ignorable_section {
+        let stanza_label = if st.in_ignorable_section {
             None
         } else {
             stanza_description_above(&lines, heading_idx, tool_name).map(str::to_string)
         };
-        if stanza_label.is_some() && result.usage.len() < MAX_RECOVERED_ENTRIES {
-            result.usage.push(heading.clone());
+        if stanza_label.is_some() && st.result.usage.len() < MAX_RECOVERED_ENTRIES {
+            st.result.usage.push(heading.clone());
         }
-        if !in_ignorable_section {
+        if !st.in_ignorable_section {
             if let Some(mut flag) = recover_stanza_head_flag(&heading, tool_name) {
                 if let Some(label) = stanza_label.clone() {
                     flag.group = Some(label);
                 }
-                if result.flags.len() < MAX_RECOVERED_ENTRIES {
-                    result.flags.push(flag);
+                if st.result.flags.len() < MAX_RECOVERED_ENTRIES {
+                    st.result.flags.push(flag);
                 }
             }
         }
@@ -968,7 +988,7 @@ fn scan_entries(
         // S-018.
         //
         // Gated on `is_recognized_command_heading(label, ...)` for this
-        // heading directly, never a `command_mode` chain, since a sticky
+        // heading directly, never a `st.command_mode` chain, since a sticky
         // chain can reach an unrelated wrapped-prose block.
         if let Some((label, inline_row)) = split_heading_inline_row(line.trim()) {
             if !is_ignorable_heading(&heading)
@@ -981,13 +1001,13 @@ fn scan_entries(
                     if let Some((end, mut entries)) = scan_bare_command_table(&lines, i) {
                         entries.insert(0, (first_name, None));
                         i = end;
-                        command_mode = true;
-                        in_ignorable_section = false;
+                        st.command_mode = true;
+                        st.in_ignorable_section = false;
                         let raw_tokens = command_table_token_index(raw);
                         let (seen, clean) =
-                            emit_headed_command_table(entries, &raw_tokens, &mut result);
-                        total_entries += seen;
-                        clean_entries += clean;
+                            emit_headed_command_table(entries, &raw_tokens, st.result);
+                        st.total_entries += seen;
+                        st.clean_entries += clean;
                         continue;
                     }
                 }
@@ -1011,12 +1031,12 @@ fn scan_entries(
                 // Positively-recognized structure clears the examples flag
                 // and contradicts a command-mode sticky chain (ar's own
                 // heading contains "command").
-                in_ignorable_section = false;
-                command_mode = false;
+                st.in_ignorable_section = false;
+                st.command_mode = false;
                 let (seen, clean) =
-                    emit_modifiers(meaningful_flag_group(heading.clone()), rows, &mut result);
-                total_entries += seen;
-                clean_entries += clean;
+                    emit_modifiers(meaningful_flag_group(heading.clone()), rows, st.result);
+                st.total_entries += seen;
+                st.clean_entries += clean;
             }
             if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
                 continue;
@@ -1031,9 +1051,9 @@ fn scan_entries(
         if !is_ignorable_heading(&heading) && i < lines.len() {
             if let Some(value_name) = argfile_row_value_name(lines[i].trim_start()) {
                 let entry = argfile_flag_entry(lines[i], value_name);
-                emit_argfile_flag(meaningful_flag_group(heading.clone()), entry, &mut result);
-                total_entries += 1;
-                clean_entries += 1;
+                emit_argfile_flag(meaningful_flag_group(heading.clone()), entry, st.result);
+                st.total_entries += 1;
+                st.clean_entries += 1;
                 i += 1;
                 if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
                     continue;
@@ -1055,12 +1075,12 @@ fn scan_entries(
         if is_environment_heading(&heading) && !is_ignorable_heading(&heading) {
             if let Some((end, rows)) = scan_env_var_table(&lines, i) {
                 i = end;
-                in_ignorable_section = false;
-                command_mode = false;
+                st.in_ignorable_section = false;
+                st.command_mode = false;
                 let (seen, clean) =
-                    emit_env_vars(meaningful_flag_group(heading.clone()), rows, &mut result);
-                total_entries += seen;
-                clean_entries += clean;
+                    emit_env_vars(meaningful_flag_group(heading.clone()), rows, st.result);
+                st.total_entries += seen;
+                st.clean_entries += clean;
                 if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
                     continue;
                 }
@@ -1080,13 +1100,13 @@ fn scan_entries(
                 scan_flags_block(&lines, flags_start, heading_is_bnf);
             i = end;
             if is_ignorable_heading(&heading) {
-                command_mode = false;
+                st.command_mode = false;
                 continue;
             }
             // A real, non-ignorable flags block — structurally strong
             // evidence we are not (or no longer) inside an examples-shaped
-            // section. See `in_ignorable_section`'s own doc comment.
-            in_ignorable_section = false;
+            // section. See `st.in_ignorable_section`'s own doc comment.
+            st.in_ignorable_section = false;
             // A stanza's own description sentence outranks its head line
             // as the group's label, and only there — every other block
             // still takes `meaningful_flag_group`'s answer unchanged. See
@@ -1099,21 +1119,21 @@ fn scan_entries(
                 emit_packed_flags(
                     group.clone(),
                     entries.into_iter().map(|(s, d, _)| (s, d)).collect(),
-                    &mut result,
+                    st.result,
                 );
-                total_entries += seen;
-                clean_entries += seen;
+                st.total_entries += seen;
+                st.clean_entries += seen;
             } else {
-                let (seen, clean) = emit_flags(group.clone(), entries, &mut result);
-                total_entries += seen;
-                clean_entries += clean;
+                let (seen, clean) = emit_flags(group.clone(), entries, st.result);
+                st.total_entries += seen;
+                st.clean_entries += clean;
             }
             if let Some(entry) = argfile_entry {
-                total_entries += 1;
-                clean_entries += 1;
-                emit_argfile_flag(group, entry, &mut result);
+                st.total_entries += 1;
+                st.clean_entries += 1;
+                emit_argfile_flag(group, entry, st.result);
             }
-            command_mode = false;
+            st.command_mode = false;
             continue;
         }
 
@@ -1129,11 +1149,11 @@ fn scan_entries(
         if profile.is_some_and(|p| p.argparse_subparser_quirk) {
             if let Some((end, entries)) = scan_argparse_subparsers(&lines, i, heading_indent) {
                 i = end;
-                command_mode = false;
-                in_ignorable_section = false;
-                let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
-                total_entries += seen;
-                clean_entries += clean;
+                st.command_mode = false;
+                st.in_ignorable_section = false;
+                let (seen, clean) = emit_subcommands(&heading, entries, st.result);
+                st.total_entries += seen;
+                st.clean_entries += clean;
                 continue;
             }
         }
@@ -1142,24 +1162,24 @@ fn scan_entries(
         // below the subparser scan since for argparse the two read the
         // same heading, and the subparser scan's `{...}`-with-entries
         // evidence is stronger than heading text alone. Also breaks the
-        // sticky `command_mode` chain. See S-078.
+        // sticky `st.command_mode` chain. See S-078.
         if profile.is_some_and(|p| {
             heading_matches_markers(&heading.to_lowercase(), p.positional_heading_markers)
         }) {
             let (end, entries) = scan_bare_block(&lines, i, heading_indent, false);
             i = end;
-            command_mode = false;
-            in_ignorable_section = false;
+            st.command_mode = false;
+            st.in_ignorable_section = false;
             let (block_seen, block_clean) =
-                emit_declared_positionals(entries, &usage_lines, &mut result);
-            total_entries += block_seen;
-            clean_entries += block_clean;
+                emit_declared_positionals(entries, &usage_lines, st.result);
+            st.total_entries += block_seen;
+            st.clean_entries += block_clean;
             continue;
         }
 
         // A framework-declared non-command heading both refuses this
         // block and breaks the engine's sticky same-indent chain, so
-        // nothing after it inherits a `command_mode` this heading
+        // nothing after it inherits a `st.command_mode` this heading
         // positively contradicts.
         let is_declared_non_command = profile.is_some_and(|p| {
             heading_matches_markers(&heading.to_lowercase(), p.non_command_heading_markers)
@@ -1171,30 +1191,30 @@ fn scan_entries(
         // is what keeps a bare ` - ` in ordinary prose from manufacturing
         // commands, the same failure class as apt-get's own description
         // paragraph, just via the column-gap rule instead.
-        let allow_dash_separator = (recognized || command_mode) && !is_declared_non_command;
+        let allow_dash_separator = (recognized || st.command_mode) && !is_declared_non_command;
 
         // A headed command table whose rows use ` = ` as a separator, or
         // no separator at all — wpa_cli's `=`-separated rows,
         // fail2ban-client's wrapped continuations. See S-019.
         //
         // Gated on `recognized` alone, deliberately narrower than
-        // `allow_dash_separator`, which also accepts a `command_mode`
+        // `allow_dash_separator`, which also accepts a `st.command_mode`
         // chain: fail2ban-client's `Command:` block nests rows whose
         // descriptions wrap across further lines, and the engine's own
         // pseudo-heading rewind re-examines each such row once
-        // `command_mode` is stuck on, satisfying every safeguard with
+        // `st.command_mode` is stuck on, satisfying every safeguard with
         // ordinary English words. `recognized` — true only when this
         // exact heading's own text names a command — is false for every
         // such pseudo-heading, so requiring it directly closes this off.
         if recognized && !is_declared_non_command {
             if let Some((end, entries)) = scan_bare_command_table(&lines, i) {
                 i = end;
-                command_mode = true;
-                in_ignorable_section = false;
+                st.command_mode = true;
+                st.in_ignorable_section = false;
                 let raw_tokens = command_table_token_index(raw);
-                let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, &mut result);
-                total_entries += seen;
-                clean_entries += clean;
+                let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, st.result);
+                st.total_entries += seen;
+                st.clean_entries += clean;
                 continue;
             }
         }
@@ -1203,18 +1223,18 @@ fn scan_entries(
         // under one heading, structurally distinct from every other
         // framework's per-line bare-word block, so it gets first refusal
         // here. Gated on the profile flag and this heading already being
-        // recognized or continuing a `command_mode` chain. See S-093.
+        // recognized or continuing a `st.command_mode` chain. See S-093.
         if profile.is_some_and(|p| p.comma_separated_command_list)
-            && (recognized || command_mode)
+            && (recognized || st.command_mode)
             && !is_declared_non_command
         {
             let (end, entries) = scan_comma_separated_commands(&lines, i);
             i = end;
-            command_mode = true;
-            in_ignorable_section = false;
-            let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
-            total_entries += seen;
-            clean_entries += clean;
+            st.command_mode = true;
+            st.in_ignorable_section = false;
+            let (seen, clean) = emit_subcommands(&heading, entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
             continue;
         }
 
@@ -1225,46 +1245,43 @@ fn scan_entries(
         }
 
         if is_declared_non_command {
-            command_mode = false;
-            let (seen, clean) = emit_choices(&heading, entries, &mut result);
-            total_entries += seen;
-            clean_entries += clean;
+            st.command_mode = false;
+            let (seen, clean) = emit_choices(&heading, entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
             continue;
         }
 
-        if recognized || command_mode {
-            command_mode = true;
+        if recognized || st.command_mode {
+            st.command_mode = true;
             // Only `recognized` (this exact heading's own text says
             // "commands") is strong enough to clear the flag here — the
-            // `command_mode` sticky-chain half of this condition is not:
+            // `st.command_mode` sticky-chain half of this condition is not:
             // it can still be true from an *inherited* chain rather than
             // this heading's own evidence, which is exactly the kind of
-            // indirect signal `in_ignorable_section` must not trust (see
+            // indirect signal `st.in_ignorable_section` must not trust (see
             // its own doc comment on why the generic bare-block fallback
             // is deliberately excluded from clearing it).
             if recognized {
-                in_ignorable_section = false;
+                st.in_ignorable_section = false;
             }
-            let (seen, clean) = emit_subcommands(&heading, entries, &mut result);
-            total_entries += seen;
-            clean_entries += clean;
+            let (seen, clean) = emit_subcommands(&heading, entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
         } else {
-            command_mode = false;
-            let (seen, clean) = emit_choices(&heading, entries, &mut result);
-            total_entries += seen;
-            clean_entries += clean;
+            st.command_mode = false;
+            let (seen, clean) = emit_choices(&heading, entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
         }
     }
-    (total_entries, clean_entries)
+    (st.total_entries, st.clean_entries)
 }
 
 /// [`parse_with_profile`]'s engine, over text whose shared heading rows
 /// have already been split out. `bnf_row_lines` records which row lines
 /// came from a `:=` BNF production rather than an ordinary column-gap
 /// heading, keyed on the row rather than the heading beside it.
-// Ratchet: the seventeen-flag body scanner; split into typed passes is tracked work. Listed in scripts/ratchet.txt.
-#[allow(clippy::too_many_lines)]
-#[allow(clippy::cognitive_complexity)]
 fn parse_body(
     raw: &str,
     profile: Option<&FrameworkProfile>,

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -295,6 +295,265 @@ pub fn parse_with_profile(
     }
 }
 
+/// The recovered usage block: where scanning stopped, the synopsis
+/// entries, and the operands read out of them.
+struct UsageScan {
+    next_index: usize,
+    entries: Vec<String>,
+    positionals: Vec<Entity>,
+}
+
+/// Walk the usage block starting at `start`, folding wrapped continuation
+/// lines into one entry each. See docs/shapes.md S-001 and S-037.
+fn scan_usage_section(
+    lines: &[&str],
+    start: usize,
+    labelled_usage_start: Option<usize>,
+    tool_name: Option<&str>,
+    usage_lines: &mut Vec<String>,
+) -> UsageScan {
+    let mut i = start;
+    let base_indent = leading_whitespace(lines[i]);
+    usage_lines.push(lines[i].trim().to_string());
+    let mut usage_entries = vec![lines[i].trim().to_string()];
+    // Parallel to `usage_lines`: which `usage_entries` index each
+    // physical line was folded into — a wrapped entry (sg_sanitize's
+    // five-line synopsis) spans several lines but is one entry, and
+    // [`primary_synopsis_lines`] needs every one of them.
+    let mut line_entry_index = vec![0usize];
+    // Running depth of an open parenthesized alternation group (LVM's
+    // "any one is required" convention), tracked only for an
+    // unlabelled synopsis: a member row routinely opens with `-`
+    // itself, which the "a continuation line that reads as a flag
+    // entry ends the block" check just below would otherwise
+    // misread as ending the block. See S-088.
+    let mut paren_group_depth: i32 = 0;
+    // True for exactly the one loop iteration right after
+    // `paren_group_depth` returns to zero — tells "a blank line right
+    // after the group's own closing `)`" (still the same stanza's
+    // trailing bracket-row flags) apart from an ordinary between-
+    // stanza blank line. Reset unconditionally elsewhere.
+    let mut just_closed_paren_group = false;
+    i += 1;
+    while i < lines.len() {
+        let l = lines[i];
+        if l.trim().is_empty() {
+            if paren_group_depth > 0 {
+                // A blank line inside an unclosed group is not a shape
+                // any real specimen produces; refuse to guess at what it
+                // means rather than fabricate a continuation across it.
+                paren_group_depth = 0;
+                just_closed_paren_group = false;
+            }
+            if just_closed_paren_group {
+                just_closed_paren_group = false;
+                if let Some(next) = lines.get(i + 1) {
+                    let t = next.trim_start();
+                    if !t.is_empty() && looks_like_bracket_flag_row(t) {
+                        // The group's trailing bracket-row flags
+                        // continue after exactly one blank line —
+                        // vgchange's `( ... )` then a blank line then
+                        // `[ -A|--autobackup y|n ]`, still the same
+                        // stanza. See S-088.
+                        i += 1;
+                        continue;
+                    }
+                }
+            }
+            // Some tools write their unlabelled synopsis as one stanza
+            // per operation mode: a description line, an own-name
+            // head, continuation rows, with a blank line between
+            // stanzas. LVM's own emitter is the specimen; adduser and
+            // pydoc3 hit the identical shape with unrelated
+            // formatters, so the predicates below key on structure,
+            // never a tool's name. A blank line ended the usage block
+            // unconditionally before this fix, so only vgck's first
+            // stanza was ever read (`vgck --updatemetadata`, a flag,
+            // was absent; lvconvert hides 26 more stanzas this way).
+            //
+            // Deliberately not "any blank line continues the block"
+            // ([M-10]): it fires only for the unlabelled-synopsis
+            // entry point, and only when the next non-consumed line is
+            // itself unambiguous synopsis-head evidence. At most one
+            // line in between may be skipped, and only when it reads
+            // as a full sentence — the stanza's own description,
+            // consumed here so it lands in neither the synopsis nor
+            // the tool's description. See S-005.
+            if labelled_usage_start.is_none() {
+                if let Some(name) = tool_name {
+                    let mut j = i + 1;
+                    // Deliberately not `looks_like_unlabeled_synopsis_line`
+                    // here: that test alone would also admit corepack's
+                    // headingless invocation-table rows (`corepack
+                    // enable [--install-directory #0] ...`), demoting a
+                    // real subcommand into fabricated usage text. See
+                    // S-016.
+                    let is_head = |lines: &[&str], j: usize| {
+                        j < lines.len() && looks_like_stanza_continuation_head(lines, j, name)
+                    };
+                    if !is_head(&lines, j) {
+                        if let Some(next) = lines.get(j) {
+                            let t = next.trim_start();
+                            if !t.is_empty() && is_prose_sentence(t) {
+                                j += 1;
+                            }
+                        }
+                    }
+                    if is_head(&lines, j) {
+                        let trimmed = lines[j].trim().to_string();
+                        usage_lines.push(trimmed.clone());
+                        usage_entries.push(trimmed);
+                        line_entry_index.push(usage_entries.len() - 1);
+                        i = j + 1;
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
+        let trimmed_start = l.trim_start();
+        if labelled_usage_start.is_none() && paren_group_depth > 0 {
+            // Already inside an open parenthesized alternation group:
+            // every line up to the matching close is a member,
+            // regardless of shape. A member row routinely opens with
+            // `-` itself, which the flag-entry-ends-the-block check
+            // below would otherwise misread — depth, not content, is
+            // what says this line still belongs. See S-088.
+            paren_group_depth += paren_depth_delta(trimmed_start);
+            if paren_group_depth <= 0 {
+                paren_group_depth = 0;
+                just_closed_paren_group = true;
+            } else {
+                just_closed_paren_group = false;
+            }
+            let trimmed = l.trim().to_string();
+            usage_lines.push(trimmed.clone());
+            if let Some(last) = usage_entries.last_mut() {
+                last.push(' ');
+                last.push_str(&trimmed);
+            }
+            line_entry_index.push(usage_entries.len() - 1);
+            i += 1;
+            continue;
+        }
+        if labelled_usage_start.is_none()
+            && paren_group_depth == 0
+            && looks_like_paren_alternation_open(trimmed_start)
+        {
+            // Opens the group: hand off to the depth-tracking branch
+            // above for every later line, but this opening row itself
+            // still falls through to the ordinary flow just below,
+            // which already appends it correctly (it is more indented
+            // than the stanza head and, starting with `(` rather than
+            // `-`, trips none of the content checks that would end the
+            // block).
+            paren_group_depth = paren_depth_delta(trimmed_start);
+        }
+        just_closed_paren_group = false;
+        let is_marker =
+            starts_with_usage_prefix(trimmed_start) || starts_with_or_marker(trimmed_start);
+        let is_own_name = tool_name.is_some_and(|name| starts_with_tool_name(trimmed_start, name));
+        let starts_new_entry = is_marker || is_own_name;
+
+        // A line the one above it ended with a backslash is a
+        // continuation by the tool's own explicit statement, and no
+        // content test may overrule that. update-xmlcatalog's
+        // backslash-wrapped synopsis tail begins with `--id`, which
+        // the flag-start guard below would otherwise end the block
+        // on, dropping `--del`/`--root`/`--type`. See S-011.
+        let continues_previous_line = i > 0 && lines[i - 1].trim_end().ends_with('\\');
+        if !starts_new_entry && !continues_previous_line {
+            // A continuation line that itself reads as a flag entry
+            // ends the usage block, even indented with no blank
+            // separator: a usage continuation is an alternative
+            // invocation form and never begins with a dash. curl's 13
+            // flag rows sit one space under `Usage:` with no `Options:`
+            // heading, and all 13 used to land in `usage` with zero
+            // flags parsed. See S-074.
+            if looks_like_flag_start(trimmed_start) {
+                break;
+            }
+            // A section heading ends the usage block no matter how
+            // far it is indented. Binutils ar indents its whole body,
+            // including its heading, under the synopsis; indentation
+            // alone would join the heading and all eight command rows
+            // into one usage string and yield zero subcommands. See
+            // S-075.
+            if is_section_heading_line(trimmed_start) {
+                break;
+            }
+            // A decorative dash-bracketed divider (tree's own
+            // `------- Listing options -------`) is never a usage
+            // continuation either. See S-064.
+            if looks_like_dash_bracketed_heading(trimmed_start) {
+                break;
+            }
+            // A line more indented than the base is not always a
+            // continuation — only when it still reads as usage
+            // grammar. sg_emc_trespass follows its usage line with two
+            // ordinary sentences indented under it; the old rule
+            // joined them onto the synopsis, and `extract_positionals`
+            // mined their bare uppercase words as fabricated operands.
+            // Drops the one prose line rather than ending the block:
+            // mdadm interleaves a description under each of several
+            // alternative `mdadm --mode ...` forms, so breaking on the
+            // first would drop every later one. Guarded to lines
+            // strictly more indented than the base — du's own
+            // trailing sentence sits at the base indent and must keep
+            // taking the base-indent fallback below. See S-003.
+            if leading_whitespace(l) > base_indent && is_prose_sentence(trimmed_start) {
+                i += 1;
+                continue;
+            }
+            // Below the base indent (never above it: `leading_whitespace`
+            // is unsigned, so this also covers "equal to"), indentation
+            // alone can't distinguish a genuine continuation (lsof) from
+            // the block having ended (du) — fall back to content shape.
+            if leading_whitespace(l) <= base_indent && !looks_like_usage_fragment(trimmed_start) {
+                break;
+            }
+        }
+        let trimmed = l.trim().to_string();
+        usage_lines.push(trimmed.clone());
+        if starts_new_entry {
+            // A form keeps the indentation its author gave it (spec
+            // §4.1): ip lines its second form up under the first. Only
+            // the display form carries it; `usage_lines` stays trimmed
+            // since it reads tokens, never columns.
+            usage_entries.push(l.trim_end().to_string());
+        } else if let Some(last) = usage_entries.last_mut() {
+            // The backslash is the join, the same way a single space
+            // is elsewhere: without dropping it, the displayed
+            // synopsis reads `--type <type> \ --id <id>`, a
+            // continuation marker stranded mid-line.
+            if last.ends_with('\\') {
+                last.pop();
+                let trimmed_tail = last.trim_end().len();
+                last.truncate(trimmed_tail);
+            }
+            last.push(' ');
+            last.push_str(&trimmed);
+        }
+        line_entry_index.push(usage_entries.len() - 1);
+        i += 1;
+    }
+    // Scoped to a labelled block, never an unlabelled synopsis
+    // (`dbus-cleanup-sockets`, `lvreduce`): the existence oracle's own
+    // synopsis scanner has no unlabelled-synopsis support yet, so any
+    // operand recovered from one reports as invented today. See
+    // S-001.
+    let primary_lines = if labelled_usage_start.is_some() {
+        primary_synopsis_lines(&usage_entries, &line_entry_index, usage_lines.len())
+    } else {
+        std::collections::HashSet::new()
+    };
+    UsageScan {
+        next_index: i,
+        positionals: extract_positionals(usage_lines, primary_lines),
+        entries: usage_entries,
+    }
+}
+
 /// [`parse_with_profile`]'s engine, over text whose shared heading rows
 /// have already been split out. `bnf_row_lines` records which row lines
 /// came from a `:=` BNF production rather than an ordinary column-gap
@@ -383,245 +642,16 @@ fn parse_body(
     };
     let usage_start = labelled_usage_start.or(unlabelled_synopsis_start);
     if let Some(start) = usage_start {
-        i = start;
-        let base_indent = leading_whitespace(lines[i]);
-        usage_lines.push(lines[i].trim().to_string());
-        let mut usage_entries = vec![lines[i].trim().to_string()];
-        // Parallel to `usage_lines`: which `usage_entries` index each
-        // physical line was folded into — a wrapped entry (sg_sanitize's
-        // five-line synopsis) spans several lines but is one entry, and
-        // [`primary_synopsis_lines`] needs every one of them.
-        let mut line_entry_index = vec![0usize];
-        // Running depth of an open parenthesized alternation group (LVM's
-        // "any one is required" convention), tracked only for an
-        // unlabelled synopsis: a member row routinely opens with `-`
-        // itself, which the "a continuation line that reads as a flag
-        // entry ends the block" check just below would otherwise
-        // misread as ending the block. See S-088.
-        let mut paren_group_depth: i32 = 0;
-        // True for exactly the one loop iteration right after
-        // `paren_group_depth` returns to zero — tells "a blank line right
-        // after the group's own closing `)`" (still the same stanza's
-        // trailing bracket-row flags) apart from an ordinary between-
-        // stanza blank line. Reset unconditionally elsewhere.
-        let mut just_closed_paren_group = false;
-        i += 1;
-        while i < lines.len() {
-            let l = lines[i];
-            if l.trim().is_empty() {
-                if paren_group_depth > 0 {
-                    // A blank line inside an unclosed group is not a shape
-                    // any real specimen produces; refuse to guess at what it
-                    // means rather than fabricate a continuation across it.
-                    paren_group_depth = 0;
-                    just_closed_paren_group = false;
-                }
-                if just_closed_paren_group {
-                    just_closed_paren_group = false;
-                    if let Some(next) = lines.get(i + 1) {
-                        let t = next.trim_start();
-                        if !t.is_empty() && looks_like_bracket_flag_row(t) {
-                            // The group's trailing bracket-row flags
-                            // continue after exactly one blank line —
-                            // vgchange's `( ... )` then a blank line then
-                            // `[ -A|--autobackup y|n ]`, still the same
-                            // stanza. See S-088.
-                            i += 1;
-                            continue;
-                        }
-                    }
-                }
-                // Some tools write their unlabelled synopsis as one stanza
-                // per operation mode: a description line, an own-name
-                // head, continuation rows, with a blank line between
-                // stanzas. LVM's own emitter is the specimen; adduser and
-                // pydoc3 hit the identical shape with unrelated
-                // formatters, so the predicates below key on structure,
-                // never a tool's name. A blank line ended the usage block
-                // unconditionally before this fix, so only vgck's first
-                // stanza was ever read (`vgck --updatemetadata`, a flag,
-                // was absent; lvconvert hides 26 more stanzas this way).
-                //
-                // Deliberately not "any blank line continues the block"
-                // ([M-10]): it fires only for the unlabelled-synopsis
-                // entry point, and only when the next non-consumed line is
-                // itself unambiguous synopsis-head evidence. At most one
-                // line in between may be skipped, and only when it reads
-                // as a full sentence — the stanza's own description,
-                // consumed here so it lands in neither the synopsis nor
-                // the tool's description. See S-005.
-                if labelled_usage_start.is_none() {
-                    if let Some(name) = tool_name {
-                        let mut j = i + 1;
-                        // Deliberately not `looks_like_unlabeled_synopsis_line`
-                        // here: that test alone would also admit corepack's
-                        // headingless invocation-table rows (`corepack
-                        // enable [--install-directory #0] ...`), demoting a
-                        // real subcommand into fabricated usage text. See
-                        // S-016.
-                        let is_head = |lines: &[&str], j: usize| {
-                            j < lines.len() && looks_like_stanza_continuation_head(lines, j, name)
-                        };
-                        if !is_head(&lines, j) {
-                            if let Some(next) = lines.get(j) {
-                                let t = next.trim_start();
-                                if !t.is_empty() && is_prose_sentence(t) {
-                                    j += 1;
-                                }
-                            }
-                        }
-                        if is_head(&lines, j) {
-                            let trimmed = lines[j].trim().to_string();
-                            usage_lines.push(trimmed.clone());
-                            usage_entries.push(trimmed);
-                            line_entry_index.push(usage_entries.len() - 1);
-                            i = j + 1;
-                            continue;
-                        }
-                    }
-                }
-                break;
-            }
-            let trimmed_start = l.trim_start();
-            if labelled_usage_start.is_none() && paren_group_depth > 0 {
-                // Already inside an open parenthesized alternation group:
-                // every line up to the matching close is a member,
-                // regardless of shape. A member row routinely opens with
-                // `-` itself, which the flag-entry-ends-the-block check
-                // below would otherwise misread — depth, not content, is
-                // what says this line still belongs. See S-088.
-                paren_group_depth += paren_depth_delta(trimmed_start);
-                if paren_group_depth <= 0 {
-                    paren_group_depth = 0;
-                    just_closed_paren_group = true;
-                } else {
-                    just_closed_paren_group = false;
-                }
-                let trimmed = l.trim().to_string();
-                usage_lines.push(trimmed.clone());
-                if let Some(last) = usage_entries.last_mut() {
-                    last.push(' ');
-                    last.push_str(&trimmed);
-                }
-                line_entry_index.push(usage_entries.len() - 1);
-                i += 1;
-                continue;
-            }
-            if labelled_usage_start.is_none()
-                && paren_group_depth == 0
-                && looks_like_paren_alternation_open(trimmed_start)
-            {
-                // Opens the group: hand off to the depth-tracking branch
-                // above for every later line, but this opening row itself
-                // still falls through to the ordinary flow just below,
-                // which already appends it correctly (it is more indented
-                // than the stanza head and, starting with `(` rather than
-                // `-`, trips none of the content checks that would end the
-                // block).
-                paren_group_depth = paren_depth_delta(trimmed_start);
-            }
-            just_closed_paren_group = false;
-            let is_marker =
-                starts_with_usage_prefix(trimmed_start) || starts_with_or_marker(trimmed_start);
-            let is_own_name =
-                tool_name.is_some_and(|name| starts_with_tool_name(trimmed_start, name));
-            let starts_new_entry = is_marker || is_own_name;
-
-            // A line the one above it ended with a backslash is a
-            // continuation by the tool's own explicit statement, and no
-            // content test may overrule that. update-xmlcatalog's
-            // backslash-wrapped synopsis tail begins with `--id`, which
-            // the flag-start guard below would otherwise end the block
-            // on, dropping `--del`/`--root`/`--type`. See S-011.
-            let continues_previous_line = i > 0 && lines[i - 1].trim_end().ends_with('\\');
-            if !starts_new_entry && !continues_previous_line {
-                // A continuation line that itself reads as a flag entry
-                // ends the usage block, even indented with no blank
-                // separator: a usage continuation is an alternative
-                // invocation form and never begins with a dash. curl's 13
-                // flag rows sit one space under `Usage:` with no `Options:`
-                // heading, and all 13 used to land in `usage` with zero
-                // flags parsed. See S-074.
-                if looks_like_flag_start(trimmed_start) {
-                    break;
-                }
-                // A section heading ends the usage block no matter how
-                // far it is indented. Binutils ar indents its whole body,
-                // including its heading, under the synopsis; indentation
-                // alone would join the heading and all eight command rows
-                // into one usage string and yield zero subcommands. See
-                // S-075.
-                if is_section_heading_line(trimmed_start) {
-                    break;
-                }
-                // A decorative dash-bracketed divider (tree's own
-                // `------- Listing options -------`) is never a usage
-                // continuation either. See S-064.
-                if looks_like_dash_bracketed_heading(trimmed_start) {
-                    break;
-                }
-                // A line more indented than the base is not always a
-                // continuation — only when it still reads as usage
-                // grammar. sg_emc_trespass follows its usage line with two
-                // ordinary sentences indented under it; the old rule
-                // joined them onto the synopsis, and `extract_positionals`
-                // mined their bare uppercase words as fabricated operands.
-                // Drops the one prose line rather than ending the block:
-                // mdadm interleaves a description under each of several
-                // alternative `mdadm --mode ...` forms, so breaking on the
-                // first would drop every later one. Guarded to lines
-                // strictly more indented than the base — du's own
-                // trailing sentence sits at the base indent and must keep
-                // taking the base-indent fallback below. See S-003.
-                if leading_whitespace(l) > base_indent && is_prose_sentence(trimmed_start) {
-                    i += 1;
-                    continue;
-                }
-                // Below the base indent (never above it: `leading_whitespace`
-                // is unsigned, so this also covers "equal to"), indentation
-                // alone can't distinguish a genuine continuation (lsof) from
-                // the block having ended (du) — fall back to content shape.
-                if leading_whitespace(l) <= base_indent && !looks_like_usage_fragment(trimmed_start)
-                {
-                    break;
-                }
-            }
-            let trimmed = l.trim().to_string();
-            usage_lines.push(trimmed.clone());
-            if starts_new_entry {
-                // A form keeps the indentation its author gave it (spec
-                // §4.1): ip lines its second form up under the first. Only
-                // the display form carries it; `usage_lines` stays trimmed
-                // since it reads tokens, never columns.
-                usage_entries.push(l.trim_end().to_string());
-            } else if let Some(last) = usage_entries.last_mut() {
-                // The backslash is the join, the same way a single space
-                // is elsewhere: without dropping it, the displayed
-                // synopsis reads `--type <type> \ --id <id>`, a
-                // continuation marker stranded mid-line.
-                if last.ends_with('\\') {
-                    last.pop();
-                    let trimmed_tail = last.trim_end().len();
-                    last.truncate(trimmed_tail);
-                }
-                last.push(' ');
-                last.push_str(&trimmed);
-            }
-            line_entry_index.push(usage_entries.len() - 1);
-            i += 1;
-        }
-        // Scoped to a labelled block, never an unlabelled synopsis
-        // (`dbus-cleanup-sockets`, `lvreduce`): the existence oracle's own
-        // synopsis scanner has no unlabelled-synopsis support yet, so any
-        // operand recovered from one reports as invented today. See
-        // S-001.
-        let primary_lines = if labelled_usage_start.is_some() {
-            primary_synopsis_lines(&usage_entries, &line_entry_index, usage_lines.len())
-        } else {
-            std::collections::HashSet::new()
-        };
-        result.positionals = extract_positionals(&usage_lines, primary_lines);
-        result.usage = usage_entries;
+        let scan = scan_usage_section(
+            &lines,
+            start,
+            labelled_usage_start,
+            tool_name,
+            &mut usage_lines,
+        );
+        i = scan.next_index;
+        result.positionals = scan.positionals;
+        result.usage = scan.entries;
     }
 
     // 2. Leading prose before the usage block (or before the first

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -642,6 +642,144 @@ fn extract_description(
 /// The mutable state the body scan threads through every branch.
 /// Bundled so a branch can be lifted into its own function without a
 /// ten-argument signature.
+/// One candidate heading line and where it sits.
+struct Heading<'a> {
+    line: &'a str,
+    heading: String,
+    heading_indent: usize,
+    heading_idx: usize,
+}
+
+/// A heading whose next non-blank line is not indented past it. The
+/// block is still emitted when the shape is unambiguous on its own,
+/// otherwise scanning rewinds past the heading. See docs/shapes.md S-016.
+fn emit_flush_heading(
+    lines: &[&str],
+    profile: Option<&FrameworkProfile>,
+    h: &Heading,
+    mut i: usize,
+    st: &mut BodyScan,
+) -> usize {
+    let line = h.line;
+    let heading = &h.heading;
+    let heading_indent = h.heading_indent;
+    let heading_idx = h.heading_idx;
+    // An environment section flush with its own heading — no
+    // indent step between "Environment variables:" and its first
+    // row. node's real `--help` writes exactly this shape (both
+    // at column 0). Gated on the row sitting at exactly
+    // `heading_indent`, the same bar the same-indent command
+    // table below requires. See S-023.
+    if i < lines.len()
+        && leading_whitespace(lines[i]) == heading_indent
+        && is_environment_heading(&heading)
+        && !is_ignorable_heading(&heading)
+    {
+        if let Some((end, rows)) = scan_env_var_table(&lines, i) {
+            i = end;
+            st.in_ignorable_section = false;
+            st.command_mode = false;
+            let (seen, clean) =
+                emit_env_vars(meaningful_flag_group(heading.clone()), rows, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+            return i;
+        }
+    }
+    // Nothing more-indented follows. openssl and BSD-style
+    // listings generally present a command list as a same-indent
+    // word grid: a heading followed by lines of several bare
+    // identifier-shaped tokens, no descriptions. Starting a grid
+    // requires >=3 name-shaped tokens on the trigger line (not
+    // the >=2 for continuation rows), so a genuine two-word
+    // heading (openssl's "Standard commands") is never itself
+    // swallowed as the first grid row — it rewinds and is
+    // re-examined as its own heading. See S-065.
+    if i < lines.len()
+        && leading_whitespace(lines[i]) == heading_indent
+        && looks_like_word_grid_start(lines[i])
+    {
+        let grid_start = i;
+        while i < lines.len() {
+            if lines[i].trim().is_empty() {
+                break;
+            }
+            if leading_whitespace(lines[i]) != heading_indent
+                || !looks_like_word_grid_line(lines[i])
+            {
+                break;
+            }
+            i += 1;
+        }
+        if !is_ignorable_heading(&heading) {
+            st.in_ignorable_section = false;
+            let recognized = is_recognized_command_heading(&heading, profile);
+            if recognized {
+                st.command_mode = true;
+            }
+            let (seen, clean) = process_word_grid(
+                &heading,
+                &lines[grid_start..i],
+                recognized || st.command_mode,
+                st.result,
+            );
+            st.total_entries += seen;
+            st.clean_entries += clean;
+        }
+        return i;
+    }
+    // A command table that sits at the same indent as its own
+    // heading rather than beneath it. dnf's flush command list is
+    // the specimen; the engine's "content indented more than its
+    // heading" rule cannot see it at all.
+    //
+    // Guarded much harder than the indented case, since this is
+    // the shape [M-10] came in through: apt-get's own prose
+    // paragraph fabricated the subcommands "and", "information",
+    // "about", "them". The heading must be a recognized command
+    // heading (never merely a line ending in a colon), every row
+    // must be column-aligned, and there must be at least two such
+    // rows. Prose is single-spaced, so it fails the second
+    // test on its first line. The heading must also not itself
+    // look like one of the rows: at a shared indent there is no
+    // structural difference otherwise, and mysqlslap's own
+    // `init-command    (No default value)` row was taken as a
+    // heading, fabricating 28 subcommands out of MySQL settings. A
+    // real heading is a single field; a row is two columns. See
+    // S-092.
+    let heading_is_itself_a_row = find_description_gap(lines[heading_idx]).is_some();
+
+    if i < lines.len()
+        && leading_whitespace(lines[i]) == heading_indent
+        && !heading_is_itself_a_row
+        && !is_ignorable_heading(&heading)
+        && is_recognized_command_heading(&heading, profile)
+    {
+        if let Some((end, entries)) = scan_same_indent_entry_table(&lines, i, heading_indent) {
+            i = end;
+            st.command_mode = true;
+            st.in_ignorable_section = false;
+            let (seen, clean) = emit_subcommands(&heading, entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+            return i;
+        }
+    }
+
+    // Not actually a heading — but if it reads like an
+    // introduction to a command list (git's own leading blurb,
+    // whose group headings say nothing about "commands"
+    // themselves), remember that. See S-070.
+    if command_mode_seed(&heading, profile) {
+        st.command_mode = true;
+    }
+    // Rewind to just past the original line and continue scanning
+    // it as its own candidate.
+    i = heading_idx + 1;
+    return i;
+    i
+}
+
 struct BodyScan<'a> {
     result: &'a mut ParsedHelp,
     command_mode: bool,
@@ -819,120 +957,13 @@ fn scan_entries(
             i += 1;
         }
         if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
-            // An environment section flush with its own heading — no
-            // indent step between "Environment variables:" and its first
-            // row. node's real `--help` writes exactly this shape (both
-            // at column 0). Gated on the row sitting at exactly
-            // `heading_indent`, the same bar the same-indent command
-            // table below requires. See S-023.
-            if i < lines.len()
-                && leading_whitespace(lines[i]) == heading_indent
-                && is_environment_heading(&heading)
-                && !is_ignorable_heading(&heading)
-            {
-                if let Some((end, rows)) = scan_env_var_table(&lines, i) {
-                    i = end;
-                    st.in_ignorable_section = false;
-                    st.command_mode = false;
-                    let (seen, clean) =
-                        emit_env_vars(meaningful_flag_group(heading.clone()), rows, st.result);
-                    st.total_entries += seen;
-                    st.clean_entries += clean;
-                    continue;
-                }
-            }
-            // Nothing more-indented follows. openssl and BSD-style
-            // listings generally present a command list as a same-indent
-            // word grid: a heading followed by lines of several bare
-            // identifier-shaped tokens, no descriptions. Starting a grid
-            // requires >=3 name-shaped tokens on the trigger line (not
-            // the >=2 for continuation rows), so a genuine two-word
-            // heading (openssl's "Standard commands") is never itself
-            // swallowed as the first grid row — it rewinds and is
-            // re-examined as its own heading. See S-065.
-            if i < lines.len()
-                && leading_whitespace(lines[i]) == heading_indent
-                && looks_like_word_grid_start(lines[i])
-            {
-                let grid_start = i;
-                while i < lines.len() {
-                    if lines[i].trim().is_empty() {
-                        break;
-                    }
-                    if leading_whitespace(lines[i]) != heading_indent
-                        || !looks_like_word_grid_line(lines[i])
-                    {
-                        break;
-                    }
-                    i += 1;
-                }
-                if !is_ignorable_heading(&heading) {
-                    st.in_ignorable_section = false;
-                    let recognized = is_recognized_command_heading(&heading, profile);
-                    if recognized {
-                        st.command_mode = true;
-                    }
-                    let (seen, clean) = process_word_grid(
-                        &heading,
-                        &lines[grid_start..i],
-                        recognized || st.command_mode,
-                        st.result,
-                    );
-                    st.total_entries += seen;
-                    st.clean_entries += clean;
-                }
-                continue;
-            }
-            // A command table that sits at the same indent as its own
-            // heading rather than beneath it. dnf's flush command list is
-            // the specimen; the engine's "content indented more than its
-            // heading" rule cannot see it at all.
-            //
-            // Guarded much harder than the indented case, since this is
-            // the shape [M-10] came in through: apt-get's own prose
-            // paragraph fabricated the subcommands "and", "information",
-            // "about", "them". The heading must be a recognized command
-            // heading (never merely a line ending in a colon), every row
-            // must be column-aligned, and there must be at least two such
-            // rows. Prose is single-spaced, so it fails the second
-            // test on its first line. The heading must also not itself
-            // look like one of the rows: at a shared indent there is no
-            // structural difference otherwise, and mysqlslap's own
-            // `init-command    (No default value)` row was taken as a
-            // heading, fabricating 28 subcommands out of MySQL settings. A
-            // real heading is a single field; a row is two columns. See
-            // S-092.
-            let heading_is_itself_a_row = find_description_gap(lines[heading_idx]).is_some();
-
-            if i < lines.len()
-                && leading_whitespace(lines[i]) == heading_indent
-                && !heading_is_itself_a_row
-                && !is_ignorable_heading(&heading)
-                && is_recognized_command_heading(&heading, profile)
-            {
-                if let Some((end, entries)) =
-                    scan_same_indent_entry_table(&lines, i, heading_indent)
-                {
-                    i = end;
-                    st.command_mode = true;
-                    st.in_ignorable_section = false;
-                    let (seen, clean) = emit_subcommands(&heading, entries, st.result);
-                    st.total_entries += seen;
-                    st.clean_entries += clean;
-                    continue;
-                }
-            }
-
-            // Not actually a heading — but if it reads like an
-            // introduction to a command list (git's own leading blurb,
-            // whose group headings say nothing about "commands"
-            // themselves), remember that. See S-070.
-            if command_mode_seed(&heading, profile) {
-                st.command_mode = true;
-            }
-            // Rewind to just past the original line and continue scanning
-            // it as its own candidate.
-            i = heading_idx + 1;
+            let h = Heading {
+                line,
+                heading,
+                heading_indent,
+                heading_idx,
+            };
+            i = emit_flush_heading(lines, profile, &h, i, &mut st);
             continue;
         }
 

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -391,7 +391,7 @@ fn scan_usage_section(
                     let is_head = |lines: &[&str], j: usize| {
                         j < lines.len() && looks_like_stanza_continuation_head(lines, j, name)
                     };
-                    if !is_head(&lines, j) {
+                    if !is_head(lines, j) {
                         if let Some(next) = lines.get(j) {
                             let t = next.trim_start();
                             if !t.is_empty() && is_prose_sentence(t) {
@@ -399,7 +399,7 @@ fn scan_usage_section(
                             }
                         }
                     }
-                    if is_head(&lines, j) {
+                    if is_head(lines, j) {
                         let trimmed = lines[j].trim().to_string();
                         usage_lines.push(trimmed.clone());
                         usage_entries.push(trimmed);
@@ -642,6 +642,386 @@ fn extract_description(
 /// The mutable state the body scan threads through every branch.
 /// Bundled so a branch can be lifted into its own function without a
 /// ten-argument signature.
+/// The command-table tail: a recognized heading, a sticky chain, or the
+/// bare-word fallback, whichever the block turns out to be.
+/// See docs/shapes.md S-017 and S-053.
+fn emit_command_table(inp: &BodyInput, h: &Heading, mut i: usize, st: &mut BodyScan) -> usize {
+    let raw = inp.raw;
+    let lines = inp.lines;
+    let profile = inp.profile;
+    let heading = &h.heading;
+    let heading_indent = h.heading_indent;
+    // A framework-declared non-command heading both refuses this
+    // block and breaks the engine's sticky same-indent chain, so
+    // nothing after it inherits a `st.command_mode` this heading
+    // positively contradicts.
+    let is_declared_non_command = profile.is_some_and(|p| {
+        heading_matches_markers(&heading.to_lowercase(), p.non_command_heading_markers)
+    });
+    let recognized = is_recognized_command_heading(heading, profile);
+    // Issue #3: ` - ` is accepted as an entry separator alongside the
+    // usual column gap, but only when this block is already headed
+    // for `emit_subcommands`. Scoping the decision to before the scan
+    // is what keeps a bare ` - ` in ordinary prose from manufacturing
+    // commands, the same failure class as apt-get's own description
+    // paragraph, just via the column-gap rule instead.
+    let allow_dash_separator = (recognized || st.command_mode) && !is_declared_non_command;
+
+    // A headed command table whose rows use ` = ` as a separator, or
+    // no separator at all — wpa_cli's `=`-separated rows,
+    // fail2ban-client's wrapped continuations. See S-019.
+    //
+    // Gated on `recognized` alone, deliberately narrower than
+    // `allow_dash_separator`, which also accepts a `st.command_mode`
+    // chain: fail2ban-client's `Command:` block nests rows whose
+    // descriptions wrap across further lines, and the engine's own
+    // pseudo-heading rewind re-examines each such row once
+    // `st.command_mode` is stuck on, satisfying every safeguard with
+    // ordinary English words. `recognized` — true only when this
+    // exact heading's own text names a command — is false for every
+    // such pseudo-heading, so requiring it directly closes this off.
+    if recognized && !is_declared_non_command {
+        if let Some((end, entries)) = scan_bare_command_table(lines, i) {
+            i = end;
+            st.command_mode = true;
+            st.in_ignorable_section = false;
+            let raw_tokens = command_table_token_index(raw);
+            let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+            return i;
+        }
+    }
+
+    // Busybox's applet list is a single flat, comma-separated run
+    // under one heading, structurally distinct from every other
+    // framework's per-line bare-word block, so it gets first refusal
+    // here. Gated on the profile flag and this heading already being
+    // recognized or continuing a `st.command_mode` chain. See S-093.
+    if profile.is_some_and(|p| p.comma_separated_command_list)
+        && (recognized || st.command_mode)
+        && !is_declared_non_command
+    {
+        let (end, entries) = scan_comma_separated_commands(lines, i);
+        i = end;
+        st.command_mode = true;
+        st.in_ignorable_section = false;
+        let (seen, clean) = emit_subcommands(heading, entries, st.result);
+        st.total_entries += seen;
+        st.clean_entries += clean;
+        return i;
+    }
+
+    let (end, entries) = scan_bare_block(lines, i, heading_indent, allow_dash_separator);
+    i = end;
+    if is_ignorable_heading(heading) {
+        return i;
+    }
+
+    if is_declared_non_command {
+        st.command_mode = false;
+        let (seen, clean) = emit_choices(heading, entries, st.result);
+        st.total_entries += seen;
+        st.clean_entries += clean;
+        return i;
+    }
+
+    if recognized || st.command_mode {
+        st.command_mode = true;
+        // Only `recognized` (this exact heading's own text says
+        // "commands") is strong enough to clear the flag here — the
+        // `st.command_mode` sticky-chain half of this condition is not:
+        // it can still be true from an *inherited* chain rather than
+        // this heading's own evidence, which is exactly the kind of
+        // indirect signal `st.in_ignorable_section` must not trust (see
+        // its own doc comment on why the generic bare-block fallback
+        // is deliberately excluded from clearing it).
+        if recognized {
+            st.in_ignorable_section = false;
+        }
+        let (seen, clean) = emit_subcommands(heading, entries, st.result);
+        st.total_entries += seen;
+        st.clean_entries += clean;
+    } else {
+        st.command_mode = false;
+        let (seen, clean) = emit_choices(heading, entries, st.result);
+        st.total_entries += seen;
+        st.clean_entries += clean;
+    }
+    i
+}
+
+/// The read-only inputs every body-scan branch needs.
+struct BodyInput<'a> {
+    raw: &'a str,
+    lines: &'a [&'a str],
+    usage_lines: &'a [String],
+    profile: Option<&'a FrameworkProfile>,
+    bnf_row_lines: &'a std::collections::HashSet<usize>,
+}
+
+/// A heading with content indented beneath it. Each recognized section
+/// shape gets first refusal in turn, and the bare-word block is the
+/// fallback. See docs/shapes.md S-013, S-019 and S-020.
+fn emit_heading_block(
+    inp: &BodyInput,
+    tool_name: Option<&str>,
+    h: &Heading,
+    mut i: usize,
+    st: &mut BodyScan,
+) -> usize {
+    let raw = inp.raw;
+    let lines = inp.lines;
+    let usage_lines = inp.usage_lines;
+    let profile = inp.profile;
+    let bnf_row_lines = inp.bnf_row_lines;
+    let line = h.line;
+    let heading = &h.heading;
+    let heading_indent = h.heading_indent;
+    let heading_idx = h.heading_idx;
+
+    // Reaching here means genuinely more-indented content follows this
+    // heading — LVM's own stanza shape, a head line naming a
+    // mode-selecting flag followed by that mode's rows. Recovering
+    // the flag is independent of what the content turns out to be, so
+    // this runs once per heading rather than folded into any later
+    // branch.
+    //
+    // Gated on `!st.in_ignorable_section`: bpftrace's own `EXAMPLES:`
+    // block writes each example in the identical shape to a real
+    // stanza head, and without this guard it fabricated `-e`/`-l`
+    // rows that displaced the real, described ones. See S-071.
+    //
+    // A stanza with its own description sentence above its head line
+    // labels its group with that sentence instead ([`stanza_description_above`]).
+    // The head line is not lost: it becomes a usage form
+    // (`st.result.usage`, spec §4.5). Pushed here because this is the
+    // one place that knows the head line is about to stop being the
+    // group label; `extract_positionals` has already run, so nothing
+    // is mined out of the added line. See S-012.
+    //
+    // Capped, not deduplicated: `i` only ever advances, so no
+    // physical line becomes `heading` twice; two identical entries
+    // mean the tool printed the stanza twice. A scan of `usage` per
+    // heading would be the quadratic shape `MAX_RECOVERED_ENTRIES`
+    // exists for (instmodsh's repeated banner, S-072).
+    let stanza_label = if st.in_ignorable_section {
+        None
+    } else {
+        stanza_description_above(lines, heading_idx, tool_name).map(str::to_string)
+    };
+    if stanza_label.is_some() && st.result.usage.len() < MAX_RECOVERED_ENTRIES {
+        st.result.usage.push(heading.clone());
+    }
+    if !st.in_ignorable_section {
+        if let Some(mut flag) = recover_stanza_head_flag(heading, tool_name) {
+            if let Some(label) = stanza_label.clone() {
+                flag.group = Some(label);
+            }
+            if st.result.flags.len() < MAX_RECOVERED_ENTRIES {
+                st.result.flags.push(flag);
+            }
+        }
+    }
+
+    // A headed command table whose first row sits on the heading's
+    // own physical line (apt-ftparchive's `Commands: packages
+    // binarypath [overridefile [pathprefix]]`), with remaining rows
+    // column-aligned beneath it. Without this it vanishes whole into
+    // the `heading` string and never reaches any scanner as data. See
+    // S-018.
+    //
+    // Gated on `is_recognized_command_heading(label, ...)` for this
+    // heading directly, never a `st.command_mode` chain, since a sticky
+    // chain can reach an unrelated wrapped-prose block.
+    if let Some((label, inline_row)) = split_heading_inline_row(line.trim()) {
+        if !is_ignorable_heading(heading)
+            && is_recognized_command_heading(label, profile)
+            && !profile.is_some_and(|p| {
+                heading_matches_markers(&label.to_lowercase(), p.non_command_heading_markers)
+            })
+        {
+            if let Some(first_name) = leading_command_name(inline_row) {
+                if let Some((end, mut entries)) = scan_bare_command_table(lines, i) {
+                    entries.insert(0, (first_name, None));
+                    i = end;
+                    st.command_mode = true;
+                    st.in_ignorable_section = false;
+                    let raw_tokens = command_table_token_index(raw);
+                    let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, st.result);
+                    st.total_entries += seen;
+                    st.clean_entries += clean;
+                    return i;
+                }
+            }
+        }
+    }
+
+    // A modifier table (ar's ` command specific modifiers:`/
+    // ` generic modifiers:`, llvm-ar's `MODIFIERS:`) gets first
+    // refusal here: a `[a]` row is not `looks_like_flag_start`, and
+    // under a heading containing "command" it went to
+    // `emit_subcommands`, where every row failed the name-shape test.
+    // See S-020.
+    //
+    // Falls through rather than `continue`ing when the block still
+    // has content past the run: ar's ` generic modifiers:` is seven
+    // bracket rows, then `@<file>`, then four real flags that must
+    // keep the group they already carry.
+    if let Some((end, rows)) = scan_modifier_table(lines, i) {
+        i = end;
+        if !is_ignorable_heading(heading) {
+            // Positively-recognized structure clears the examples flag
+            // and contradicts a command-mode sticky chain (ar's own
+            // heading contains "command").
+            st.in_ignorable_section = false;
+            st.command_mode = false;
+            let (seen, clean) =
+                emit_modifiers(meaningful_flag_group(heading.clone()), rows, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+        }
+        if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
+            return i;
+        }
+    }
+
+    // The argfile sigil row (spec §4.5) sometimes sits directly where
+    // a modifier table's rows just ended — ar's `@<file>` row after
+    // its modifier table — and `flags_block_start` below never sees
+    // it there. Captured here instead, mirroring the modifier
+    // branch's "falls through" shape. See S-021.
+    if !is_ignorable_heading(heading) && i < lines.len() {
+        if let Some(value_name) = argfile_row_value_name(lines[i].trim_start()) {
+            let entry = argfile_flag_entry(lines[i], value_name);
+            emit_argfile_flag(meaningful_flag_group(heading.clone()), entry, st.result);
+            st.total_entries += 1;
+            st.clean_entries += 1;
+            i += 1;
+            if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
+                return i;
+            }
+        }
+    }
+
+    // An environment section (bpftrace's `ENVIRONMENT:`, node's
+    // `Environment variables:`, mksquashfs's `Environment:`) — spec
+    // §4.5's "strict-sections-only" rule made structural: unlike the
+    // modifier table above, gated on the heading itself first, never
+    // row shape alone, since a bare identifier plus a column gap is
+    // indistinguishable from mysqlslap's own flush-left settings
+    // table otherwise. See S-023.
+    //
+    // Falls through rather than `continue`ing, mirroring the modifier
+    // branch, so a block running on past its rows into ordinary flags
+    // does not lose those flags' group.
+    if is_environment_heading(heading) && !is_ignorable_heading(heading) {
+        if let Some((end, rows)) = scan_env_var_table(lines, i) {
+            i = end;
+            st.in_ignorable_section = false;
+            st.command_mode = false;
+            let (seen, clean) =
+                emit_env_vars(meaningful_flag_group(heading.clone()), rows, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+            if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
+                return i;
+            }
+        }
+    }
+
+    // Peek the first content lines to decide flags vs. bare-word. Not
+    // just the *first*: some tools document a positional at the top of
+    // their options table, and keying the whole decision off row one
+    // threw the rest of the block away. See `flags_block_start`.
+    if let Some(flags_start) = flags_block_start(lines, i) {
+        // `flags_start` — never `heading_idx` — is the evidence: see
+        // `split_shared_heading_rows`'s doc comment for why the BNF
+        // fact is keyed on the row rather than the heading beside it.
+        let heading_is_bnf = bnf_row_lines.contains(&flags_start);
+        let (end, entries, packed, argfile_entry) =
+            scan_flags_block(lines, flags_start, heading_is_bnf);
+        i = end;
+        if is_ignorable_heading(heading) {
+            st.command_mode = false;
+            return i;
+        }
+        // A real, non-ignorable flags block — structurally strong
+        // evidence we are not (or no longer) inside an examples-shaped
+        // section. See `st.in_ignorable_section`'s own doc comment.
+        st.in_ignorable_section = false;
+        // A stanza's own description sentence outranks its head line
+        // as the group's label, and only there — every other block
+        // still takes `meaningful_flag_group`'s answer unchanged. See
+        // S-012.
+        let group = stanza_label
+            .clone()
+            .or_else(|| meaningful_flag_group(heading.clone()));
+        if packed {
+            let seen = entries.len();
+            emit_packed_flags(
+                group.clone(),
+                entries.into_iter().map(|(s, d, _)| (s, d)).collect(),
+                st.result,
+            );
+            st.total_entries += seen;
+            st.clean_entries += seen;
+        } else {
+            let (seen, clean) = emit_flags(group.clone(), entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+        }
+        if let Some(entry) = argfile_entry {
+            st.total_entries += 1;
+            st.clean_entries += 1;
+            emit_argfile_flag(group, entry, st.result);
+        }
+        st.command_mode = false;
+        return i;
+    }
+
+    // Argparse's subparser blocks get first refusal here, gated on
+    // the profile explicitly opting in. Deliberately not also gated
+    // on the heading reading "positional arguments": it was, and that
+    // made `add_subparsers(title=...)`'s ordinary heading style
+    // collapse the entire command tree — smokecli's fixture rendered
+    // one node. The structural evidence the scan demands (a `{...}`
+    // pseudo-entry with deeper lines beneath it) is strictly stronger
+    // than the heading text was; a plain positional's `{...}` metavar
+    // has nothing beneath it and is still never promoted. See S-073.
+    if profile.is_some_and(|p| p.argparse_subparser_quirk) {
+        if let Some((end, entries)) = scan_argparse_subparsers(lines, i, heading_indent) {
+            i = end;
+            st.command_mode = false;
+            st.in_ignorable_section = false;
+            let (seen, clean) = emit_subcommands(heading, entries, st.result);
+            st.total_entries += seen;
+            st.clean_entries += clean;
+            return i;
+        }
+    }
+
+    // A framework-declared positional-operand heading. Sits directly
+    // below the subparser scan since for argparse the two read the
+    // same heading, and the subparser scan's `{...}`-with-entries
+    // evidence is stronger than heading text alone. Also breaks the
+    // sticky `st.command_mode` chain. See S-078.
+    if profile.is_some_and(|p| {
+        heading_matches_markers(&heading.to_lowercase(), p.positional_heading_markers)
+    }) {
+        let (end, entries) = scan_bare_block(lines, i, heading_indent, false);
+        i = end;
+        st.command_mode = false;
+        st.in_ignorable_section = false;
+        let (block_seen, block_clean) = emit_declared_positionals(entries, usage_lines, st.result);
+        st.total_entries += block_seen;
+        st.clean_entries += block_clean;
+        return i;
+    }
+
+    emit_command_table(inp, h, i, st)
+}
+
 /// One candidate heading line and where it sits.
 struct Heading<'a> {
     line: &'a str,
@@ -660,7 +1040,6 @@ fn emit_flush_heading(
     mut i: usize,
     st: &mut BodyScan,
 ) -> usize {
-    let line = h.line;
     let heading = &h.heading;
     let heading_indent = h.heading_indent;
     let heading_idx = h.heading_idx;
@@ -672,10 +1051,10 @@ fn emit_flush_heading(
     // table below requires. See S-023.
     if i < lines.len()
         && leading_whitespace(lines[i]) == heading_indent
-        && is_environment_heading(&heading)
-        && !is_ignorable_heading(&heading)
+        && is_environment_heading(heading)
+        && !is_ignorable_heading(heading)
     {
-        if let Some((end, rows)) = scan_env_var_table(&lines, i) {
+        if let Some((end, rows)) = scan_env_var_table(lines, i) {
             i = end;
             st.in_ignorable_section = false;
             st.command_mode = false;
@@ -711,14 +1090,14 @@ fn emit_flush_heading(
             }
             i += 1;
         }
-        if !is_ignorable_heading(&heading) {
+        if !is_ignorable_heading(heading) {
             st.in_ignorable_section = false;
-            let recognized = is_recognized_command_heading(&heading, profile);
+            let recognized = is_recognized_command_heading(heading, profile);
             if recognized {
                 st.command_mode = true;
             }
             let (seen, clean) = process_word_grid(
-                &heading,
+                heading,
                 &lines[grid_start..i],
                 recognized || st.command_mode,
                 st.result,
@@ -752,14 +1131,14 @@ fn emit_flush_heading(
     if i < lines.len()
         && leading_whitespace(lines[i]) == heading_indent
         && !heading_is_itself_a_row
-        && !is_ignorable_heading(&heading)
-        && is_recognized_command_heading(&heading, profile)
+        && !is_ignorable_heading(heading)
+        && is_recognized_command_heading(heading, profile)
     {
-        if let Some((end, entries)) = scan_same_indent_entry_table(&lines, i, heading_indent) {
+        if let Some((end, entries)) = scan_same_indent_entry_table(lines, i, heading_indent) {
             i = end;
             st.command_mode = true;
             st.in_ignorable_section = false;
-            let (seen, clean) = emit_subcommands(&heading, entries, st.result);
+            let (seen, clean) = emit_subcommands(heading, entries, st.result);
             st.total_entries += seen;
             st.clean_entries += clean;
             return i;
@@ -770,13 +1149,12 @@ fn emit_flush_heading(
     // introduction to a command list (git's own leading blurb,
     // whose group headings say nothing about "commands"
     // themselves), remember that. See S-070.
-    if command_mode_seed(&heading, profile) {
+    if command_mode_seed(heading, profile) {
         st.command_mode = true;
     }
     // Rewind to just past the original line and continue scanning
     // it as its own candidate.
     i = heading_idx + 1;
-    return i;
     i
 }
 
@@ -790,15 +1168,15 @@ struct BodyScan<'a> {
 }
 
 fn scan_entries(
-    raw: &str,
-    lines: &[&str],
-    usage_lines: &[String],
+    inp: &BodyInput,
+    tool_name: Option<&str>,
     mut i: usize,
     result: &mut ParsedHelp,
-    profile: Option<&FrameworkProfile>,
-    tool_name: Option<&str>,
-    bnf_row_lines: &std::collections::HashSet<usize>,
 ) -> (usize, usize) {
+    let raw = inp.raw;
+    let lines = inp.lines;
+    let profile = inp.profile;
+    let bnf_row_lines = inp.bnf_row_lines;
     // A run of command-group headings is recognized either by its own
     // wording or by being contiguous with an earlier signal — git's own
     // group headings never say "command" themselves, but the leading
@@ -856,7 +1234,7 @@ fn scan_entries(
             continue;
         }
         if let Some((marker_indent, prior_ignorable)) = st.obscured_ignorable_indent {
-            if obscured_fence_reopens(&lines, i, marker_indent) {
+            if obscured_fence_reopens(lines, i, marker_indent) {
                 st.obscured_ignorable_indent = None;
                 st.in_ignorable_section = prior_ignorable;
             } else {
@@ -873,7 +1251,7 @@ fn scan_entries(
             // revisited as a heading — dcb and vdpa's `OPTIONS` row.
             // See S-042, noted as `bnf_row_lines`.
             let heading_is_bnf = bnf_row_lines.contains(&i);
-            let (end, entries, packed, argfile_entry) = scan_flags_block(&lines, i, heading_is_bnf);
+            let (end, entries, packed, argfile_entry) = scan_flags_block(lines, i, heading_is_bnf);
             i = end;
             if packed {
                 let seen = entries.len();
@@ -906,7 +1284,7 @@ fn scan_entries(
         if let Some(tool_name) = tool_name {
             if starts_with_tool_name(line.trim_start(), tool_name) {
                 if let Some((end, nodes, seen, clean)) =
-                    scan_headingless_invocation_table(&lines, i, tool_name, raw)
+                    scan_headingless_invocation_table(lines, i, tool_name, raw)
                 {
                     i = end;
                     st.total_entries += seen;
@@ -948,7 +1326,7 @@ fn scan_entries(
         // A hard-wrapped prose sentence, whose second physical line the
         // indentation-alone heading rule would otherwise hand to the
         // flags scanner. Fenced whole.
-        if let Some(end) = wrapped_prose_region_end(&lines, heading_idx) {
+        if let Some(end) = wrapped_prose_region_end(lines, heading_idx) {
             i = end;
             continue;
         }
@@ -966,345 +1344,13 @@ fn scan_entries(
             i = emit_flush_heading(lines, profile, &h, i, &mut st);
             continue;
         }
-
-        // Reaching here means genuinely more-indented content follows this
-        // heading — LVM's own stanza shape, a head line naming a
-        // mode-selecting flag followed by that mode's rows. Recovering
-        // the flag is independent of what the content turns out to be, so
-        // this runs once per heading rather than folded into any later
-        // branch.
-        //
-        // Gated on `!st.in_ignorable_section`: bpftrace's own `EXAMPLES:`
-        // block writes each example in the identical shape to a real
-        // stanza head, and without this guard it fabricated `-e`/`-l`
-        // rows that displaced the real, described ones. See S-071.
-        //
-        // A stanza with its own description sentence above its head line
-        // labels its group with that sentence instead ([`stanza_description_above`]).
-        // The head line is not lost: it becomes a usage form
-        // (`st.result.usage`, spec §4.5). Pushed here because this is the
-        // one place that knows the head line is about to stop being the
-        // group label; `extract_positionals` has already run, so nothing
-        // is mined out of the added line. See S-012.
-        //
-        // Capped, not deduplicated: `i` only ever advances, so no
-        // physical line becomes `heading` twice; two identical entries
-        // mean the tool printed the stanza twice. A scan of `usage` per
-        // heading would be the quadratic shape `MAX_RECOVERED_ENTRIES`
-        // exists for (instmodsh's repeated banner, S-072).
-        let stanza_label = if st.in_ignorable_section {
-            None
-        } else {
-            stanza_description_above(&lines, heading_idx, tool_name).map(str::to_string)
+        let h = Heading {
+            line,
+            heading,
+            heading_indent,
+            heading_idx,
         };
-        if stanza_label.is_some() && st.result.usage.len() < MAX_RECOVERED_ENTRIES {
-            st.result.usage.push(heading.clone());
-        }
-        if !st.in_ignorable_section {
-            if let Some(mut flag) = recover_stanza_head_flag(&heading, tool_name) {
-                if let Some(label) = stanza_label.clone() {
-                    flag.group = Some(label);
-                }
-                if st.result.flags.len() < MAX_RECOVERED_ENTRIES {
-                    st.result.flags.push(flag);
-                }
-            }
-        }
-
-        // A headed command table whose first row sits on the heading's
-        // own physical line (apt-ftparchive's `Commands: packages
-        // binarypath [overridefile [pathprefix]]`), with remaining rows
-        // column-aligned beneath it. Without this it vanishes whole into
-        // the `heading` string and never reaches any scanner as data. See
-        // S-018.
-        //
-        // Gated on `is_recognized_command_heading(label, ...)` for this
-        // heading directly, never a `st.command_mode` chain, since a sticky
-        // chain can reach an unrelated wrapped-prose block.
-        if let Some((label, inline_row)) = split_heading_inline_row(line.trim()) {
-            if !is_ignorable_heading(&heading)
-                && is_recognized_command_heading(label, profile)
-                && !profile.is_some_and(|p| {
-                    heading_matches_markers(&label.to_lowercase(), p.non_command_heading_markers)
-                })
-            {
-                if let Some(first_name) = leading_command_name(inline_row) {
-                    if let Some((end, mut entries)) = scan_bare_command_table(&lines, i) {
-                        entries.insert(0, (first_name, None));
-                        i = end;
-                        st.command_mode = true;
-                        st.in_ignorable_section = false;
-                        let raw_tokens = command_table_token_index(raw);
-                        let (seen, clean) =
-                            emit_headed_command_table(entries, &raw_tokens, st.result);
-                        st.total_entries += seen;
-                        st.clean_entries += clean;
-                        continue;
-                    }
-                }
-            }
-        }
-
-        // A modifier table (ar's ` command specific modifiers:`/
-        // ` generic modifiers:`, llvm-ar's `MODIFIERS:`) gets first
-        // refusal here: a `[a]` row is not `looks_like_flag_start`, and
-        // under a heading containing "command" it went to
-        // `emit_subcommands`, where every row failed the name-shape test.
-        // See S-020.
-        //
-        // Falls through rather than `continue`ing when the block still
-        // has content past the run: ar's ` generic modifiers:` is seven
-        // bracket rows, then `@<file>`, then four real flags that must
-        // keep the group they already carry.
-        if let Some((end, rows)) = scan_modifier_table(&lines, i) {
-            i = end;
-            if !is_ignorable_heading(&heading) {
-                // Positively-recognized structure clears the examples flag
-                // and contradicts a command-mode sticky chain (ar's own
-                // heading contains "command").
-                st.in_ignorable_section = false;
-                st.command_mode = false;
-                let (seen, clean) =
-                    emit_modifiers(meaningful_flag_group(heading.clone()), rows, st.result);
-                st.total_entries += seen;
-                st.clean_entries += clean;
-            }
-            if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
-                continue;
-            }
-        }
-
-        // The argfile sigil row (spec §4.5) sometimes sits directly where
-        // a modifier table's rows just ended — ar's `@<file>` row after
-        // its modifier table — and `flags_block_start` below never sees
-        // it there. Captured here instead, mirroring the modifier
-        // branch's "falls through" shape. See S-021.
-        if !is_ignorable_heading(&heading) && i < lines.len() {
-            if let Some(value_name) = argfile_row_value_name(lines[i].trim_start()) {
-                let entry = argfile_flag_entry(lines[i], value_name);
-                emit_argfile_flag(meaningful_flag_group(heading.clone()), entry, st.result);
-                st.total_entries += 1;
-                st.clean_entries += 1;
-                i += 1;
-                if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
-                    continue;
-                }
-            }
-        }
-
-        // An environment section (bpftrace's `ENVIRONMENT:`, node's
-        // `Environment variables:`, mksquashfs's `Environment:`) — spec
-        // §4.5's "strict-sections-only" rule made structural: unlike the
-        // modifier table above, gated on the heading itself first, never
-        // row shape alone, since a bare identifier plus a column gap is
-        // indistinguishable from mysqlslap's own flush-left settings
-        // table otherwise. See S-023.
-        //
-        // Falls through rather than `continue`ing, mirroring the modifier
-        // branch, so a block running on past its rows into ordinary flags
-        // does not lose those flags' group.
-        if is_environment_heading(&heading) && !is_ignorable_heading(&heading) {
-            if let Some((end, rows)) = scan_env_var_table(&lines, i) {
-                i = end;
-                st.in_ignorable_section = false;
-                st.command_mode = false;
-                let (seen, clean) =
-                    emit_env_vars(meaningful_flag_group(heading.clone()), rows, st.result);
-                st.total_entries += seen;
-                st.clean_entries += clean;
-                if i >= lines.len() || leading_whitespace(lines[i]) <= heading_indent {
-                    continue;
-                }
-            }
-        }
-
-        // Peek the first content lines to decide flags vs. bare-word. Not
-        // just the *first*: some tools document a positional at the top of
-        // their options table, and keying the whole decision off row one
-        // threw the rest of the block away. See `flags_block_start`.
-        if let Some(flags_start) = flags_block_start(&lines, i) {
-            // `flags_start` — never `heading_idx` — is the evidence: see
-            // `split_shared_heading_rows`'s doc comment for why the BNF
-            // fact is keyed on the row rather than the heading beside it.
-            let heading_is_bnf = bnf_row_lines.contains(&flags_start);
-            let (end, entries, packed, argfile_entry) =
-                scan_flags_block(&lines, flags_start, heading_is_bnf);
-            i = end;
-            if is_ignorable_heading(&heading) {
-                st.command_mode = false;
-                continue;
-            }
-            // A real, non-ignorable flags block — structurally strong
-            // evidence we are not (or no longer) inside an examples-shaped
-            // section. See `st.in_ignorable_section`'s own doc comment.
-            st.in_ignorable_section = false;
-            // A stanza's own description sentence outranks its head line
-            // as the group's label, and only there — every other block
-            // still takes `meaningful_flag_group`'s answer unchanged. See
-            // S-012.
-            let group = stanza_label
-                .clone()
-                .or_else(|| meaningful_flag_group(heading));
-            if packed {
-                let seen = entries.len();
-                emit_packed_flags(
-                    group.clone(),
-                    entries.into_iter().map(|(s, d, _)| (s, d)).collect(),
-                    st.result,
-                );
-                st.total_entries += seen;
-                st.clean_entries += seen;
-            } else {
-                let (seen, clean) = emit_flags(group.clone(), entries, st.result);
-                st.total_entries += seen;
-                st.clean_entries += clean;
-            }
-            if let Some(entry) = argfile_entry {
-                st.total_entries += 1;
-                st.clean_entries += 1;
-                emit_argfile_flag(group, entry, st.result);
-            }
-            st.command_mode = false;
-            continue;
-        }
-
-        // Argparse's subparser blocks get first refusal here, gated on
-        // the profile explicitly opting in. Deliberately not also gated
-        // on the heading reading "positional arguments": it was, and that
-        // made `add_subparsers(title=...)`'s ordinary heading style
-        // collapse the entire command tree — smokecli's fixture rendered
-        // one node. The structural evidence the scan demands (a `{...}`
-        // pseudo-entry with deeper lines beneath it) is strictly stronger
-        // than the heading text was; a plain positional's `{...}` metavar
-        // has nothing beneath it and is still never promoted. See S-073.
-        if profile.is_some_and(|p| p.argparse_subparser_quirk) {
-            if let Some((end, entries)) = scan_argparse_subparsers(&lines, i, heading_indent) {
-                i = end;
-                st.command_mode = false;
-                st.in_ignorable_section = false;
-                let (seen, clean) = emit_subcommands(&heading, entries, st.result);
-                st.total_entries += seen;
-                st.clean_entries += clean;
-                continue;
-            }
-        }
-
-        // A framework-declared positional-operand heading. Sits directly
-        // below the subparser scan since for argparse the two read the
-        // same heading, and the subparser scan's `{...}`-with-entries
-        // evidence is stronger than heading text alone. Also breaks the
-        // sticky `st.command_mode` chain. See S-078.
-        if profile.is_some_and(|p| {
-            heading_matches_markers(&heading.to_lowercase(), p.positional_heading_markers)
-        }) {
-            let (end, entries) = scan_bare_block(&lines, i, heading_indent, false);
-            i = end;
-            st.command_mode = false;
-            st.in_ignorable_section = false;
-            let (block_seen, block_clean) =
-                emit_declared_positionals(entries, &usage_lines, st.result);
-            st.total_entries += block_seen;
-            st.clean_entries += block_clean;
-            continue;
-        }
-
-        // A framework-declared non-command heading both refuses this
-        // block and breaks the engine's sticky same-indent chain, so
-        // nothing after it inherits a `st.command_mode` this heading
-        // positively contradicts.
-        let is_declared_non_command = profile.is_some_and(|p| {
-            heading_matches_markers(&heading.to_lowercase(), p.non_command_heading_markers)
-        });
-        let recognized = is_recognized_command_heading(&heading, profile);
-        // Issue #3: ` - ` is accepted as an entry separator alongside the
-        // usual column gap, but only when this block is already headed
-        // for `emit_subcommands`. Scoping the decision to before the scan
-        // is what keeps a bare ` - ` in ordinary prose from manufacturing
-        // commands, the same failure class as apt-get's own description
-        // paragraph, just via the column-gap rule instead.
-        let allow_dash_separator = (recognized || st.command_mode) && !is_declared_non_command;
-
-        // A headed command table whose rows use ` = ` as a separator, or
-        // no separator at all — wpa_cli's `=`-separated rows,
-        // fail2ban-client's wrapped continuations. See S-019.
-        //
-        // Gated on `recognized` alone, deliberately narrower than
-        // `allow_dash_separator`, which also accepts a `st.command_mode`
-        // chain: fail2ban-client's `Command:` block nests rows whose
-        // descriptions wrap across further lines, and the engine's own
-        // pseudo-heading rewind re-examines each such row once
-        // `st.command_mode` is stuck on, satisfying every safeguard with
-        // ordinary English words. `recognized` — true only when this
-        // exact heading's own text names a command — is false for every
-        // such pseudo-heading, so requiring it directly closes this off.
-        if recognized && !is_declared_non_command {
-            if let Some((end, entries)) = scan_bare_command_table(&lines, i) {
-                i = end;
-                st.command_mode = true;
-                st.in_ignorable_section = false;
-                let raw_tokens = command_table_token_index(raw);
-                let (seen, clean) = emit_headed_command_table(entries, &raw_tokens, st.result);
-                st.total_entries += seen;
-                st.clean_entries += clean;
-                continue;
-            }
-        }
-
-        // Busybox's applet list is a single flat, comma-separated run
-        // under one heading, structurally distinct from every other
-        // framework's per-line bare-word block, so it gets first refusal
-        // here. Gated on the profile flag and this heading already being
-        // recognized or continuing a `st.command_mode` chain. See S-093.
-        if profile.is_some_and(|p| p.comma_separated_command_list)
-            && (recognized || st.command_mode)
-            && !is_declared_non_command
-        {
-            let (end, entries) = scan_comma_separated_commands(&lines, i);
-            i = end;
-            st.command_mode = true;
-            st.in_ignorable_section = false;
-            let (seen, clean) = emit_subcommands(&heading, entries, st.result);
-            st.total_entries += seen;
-            st.clean_entries += clean;
-            continue;
-        }
-
-        let (end, entries) = scan_bare_block(&lines, i, heading_indent, allow_dash_separator);
-        i = end;
-        if is_ignorable_heading(&heading) {
-            continue;
-        }
-
-        if is_declared_non_command {
-            st.command_mode = false;
-            let (seen, clean) = emit_choices(&heading, entries, st.result);
-            st.total_entries += seen;
-            st.clean_entries += clean;
-            continue;
-        }
-
-        if recognized || st.command_mode {
-            st.command_mode = true;
-            // Only `recognized` (this exact heading's own text says
-            // "commands") is strong enough to clear the flag here — the
-            // `st.command_mode` sticky-chain half of this condition is not:
-            // it can still be true from an *inherited* chain rather than
-            // this heading's own evidence, which is exactly the kind of
-            // indirect signal `st.in_ignorable_section` must not trust (see
-            // its own doc comment on why the generic bare-block fallback
-            // is deliberately excluded from clearing it).
-            if recognized {
-                st.in_ignorable_section = false;
-            }
-            let (seen, clean) = emit_subcommands(&heading, entries, st.result);
-            st.total_entries += seen;
-            st.clean_entries += clean;
-        } else {
-            st.command_mode = false;
-            let (seen, clean) = emit_choices(&heading, entries, st.result);
-            st.total_entries += seen;
-            st.clean_entries += clean;
-        }
+        i = emit_heading_block(inp, tool_name, &h, i, &mut st);
     }
     (st.total_entries, st.clean_entries)
 }
@@ -1419,16 +1465,14 @@ fn parse_body(
         result.description = Some(description);
     }
 
-    let (total_entries, clean_entries) = scan_entries(
+    let inp = BodyInput {
         raw,
-        &lines,
-        &usage_lines,
-        i,
-        &mut result,
+        lines: &lines,
+        usage_lines: &usage_lines,
         profile,
-        tool_name,
         bnf_row_lines,
-    );
+    };
+    let (total_entries, clean_entries) = scan_entries(&inp, tool_name, i, &mut result);
 
     // spec [M-15]: mine the usage synopsis for flag spellings too, not just
     // positionals — git's own flags documented only in its usage block

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -554,115 +554,15 @@ fn scan_usage_section(
     }
 }
 
-/// [`parse_with_profile`]'s engine, over text whose shared heading rows
-/// have already been split out. `bnf_row_lines` records which row lines
-/// came from a `:=` BNF production rather than an ordinary column-gap
-/// heading, keyed on the row rather than the heading beside it.
-// Ratchet: the seventeen-flag body scanner; split into typed passes is tracked work. Listed in scripts/ratchet.txt.
-#[allow(clippy::too_many_lines)]
-#[allow(clippy::cognitive_complexity)]
-fn parse_body(
-    raw: &str,
-    profile: Option<&FrameworkProfile>,
-    tool_name: Option<&str>,
-    bnf_row_lines: &std::collections::HashSet<usize>,
-) -> ParsedHelp {
-    let lines: Vec<&str> = raw.lines().collect();
-    let mut result = ParsedHelp::default();
-
-    // Some tools answer `--help` with their man page rather than a help
-    // summary — git bisect renders GIT-BISECT(1) in full, and feeding
-    // that to this grammar fabricates subcommands from DESCRIPTION prose.
-    // Man pages are Tier D's job (not yet implemented), so the honest
-    // outcome here is no structure at all, rendered verbatim by the
-    // caller (spec §7 Tier B step 3). See S-066.
-    if looks_like_man_page(&lines) {
-        return result;
-    }
-
-    let mut i = 0;
-    // Physical usage lines (one string per source line, pre-join), kept
-    // alive past the block below so the deferred `extract_usage_flags`
-    // call can read the same per-line shape `extract_positionals` does.
-    let mut usage_lines: Vec<String> = Vec::new();
-    // 1. Usage block: one or more logical entries — each a `usage:`/
-    // `or:`/own-name line plus whatever continues it. `usage_lines` stays
-    // one string per physical line (feeds the [M-15] synopsis flag
-    // grammar); `usage_entries` is the joined display/verbatim form
-    // (`result.usage`).
-    //
-    // A line starts a new entry, regardless of indentation, when it is
-    // itself a `usage:`/`Usage:` line, starts with the `or:` marker, or
-    // begins with the tool's own name at a word boundary. Anything else
-    // is a continuation, unless it ends the block.
-    //
-    // Indentation alone cannot decide "continuation vs. block end": git's
-    // wrap sits more indented than `usage:`, lsof's sits at the same
-    // indent as its marker, and du's trailing prose sentence sits there
-    // too, yet must still end the block. Only content shape tells these
-    // apart: more indented is always a continuation; at or below base
-    // indent, a line continues only if it reads as usage grammar (a
-    // docopt delimiter `[`, `<`, `{`). See S-037. Joined fragments are
-    // separated by a single space, not re-flowed (spec §7).
-    //
-    // Entry point, tried in this order: (1) an ordinary `usage:`/`Usage:`
-    // line anywhere; (2) the C fprintf idiom, nfsidmap's `nfsidmap:
-    // Usage: nfsidmap [-vh] ...` (S-001); (3) only when neither appears,
-    // an unlabelled synopsis bounded to the lines before the document's
-    // real body starts.
-    let labelled_usage_start = lines.iter().position(|l| {
-        let t = l.trim_start();
-        starts_with_usage_prefix(t)
-            || tool_name.is_some_and(|name| starts_with_name_prefixed_usage(t, name))
-    });
-    let unlabelled_synopsis_start = if labelled_usage_start.is_none() {
-        tool_name.and_then(|name| {
-            let body_start = lines
-                .iter()
-                .position(|l| {
-                    let t = l.trim_start();
-                    !t.is_empty() && (looks_like_flag_start(t) || is_section_heading_line(t))
-                })
-                .unwrap_or(lines.len());
-            lines[..body_start].iter().enumerate().position(|(idx, l)| {
-                let t = l.trim_start();
-                looks_like_unlabeled_synopsis_line(t, name)
-                    // LVM's own emitter writes a bare invocation line
-                    // (`vgck` alone) with all docopt notation on the rows
-                    // that continue it, invisible to
-                    // `looks_like_unlabeled_synopsis_line` alone. A bare
-                    // own-name line is accepted too, but only when the
-                    // next physical line is unambiguous flag-row
-                    // evidence. See S-005.
-                    || looks_like_bare_synopsis_head(&lines, idx, name)
-            })
-        })
-    } else {
-        None
-    };
-    let usage_start = labelled_usage_start.or(unlabelled_synopsis_start);
-    if let Some(start) = usage_start {
-        let scan = scan_usage_section(
-            &lines,
-            start,
-            labelled_usage_start,
-            tool_name,
-            &mut usage_lines,
-        );
-        i = scan.next_index;
-        result.positionals = scan.positionals;
-        result.usage = scan.entries;
-    }
-
-    // 2. Leading prose before the usage block (or before the first
-    // section, if there's no usage block) becomes the description.
-    //
-    // `leading_prose_bound` is O(lines.len()) and must be computed once
-    // here, not inside the loop condition below — re-running it per
-    // iteration made this function quadratic, found via the coverage
-    // harness (spec §13.1) parsing a degenerate input in minutes instead
-    // of milliseconds.
-    let description_bound = i.max(leading_prose_bound(&lines));
+/// The leading prose before the usage block, as the node description.
+/// Paragraph-aware so a version or author banner can be dropped.
+/// See docs/shapes.md S-001.
+fn extract_description(
+    lines: &[&str],
+    description_bound: usize,
+    usage_start: Option<usize>,
+    i: usize,
+) -> Option<String> {
     // A column-0 line inside the recovered usage block's own line range is
     // never description prose, whichever of the three entry shapes found
     // it — checking the range rather than re-testing
@@ -728,10 +628,27 @@ fn parse_body(
         .filter(|paragraph| !paragraph.trim().is_empty())
         .collect::<Vec<_>>()
         .join("\n\n");
-    if !description.is_empty() {
-        result.description = Some(description);
+    if description.is_empty() {
+        None
+    } else {
+        Some(description)
     }
+}
 
+/// Walk the document body after the description, emitting flags,
+/// subcommands, modifiers, positionals and environment variables as
+/// each recognized section shape is met. Returns the entry counts
+/// `compute_confidence` scores. See docs/shapes.md S-013 and S-019.
+fn scan_entries(
+    raw: &str,
+    lines: &[&str],
+    usage_lines: &[String],
+    mut i: usize,
+    mut result: &mut ParsedHelp,
+    profile: Option<&FrameworkProfile>,
+    tool_name: Option<&str>,
+    bnf_row_lines: &std::collections::HashSet<usize>,
+) -> (usize, usize) {
     // A run of command-group headings is recognized either by its own
     // wording or by being contiguous with an earlier signal — git's own
     // group headings never say "command" themselves, but the leading
@@ -1338,6 +1255,132 @@ fn parse_body(
             clean_entries += clean;
         }
     }
+    (total_entries, clean_entries)
+}
+
+/// [`parse_with_profile`]'s engine, over text whose shared heading rows
+/// have already been split out. `bnf_row_lines` records which row lines
+/// came from a `:=` BNF production rather than an ordinary column-gap
+/// heading, keyed on the row rather than the heading beside it.
+// Ratchet: the seventeen-flag body scanner; split into typed passes is tracked work. Listed in scripts/ratchet.txt.
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::cognitive_complexity)]
+fn parse_body(
+    raw: &str,
+    profile: Option<&FrameworkProfile>,
+    tool_name: Option<&str>,
+    bnf_row_lines: &std::collections::HashSet<usize>,
+) -> ParsedHelp {
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut result = ParsedHelp::default();
+
+    // Some tools answer `--help` with their man page rather than a help
+    // summary — git bisect renders GIT-BISECT(1) in full, and feeding
+    // that to this grammar fabricates subcommands from DESCRIPTION prose.
+    // Man pages are Tier D's job (not yet implemented), so the honest
+    // outcome here is no structure at all, rendered verbatim by the
+    // caller (spec §7 Tier B step 3). See S-066.
+    if looks_like_man_page(&lines) {
+        return result;
+    }
+
+    let mut i = 0;
+    // Physical usage lines (one string per source line, pre-join), kept
+    // alive past the block below so the deferred `extract_usage_flags`
+    // call can read the same per-line shape `extract_positionals` does.
+    let mut usage_lines: Vec<String> = Vec::new();
+    // 1. Usage block: one or more logical entries — each a `usage:`/
+    // `or:`/own-name line plus whatever continues it. `usage_lines` stays
+    // one string per physical line (feeds the [M-15] synopsis flag
+    // grammar); `usage_entries` is the joined display/verbatim form
+    // (`result.usage`).
+    //
+    // A line starts a new entry, regardless of indentation, when it is
+    // itself a `usage:`/`Usage:` line, starts with the `or:` marker, or
+    // begins with the tool's own name at a word boundary. Anything else
+    // is a continuation, unless it ends the block.
+    //
+    // Indentation alone cannot decide "continuation vs. block end": git's
+    // wrap sits more indented than `usage:`, lsof's sits at the same
+    // indent as its marker, and du's trailing prose sentence sits there
+    // too, yet must still end the block. Only content shape tells these
+    // apart: more indented is always a continuation; at or below base
+    // indent, a line continues only if it reads as usage grammar (a
+    // docopt delimiter `[`, `<`, `{`). See S-037. Joined fragments are
+    // separated by a single space, not re-flowed (spec §7).
+    //
+    // Entry point, tried in this order: (1) an ordinary `usage:`/`Usage:`
+    // line anywhere; (2) the C fprintf idiom, nfsidmap's `nfsidmap:
+    // Usage: nfsidmap [-vh] ...` (S-001); (3) only when neither appears,
+    // an unlabelled synopsis bounded to the lines before the document's
+    // real body starts.
+    let labelled_usage_start = lines.iter().position(|l| {
+        let t = l.trim_start();
+        starts_with_usage_prefix(t)
+            || tool_name.is_some_and(|name| starts_with_name_prefixed_usage(t, name))
+    });
+    let unlabelled_synopsis_start = if labelled_usage_start.is_none() {
+        tool_name.and_then(|name| {
+            let body_start = lines
+                .iter()
+                .position(|l| {
+                    let t = l.trim_start();
+                    !t.is_empty() && (looks_like_flag_start(t) || is_section_heading_line(t))
+                })
+                .unwrap_or(lines.len());
+            lines[..body_start].iter().enumerate().position(|(idx, l)| {
+                let t = l.trim_start();
+                looks_like_unlabeled_synopsis_line(t, name)
+                    // LVM's own emitter writes a bare invocation line
+                    // (`vgck` alone) with all docopt notation on the rows
+                    // that continue it, invisible to
+                    // `looks_like_unlabeled_synopsis_line` alone. A bare
+                    // own-name line is accepted too, but only when the
+                    // next physical line is unambiguous flag-row
+                    // evidence. See S-005.
+                    || looks_like_bare_synopsis_head(&lines, idx, name)
+            })
+        })
+    } else {
+        None
+    };
+    let usage_start = labelled_usage_start.or(unlabelled_synopsis_start);
+    if let Some(start) = usage_start {
+        let scan = scan_usage_section(
+            &lines,
+            start,
+            labelled_usage_start,
+            tool_name,
+            &mut usage_lines,
+        );
+        i = scan.next_index;
+        result.positionals = scan.positionals;
+        result.usage = scan.entries;
+    }
+
+    // 2. Leading prose before the usage block (or before the first
+    // section, if there's no usage block) becomes the description.
+    //
+    // `leading_prose_bound` is O(lines.len()) and must be computed once
+    // here, not inside the loop condition below — re-running it per
+    // iteration made this function quadratic, found via the coverage
+    // harness (spec §13.1) parsing a degenerate input in minutes instead
+    // of milliseconds.
+    let description_bound = i.max(leading_prose_bound(&lines));
+    if let Some(description) = extract_description(&lines, description_bound, usage_start, i) {
+        result.description = Some(description);
+    }
+
+    let (total_entries, clean_entries) = scan_entries(
+        raw,
+        &lines,
+        &usage_lines,
+        i,
+        &mut result,
+        profile,
+        tool_name,
+        bnf_row_lines,
+    );
 
     // spec [M-15]: mine the usage synopsis for flag spellings too, not just
     // positionals — git's own flags documented only in its usage block

--- a/scripts/ratchet.txt
+++ b/scripts/ratchet.txt
@@ -4,10 +4,8 @@
 # this file lists. Removing a line is the only edit it should receive.
 #
 # lint	file	function
-clippy::cognitive_complexity	mandible-extract/src/help_text/sections/mod.rs	parse_body
 clippy::cognitive_complexity	mandible-extract/src/help_text/sections/scan.rs	scan_headingless_invocation_table
 clippy::cognitive_complexity	xtask/src/transition.rs	render_markdown
-clippy::too_many_lines	mandible-extract/src/help_text/sections/mod.rs	parse_body
 clippy::too_many_lines	xtask/src/audit.rs	render_report
 clippy::too_many_lines	xtask/src/corpus.rs	check_contract
 clippy::too_many_lines	xtask/src/corpus.rs	run_with_ceiling


### PR DESCRIPTION
Breaks the 1064-line `parse_body` into five named passes and lifts the body scan's branches into their own functions, so both of its size-lint exemptions come out of `scripts/ratchet.txt`. A function nobody can read in one sitting is where this parser's hardest bugs have hidden.

Pure move. A full-PATH sweep before and after reports `overall: IDENTICAL`, with zero status transitions, zero flag gains, zero flag losses and zero field-level changes across 2264 matched tools. 1534 tests and 123 corpus fixtures unchanged.