### PR TITLE
corpus: contract fields for issue 102 items 1 to 3

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -127,6 +127,25 @@ must_contain_modifiers = ["a", "U"]  # same, for the single-letter modifiers
 # exist" below for exactly what it does and does not assert.
 must_not_contain_flags = ["--------------------------------"]
 
+# The other negative shape: spellings that really exist and must NOT
+# resolve to the same entity. Guards the alias-run fold specifically. See
+# "Stating that two flags did not fuse" below.
+must_keep_separate = [["-w", "-X"], ["-C", "-CC"]]
+
+# A flag must own the named choice values, so a choices block that
+# attached to the wrong flag is checkable instead of only visible in a
+# snapshot diff. Matched the way `must_contain_flags` matches; the flag
+# must exist and its choices must include every value listed.
+[contract.must_attach_choices]
+"--warnings" = ["gnu", "obsolete", "portability"]
+
+# A flag's rendered description must contain this text — substring match
+# after collapsing runs of whitespace on both sides to a single space
+# (descriptions wrap), case-sensitive. Makes description recovery
+# checkable instead of guarded only by the snapshot.
+[contract.must_describe]
+"--target" = "the triple to build for"
+
 # Same idea, for a subcommand's own flags — keyed by its path (space-
 # separated, tool's own name excluded), since `must_contain_flags` alone
 # can only ever assert what a tool publishes at its *root*. Requires a
@@ -181,6 +200,72 @@ A fixture that produces no root at all satisfies this vacuously and is not
 reported — the one asymmetry with the positive fields, which a missing tree
 trivially breaks. Dropping an entry is a weakening exactly as dropping a
 `must_contain_flags` entry is, and `--baseline-dir` reports it as one.
+
+### Stating that two flags did not fuse: `must_keep_separate`
+
+`must_not_contain_flags` catches invention. It says nothing about a
+different failure mode: two real, distinct flags read correctly on their
+own, then wrongly merged onto one multi-spelling entity. An earlier
+alias-run fold did exactly this — it merged rows on description equality
+and fused unrelated flags together — and had to be reverted, because
+nothing said the fold was not allowed to do that.
+
+`must_keep_separate` is that field: a list of spelling groups, each
+naming spellings that must resolve to distinct entities.
+
+```toml
+must_keep_separate = [["-w", "-X"], ["-C", "-CC"]]
+```
+
+Each inner list is checked independently. `cargo xtask corpus` fails,
+naming the group and which of its spellings collapsed together, when two
+or more spellings in one group resolve to the same entity. Matched
+**exactly the way `must_contain_flags` is**, root flags only — the same
+scope every other flag-shaped field has.
+
+This is a negative claim, the same shape as `must_not_contain_flags`, and
+follows it for the missing-root case: "these spellings never fused" holds
+vacuously of a tree with no flags at all, so a fixture that produces no
+root satisfies it and is not reported.
+
+### A flag must own its choices: `must_attach_choices`
+
+`--format`'s choice values belong to `--format`, not to whichever flag
+happens to sit next to it in the source. A choices block that attaches to
+the wrong flag produces a tree that looks complete — the values are
+somewhere — and only a snapshot diff, read carefully, would ever say so.
+
+```toml
+[contract.must_attach_choices]
+"--warnings" = ["gnu", "obsolete", "portability"]
+```
+
+The named flag, matched the way `must_contain_flags` matches, must exist
+and its `Entity::choices` must include every value listed. This is a
+**positive** claim: `cargo xtask corpus` fails when the flag is absent, or
+when any listed value is not among the choices attached to it, naming
+either the missing flag or the missing values. A fixture that produces no
+root fails this exactly as it fails `must_contain_flags`.
+
+### A flag's description says what it should: `must_describe`
+
+A flag can carry a description and still carry the wrong one — text
+recovered from the wrong line, or from a neighboring row. Nothing but a
+byte-exact snapshot diff caught that until now (issue #102 item 5).
+
+```toml
+[contract.must_describe]
+"--target" = "the triple to build for"
+```
+
+The named flag's rendered description must contain this text as a
+substring. Both sides are compared after collapsing runs of whitespace to
+a single space, because a real description wraps and a fixture author's
+TOML value may not wrap the same way; the match itself is case-sensitive.
+`cargo xtask corpus` fails when the flag is absent, or when the
+description does not contain the text, naming what was expected and what
+the description actually is (truncated to a readable length). A fixture
+that produces no root fails this exactly as it fails `must_contain_flags`.
 
 ### What `--bless` does and does not assert: `verdict_scope`
 
@@ -394,7 +479,8 @@ $ cargo run -p xtask -- corpus --baseline-dir /tmp/corpus-at-main   # also flag 
 corpus directory and prints a prominent `CONTRACT WEAKENED: <fixture> <field>`
 line for each field that got weaker (lowered `min_status`/`min_subcommands`,
 a dropped `must_contain_flags`/`must_contain_flags_by_path`/
-`must_contain_positionals`/`must_not_contain_flags` entry, a fixture
+`must_contain_positionals`/`must_not_contain_flags`/`must_keep_separate`/
+`must_attach_choices` entry, a removed `must_describe` entry, a fixture
 newly marked `[xfail]`, or a fixture missing entirely) — reported, never
 gated, since weakening a contract deliberately is still legal (the lifecycle
 rules above). This binary **has no git access and never will** — the

--- a/corpus/as/2.42/expected.snap
+++ b/corpus/as/2.42/expected.snap
@@ -1,0 +1,451 @@
+name: as
+description: 'Options:'
+usage:
+- 'Usage: /usr/bin/as [option...] [asmfile...]'
+flags:
+- spellings:
+  - -a
+  value_name: sub-option...
+  value_kind: Optional
+  choices:
+  - name: c
+    description: omit false conditionals
+  - name: d
+    description: omit debugging directives
+  - name: g
+    description: include general info
+  - name: h
+    description: include high-level source
+  - name: i
+    description: include ginsn and synthesized CFI info
+  - name: l
+    description: include assembly
+  - name: m
+    description: include macro expansions
+  - name: n
+    description: omit forms processing
+  - name: s
+    description: include symbols
+  - FILE
+  description: 'turn on listings Sub-options [default hls]:'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --alternate
+  description: initially turn on alternate macro syntax
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --compress-debug-sections
+  value_name: '{none|zlib|zlib-gnu|zlib-gabi|zstd}'
+  value_kind: Optional
+  description: 'compress DWARF debug sections Default: none'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --nocompress-debug-sections
+  description: don't compress DWARF debug sections
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -D
+  description: produce assembler debugging messages
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --dump-config
+  description: display how the assembler is configured and then exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --debug-prefix-map
+  value_name: OLD=NEW
+  value_kind: Required
+  description: map OLD to NEW in debug information
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --defsym
+  value_name: SYM=VAL
+  value_kind: Required
+  description: define symbol SYM to given value
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --execstack
+  description: require executable stack for this object
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --noexecstack
+  description: don't require executable stack for this object
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --size-check
+  value_name: '[error|warning]'
+  value_kind: Required
+  description: ELF .size directive check (default --size-check=error)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --elf-stt-common
+  value_name: '[no|yes]'
+  value_kind: Required
+  description: no) generate ELF common symbols with STT_COMMON type
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --sectname-subst
+  description: enable section name substitution sequences
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --generate-missing-build-notes
+  value_name: '[no|yes]'
+  value_kind: Required
+  description: no) generate GNU Build notes if none are present in the input
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --gsframe
+  description: generate SFrame stack trace information
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -f
+  description: skip whitespace and comment preprocessing
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -g
+  - --gen-debug
+  description: generate debugging information
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --gstabs
+  description: generate STABS debugging information
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --gstabs
+  value_name: +
+  value_kind: Required
+  description: generate STABS debug info with GNU extensions
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --gdwarf-
+  value_name: <N>
+  value_kind: Required
+  description: generate DWARF<N> debugging information. 2 <= <N> <= 5
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --gdwarf-cie-version
+  value_name: <N>
+  value_kind: Required
+  description: generate version 1, 3 or 4 DWARF CIEs
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --gdwarf-sections
+  description: generate per-function section names for DWARF line information
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --hash-size
+  value_name: <N>
+  value_kind: Required
+  description: ignored
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --help
+  description: show all assembler options
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --target-help
+  description: show target specific options
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -I
+  value_name: DIR
+  value_kind: Required
+  description: add DIR to search list for .include directives
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -J
+  description: don't warn about signed overflow
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -K
+  description: warn when differences altered for long displacements
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -L
+  - --keep-locals
+  description: keep local symbols (e.g. starting with `L')
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -M
+  - --mri
+  description: assemble in MRI compatibility mode
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --MD
+  value_name: FILE
+  value_kind: Required
+  description: write dependency information in FILE (default none)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --multibyte-handling
+  value_name: <method>
+  value_kind: Required
+  description: what to do with multibyte characters encountered in the input
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -nocpp
+  description: ignored
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-pad-sections
+  description: do not pad the end of sections to alignment boundaries
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  value_name: OBJFILE
+  value_kind: Required
+  description: name the object-file output OBJFILE (default a.out)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -R
+  description: fold data section into text section
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --reduce-memory-overheads
+  value_name: ignored
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --statistics
+  description: print various measured statistics from execution
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --strip-local-absolute
+  description: strip local absolute symbols
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --traditional-format
+  description: Use same format as native assembler when possible
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --version
+  description: print assembler version number and exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -W
+  description: --no-warn suppress warnings
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --warn
+  description: don't suppress warnings
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --fatal-warnings
+  description: treat warnings as errors
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -w
+  description: ignored
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -X
+  description: ignored
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Z
+  description: generate object file even after errors
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --listing-lhs-width
+  description: set the width in words of the output data column of the listing
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --listing-lhs-width2
+  description: set the width in words of the continuation lines of the output data column; ignored if smaller than the width of the first line
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --listing-rhs-width
+  description: set the max width in characters of the lines from the source file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --listing-cont-lines
+  description: set the maximum number of continuation lines used for the output data column of the listing
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - '@'
+  value_name: FILE
+  value_kind: Required
+  description: read options from FILE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mbig-endian
+  group: 'AArch64-specific assembler options:'
+  description: assemble for big-endian
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mlittle-endian
+  group: 'AArch64-specific assembler options:'
+  description: assemble for little-endian
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mverbose-error
+  group: 'AArch64-specific assembler options:'
+  description: output verbose error messages
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mno-verbose-error
+  group: 'AArch64-specific assembler options:'
+  description: do not output verbose error messages
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mabi
+  value_name: <abi
+  value_kind: Required
+  group: 'AArch64-specific assembler options:'
+  description: specify for ABI <abi name>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mcpu
+  value_name: <cpu
+  value_kind: Required
+  group: 'AArch64-specific assembler options:'
+  description: assemble for CPU <cpu name>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -march
+  value_name: <arch
+  value_kind: Required
+  group: 'AArch64-specific assembler options:'
+  description: assemble for architecture <arch name>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -E
+  value_name: B
+  value_kind: Required
+  group: 'AArch64-specific assembler options:'
+  description: assemble code for a big-endian cpu
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -E
+  value_name: L
+  value_kind: Required
+  group: 'AArch64-specific assembler options:'
+  description: assemble code for a little-endian cpu
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/as/2.42/help.txt
+++ b/corpus/as/2.42/help.txt
@@ -1,0 +1,90 @@
+Usage: /usr/bin/as [option...] [asmfile...]
+Options:
+  -a[sub-option...]	  turn on listings
+                      	  Sub-options [default hls]:
+                      	  c      omit false conditionals
+                      	  d      omit debugging directives
+                      	  g      include general info
+                      	  h      include high-level source
+                      	  i      include ginsn and synthesized CFI info
+                      	  l      include assembly
+                      	  m      include macro expansions
+                      	  n      omit forms processing
+                      	  s      include symbols
+                      	  =FILE  list to FILE (must be last sub-option)
+  --alternate             initially turn on alternate macro syntax
+  --compress-debug-sections[={none|zlib|zlib-gnu|zlib-gabi|zstd}]
+                          compress DWARF debug sections
+		            Default: none
+  --nocompress-debug-sections
+                          don't compress DWARF debug sections
+  -D                      produce assembler debugging messages
+  --dump-config           display how the assembler is configured and then exit
+  --debug-prefix-map OLD=NEW
+                          map OLD to NEW in debug information
+  --defsym SYM=VAL        define symbol SYM to given value
+  --execstack             require executable stack for this object
+  --noexecstack           don't require executable stack for this object
+  --size-check=[error|warning]
+			  ELF .size directive check (default --size-check=error)
+  --elf-stt-common=[no|yes] (default: no)
+                          generate ELF common symbols with STT_COMMON type
+  --sectname-subst        enable section name substitution sequences
+  --generate-missing-build-notes=[no|yes] (default: no)
+                          generate GNU Build notes if none are present in the input
+  --gsframe               generate SFrame stack trace information
+  -f                      skip whitespace and comment preprocessing
+  -g --gen-debug          generate debugging information
+  --gstabs                generate STABS debugging information
+  --gstabs+               generate STABS debug info with GNU extensions
+  --gdwarf-<N>            generate DWARF<N> debugging information. 2 <= <N> <= 5
+  --gdwarf-cie-version=<N> generate version 1, 3 or 4 DWARF CIEs
+  --gdwarf-sections       generate per-function section names for DWARF line information
+  --hash-size=<N>         ignored
+  --help                  show all assembler options
+  --target-help           show target specific options
+  -I DIR                  add DIR to search list for .include directives
+  -J                      don't warn about signed overflow
+  -K                      warn when differences altered for long displacements
+  -L,--keep-locals        keep local symbols (e.g. starting with `L')
+  -M,--mri                assemble in MRI compatibility mode
+  --MD FILE               write dependency information in FILE (default none)
+  --multibyte-handling=<method>
+                          what to do with multibyte characters encountered in the input
+  -nocpp                  ignored
+  -no-pad-sections        do not pad the end of sections to alignment boundaries
+  -o OBJFILE              name the object-file output OBJFILE (default a.out)
+  -R                      fold data section into text section
+  --reduce-memory-overheads ignored
+  --statistics            print various measured statistics from execution
+  --strip-local-absolute  strip local absolute symbols
+  --traditional-format    Use same format as native assembler when possible
+  --version               print assembler version number and exit
+  -W  --no-warn           suppress warnings
+  --warn                  don't suppress warnings
+  --fatal-warnings        treat warnings as errors
+  -w                      ignored
+  -X                      ignored
+  -Z                      generate object file even after errors
+  --listing-lhs-width     set the width in words of the output data column of
+                          the listing
+  --listing-lhs-width2    set the width in words of the continuation lines
+                          of the output data column; ignored if smaller than
+                          the width of the first line
+  --listing-rhs-width     set the max width in characters of the lines from
+                          the source file
+  --listing-cont-lines    set the maximum number of continuation lines used
+                          for the output data column of the listing
+  @FILE                   read options from FILE
+ AArch64-specific assembler options:
+  -mbig-endian            assemble for big-endian
+  -mlittle-endian         assemble for little-endian
+  -mverbose-error         output verbose error messages
+  -mno-verbose-error      do not output verbose error messages
+  -mabi=<abi name>	  specify for ABI <abi name>
+  -mcpu=<cpu name>	  assemble for CPU <cpu name>
+  -march=<arch name>	  assemble for architecture <arch name>
+  -EB                     assemble code for a big-endian cpu
+  -EL                     assemble code for a little-endian cpu
+
+Report bugs to <https://sourceware.org/bugzilla/>

--- a/corpus/as/2.42/meta.toml
+++ b/corpus/as/2.42/meta.toml
@@ -1,0 +1,20 @@
+# From issue 102 item 1 (alias-run fold needs a real discriminator).
+# `-w` and `-X` are adjacent single-spelling rows sharing the description
+# "ignored". They must stay two entities: an earlier fold merged rows on
+# description equality and was withdrawn from #97 for fusing exactly these.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "as"
+version = "2.42"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["as", "--help"]
+stdout = "help.txt"
+
+[contract]
+must_keep_separate = [["-w", "-X"]]

--- a/corpus/automake/1.16.5/help.txt
+++ b/corpus/automake/1.16.5/help.txt
@@ -1,0 +1,63 @@
+Usage: /usr/bin/automake [OPTION]... [Makefile]...
+
+Generate Makefile.in for configure from Makefile.am.
+
+Operation modes:
+      --help               print this help, then exit
+      --version            print version number, then exit
+  -v, --verbose            verbosely list files processed
+      --no-force           only update Makefile.in's that are out of date
+  -W, --warnings=CATEGORY  report the warnings falling in CATEGORY
+
+Dependency tracking:
+  -i, --ignore-deps      disable dependency tracking code
+      --include-deps     enable dependency tracking code
+
+Flavors:
+      --foreign          set strictness to foreign
+      --gnits            set strictness to gnits
+      --gnu              set strictness to gnu
+
+Library files:
+  -a, --add-missing      add missing standard files to package
+      --libdir=DIR       set directory storing library files
+      --print-libdir     print directory storing library files
+  -c, --copy             with -a, copy missing files (default is symlink)
+  -f, --force-missing    force update of standard files
+
+Warning categories include:
+  cross                  cross compilation issues
+  gnu                    GNU coding standards (default in gnu and gnits modes)
+  obsolete               obsolete features or constructions (default)
+  override               user redefinitions of Automake rules or variables
+  portability            portability issues (default in gnu and gnits modes)
+  portability-recursive  nested Make variables (default with -Wportability)
+  extra-portability      extra portability issues related to obscure tools
+  syntax                 dubious syntactic constructs (default)
+  unsupported            unsupported or incomplete features (default)
+  all                    all the warnings
+  no-CATEGORY            turn off warnings in CATEGORY
+  none                   turn off all the warnings
+  error                  treat warnings as errors
+
+Files automatically distributed if found (always):
+  ABOUT-GNU           TODO                install-sh          mdate-sh
+  ABOUT-NLS           ar-lib              libversion.in       missing
+  BACKLOG             compile             ltcf-c.sh           mkinstalldirs
+  COPYING             config.guess        ltcf-cxx.sh         py-compile
+  COPYING.DOC         config.rpath        ltcf-gcj.sh         texinfo.tex
+  COPYING.LESSER      config.sub          ltconfig            ylwrap
+  COPYING.LIB         depcomp             ltmain.sh
+
+Files automatically distributed if found (as .md if needed):
+  AUTHORS[.md]        INSTALL[.md]        README[.md]         THANKS[.md]
+  ChangeLog[.md]      NEWS[.md]
+
+Files automatically distributed if found (under certain conditions):
+  README-alpha[.md]   config.h.bot        configure           configure.in
+  acconfig.h          config.h.top        configure.ac        stamp-vti
+  aclocal.m4
+
+Report bugs to <bug-automake@gnu.org>.
+GNU Automake home page: <https://www.gnu.org/software/automake/>.
+General help using GNU software: <https://www.gnu.org/gethelp/>.

--- a/corpus/automake/1.16.5/meta.toml
+++ b/corpus/automake/1.16.5/meta.toml
@@ -1,0 +1,27 @@
+# From issue 102 item 2 (choices-block ownership beyond literal matches).
+# "Warning categories include:" belongs to `-W, --warnings=CATEGORY`, but
+# the heading says "categories" where the flag's value name is CATEGORY,
+# so the morphological variant goes unproven and the block attaches
+# elsewhere.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "automake"
+version = "1.16.5"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["automake", "--help"]
+stdout = "help.txt"
+
+[contract]
+
+[contract.must_attach_choices]
+"--warnings" = ["cross", "gnu", "obsolete", "override", "portability", "syntax"]
+
+[xfail]
+broken = true
+reason = "the 'Warning categories include:' block does not attach to -W, --warnings=CATEGORY. The heading says 'categories' where the flag's value name is CATEGORY, and #99 attaches a choices block only when the heading literally names the flag or contains its value_name as a word. A stem or plural rule needs a fleet measurement of its false-positive cost before it can be admitted."

--- a/corpus/cp/9.4/expected.snap
+++ b/corpus/cp/9.4/expected.snap
@@ -1,0 +1,289 @@
+name: cp
+description: Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.
+usage:
+- 'Usage: /usr/bin/cp [OPTION]... [-T] SOURCE DEST'
+- '  or:  /usr/bin/cp [OPTION]... SOURCE... DIRECTORY'
+- '  or:  /usr/bin/cp [OPTION]... -t DIRECTORY SOURCE...'
+positionals:
+- name: SOURCE
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: DEST
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: DIRECTORY
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -a
+  - --archive
+  description: same as -dR --preserve=all
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --attributes-only
+  description: don't copy the file data, just the attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --backup
+  value_name: CONTROL
+  value_kind: Optional
+  choices:
+  - name: none
+    description: never make backups (even if --backup is given)
+  - name: off
+    description: never make backups (even if --backup is given)
+  - name: numbered
+    description: make numbered backups
+  - name: t
+    description: make numbered backups
+  - name: existing
+    description: numbered if numbered backups exist, simple otherwise
+  - name: nil
+    description: numbered if numbered backups exist, simple otherwise
+  - name: simple
+    description: always make simple backups
+  - name: never
+    description: always make simple backups
+  description: make a backup of each existing destination file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -b
+  description: like --backup but does not accept an argument
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --copy-contents
+  description: copy contents of special files when recursive
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  description: same as --no-dereference --preserve=links
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --debug
+  description: explain how a file is copied. Implies -v
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -f
+  - --force
+  description: if an existing destination file cannot be opened, remove it and try again (this option is ignored when the -n option is also used)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -i
+  - --interactive
+  description: prompt before overwrite (overrides a previous -n option)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -H
+  description: follow command-line symbolic links in SOURCE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -l
+  - --link
+  description: hard link files instead of copying
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -L
+  - --dereference
+  description: always follow symbolic links in SOURCE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -n
+  - --no-clobber
+  description: do not overwrite an existing file and do not fail (overrides a -u or previous -i option). See also --update; equivalent to --update=none.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -P
+  - --no-dereference
+  description: never follow symbolic links in SOURCE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -p
+  description: same as --preserve=mode,ownership,timestamps
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --preserve
+  value_name: ATTR_LIST
+  value_kind: Optional
+  description: preserve the specified attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --no-preserve
+  value_name: ATTR_LIST
+  value_kind: Required
+  description: don't preserve the specified attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --parents
+  description: use full source file name under DIRECTORY
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -R
+  - -r
+  - --recursive
+  description: copy directories recursively
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --reflink
+  value_name: WHEN
+  value_kind: Optional
+  description: control clone/CoW copies. See below
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --remove-destination
+  description: remove each existing destination file before attempting to open it (contrast with --force)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --sparse
+  value_name: WHEN
+  value_kind: Required
+  description: control creation of sparse files. See below
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --strip-trailing-slashes
+  description: remove any trailing slashes from each SOURCE argument
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -s
+  - --symbolic-link
+  description: make symbolic links instead of copying
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -S
+  - --suffix
+  value_name: SUFFIX
+  value_kind: Required
+  description: override the usual backup suffix
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -t
+  - --target-directory
+  value_name: DIRECTORY
+  value_kind: Required
+  description: copy all SOURCE arguments into DIRECTORY
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -T
+  - --no-target-directory
+  description: treat DEST as a normal file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --update
+  value_name: UPDATE
+  value_kind: Optional
+  description: control which existing files are updated; UPDATE={all,none,older(default)}. See below
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -u
+  description: equivalent to --update[=older]
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -v
+  - --verbose
+  description: explain what is being done
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -x
+  - --one-file-system
+  description: stay on this file system
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Z
+  description: set SELinux security context of destination file to default type
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --context
+  value_name: CTX
+  value_kind: Optional
+  description: like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --help
+  description: display this help and exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --version
+  description: output version information and exit
+  provenance:
+    sources:
+    - help-text
+detected_framework: GNU argp/getopt_long
+provenance:
+  sources:
+  - help-text
+  confidence: 1.0
+children_filled: true

--- a/corpus/cp/9.4/help.txt
+++ b/corpus/cp/9.4/help.txt
@@ -1,0 +1,94 @@
+Usage: /usr/bin/cp [OPTION]... [-T] SOURCE DEST
+  or:  /usr/bin/cp [OPTION]... SOURCE... DIRECTORY
+  or:  /usr/bin/cp [OPTION]... -t DIRECTORY SOURCE...
+Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.
+
+Mandatory arguments to long options are mandatory for short options too.
+  -a, --archive                same as -dR --preserve=all
+      --attributes-only        don't copy the file data, just the attributes
+      --backup[=CONTROL]       make a backup of each existing destination file
+  -b                           like --backup but does not accept an argument
+      --copy-contents          copy contents of special files when recursive
+  -d                           same as --no-dereference --preserve=links
+      --debug                  explain how a file is copied.  Implies -v
+  -f, --force                  if an existing destination file cannot be
+                                 opened, remove it and try again (this option
+                                 is ignored when the -n option is also used)
+  -i, --interactive            prompt before overwrite (overrides a previous -n
+                                  option)
+  -H                           follow command-line symbolic links in SOURCE
+  -l, --link                   hard link files instead of copying
+  -L, --dereference            always follow symbolic links in SOURCE
+  -n, --no-clobber             do not overwrite an existing file and do not fail
+                                 (overrides a -u or previous -i option). See also
+                                 --update; equivalent to --update=none.
+  -P, --no-dereference         never follow symbolic links in SOURCE
+  -p                           same as --preserve=mode,ownership,timestamps
+      --preserve[=ATTR_LIST]   preserve the specified attributes
+      --no-preserve=ATTR_LIST  don't preserve the specified attributes
+      --parents                use full source file name under DIRECTORY
+  -R, -r, --recursive          copy directories recursively
+      --reflink[=WHEN]         control clone/CoW copies. See below
+      --remove-destination     remove each existing destination file before
+                                 attempting to open it (contrast with --force)
+      --sparse=WHEN            control creation of sparse files. See below
+      --strip-trailing-slashes  remove any trailing slashes from each SOURCE
+                                 argument
+  -s, --symbolic-link          make symbolic links instead of copying
+  -S, --suffix=SUFFIX          override the usual backup suffix
+  -t, --target-directory=DIRECTORY  copy all SOURCE arguments into DIRECTORY
+  -T, --no-target-directory    treat DEST as a normal file
+  --update[=UPDATE]            control which existing files are updated;
+                                 UPDATE={all,none,older(default)}.  See below
+  -u                           equivalent to --update[=older]
+  -v, --verbose                explain what is being done
+  -x, --one-file-system        stay on this file system
+  -Z                           set SELinux security context of destination
+                                 file to default type
+      --context[=CTX]          like -Z, or if CTX is specified then set the
+                                 SELinux or SMACK security context to CTX
+      --help        display this help and exit
+      --version     output version information and exit
+
+ATTR_LIST is a comma-separated list of attributes. Attributes are 'mode' for
+permissions (including any ACL and xattr permissions), 'ownership' for user
+and group, 'timestamps' for file timestamps, 'links' for hard links, 'context'
+for security context, 'xattr' for extended attributes, and 'all' for all
+attributes.
+
+By default, sparse SOURCE files are detected by a crude heuristic and the
+corresponding DEST file is made sparse as well.  That is the behavior
+selected by --sparse=auto.  Specify --sparse=always to create a sparse DEST
+file whenever the SOURCE file contains a long enough sequence of zero bytes.
+Use --sparse=never to inhibit creation of sparse files.
+
+UPDATE controls which existing files in the destination are replaced.
+'all' is the default operation when an --update option is not specified,
+and results in all existing files in the destination being replaced.
+'none' is similar to the --no-clobber option, in that no files in the
+destination are replaced, but also skipped files do not induce a failure.
+'older' is the default operation when --update is specified, and results
+in files being replaced if they're older than the corresponding source file.
+
+When --reflink[=always] is specified, perform a lightweight copy, where the
+data blocks are copied only when modified.  If this is not possible the copy
+fails, or if --reflink=auto is specified, fall back to a standard copy.
+Use --reflink=never to ensure a standard copy is performed.
+
+The backup suffix is '~', unless set with --suffix or SIMPLE_BACKUP_SUFFIX.
+The version control method may be selected via the --backup option or through
+the VERSION_CONTROL environment variable.  Here are the values:
+
+  none, off       never make backups (even if --backup is given)
+  numbered, t     make numbered backups
+  existing, nil   numbered if numbered backups exist, simple otherwise
+  simple, never   always make simple backups
+
+As a special case, cp makes a backup of SOURCE when the force and backup
+options are given and SOURCE and DEST are the same name for an existing,
+regular file.
+
+GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
+Report any translation bugs to <https://translationproject.org/team/>
+Full documentation <https://www.gnu.org/software/coreutils/cp>
+or available locally via: info '(coreutils) cp invocation'

--- a/corpus/cp/9.4/meta.toml
+++ b/corpus/cp/9.4/meta.toml
@@ -1,0 +1,21 @@
+# From issue 102 item 2. The backup-control block's enclosing sentence
+# literally names `--backup`, which is the case #99 already proves, so this
+# fixture is the control for automake's unproven morphological variant.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "cp"
+version = "9.4"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["cp", "--help"]
+stdout = "help.txt"
+
+[contract]
+
+[contract.must_attach_choices]
+"--backup" = ["none", "numbered", "existing", "simple"]

--- a/corpus/ld/2.42/help.txt
+++ b/corpus/ld/2.42/help.txt
@@ -1,0 +1,644 @@
+Usage: /usr/bin/ld [options] file...
+Options:
+  -a KEYWORD                  Shared library control for HP/UX compatibility
+  -A ARCH, --architecture ARCH
+                              Set architecture
+  -b TARGET, --format TARGET  Specify target for following input files
+  -c FILE, --mri-script FILE  Read MRI format linker script
+  -d, -dc, -dp                Force common symbols to be defined
+  --dependency-file FILE      Write dependency file
+  --force-group-allocation    Force group members out of groups
+  -e ADDRESS, --entry ADDRESS Set start address
+  -E, --export-dynamic        Export all dynamic symbols
+  --no-export-dynamic         Undo the effect of --export-dynamic
+  --enable-non-contiguous-regions
+                              Enable support of non-contiguous memory regions
+  --enable-non-contiguous-regions-warnings
+                              Enable warnings when --enable-non-contiguous-regions may cause unexpected behaviour
+  --disable-linker-version    Disable the LINKER_VERSION linker script directive
+  --enable-linker-version     Enable the LINKER_VERSION linker script directive
+  -EB                         Link big-endian objects
+  -EL                         Link little-endian objects
+  -f SHLIB, --auxiliary SHLIB Auxiliary filter for shared object symbol table
+  -F SHLIB, --filter SHLIB    Filter for shared object symbol table
+  -g                          Ignored
+  -G SIZE, --gpsize SIZE      Small data size (if no size, same as --shared)
+  -h FILENAME, -soname FILENAME
+                              Set internal name of shared library
+  -I PROGRAM, --dynamic-linker PROGRAM
+                              Set PROGRAM as the dynamic linker to use
+  --no-dynamic-linker         Produce an executable with no program interpreter header
+  -l LIBNAME, --library LIBNAME
+                              Search for library LIBNAME
+  -L DIRECTORY, --library-path DIRECTORY
+                              Add DIRECTORY to library search path
+  --sysroot=<DIRECTORY>       Override the default sysroot location
+  -m EMULATION                Set emulation
+  -M, --print-map             Print map file on standard output
+  -n, --nmagic                Do not page align data
+  -N, --omagic                Do not page align data, do not make text readonly
+  --no-omagic                 Page align data, make text readonly
+  -o FILE, --output FILE      Set output file name
+  -O                          Optimize output file
+  --out-implib FILE           Generate import library
+  -plugin PLUGIN              Load named plugin
+  -plugin-opt ARG             Send arg to last-loaded plugin
+  -flto                       Ignored for GCC LTO option compatibility
+  -flto-partition=            Ignored for GCC LTO option compatibility
+  -fuse-ld=                   Ignored for GCC linker option compatibility
+  --map-whole-files           Ignored for gold option compatibility
+  --no-map-whole-files        Ignored for gold option compatibility
+  -Qy                         Ignored for SVR4 compatibility
+  -q, --emit-relocs           Generate relocations in final output
+  -r, -i, --relocatable       Generate relocatable output
+  -R FILE, --just-symbols FILE
+                              Just link symbols (if directory, same as --rpath)
+  --remap-inputs-file FILE    Provide a FILE containing input remapings
+  --remap-inputs PATTERN=FILE Remap input files matching PATTERN to FILE
+  -s, --strip-all             Strip all symbols
+  -S, --strip-debug           Strip debugging symbols
+  --strip-discarded           Strip symbols in discarded sections
+  --no-strip-discarded        Do not strip symbols in discarded sections
+  -t, --trace                 Trace file opens
+  -T FILE, --script FILE      Read linker script
+  --default-script FILE, -dT  Read default linker script
+  -u SYMBOL, --undefined SYMBOL
+                              Start with undefined reference to SYMBOL
+  --require-defined SYMBOL    Require SYMBOL be defined in the final output
+  --unique [=SECTION]         Don't merge input [SECTION | orphan] sections
+  -Ur                         Build global constructor/destructor tables
+  -v, --version               Print version information
+  -V                          Print version and emulation information
+  -x, --discard-all           Discard all local symbols
+  -X, --discard-locals        Discard temporary local symbols (default)
+  --discard-none              Don't discard any local symbols
+  -y SYMBOL, --trace-symbol SYMBOL
+                              Trace mentions of SYMBOL
+  -Y PATH                     Default search path for Solaris compatibility
+  -(, --start-group           Start a group
+  -), --end-group             End a group
+  --accept-unknown-input-arch Accept input files whose architecture cannot be determined
+  --no-accept-unknown-input-arch
+                              Reject input files whose architecture is unknown
+  --as-needed                 Only set DT_NEEDED for following dynamic libs if used
+  --no-as-needed              Always set DT_NEEDED for dynamic libraries mentioned on
+                                the command line
+  -assert KEYWORD             Ignored for SunOS compatibility
+  -Bdynamic, -dy, -call_shared
+                              Link against shared libraries
+  -Bstatic, -dn, -non_shared, -static
+                              Do not link against shared libraries
+  -Bno-symbolic               Don't bind global references locally
+  -Bsymbolic                  Bind global references locally
+  -Bsymbolic-functions        Bind global function references locally
+  --check-sections            Check section addresses for overlaps (default)
+  --no-check-sections         Do not check section addresses for overlaps
+  --copy-dt-needed-entries    Copy DT_NEEDED links mentioned inside DSOs that follow
+  --no-copy-dt-needed-entries Do not copy DT_NEEDED links mentioned inside DSOs that follow
+  --cref                      Output cross reference table
+  --defsym SYMBOL=EXPRESSION  Define a symbol
+  --demangle [=STYLE]         Demangle symbol names [using STYLE]
+  --disable-multiple-abs-defs Do not allow multiple definitions with symbols included
+                                in filename invoked by -R or --just-symbols
+  --embedded-relocs           Generate embedded relocs
+  --fatal-warnings            Treat warnings as errors
+  --no-fatal-warnings         Do not treat warnings as errors (default)
+  -fini SYMBOL                Call SYMBOL at unload-time
+  --force-exe-suffix          Force generation of file with .exe suffix
+  --gc-sections               Remove unused sections (on some targets)
+  --no-gc-sections            Don't remove unused sections (default)
+  --print-gc-sections         List removed unused sections on stderr
+  --no-print-gc-sections      Do not list removed unused sections
+  --gc-keep-exported          Keep exported symbols when removing unused sections
+  --hash-size=<NUMBER>        Set default hash table size close to <NUMBER>
+  --help                      Print option help
+  -init SYMBOL                Call SYMBOL at load-time
+  -Map FILE/DIR               Write a linker map to FILE or DIR/<outputname>.map
+  --no-define-common          Do not define Common storage
+  --no-demangle               Do not demangle symbol names
+  --no-keep-memory            Use less memory and more disk I/O
+  --no-undefined              Do not allow unresolved references in object files
+  -w, --no-warnings           Do not display any warning or error messages
+  --allow-shlib-undefined     Allow unresolved references in shared libraries
+  --no-allow-shlib-undefined  Do not allow unresolved references in shared libs
+  --allow-multiple-definition Allow multiple definitions
+  --error-handling-script SCRIPT
+                              Provide a script to help with undefined symbol errors
+  --undefined-version         Allow undefined version
+  --no-undefined-version      Disallow undefined version
+  --default-symver            Create default symbol version
+  --default-imported-symver   Create default symbol version for imported symbols
+  --no-warn-mismatch          Don't warn about mismatched input files
+  --no-warn-search-mismatch   Don't warn on finding an incompatible library
+  --no-whole-archive          Turn off --whole-archive
+  --noinhibit-exec            Create an output file even if errors occur
+  -nostdlib                   Only use library directories specified on
+                                the command line
+  --oformat TARGET            Specify target of output file
+  --print-output-format       Print default output format
+  --print-sysroot             Print current sysroot
+  -qmagic                     Ignored for Linux compatibility
+  --reduce-memory-overheads   Reduce memory overheads, possibly taking much longer
+  --max-cache-size=SIZE       Set the maximum cache size to SIZE bytes
+  --relax                     Reduce code size by using target specific optimizations
+  --no-relax                  Do not use relaxation techniques to reduce code size
+  --retain-symbols-file FILE  Keep only symbols listed in FILE
+  -rpath PATH                 Set runtime shared library search path
+  -rpath-link PATH            Set link time shared library search path
+  -shared, -Bshareable        Create a shared library
+  -pie, --pic-executable      Create a position independent executable
+  -no-pie                     Create a position dependent executable (default)
+  --sort-common [=ascending|descending]
+                              Sort common symbols by alignment [in specified order]
+  --sort-section name|alignment
+                              Sort sections by name or maximum alignment
+  --spare-dynamic-tags COUNT  How many tags to reserve in .dynamic section
+  --split-by-file [=SIZE]     Split output sections every SIZE octets
+  --split-by-reloc [=COUNT]   Split output sections every COUNT relocs
+  --stats                     Print memory usage statistics
+  --target-help               Display target specific options
+  --task-link SYMBOL          Do task level linking
+  --traditional-format        Use same format as native linker
+  --section-start SECTION=ADDRESS
+                              Set address of named section
+  -Tbss ADDRESS               Set address of .bss section
+  -Tdata ADDRESS              Set address of .data section
+  -Ttext ADDRESS              Set address of .text section
+  -Ttext-segment ADDRESS      Set address of text segment
+  -Trodata-segment ADDRESS    Set address of rodata segment
+  -Tldata-segment ADDRESS     Set address of ldata segment
+  --unresolved-symbols=<method>
+                              How to handle unresolved symbols.  <method> is:
+                                ignore-all, report-all, ignore-in-object-files,
+                                ignore-in-shared-libs
+  --verbose [=NUMBER]         Output lots of information during link
+  --version-script FILE       Read version information script
+  --version-exports-section SYMBOL
+                              Take export symbols list from .exports, using
+                                SYMBOL as the version.
+  --dynamic-list-data         Add data symbols to dynamic list
+  --dynamic-list-cpp-new      Use C++ operator new/delete dynamic list
+  --dynamic-list-cpp-typeinfo Use C++ typeinfo dynamic list
+  --dynamic-list FILE         Read dynamic list
+  --export-dynamic-symbol SYMBOL
+                              Export the specified symbol
+  --export-dynamic-symbol-list FILE
+                              Read export dynamic symbol list
+  --warn-common               Warn about duplicate common symbols
+  --warn-constructors, --error-execstack, --no-error-execstack, --warn-execstack-objects, --warn-execstack, --no-warn-execstack, --error-rwx-segments, --no-error-rwx-segments, --warn-rwx-segments, --no-warn-rwx-segments
+                              Warn if global constructors/destructors are seen
+  --warn-multiple-gp          Warn if the multiple GP values are used
+  --warn-once                 Warn only once per undefined symbol
+  --warn-section-align        Warn if start of section changes due to alignment
+  --warn-textrel              Warn if output has DT_TEXTREL
+  --warn-alternate-em         Warn if an object has alternate ELF machine code
+  --warn-unresolved-symbols   Report unresolved symbols as warnings
+  --error-unresolved-symbols  Report unresolved symbols as errors
+  --whole-archive             Include all objects from following archives
+  --wrap SYMBOL               Use wrapper functions for SYMBOL
+  --ignore-unresolved-symbol SYMBOL
+                              Unresolved SYMBOL will not cause an error or warning
+  --push-state                Push state of flags governing input file handling
+  --pop-state                 Pop state of flags governing input file handling
+  --print-memory-usage        Report target memory usage
+  --orphan-handling =MODE     Control how orphan sections are handled.
+  --print-map-discarded       Show discarded sections in map file output (default)
+  --no-print-map-discarded    Do not show discarded sections in map file output
+  --print-map-locals          Show local symbols in map file output
+  --no-print-map-locals       Do not show local symbols in map file output (default)
+  --ctf-variables             Emit names and types of static variables in CTF
+  --no-ctf-variables          Do not emit names and types of static variables in CTF
+  --ctf-share-types=<method>  How to share CTF types between translation units.
+                                <method> is: share-unconflicted (default),
+                                             share-duplicated
+  @FILE                       Read options from FILE
+/usr/bin/ld: supported targets: elf64-littleaarch64 elf64-bigaarch64 elf32-littleaarch64 elf32-bigaarch64 elf32-littlearm elf32-bigarm pei-aarch64-little pe-aarch64-little elf64-little elf64-big elf32-little elf32-big srec symbolsrec verilog tekhex binary ihex plugin
+/usr/bin/ld: supported emulations: aarch64linux aarch64elf aarch64elf32 aarch64elf32b aarch64elfb armelf armelfb aarch64linuxb aarch64linux32 aarch64linux32b armelfb_linux_eabi armelf_linux_eabi
+/usr/bin/ld: emulation specific options:
+ELF emulations:
+  --build-id[=STYLE]          Generate build ID note
+  --package-metadata[=JSON]   Generate package metadata note
+  --compress-debug-sections=[none|zlib|zlib-gnu|zlib-gabi|zstd]
+			      Compress DWARF debug sections
+                                Default: none
+  -z common-page-size=SIZE    Set common page size to SIZE
+  -z max-page-size=SIZE       Set maximum page size to SIZE
+  -z defs                     Report unresolved symbols in object files
+  -z undefs                   Ignore unresolved symbols in object files
+  -z muldefs                  Allow multiple definitions
+  -z stack-size=SIZE          Set size of stack segment
+  -z execstack                Mark executable as requiring executable stack
+  -z noexecstack              Mark executable as not requiring executable stack
+  --warn-execstack-objects    Generate a warning if an object file requests an executable stack
+  --warn-execstack            Generate a warning if creating an executable stack (default)
+  --no-warn-execstack         Do not generate a warning if creating an executable stack
+  --error-execstack           Turn warnings about executable stacks into errors
+  --no-error-execstack         Do not turn warnings about executable stacks into errors
+  --warn-rwx-segments         Generate a warning if a LOAD segment has RWX permissions (default)
+  --no-warn-rwx-segments      Do not generate a warning if a LOAD segments has RWX permissions
+  --error-rwx-segments        Turn warnings about loadable RWX segments into errors
+  --no-error-rwx-segments     Do not turn warnings about loadable RWX segments into errors
+  -z unique-symbol            Avoid duplicated local symbol names
+  -z nounique-symbol          Keep duplicated local symbol names (default)
+  -z globalaudit              Mark executable requiring global auditing
+  -z start-stop-gc            Enable garbage collection on __start/__stop
+  -z nostart-stop-gc          Don't garbage collect __start/__stop (default)
+  -z start-stop-visibility=V  Set visibility of built-in __start/__stop symbols
+                                to DEFAULT, PROTECTED, HIDDEN or INTERNAL
+  -z sectionheader            Generate section header (default)
+  -z nosectionheader          Do not generate section header
+  --audit=AUDITLIB            Specify a library to use for auditing
+  -Bgroup                     Selects group name lookup rules for DSO
+  --disable-new-dtags         Disable new dynamic tags
+  --enable-new-dtags          Enable new dynamic tags
+  --eh-frame-hdr              Create .eh_frame_hdr section
+  --no-eh-frame-hdr           Do not create .eh_frame_hdr section
+  --exclude-libs=LIBS         Make all symbols in LIBS hidden
+  --hash-style=STYLE          Set hash style to sysv/gnu/both.  Default: both
+  -P AUDITLIB, --depaudit=AUDITLIB
+                              Specify a library to use for auditing dependencies
+  -z combreloc                Merge dynamic relocs into one section and sort
+  -z nocombreloc              Don't merge dynamic relocs into one section
+  -z global                   Make symbols in DSO available for subsequently
+                                loaded objects
+  -z initfirst                Mark DSO to be initialized first at runtime
+  -z interpose                Mark object to interpose all DSOs but executable
+  -z unique                   Mark DSO to be loaded at most once by default, and only in the main namespace
+  -z nounique                 Don't mark DSO as a loadable at most once
+  -z lazy                     Mark object lazy runtime binding (default)
+  -z loadfltr                 Mark object requiring immediate process
+  -z nocopyreloc              Don't create copy relocs
+  -z nodefaultlib             Mark object not to use default search paths
+  -z nodelete                 Mark DSO non-deletable at runtime
+  -z nodlopen                 Mark DSO not available to dlopen
+  -z nodump                   Mark DSO not available to dldump
+  -z now                      Mark object non-lazy runtime binding
+  -z origin                   Mark object requiring immediate $ORIGIN
+                                processing at runtime
+  -z relro                    Create RELRO program header (default)
+  -z norelro                  Don't create RELRO program header
+  -z separate-code            Create separate code program header
+  -z noseparate-code          Don't create separate code program header (default)
+  -z common                   Generate common symbols with STT_COMMON type
+  -z nocommon                 Generate common symbols with STT_OBJECT type
+  -z text                     Treat DT_TEXTREL in output as error
+  -z notext                   Don't treat DT_TEXTREL in output as error (default)
+  -z textoff                  Don't treat DT_TEXTREL in output as error (default)
+aarch64linux: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+aarch64elf: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+aarch64elf32: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+aarch64elf32b: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+aarch64elfb: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+armelf: 
+  --thumb-entry=<sym>         Set the entry point to be Thumb symbol <sym>
+  --be8                       Output BE8 format image
+  --target1-rel               Interpret R_ARM_TARGET1 as R_ARM_REL32
+  --target1-abs               Interpret R_ARM_TARGET1 as R_ARM_ABS32
+  --target2=<type>            Specify definition of R_ARM_TARGET2
+  --fix-v4bx                  Rewrite BX rn as MOV pc, rn for ARMv4
+  --fix-v4bx-interworking     Rewrite BX rn branch to ARMv4 interworking veneer
+  --use-blx                   Enable use of BLX instructions
+  --vfp11-denorm-fix          Specify how to fix VFP11 denorm erratum
+  --fix-stm32l4xx-629360      Specify how to fix STM32L4XX 629360 erratum
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --long-plt                  Generate long .plt entries
+                              to handle large .plt/.got displacements
+  --cmse-implib               Make import library to be a secure gateway import
+                                library as per ARMv8-M Security Extensions
+  --in-implib                 Import library whose symbols address must
+                                remain stable
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --[no-]fix-cortex-a8        Disable/enable Cortex-A8 Thumb-2 branch erratum fix
+  --no-merge-exidx-entries    Disable merging exidx entries
+  --[no-]fix-arm1176          Disable/enable ARM1176 BLX immediate erratum fix
+armelfb: 
+  --thumb-entry=<sym>         Set the entry point to be Thumb symbol <sym>
+  --be8                       Output BE8 format image
+  --target1-rel               Interpret R_ARM_TARGET1 as R_ARM_REL32
+  --target1-abs               Interpret R_ARM_TARGET1 as R_ARM_ABS32
+  --target2=<type>            Specify definition of R_ARM_TARGET2
+  --fix-v4bx                  Rewrite BX rn as MOV pc, rn for ARMv4
+  --fix-v4bx-interworking     Rewrite BX rn branch to ARMv4 interworking veneer
+  --use-blx                   Enable use of BLX instructions
+  --vfp11-denorm-fix          Specify how to fix VFP11 denorm erratum
+  --fix-stm32l4xx-629360      Specify how to fix STM32L4XX 629360 erratum
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --long-plt                  Generate long .plt entries
+                              to handle large .plt/.got displacements
+  --cmse-implib               Make import library to be a secure gateway import
+                                library as per ARMv8-M Security Extensions
+  --in-implib                 Import library whose symbols address must
+                                remain stable
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --[no-]fix-cortex-a8        Disable/enable Cortex-A8 Thumb-2 branch erratum fix
+  --no-merge-exidx-entries    Disable merging exidx entries
+  --[no-]fix-arm1176          Disable/enable ARM1176 BLX immediate erratum fix
+aarch64linuxb: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+aarch64linux32: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+aarch64linux32b: 
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --fix-cortex-a53-835769      Fix erratum 835769
+  --fix-cortex-a53-843419[=full|adr|adrp]      Fix erratum 843419 and optionally specify which workaround to use.
+                                               full (default): Use both ADRP and ADR workaround, this will 
+                                                 increase the size of your binaries.
+                                               adr: Only use the ADR workaround, this will not cause any increase
+                                                 in binary size but linking will fail if the referenced address is
+                                                 out of range of an ADR instruction.  This will remove the need of using
+                                                 a veneer and results in both performance and size benefits.
+                                               adrp: Use only the ADRP workaround, this will never rewrite your ADRP
+                                                 instruction into an ADR.  As such the workaround will always use a
+                                                 veneer and this will give you both a performance and size overhead.
+  --no-apply-dynamic-relocs    Do not apply link-time values for dynamic relocations
+  -z force-bti                  Turn on Branch Target Identification mechanism and generate PLTs with BTI. Generate warnings for missing BTI on inputs
+  -z pac-plt                    Protect PLTs with Pointer Authentication.
+armelfb_linux_eabi: 
+  --thumb-entry=<sym>         Set the entry point to be Thumb symbol <sym>
+  --be8                       Output BE8 format image
+  --target1-rel               Interpret R_ARM_TARGET1 as R_ARM_REL32
+  --target1-abs               Interpret R_ARM_TARGET1 as R_ARM_ABS32
+  --target2=<type>            Specify definition of R_ARM_TARGET2
+  --fix-v4bx                  Rewrite BX rn as MOV pc, rn for ARMv4
+  --fix-v4bx-interworking     Rewrite BX rn branch to ARMv4 interworking veneer
+  --use-blx                   Enable use of BLX instructions
+  --vfp11-denorm-fix          Specify how to fix VFP11 denorm erratum
+  --fix-stm32l4xx-629360      Specify how to fix STM32L4XX 629360 erratum
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --long-plt                  Generate long .plt entries
+                              to handle large .plt/.got displacements
+  --cmse-implib               Make import library to be a secure gateway import
+                                library as per ARMv8-M Security Extensions
+  --in-implib                 Import library whose symbols address must
+                                remain stable
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --[no-]fix-cortex-a8        Disable/enable Cortex-A8 Thumb-2 branch erratum fix
+  --no-merge-exidx-entries    Disable merging exidx entries
+  --[no-]fix-arm1176          Disable/enable ARM1176 BLX immediate erratum fix
+armelf_linux_eabi: 
+  --thumb-entry=<sym>         Set the entry point to be Thumb symbol <sym>
+  --be8                       Output BE8 format image
+  --target1-rel               Interpret R_ARM_TARGET1 as R_ARM_REL32
+  --target1-abs               Interpret R_ARM_TARGET1 as R_ARM_ABS32
+  --target2=<type>            Specify definition of R_ARM_TARGET2
+  --fix-v4bx                  Rewrite BX rn as MOV pc, rn for ARMv4
+  --fix-v4bx-interworking     Rewrite BX rn branch to ARMv4 interworking veneer
+  --use-blx                   Enable use of BLX instructions
+  --vfp11-denorm-fix          Specify how to fix VFP11 denorm erratum
+  --fix-stm32l4xx-629360      Specify how to fix STM32L4XX 629360 erratum
+  --no-enum-size-warning      Don't warn about objects with incompatible
+                                enum sizes
+  --no-wchar-size-warning     Don't warn about objects with incompatible
+                                wchar_t sizes
+  --pic-veneer                Always generate PIC interworking veneers
+  --long-plt                  Generate long .plt entries
+                              to handle large .plt/.got displacements
+  --cmse-implib               Make import library to be a secure gateway import
+                                library as per ARMv8-M Security Extensions
+  --in-implib                 Import library whose symbols address must
+                                remain stable
+  --stub-group-size=N         Maximum size of a group of input sections that
+                                can be handled by one stub section.  A negative
+                                value locates all stubs after their branches
+                                (with a group size of -N), while a positive
+                                value allows two groups of input sections, one
+                                before, and one after each stub section.
+                                Values of +/-1 indicate the linker should
+                                choose suitable defaults.
+  --[no-]fix-cortex-a8        Disable/enable Cortex-A8 Thumb-2 branch erratum fix
+  --no-merge-exidx-entries    Disable merging exidx entries
+  --[no-]fix-arm1176          Disable/enable ARM1176 BLX immediate erratum fix
+
+Report bugs to <https://sourceware.org/bugzilla/>

--- a/corpus/ld/2.42/meta.toml
+++ b/corpus/ld/2.42/meta.toml
@@ -1,0 +1,29 @@
+# From issue 102 item 3 (list rows naming independent options). One row
+# carries ten independent long options separated by commas, and the row's
+# own grammar reads as an alias list. The same document's
+# `-Bstatic, -dn, -non_shared, -static` row IS a genuine alias run, so a
+# fix must separate the first without splitting the second.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "ld"
+version = "2.42"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["ld", "--help"]
+stdout = "help.txt"
+
+[contract]
+must_keep_separate = [
+    ["--warn-constructors", "--error-execstack"],
+    ["--warn-execstack", "--no-warn-execstack"],
+    ["--error-rwx-segments", "--warn-rwx-segments"],
+]
+
+[xfail]
+broken = true
+reason = "a row of ten independent long options separated by commas reads as one multi-spelling entity, because the row's own grammar says alias list while the tool means 'any of these'. No shape-level evidence distinguishes it from a genuine alias row such as this same document's -Bstatic, -dn, -non_shared, -static. A fix needs evidence outside the row."

--- a/corpus/llvm-size/18.1.3/expected.snap
+++ b/corpus/llvm-size/18.1.3/expected.snap
@@ -1,0 +1,114 @@
+name: llvm-size
+description: 'OVERVIEW: LLVM object size dumper'
+usage:
+- 'USAGE: /usr/bin/llvm-size-18 [options] <input object files>'
+flags:
+- spellings:
+  - -A
+  description: Alias for --format
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -B
+  description: Alias for --format
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --common
+  description: Print common symbols in the ELF file. When using Berkeley format, this is added to bss
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  description: Alias for --radix=10
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --format
+  value_name: <value>
+  value_kind: Required
+  description: Specify output format
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --help
+  description: Display this help
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  description: Alias for --help
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -m
+  description: Alias for --format
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  description: Alias for --radix=8
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --radix
+  value_name: <value>
+  value_kind: Required
+  description: Print size in radix
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --totals
+  description: Print totals of all objects - Berkeley format only
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -t
+  description: Alias for --totals
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --version
+  description: Display the version
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -x
+  description: Alias for --radix=16
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --arch
+  value_name: <value>
+  value_kind: Required
+  group: 'OPTIONS (Mach-O specific):'
+  description: architecture(s) from a Mach-O file to dump
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -l
+  group: 'OPTIONS (Mach-O specific):'
+  description: When format is darwin, use long format to include addresses and offsets
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/llvm-size/18.1.3/help.txt
+++ b/corpus/llvm-size/18.1.3/help.txt
@@ -1,0 +1,25 @@
+OVERVIEW: LLVM object size dumper
+
+USAGE: /usr/bin/llvm-size-18 [options] <input object files>
+
+OPTIONS:
+  -A               Alias for --format
+  -B               Alias for --format
+  --common         Print common symbols in the ELF file. When using Berkeley format, this is added to bss
+  -d               Alias for --radix=10
+  --format=<value> Specify output format
+  --help           Display this help
+  -h               Alias for --help
+  -m               Alias for --format
+  -o               Alias for --radix=8
+  --radix=<value>  Print size in radix
+  --totals         Print totals of all objects - Berkeley format only
+  -t               Alias for --totals
+  --version        Display the version
+  -x               Alias for --radix=16
+
+OPTIONS (Mach-O specific):
+  --arch=<value> architecture(s) from a Mach-O file to dump
+  -l             When format is darwin, use long format to include addresses and offsets
+
+Pass @FILE as argument to read options from FILE.

--- a/corpus/llvm-size/18.1.3/meta.toml
+++ b/corpus/llvm-size/18.1.3/meta.toml
@@ -1,0 +1,18 @@
+# From issue 102 item 1. `-A` and `-B` are both described "Alias for
+# --format", but to different values, so they are not aliases of each other.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "llvm-size"
+version = "18.1.3"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["llvm-size-18", "--help"]
+stdout = "help.txt"
+
+[contract]
+must_keep_separate = [["-A", "-B"]]

--- a/corpus/lto-dump/13.3.0/help.txt
+++ b/corpus/lto-dump/13.3.0/help.txt
@@ -1,0 +1,1838 @@
+The following options are specific to just the language Ada:
+  -fdump-scos                 		[available in Ada]
+
+The following options are specific to just the language AdaSCIL:
+ None found.  Use --help=AdaSCIL to show *all* the options supported by the AdaSCIL front-end.
+
+The following options are specific to just the language AdaWhy:
+ None found.  Use --help=AdaWhy to show *all* the options supported by the AdaWhy front-end.
+
+The following options are specific to just the language C:
+  -fgimple                    		[available in C]
+
+The following options are specific to just the language C++:
+  --param=lazy-modules=       		[available in C++]
+  -Wplacement-new             		-Wplacement-new=1
+  -Wplacement-new=<0,2>       		[available in C++]
+  -fcontract-assumption-mode=[on|off] 	
+  -fcontract-build-level=[off|default|audit] 	
+  -fcontract-continuation-mode=[on|off] 	
+  -fcontract-mode=[on|off]    		[available in C++]
+  -fcontract-role=<name>:<semantics> 	
+  -fcontract-semantic=<level>:<semantic> 	
+  -fcontract-strict-declarations=[on|off] 	[available in C++]
+  -flang-info-include-translate 	[available in C++]
+  -flang-info-include-translate-not 	[available in C++]
+  -flang-info-include-translate= 	
+  -flang-info-module-cmi      		[available in C++]
+  -flang-info-module-cmi=     		
+
+The following options are specific to just the language D:
+  -Hd <dir>                   		
+  -Hf <file>                  		
+  -Wcast-result               		[available in D]
+  -Wmismatched-special-enum   		[available in D]
+  -Wspeculative               		[disabled]
+  -X                          		[disabled]
+  -Xf <file>                  		
+  -fall-instantiations        		[disabled]
+  -fassert                    		[available in D]
+  -fbounds-check              		[available in D]
+  -fbounds-check=[on|safeonly|off] 	[available in D]
+  -fcheckaction=[throw,halt,context] 	[available in D]
+  -fdebug                     		[disabled]
+  -fdebug=<ident>             		
+  -fdoc                       		[disabled]
+  -fdoc-dir=<dir>             		
+  -fdoc-file=<file>           		
+  -fdoc-inc=<file>            		
+  -fdruntime                  		[disabled]
+  -fdump-c++-spec-verbose     		[disabled]
+  -fdump-cxx-spec=<filename>  		
+  -fdump-d-original           		[disabled]
+  -fextern-std=<standard>     		[available in D]
+  -fignore-unknown-pragmas    		[disabled]
+  -finvariants                		[available in D]
+  -fmain                      		[disabled]
+  -fmodule-file=<package.module>=<filespec> 	
+  -fmoduleinfo                		[available in D]
+  -fonly=                     		
+  -fpostconditions            		[available in D]
+  -fpreconditions             		[available in D]
+  -fpreview=all               		[disabled]
+  -fpreview=bitfields         		[disabled]
+  -fpreview=dip1000           		[disabled]
+  -fpreview=dip1008           		[disabled]
+  -fpreview=dip1021           		[disabled]
+  -fpreview=dtorfields        		[disabled]
+  -fpreview=fieldwise         		[disabled]
+  -fpreview=fixaliasthis      		[disabled]
+  -fpreview=fiximmutableconv  		[disabled]
+  -fpreview=in                		[disabled]
+  -fpreview=inclusiveincontracts 	[disabled]
+  -fpreview=nosharedaccess    		[disabled]
+  -fpreview=rvaluerefparam    		[disabled]
+  -fpreview=systemvariables   		[disabled]
+  -frelease                   		[disabled]
+  -frevert=all                		[disabled]
+  -frevert=dip1000            		[disabled]
+  -frevert=dtorfields         		[disabled]
+  -frevert=intpromote         		[disabled]
+  -fsave-mixins=<filename>    		
+  -fswitch-errors             		[available in D]
+  -ftransition=all            		[disabled]
+  -ftransition=field          		[disabled]
+  -ftransition=in             		[disabled]
+  -ftransition=nogc           		[disabled]
+  -ftransition=templates      		[disabled]
+  -ftransition=tls            		[disabled]
+  -funittest                  		[disabled]
+  -fversion=<ident>           		
+  -fweak-templates            		[available in D]
+
+The following options are specific to just the language Fortran:
+  -Waliasing                  		[available in Fortran]
+  -Walign-commons             		[available in Fortran]
+  -Wampersand                 		[available in Fortran]
+  -Wargument-mismatch         		[disabled]
+  -Warray-temporaries         		[available in Fortran]
+  -Wc-binding-type            		[available in Fortran]
+  -Wcharacter-truncation      		[available in Fortran]
+  -Wcompare-reals             		[available in Fortran]
+  -Wconversion-extra          		[available in Fortran]
+  -Wdo-subscript              		[available in Fortran]
+  -Wfrontend-loop-interchange 		[available in Fortran]
+  -Wfunction-elimination      		[available in Fortran]
+  -Wimplicit-interface        		[available in Fortran]
+  -Wimplicit-procedure        		[available in Fortran]
+  -Winteger-division          		[available in Fortran]
+  -Wintrinsic-shadow          		[available in Fortran]
+  -Wintrinsics-std            		[available in Fortran]
+  -Wline-truncation           		[available in Fortran]
+  -Woverwrite-recursive       		[available in Fortran]
+  -Wreal-q-constant           		[available in Fortran]
+  -Wrealloc-lhs               		[available in Fortran]
+  -Wrealloc-lhs-all           		[available in Fortran]
+  -Wsurprising                		[available in Fortran]
+  -Wtabs                      		[available in Fortran]
+  -Wtarget-lifetime           		[available in Fortran]
+  -Wundefined-do-loop         		[available in Fortran]
+  -Wunderflow                 		[available in Fortran]
+  -Wunused-dummy-argument     		[available in Fortran]
+  -Wuse-without-only          		[available in Fortran]
+  -Wzerotrip                  		[available in Fortran]
+  -cpp                        		[disabled]
+  -faggressive-function-elimination 	[available in Fortran]
+  -falign-commons             		[available in Fortran]
+  -fall-intrinsics            		[available in Fortran]
+  -fallow-argument-mismatch   		[available in Fortran]
+  -fallow-invalid-boz         		[available in Fortran]
+  -fautomatic                 		[available in Fortran]
+  -fbackslash                 		[available in Fortran]
+  -fbacktrace                 		[available in Fortran]
+  -fblas-matmul-limit=<n>     		[available in Fortran]
+  -fc-prototypes              		[available in Fortran]
+  -fc-prototypes-external     		[available in Fortran]
+  -fcheck-array-temporaries   		[disabled]
+  -fcheck=[...]               		
+  -fcoarray=<none|single|lib> 		[available in Fortran]
+  -fconvert=<big-endian|little-endian|native|swap|r16_ieee|r16_ibm> 	[available
+                              in Fortran]
+  -fcray-pointer              		[available in Fortran]
+  -fd-lines-as-code           		[disabled]
+  -fd-lines-as-comments       		[disabled]
+  -fdebug-aux-vars            		[available in Fortran]
+  -fdec                       		[available in Fortran]
+  -fdec-blank-format-item     		[available in Fortran]
+  -fdec-char-conversions      		[available in Fortran]
+  -fdec-format-defaults       		[available in Fortran]
+  -fdec-include               		[available in Fortran]
+  -fdec-intrinsic-ints        		[available in Fortran]
+  -fdec-math                  		[available in Fortran]
+  -fdec-static                		[available in Fortran]
+  -fdec-structure             		[available in Fortran]
+  -fdefault-double-8          		[available in Fortran]
+  -fdefault-integer-8         		[available in Fortran]
+  -fdefault-real-10           		[available in Fortran]
+  -fdefault-real-16           		[available in Fortran]
+  -fdefault-real-8            		[available in Fortran]
+  -fdollar-ok                 		[available in Fortran]
+  -fdump-core                 		[ignored]
+  -fdump-fortran-global       		[available in Fortran]
+  -fdump-fortran-optimized    		[available in Fortran]
+  -fdump-fortran-original     		[available in Fortran]
+  -fdump-parse-tree           		-fdump-fortran-original
+  -fexternal-blas             		[available in Fortran]
+  -ff2c                       		[available in Fortran]
+  -ffixed-form                		[disabled]
+  -ffixed-line-length-<n>     		[available in Fortran]
+  -ffixed-line-length-none    		[available in Fortran]
+  -ffpe-summary=[...]         		
+  -ffpe-trap=[...]            		
+  -ffree-form                 		[disabled]
+  -ffree-line-length-<n>      		[available in Fortran]
+  -ffree-line-length-none     		[available in Fortran]
+  -ffrontend-loop-interchange 		[available in Fortran]
+  -ffrontend-optimize         		[available in Fortran]
+  -fimplicit-none             		[available in Fortran]
+  -finit-character=<n>        		
+  -finit-derived              		[available in Fortran]
+  -finit-integer=<n>          		
+  -finit-local-zero           		[disabled]
+  -finit-logical=<true|false> 		
+  -finit-real=<zero|snan|nan|inf|-inf> 	[available in Fortran]
+  -finline-arg-packing        		[available in Fortran]
+  -finline-matmul-limit=<n>   		[available in Fortran]
+  -finteger-4-integer-8       		[available in Fortran]
+  -fintrinsic-modules-path    		[disabled]
+  -fintrinsic-modules-path=   		
+  -fmax-array-constructor=<n> 		[available in Fortran]
+  -fmax-identifier-length=<n> 		
+  -fmax-stack-var-size=<n>    		[available in Fortran]
+  -fmax-subrecord-length=<n>  		[available in Fortran]
+  -fmodule-private            		[available in Fortran]
+  -fpack-derived              		[available in Fortran]
+  -fpad-source                		[available in Fortran]
+  -fprotect-parens            		[available in Fortran]
+  -frange-check               		[available in Fortran]
+  -freal-4-real-10            		[available in Fortran]
+  -freal-4-real-16            		[available in Fortran]
+  -freal-4-real-8             		[available in Fortran]
+  -freal-8-real-10            		[available in Fortran]
+  -freal-8-real-16            		[available in Fortran]
+  -freal-8-real-4             		[available in Fortran]
+  -frealloc-lhs               		[available in Fortran]
+  -frecord-marker=4           		[available in Fortran]
+  -frecord-marker=8           		[available in Fortran]
+  -frecursive                 		[available in Fortran]
+  -frepack-arrays             		[available in Fortran]
+  -fsecond-underscore         		[available in Fortran]
+  -fsign-zero                 		[available in Fortran]
+  -fstack-arrays              		[available in Fortran]
+  -ftail-call-workaround=<0,2> 		[available in Fortran]
+  -ftest-forall-temp          		[available in Fortran]
+  -funderscoring              		[available in Fortran]
+  -fwhole-file                		[ignored]
+  -nocpp                      		[disabled]
+  -std=f2003                  		[disabled]
+  -std=f2008                  		[disabled]
+  -std=f2008ts                		[disabled]
+  -std=f2018                  		[disabled]
+  -std=f95                    		[disabled]
+  -std=gnu                    		[disabled]
+  -std=legacy                 		[disabled]
+
+The following options are specific to just the language Go:
+  -fgo-c-header=<file>        		
+  -fgo-check-divide-overflow  		[available in Go]
+  -fgo-check-divide-zero      		[available in Go]
+  -fgo-compiling-runtime      		[available in Go]
+  -fgo-debug-escape           		[available in Go]
+  -fgo-debug-escape-hash=<string> 	[available in Go]
+  -fgo-debug-optimization     		[available in Go]
+  -fgo-dump-<type>            		
+  -fgo-embedcfg=<file>        		
+  -fgo-optimize-<type>        		
+  -fgo-pkgpath=<string>       		
+  -fgo-prefix=<string>        		
+  -fgo-relative-import-path=<path> 	
+  -frequire-return-statement  		[available in Go]
+
+The following options are specific to just the language LTO:
+  -flinker-output=            		[available in LTO]
+  -fltrans                    		[available in LTO]
+  -fltrans-output-list=       		[available in LTO]
+  -fresolution=               		
+  -fwpa                       		[disabled]
+  -fwpa=                      		[available in LTO]
+
+The following options are specific to just the language LTODump:
+  -callgraph                  		[disabled]
+  -defined-only               		[disabled]
+  -demangle                   		[disabled]
+  -gimple-stats               		[disabled]
+  -help                       		[disabled]
+  -list                       		[disabled]
+  -name-sort                  		[disabled]
+  -objects                    		[disabled]
+  -print-value                		[disabled]
+  -reverse-sort               		[disabled]
+  -size-sort                  		[disabled]
+  -tree-stats                 		[disabled]
+  -type-stats                 		[disabled]
+
+The following options are specific to just the language Modula-2:
+  -Wcase-enum                 		[disabled]
+  -Wpedantic-cast             		[disabled]
+  -Wpedantic-param-names      		[disabled]
+  -Wstyle                     		[disabled]
+  -Wuninit-variable-checking  		[disabled]
+  -Wuninit-variable-checking= 		
+  -Wunused-parameter          		[available in Modula-2]
+  -Wverbose-unbounded         		[disabled]
+  -fauto-init                 		[disabled]
+  -fbounds                    		[disabled]
+  -fcase                      		[disabled]
+  -fcpp                       		[disabled]
+  -fcpp-begin                 		[disabled]
+  -fcpp-end                   		[disabled]
+  -fd                         		[disabled]
+  -fdebug-builtins            		[disabled]
+  -fdebug-function-line-numbers 	[disabled]
+  -fdebug-trace-api           		[disabled]
+  -fdebug-trace-quad          		[disabled]
+  -fdef=                      		
+  -fdump-system-exports       		[disabled]
+  -fextended-opaque           		[disabled]
+  -ffloatvalue                		[disabled]
+  -fgen-module-list=          		
+  -findex                     		[disabled]
+  -fiso                       		[disabled]
+  -flibs=                     		
+  -flocation=                 		
+  -fm2-g                      		[disabled]
+  -fm2-lower-case             		[disabled]
+  -fm2-pathname=              		
+  -fm2-plugin                 		[disabled]
+  -fm2-prefix=                		
+  -fm2-statistics             		[disabled]
+  -fm2-strict-type            		[disabled]
+  -fm2-whole-program          		[disabled]
+  -fmod=                      		
+  -fnil                       		[disabled]
+  -fpim                       		[disabled]
+  -fpim2                      		[disabled]
+  -fpim3                      		[disabled]
+  -fpim4                      		[disabled]
+  -fpositive-mod-floor-div    		[disabled]
+  -fpthread                   		[disabled]
+  -fq                         		[disabled]
+  -frange                     		[disabled]
+  -freturn                    		[disabled]
+  -fruntime-modules=          		
+  -fscaffold-c                		[disabled]
+  -fscaffold-c++              		[disabled]
+  -fscaffold-dynamic          		[disabled]
+  -fscaffold-main             		[disabled]
+  -fscaffold-static           		[disabled]
+  -fshared                    		[disabled]
+  -fsoft-check-all            		[disabled]
+  -fsources                   		[disabled]
+  -fswig                      		[disabled]
+  -funbounded-by-reference    		[disabled]
+  -fuse-list=                 		
+  -fwholediv                  		[disabled]
+  -fwholevalue                		[disabled]
+  -save-temps                 		[disabled]
+  -save-temps=                		
+
+The following options are specific to just the language ObjC:
+ None found.  Use --help=ObjC to show *all* the options supported by the ObjC front-end.
+
+The following options are specific to just the language ObjC++:
+  -fobjc-call-cxx-cdtors      		[available in ObjC++]
+
+The following options are specific to just the language Rust:
+  -frust-cfg=                 		
+  -frust-compile-until=       		[available in Rust]
+  -frust-crate=               		
+  -frust-debug                		[available in Rust]
+  -frust-dump-<type>          		
+  -frust-edition=             		[available in Rust]
+  -frust-embed-metadata       		[available in Rust]
+  -frust-incomplete-and-experimental-compiler-do-not-use 	[available in Rust]
+  -frust-mangling=            		[available in Rust]
+  -frust-max-recursion-depth= 		[available in Rust]
+  -frust-metadata-output=     		
+
+The following options are language-related:
+  -A<question>=<answer>       		
+  -C                          		[disabled]
+  -CC                         		[disabled]
+  -D<macro>[=<val>]           		
+  -F <dir>                    		
+  -H                          		[disabled]
+  -I <dir>                    		
+  -J<directory>               		
+  -M                          		[disabled]
+  -MD                         		[disabled]
+  -MF <file>                  		
+  -MG                         		[disabled]
+  -MM                         		[disabled]
+  -MMD                        		[disabled]
+  -MP                         		[disabled]
+  -MQ <target>                		
+  -MT <target>                		
+  -Mmodules                   		[disabled]
+  -P                          		[disabled]
+  -U<macro>                   		
+  -WNSObject-attribute        		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wabi                       		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wabi-tag                   		[available in C++, ObjC++]
+  -Wabi=                      		
+  -Wabsolute-value            		[available in C, ObjC]
+  -Waddress                   		[available in C, C++, D, ObjC, ObjC++]
+  -Waddress-of-packed-member  		[available in C, C++, ObjC, ObjC++]
+  -Waligned-new               		-Waligned-new=global
+  -Waligned-new=[none|global|all] 	[available in C++, ObjC++]
+  -Wall                       		[disabled]
+  -Walloc-size-larger-than=<bytes> 	[available in C, C++, LTO, ObjC, ObjC++]
+  -Walloc-zero                		[available in C, C++, ObjC, ObjC++]
+  -Walloca                    		[available in C, C++, D, ObjC, ObjC++]
+  -Walloca-larger-than=<number> 	[available in C, C++, D, LTO, ObjC, ObjC++]
+  -Warith-conversion          		[available in C, C++, ObjC, ObjC++]
+  -Warray-compare             		[available in C, C++, ObjC, ObjC++]
+  -Warray-parameter           		-Warray-parameter=2
+  -Warray-parameter=<0,2>     		[available in C, C++, ObjC, ObjC++]
+  -Wassign-intercept          		[available in ObjC, ObjC++]
+  -Wbad-function-cast         		[available in C, ObjC]
+  -Wbidi-chars=               		[available in C, C++, ObjC, ObjC++]
+  -Wbool-compare              		[available in C, C++, ObjC, ObjC++]
+  -Wbool-operation            		[available in C, C++, ObjC, ObjC++]
+  -Wbuiltin-declaration-mismatch 	[available in C, C++, D, ObjC, ObjC++]
+  -Wbuiltin-macro-redefined   		[available in C, C++, ObjC, ObjC++]
+  -Wc++-compat                		[available in C, ObjC]
+  -Wc++11-compat              		[available in C++, ObjC++]
+  -Wc++11-extensions          		[available in C++, ObjC++]
+  -Wc++14-compat              		[available in C++, ObjC++]
+  -Wc++14-extensions          		[available in C++, ObjC++]
+  -Wc++17-compat              		[available in C++, ObjC++]
+  -Wc++17-extensions          		[available in C++, ObjC++]
+  -Wc++20-compat              		[available in C++, ObjC++]
+  -Wc++20-extensions          		[available in C++, ObjC++]
+  -Wc++23-extensions          		[available in C++, ObjC++]
+  -Wc11-c2x-compat            		[available in C, ObjC]
+  -Wc90-c99-compat            		[available in C, ObjC]
+  -Wc99-c11-compat            		[available in C, ObjC]
+  -Wcast-function-type        		[available in C, C++, ObjC, ObjC++]
+  -Wcast-qual                 		[available in C, C++, ObjC, ObjC++]
+  -Wcatch-value               		-Wcatch-value=1
+  -Wcatch-value=<0,3>         		[available in C++, ObjC++]
+  -Wchanges-meaning           		[available in C++, ObjC++]
+  -Wchar-subscripts           		[available in C, C++, ObjC, ObjC++]
+  -Wchkp                      		[disabled]
+  -Wclass-conversion          		[available in C++, ObjC++]
+  -Wclass-memaccess           		[available in C++, ObjC++]
+  -Wclobbered                 		[available in C, C++, ObjC, ObjC++]
+  -Wcomma-subscript           		[available in C++, ObjC++]
+  -Wcomment                   		[available in C, C++, ObjC, ObjC++]
+  -Wcomments                  		-Wcomment
+  -Wconditionally-supported   		[available in C++, ObjC++]
+  -Wconversion                		[available in C, C++, Fortran, ObjC, ObjC++]
+  -Wconversion-null           		[available in C++, ObjC++]
+  -Wcpp                       		[available in C, C++, ObjC, ObjC++]
+  -Wctad-maybe-unsupported    		[available in C++, ObjC++]
+  -Wctor-dtor-privacy         		[available in C++, ObjC++]
+  -Wdangling-else             		[available in C, C++, ObjC, ObjC++]
+  -Wdangling-pointer          		-Wdangling-pointer=2
+  -Wdangling-pointer=<0,2>    		[available in C, C++, ObjC, ObjC++]
+  -Wdangling-reference        		[available in C++, ObjC++]
+  -Wdate-time                 		[available in C, C++, Fortran, ObjC, ObjC++]
+  -Wdeclaration-after-statement 	[available in C, ObjC]
+  -Wdelete-incomplete         		[available in C++, ObjC++]
+  -Wdelete-non-virtual-dtor   		[available in C++, ObjC++]
+  -Wdeprecated                		[available in C, C++, D, ObjC, ObjC++]
+  -Wdeprecated-copy           		[available in C++, ObjC++]
+  -Wdeprecated-copy-dtor      		[available in C++, ObjC++]
+  -Wdeprecated-enum-enum-conversion 	[available in C++, ObjC++]
+  -Wdeprecated-enum-float-conversion 	[available in C++, ObjC++]
+  -Wdesignated-init           		[available in C, ObjC]
+  -Wdiscarded-array-qualifiers 		[available in C, ObjC]
+  -Wdiscarded-qualifiers      		[available in C, ObjC]
+  -Wdiv-by-zero               		[available in C, C++, ObjC, ObjC++]
+  -Wdouble-promotion          		[available in C, C++, ObjC, ObjC++]
+  -Wduplicate-decl-specifier  		[available in C, ObjC]
+  -Wduplicated-branches       		[available in C, C++, ObjC, ObjC++]
+  -Wduplicated-cond           		[available in C, C++, ObjC, ObjC++]
+  -Weffc++                    		[available in C++, ObjC++]
+  -Wempty-body                		[available in C, C++, ObjC, ObjC++]
+  -Wendif-labels              		[available in C, C++, ObjC, ObjC++]
+  -Wenum-compare              		[available in C, C++, ObjC, ObjC++]
+  -Wenum-conversion           		[available in C, C++, ObjC, ObjC++]
+  -Wenum-int-mismatch         		[available in C, ObjC]
+  -Werror                     		[available in C, C++, D, ObjC, ObjC++]
+  -Werror-implicit-function-declaration 	-Werror=implicit-function-declaration
+  -Wexceptions                		[available in C++, ObjC++]
+  -Wexpansion-to-defined      		[available in C, C++, ObjC, ObjC++]
+  -Wextra                     		[available in C, C++, D, Fortran, ObjC, ObjC++]
+  -Wextra-semi                		[available in C++, ObjC++]
+  -Wfloat-conversion          		[available in C, C++, ObjC, ObjC++]
+  -Wfloat-equal               		[available in C, C++, ObjC, ObjC++]
+  -Wformat                    		-Wformat=1
+  -Wformat-contains-nul       		[available in C, C++, ObjC, ObjC++]
+  -Wformat-diag               		[available in C, C++, ObjC, ObjC++]
+  -Wformat-extra-args         		[available in C, C++, ObjC, ObjC++]
+  -Wformat-nonliteral         		[available in C, C++, ObjC, ObjC++]
+  -Wformat-overflow<0,2>      		-Wformat-overflow=1
+  -Wformat-overflow=<0,2>     		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wformat-security           		[available in C, C++, ObjC, ObjC++]
+  -Wformat-signedness         		[available in C, C++, ObjC, ObjC++]
+  -Wformat-truncation         		-Wformat-truncation=1
+  -Wformat-truncation=<0,2>   		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wformat-y2k                		[available in C, C++, ObjC, ObjC++]
+  -Wformat-zero-length        		[available in C, C++, ObjC, ObjC++]
+  -Wformat=<0,2>              		[available in C, C++, ObjC, ObjC++]
+  -Wframe-address             		[available in C, C++, ObjC, ObjC++]
+  -Wif-not-aligned            		[available in C, C++, ObjC, ObjC++]
+  -Wignored-attributes        		[available in C, C++]
+  -Wignored-qualifiers        		[available in C, C++]
+  -Wimplicit                  		[available in C, ObjC]
+  -Wimplicit-function-declaration 	[available in C, ObjC]
+  -Wimplicit-int              		[available in C, ObjC]
+  -Winaccessible-base         		[available in C++, ObjC++]
+  -Wincompatible-pointer-types 		[available in C, ObjC]
+  -Winfinite-recursion        		[available in C, C++, LTO, ObjC, ObjC++]
+  -Winherited-variadic-ctor   		[available in C++, ObjC++]
+  -Winit-list-lifetime        		[available in C++, ObjC++]
+  -Winit-self                 		[available in C, C++, ObjC, ObjC++]
+  -Wint-conversion            		[available in C, ObjC]
+  -Wint-in-bool-context       		[available in C, C++, ObjC, ObjC++]
+  -Wint-to-pointer-cast       		[available in C, C++, ObjC, ObjC++]
+  -Winterference-size         		[available in C++, ObjC++]
+  -Winvalid-constexpr         		[available in C++, ObjC++]
+  -Winvalid-imported-macros   		[available in C++, ObjC++]
+  -Winvalid-offsetof          		[available in C++, ObjC++]
+  -Winvalid-pch               		[available in C, C++, ObjC, ObjC++]
+  -Winvalid-utf8              		[available in C, C++, ObjC, ObjC++]
+  -Wjump-misses-init          		[available in C, ObjC]
+  -Wliteral-suffix            		[available in C++, ObjC++]
+  -Wlogical-not-parentheses   		[available in C, C++, ObjC, ObjC++]
+  -Wlogical-op                		[available in C, C++, ObjC, ObjC++]
+  -Wlong-long                 		[available in C, C++, ObjC, ObjC++]
+  -Wmain                      		[available in C, C++, ObjC, ObjC++]
+  -Wmaybe-uninitialized       		[available in C, C++, Fortran, LTO, ObjC,
+                              ObjC++]
+  -Wmemset-elt-size           		[available in C, C++, ObjC, ObjC++]
+  -Wmemset-transposed-args    		[available in C, C++, ObjC, ObjC++]
+  -Wmisleading-indentation    		[available in C, C++]
+  -Wmismatched-dealloc        		[available in C, C++, ObjC, ObjC++]
+  -Wmismatched-new-delete     		[available in C++, ObjC++]
+  -Wmismatched-tags           		[available in C++, ObjC++]
+  -Wmissing-attributes        		[available in C, C++, ObjC, ObjC++]
+  -Wmissing-braces            		[available in C, C++, ObjC, ObjC++]
+  -Wmissing-declarations      		[available in C, C++, ObjC, ObjC++]
+  -Wmissing-field-initializers 		[available in C, C++, ObjC, ObjC++]
+  -Wmissing-include-dirs      		[available in C, C++, Fortran, ObjC, ObjC++]
+  -Wmissing-parameter-type    		[available in C, ObjC]
+  -Wmissing-prototypes        		[available in C, ObjC]
+  -Wmissing-requires          		[available in C++, ObjC++]
+  -Wmissing-template-keyword  		[available in C++, ObjC++]
+  -Wmultichar                 		[available in C, C++, ObjC, ObjC++]
+  -Wmultiple-inheritance      		[available in C++, ObjC++]
+  -Wmultistatement-macros     		[available in C, C++, ObjC, ObjC++]
+  -Wnamespaces                		[available in C++, ObjC++]
+  -Wnarrowing                 		[available in C, C++, ObjC, ObjC++]
+  -Wnested-externs            		[available in C, ObjC]
+  -Wno-alloc-size-larger-than 		-Walloc-size-larger-than=18446744073709551615EiB
+  -Wno-alloca-larger-than     		-Walloca-larger-than=18446744073709551615EiB
+  -Wno-vla-larger-than        		-Wvla-larger-than=18446744073709551615EiB
+  -Wnoexcept                  		[available in C++, ObjC++]
+  -Wnoexcept-type             		[available in C++, ObjC++]
+  -Wnon-template-friend       		[available in C++, ObjC++]
+  -Wnon-virtual-dtor          		[available in C++, ObjC++]
+  -Wnonnull                   		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wnonnull-compare           		[available in C, C++, ObjC, ObjC++]
+  -Wnormalized=[none|id|nfc|nfkc] 	[available in C, C++, ObjC, ObjC++]
+  -Wobjc-root-class           		[available in ObjC, ObjC++]
+  -Wold-style-cast            		[available in C++, ObjC++]
+  -Wold-style-declaration     		[available in C, ObjC]
+  -Wold-style-definition      		[available in C, ObjC]
+  -Wopenacc-parallelism       		[available in C, C++, Fortran]
+  -Wopenmp-simd               		[available in C, C++, Fortran]
+  -Woverlength-strings        		[available in C, C++, ObjC, ObjC++]
+  -Woverloaded-virtual        		-Woverloaded-virtual=2
+  -Woverloaded-virtual=<0,2>  		[available in C++, ObjC++]
+  -Woverride-init             		[available in C, ObjC]
+  -Woverride-init-side-effects 		[available in C, ObjC]
+  -Wpacked-bitfield-compat    		[available in C, C++, ObjC, ObjC++]
+  -Wpacked-not-aligned        		[available in C, C++, ObjC, ObjC++]
+  -Wparentheses               		[available in C, C++, ObjC, ObjC++]
+  -Wpedantic                  		[available in C, C++, Fortran, Modula-2, ObjC,
+                              ObjC++]
+  -Wpessimizing-move          		[available in C++, ObjC++]
+  -Wpmf-conversions           		[available in C++, ObjC++]
+  -Wpointer-arith             		[available in C, C++, ObjC, ObjC++]
+  -Wpointer-compare           		[available in C, C++, ObjC, ObjC++]
+  -Wpointer-sign              		[available in C, ObjC]
+  -Wpointer-to-int-cast       		[available in C, ObjC]
+  -Wpragmas                   		[available in C, C++, ObjC, ObjC++]
+  -Wprio-ctor-dtor            		[available in C, C++, ObjC, ObjC++]
+  -Wproperty-assign-default   		[available in ObjC, ObjC++]
+  -Wprotocol                  		[available in ObjC, ObjC++]
+  -Wrange-loop-construct      		[available in C++, ObjC++]
+  -Wredundant-decls           		[available in C, C++, ObjC, ObjC++]
+  -Wredundant-move            		[available in C++, ObjC++]
+  -Wredundant-tags            		[available in C++, ObjC++]
+  -Wregister                  		[available in C++, ObjC++]
+  -Wreorder                   		[available in C++, ObjC++]
+  -Wrestrict                  		[available in C, C++, ObjC, ObjC++]
+  -Wreturn-type               		[available in C, C++, Fortran, Modula-2, ObjC,
+                              ObjC++]
+  -Wscalar-storage-order      		[available in C, C++, ObjC, ObjC++]
+  -Wselector                  		[available in ObjC, ObjC++]
+  -Wself-move                 		[available in C++, ObjC++]
+  -Wsequence-point            		[available in C, C++, ObjC, ObjC++]
+  -Wshadow-ivar               		[available in ObjC, ObjC++]
+  -Wshift-count-negative      		[available in C, C++, ObjC, ObjC++]
+  -Wshift-count-overflow      		[available in C, C++, ObjC, ObjC++]
+  -Wshift-negative-value      		[available in C, C++, ObjC, ObjC++]
+  -Wshift-overflow            		-Wshift-overflow=1
+  -Wshift-overflow=<0,2>      		[available in C, C++, ObjC, ObjC++]
+  -Wsign-compare              		[available in C, C++, ObjC, ObjC++]
+  -Wsign-conversion           		[available in C, C++, ObjC, ObjC++]
+  -Wsign-promo                		[available in C++, ObjC++]
+  -Wsized-deallocation        		[available in C++, ObjC++]
+  -Wsizeof-array-argument     		[available in C, C++, ObjC, ObjC++]
+  -Wsizeof-array-div          		[available in C, C++, ObjC, ObjC++]
+  -Wsizeof-pointer-div        		[available in C, C++, ObjC, ObjC++]
+  -Wsizeof-pointer-memaccess  		[available in C, C++, ObjC, ObjC++]
+  -Wstrict-aliasing=<0,3>     		[available in C, C++, ObjC, ObjC++]
+  -Wstrict-flex-arrays        		[available in C, C++]
+  -Wstrict-null-sentinel      		[available in C++, ObjC++]
+  -Wstrict-overflow=<0,5>     		[available in C, C++, ObjC, ObjC++]
+  -Wstrict-prototypes         		[available in C, ObjC]
+  -Wstrict-selector-match     		[available in ObjC, ObjC++]
+  -Wstring-compare            		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wstringop-overflow         		-Wstringop-overflow=2
+  -Wstringop-overflow=<0,4>   		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wstringop-overread         		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wstringop-truncation       		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wsubobject-linkage         		[available in C++, ObjC++]
+  -Wsuggest-attribute=format  		[available in C, C++, ObjC, ObjC++]
+  -Wsuggest-override          		[available in C++, ObjC++]
+  -Wswitch                    		[available in C, C++, ObjC, ObjC++]
+  -Wswitch-bool               		[available in C, C++, ObjC, ObjC++]
+  -Wswitch-default            		[available in C, C++, ObjC, ObjC++]
+  -Wswitch-enum               		[available in C, C++, ObjC, ObjC++]
+  -Wswitch-outside-range      		[available in C, C++, ObjC, ObjC++]
+  -Wsync-nand                 		[available in C, C++]
+  -Wsynth                     		[available in C++, ObjC++]
+  -Wsystem-headers            		[available in C, C++, ObjC, ObjC++]
+  -Wtautological-compare      		[available in C, C++, ObjC, ObjC++]
+  -Wtemplates                 		[available in C++, ObjC++]
+  -Wterminate                 		[available in C++, ObjC++]
+  -Wtraditional               		[available in C, ObjC]
+  -Wtraditional-conversion    		[available in C, ObjC]
+  -Wtrigraphs                 		[available in C, C++, ObjC, ObjC++]
+  -Wundeclared-selector       		[available in ObjC, ObjC++]
+  -Wundef                     		[available in C, C++, ObjC, ObjC++]
+  -Wunicode                   		[available in C, C++, ObjC, ObjC++]
+  -Wuninitialized             		[available in C, C++, Fortran, LTO, ObjC,
+                              ObjC++]
+  -Wunknown-pragmas           		[available in C, C++, D, ObjC, ObjC++]
+  -Wunsuffixed-float-constants 		[available in C, ObjC]
+  -Wunused                    		[available in C, C++, ObjC, ObjC++]
+  -Wunused-const-variable     		-Wunused-const-variable=2
+  -Wunused-const-variable=<0,2> 		[available in C, C++, ObjC, ObjC++, Rust]
+  -Wunused-local-typedefs     		[available in C, C++, ObjC, ObjC++]
+  -Wunused-macros             		[available in C, C++, ObjC, ObjC++]
+  -Wunused-result             		[available in C, C++, ObjC, ObjC++, Rust]
+  -Wunused-variable           		[available in C, C++, Modula-2, ObjC, ObjC++,
+                              Rust]
+  -Wuseless-cast              		[available in C++, ObjC++]
+  -Wvarargs                   		[available in C, C++, D, ObjC, ObjC++]
+  -Wvariadic-macros           		[available in C, C++, ObjC, ObjC++]
+  -Wvexing-parse              		[available in C++, ObjC++]
+  -Wvirtual-inheritance       		[available in C++, ObjC++]
+  -Wvirtual-move-assign       		[available in C++, ObjC++]
+  -Wvla                       		[available in C, C++, ObjC, ObjC++]
+  -Wvla-larger-than=<number>  		[available in C, C++, LTO, ObjC, ObjC++]
+  -Wvla-parameter             		[available in C, C++, ObjC, ObjC++]
+  -Wvolatile                  		[available in C++, ObjC++]
+  -Wvolatile-register-var     		[available in C, C++, ObjC, ObjC++]
+  -Wwrite-strings             		[available in C, C++, ObjC, ObjC++]
+  -Wxor-used-as-pow           		[available in C, C++, ObjC, ObjC++]
+  -Wzero-as-null-pointer-constant 	[available in C++, ObjC++]
+  -Wzero-length-bounds        		[available in C, C++, ObjC, ObjC++]
+  -ansi                       		[disabled]
+  -d<letters>                 		
+  -fRTS=                      		
+  -fabi-compat-version=       		[available in C++, ObjC++]
+  -faccess-control            		[available in C++, ObjC++]
+  -fada-spec-parent=unit      		[available in C, C++, ObjC, ObjC++]
+  -faligned-new               		-faligned-new=1
+  -faligned-new=<N>           		[available in C++, ObjC++]
+  -fallow-parameterless-variadic-functions 	[ignored]
+  -falt-external-templates    		[disabled]
+  -fasm                       		[available in C, C++, ObjC, ObjC++]
+  -fbuiltin                   		[available in C, C++, D, ObjC, ObjC++]
+  -fcanonical-system-headers  		[disabled]
+  -fchar8_t                   		[available in C++, ObjC++]
+  -fcheck-pointer-bounds      		[disabled]
+  -fchkp-check-incomplete-type 		[disabled]
+  -fchkp-check-read           		[disabled]
+  -fchkp-check-write          		[disabled]
+  -fchkp-first-field-has-own-bounds 	[disabled]
+  -fchkp-flexible-struct-trailing-arrays 	[disabled]
+  -fchkp-instrument-calls     		[disabled]
+  -fchkp-instrument-marked-only 	[disabled]
+  -fchkp-narrow-bounds        		[disabled]
+  -fchkp-narrow-to-innermost-array 	[disabled]
+  -fchkp-store-bounds         		[disabled]
+  -fchkp-treat-zero-dynamic-size-as-infinite 	[disabled]
+  -fchkp-use-fast-string-functions 	[disabled]
+  -fchkp-use-nochk-string-functions 	[disabled]
+  -fchkp-use-static-bounds    		[disabled]
+  -fchkp-use-static-const-bounds 	[disabled]
+  -fchkp-use-wrappers         		[disabled]
+  -fchkp-zero-input-bounds-for-main 	[disabled]
+  -fconcepts                  		[available in C++, ObjC++]
+  -fconcepts-diagnostics-depth= 	[available in C++, ObjC++]
+  -fconcepts-ts               		[available in C++, ObjC++]
+  -fcond-mismatch             		[disabled]
+  -fconserve-space            		[ignored]
+  -fconst-string-class=<name> 		
+  -fconstexpr-cache-depth=<number> 	[available in C++, ObjC++]
+  -fconstexpr-depth=<number>  		[available in C++, ObjC++]
+  -fconstexpr-fp-except       		[available in C++, ObjC++]
+  -fconstexpr-loop-limit=<number> 	[available in C++, ObjC++]
+  -fconstexpr-ops-limit=<number> 	[available in C++, ObjC++]
+  -fcontracts                 		[available in C++, ObjC++]
+  -fcoroutines                		[available in C++, LTO]
+  -fdebug-cpp                 		[disabled]
+  -fdeclone-ctor-dtor         		[available in C++, ObjC++]
+  -fdeduce-init-list          		[ignored]
+  -fdefault-inline            		[ignored]
+  -fdiagnostics-show-template-tree 	[available in C++, ObjC++]
+  -fdirectives-only           		[disabled]
+  -fdollars-in-identifiers    		[disabled]
+  -fdump-ada-spec             		[available in C, C++, ObjC, ObjC++]
+  -fdump-ada-spec-slim        		[available in C, C++, ObjC, ObjC++]
+  -felide-type                		[available in C++, ObjC++]
+  -femit-struct-debug-baseonly 		[disabled]
+  -femit-struct-debug-detailed=<spec-list> 	
+  -femit-struct-debug-reduced 		[disabled]
+  -fenforce-eh-specs          		[available in C++, ObjC++]
+  -fexceptions                		[available in D, Modula-2]
+  -fexec-charset=<cset>       		
+  -fext-numeric-literals      		[available in C++, ObjC++]
+  -fextended-identifiers      		[disabled]
+  -fextern-tls-init           		[available in C++, ObjC++]
+  -ffold-simple-inlines       		[available in C++, ObjC++]
+  -ffreestanding              		[disabled]
+  -fgnu-keywords              		[available in C++, ObjC++]
+  -fgnu-runtime               		[available in LTO, ObjC, ObjC++]
+  -fgnu89-inline              		[available in C, ObjC]
+  -fhosted                    		[disabled]
+  -fhuge-objects              		[disabled]
+  -fimplement-inlines         		[available in C++, ObjC++]
+  -fimplicit-constexpr        		[available in C++, ObjC++]
+  -fimplicit-inline-templates 		[available in C++, ObjC++]
+  -fimplicit-templates        		[available in C++, ObjC++]
+  -finput-charset=<cset>      		
+  -fvisibility=[private|protected|public|package] 	[available in ObjC, ObjC++]
+  -flax-vector-conversions    		[available in C, C++, ObjC, ObjC++]
+  -flocal-ivars               		[available in ObjC, ObjC++]
+  -fmacro-prefix-map=<old>=<new> 	
+  -fmax-include-depth=        		
+  -fmodule-header             		[available in C++, ObjC]
+  -fmodule-implicit-inline    		[available in C++, ObjC++]
+  -fmodule-lazy               		[available in C++, ObjC++]
+  -fmodule-mapper=            		
+  -fmodule-only               		[available in C++, ObjC]
+  -fmodules-ts                		[available in C++, ObjC++]
+  -fms-extensions             		[available in C, C++, ObjC, ObjC++]
+  -fnew-inheriting-ctors      		[available in C++, ObjC++]
+  -fnew-ttp-matching          		[available in C++, ObjC++]
+  -fnext-runtime              		[available in LTO, ObjC, ObjC++]
+  -fnil-receivers             		[available in ObjC, ObjC++]
+  -fnothrow-opt               		[available in C++, ObjC++]
+  -fobjc-abi-version=         		[available in LTO, ObjC, ObjC++]
+  -fobjc-direct-dispatch      		[available in ObjC, ObjC++]
+  -fobjc-exceptions           		[available in ObjC, ObjC++]
+  -fobjc-gc                   		[available in LTO, ObjC, ObjC++]
+  -fobjc-nilcheck             		[available in ObjC, ObjC++]
+  -fobjc-sjlj-exceptions      		[available in ObjC, ObjC++]
+  -fobjc-std=objc1            		[available in Modula-2, ObjC, ObjC++]
+  -fopenacc                   		[available in C, C++, Fortran, LTO, ObjC,
+                              ObjC++]
+  -fopenacc-dim=              		[available in C, C++, Fortran, LTO, ObjC,
+                              ObjC++]
+  -fopenmp                    		[available in C, C++, Fortran, LTO, ObjC,
+                              ObjC++]
+  -fopenmp-simd               		[available in C, C++, Fortran, ObjC, ObjC++]
+  -foperator-names            		[disabled]
+  -foptional-diags            		[ignored]
+  -fpch-preprocess            		[disabled]
+  -fpermissive                		[available in C++, ObjC++]
+  -fplan9-extensions          		[available in C, ObjC]
+  -fpreprocessed              		[disabled]
+  -fpretty-templates          		[available in C++, ObjC++]
+  -fprintf-return-value       		[available in C, C++, LTO, ObjC, ObjC++]
+  -freplace-objc-classes      		[available in LTO, ObjC, ObjC++]
+  -frepo                      		[disabled]
+  -frtti                      		[available in C++, D, ObjC++]
+  -fshort-enums               		[available in Ada, AdaSCIL, AdaWhy, C, C++,
+                              Fortran, LTO, ObjC, ObjC++]
+  -fshort-wchar               		[available in C, C++, LTO, ObjC, ObjC++]
+  -fsigned-bitfields          		[available in C, C++, ObjC, ObjC++]
+  -fsigned-char               		[available in Ada, AdaSCIL, AdaWhy, C, C++,
+                              LTO, ObjC, ObjC++]
+  -fsized-deallocation        		[available in C++, ObjC++]
+  -fsso-struct=[big-endian|little-endian|native] 	[available in C, ObjC]
+  -fstats                     		[available in C++, ObjC++]
+  -fstrict-enums              		[available in C++, ObjC++]
+  -fstrict-flex-arrays=<0,3>  		[available in C, C++]
+  -fstrong-eval-order         		-fstrong-eval-order=all
+  -fstrong-eval-order=        		[available in C++, ObjC++]
+  -ftemplate-backtrace-limit= 		[available in C++, ObjC++]
+  -ftemplate-depth=<number>   		
+  -fno-threadsafe-statics     		[available in C++, ObjC++]
+  -ftrack-macro-expansion=<0|1|2> 	
+  -funsigned-bitfields        		[available in C, C++, ObjC, ObjC++]
+  -funsigned-char             		[available in Ada, AdaSCIL, AdaWhy, C, C++,
+                              LTO, ObjC, ObjC++]
+  -fuse-cxa-atexit            		[available in C++, ObjC++]
+  -fuse-cxa-get-exception-ptr 		[available in C++, ObjC++]
+  -fvisibility-inlines-hidden 		[disabled]
+  -fvisibility-ms-compat      		[available in C++, ObjC++]
+  -fvtable-gc                 		[disabled]
+  -fvtable-thunks             		[disabled]
+  -fweak                      		[available in C++, ObjC++]
+  -fwide-exec-charset=<cset>  		
+  -fworking-directory         		[available in C, C++, Fortran, Modula-2, ObjC,
+                              ObjC++]
+  -fxref                      		[disabled]
+  -fzero-link                 		[available in ObjC, ObjC++]
+  -gen-decls                  		[available in ObjC, ObjC++]
+  -gnat<options>              		
+  -gnatO                      		[disabled]
+  -idirafter <dir>            		
+  -imacros <file>             		
+  -imultilib <dir>            		
+  -include <file>             		
+  -iprefix <path>             		
+  -iquote <dir>               		
+  -isysroot <dir>             		
+  -isystem <dir>              		
+  -iwithprefix <dir>          		
+  -iwithprefixbefore <dir>    		
+  -nostdinc                   		[disabled]
+  -nostdinc++                 		[disabled]
+  -nostdlib                   		[disabled]
+  -o <file>                   		[available in C, C++, Fortran, Go, ObjC,
+                              ObjC++, Rust]
+  -print-objc-runtime-info    		[disabled]
+  -remap                      		[disabled]
+  -std=c++03                  		-std=c++98
+  -std=c++11                  		[disabled]
+  -std=c++14                  		[disabled]
+  -std=c++17                  		[disabled]
+  -std=c++20                  		[disabled]
+  -std=c++2b                  		-std=c++23
+  -std=c++98                  		[disabled]
+  -std=c11                    		[disabled]
+  -std=c17                    		[disabled]
+  -std=c18                    		-std=c17
+  -std=c1x                    		-std=c11
+  -std=c2x                    		[disabled]
+  -std=c89                    		-std=c90
+  -std=c90                    		[disabled]
+  -std=c99                    		[disabled]
+  -std=c9x                    		-std=c99
+  -std=gnu++03                		-std=gnu++98
+  -std=gnu++11                		[disabled]
+  -std=gnu++14                		[disabled]
+  -std=gnu++17                		[disabled]
+  -std=gnu++20                		[disabled]
+  -std=gnu++2b                		-std=gnu++23
+  -std=gnu++98                		[disabled]
+  -std=gnu11                  		[disabled]
+  -std=gnu17                  		[disabled]
+  -std=gnu18                  		-std=gnu17
+  -std=gnu1x                  		-std=gnu11
+  -std=gnu2x                  		[disabled]
+  -std=gnu89                  		-std=gnu90
+  -std=gnu90                  		[disabled]
+  -std=gnu99                  		[disabled]
+  -std=gnu9x                  		-std=gnu99
+  -std=iso9899:1990           		-std=c90
+  -std=iso9899:199409         		[disabled]
+  -std=iso9899:1999           		-std=c99
+  -std=iso9899:199x           		-std=c99
+  -std=iso9899:2011           		-std=c11
+  -std=iso9899:2017           		-std=c17
+  -std=iso9899:2018           		-std=c17
+  -traditional-cpp            		[disabled]
+  -trigraphs                  		[disabled]
+  -undef                      		[available in C, C++, Fortran, ObjC, ObjC++]
+  -v                          		[available in C, C++, D, Fortran, ObjC, ObjC++]
+  -w                          		[available in C, C++, ObjC, ObjC++]
+
+The following options control parameters:
+  --param=aarch64-double-recp-precision=<1,5> 	2
+  --param=aarch64-float-recp-precision=<1,5> 	1
+  --param=aarch64-mops-memcpy-size-threshold= 	256
+  --param=aarch64-mops-memmove-size-threshold= 	0
+  --param=aarch64-mops-memset-size-threshold= 	256
+  --param=aarch64-sve-compare-costs=<0,1> 	1
+  --param=aarch64-vect-unroll-limit= 	4
+  --param=align-loop-iterations= 	4
+  --param=align-threshold=<1,65536> 		100
+  --param=analyzer-bb-explosion-factor= 	5
+  --param=analyzer-max-constraints= 	20
+  --param=analyzer-max-enodes-for-full-dump= 	200
+  --param=analyzer-max-enodes-per-program-point= 	8
+  --param=analyzer-max-infeasible-edges= 	10
+  --param=analyzer-max-recursion-depth= 	2
+  --param=analyzer-max-svalue-depth= 	12
+  --param=analyzer-min-snodes-for-call-summary= 	10
+  --param=asan-globals=<0,1>  		1
+  --param=asan-instrument-allocas=<0,1> 	1
+  --param=asan-instrument-reads=<0,1> 	1
+  --param=asan-instrument-writes=<0,1> 	1
+  --param=asan-instrumentation-with-call-threshold= 	7000
+  --param=asan-kernel-mem-intrinsic-prefix=<0,1> 	0
+  --param=asan-memintrin=<0,1> 		1
+  --param=asan-stack=<0,1>    		1
+  --param=asan-use-after-return=<0,1> 	1
+  --param=avg-loop-niter=<1,65536> 		10
+  --param=avoid-fma-max-bits=<0,512> 		0
+  --param=builtin-expect-probability=<0,100> 	90
+  --param=builtin-string-cmp-inline-length=<0,100> 	3
+  --param=case-values-threshold= 	0
+  --param=comdat-sharing-probability= 	20
+  --param=constructive-interference-size= 	64
+  --param=cxx-max-namespaces-for-diagnostic-help= 	1000
+  --param=destructive-interference-size= 	256
+  --param=dse-max-alias-queries-per-store= 	256
+  --param=dse-max-object-size= 		256
+  --param=early-inlining-insns= 	6
+  --param=evrp-sparse-threshold= 	800
+  --param=evrp-switch-limit=  		50
+  --param=fsm-scale-path-stmts=<1,10> 	2
+  --param=gcse-after-reload-critical-fraction= 	10
+  --param=gcse-after-reload-partial-fraction= 	3
+  --param=gcse-cost-distance-ratio= 	10
+  --param=gcse-unrestricted-cost= 	3
+  --param=ggc-min-expand=     		100
+  --param=ggc-min-heapsize=   		131072
+  --param=gimple-fe-computed-hot-bb-threshold= 	0
+  --param=graphite-allow-codegen-errors=<0,1> 	0
+  --param=graphite-max-arrays-per-scop= 	100
+  --param=graphite-max-nb-scop-params= 	10
+  --param=hash-table-verification-limit= 	10
+  --param=hot-bb-count-fraction= 	10000
+  --param=hot-bb-count-ws-permille=<0,1000> 	990
+  --param=hot-bb-frequency-fraction= 	1000
+  --param=hwasan-instrument-allocas=<0,1> 	1
+  --param=hwasan-instrument-mem-intrinsics=<0,1> 	1
+  --param=hwasan-instrument-reads=<0,1> 	1
+  --param=hwasan-instrument-stack=<0,1> 	1
+  --param=hwasan-instrument-writes=<0,1> 	1
+  --param=hwasan-random-frame-tag=<0,1> 	1
+  --param=inline-heuristics-hint-percent=<100,1000000> 	200
+  --param=inline-min-speedup=<0,100> 		30
+  --param=inline-unit-growth= 		40
+  --param=integer-share-limit=<2,65536> 		251
+  --param=ipa-cp-eval-threshold= 	500
+  --param=ipa-cp-large-unit-insns= 	16000
+  --param=ipa-cp-loop-hint-bonus= 	64
+  --param=ipa-cp-max-recursive-depth= 	8
+  --param=ipa-cp-min-recursive-probability= 	2
+  --param=ipa-cp-profile-count-base=<0,100> 	10
+  --param=ipa-cp-recursion-penalty=<0,100> 	40
+  --param=ipa-cp-recursive-freq-factor= 	6
+  --param=ipa-cp-single-call-penalty=<0,100> 	15
+  --param=ipa-cp-unit-growth= 		10
+  --param=ipa-cp-value-list-size= 	8
+  --param=ipa-jump-function-lookups= 	8
+  --param=ipa-max-aa-steps=   		25000
+  --param=ipa-max-agg-items=  		16
+  --param=ipa-max-loop-predicates= 	16
+  --param=ipa-max-param-expr-ops= 	10
+  --param=ipa-max-switch-predicate-bounds= 	5
+  --param=ipa-sra-deref-prob-threshold=<0,100> 	50
+  --param=ipa-sra-max-replacements=<0,16> 	8
+  --param=ipa-sra-ptr-growth-factor= 	2
+  --param=ipa-sra-ptrwrap-growth-factor=<1,8> 	4
+  --param=ira-consider-dup-in-all-alts=<0,1> 	1
+  --param=ira-loop-reserved-regs= 	2
+  --param=ira-max-conflict-table-size= 	1000
+  --param=ira-max-loops-num=  		100
+  --param=ira-simple-lra-insn-threshold= 	1000
+  --param=iv-always-prune-cand-set-bound= 	10
+  --param=iv-consider-all-candidates-bound= 	40
+  --param=iv-max-considered-uses= 	250
+  --param=jump-table-max-growth-ratio-for-size=<0,10000> 	300
+  --param=jump-table-max-growth-ratio-for-speed=<0,10000> 	800
+  --param=l1-cache-line-size= 		32
+  --param=l1-cache-size=      		64
+  --param=l2-cache-size=      		512
+  --param=large-function-growth= 	100
+  --param=large-function-insns= 	2700
+  --param=large-stack-frame-growth= 	1000
+  --param=large-stack-frame=  		256
+  --param=large-unit-insns=   		10000
+  --param=lim-expensive=      		20
+  --param=logical-op-non-short-circuit=<0,1> 	-1
+  --param=loop-block-tile-size= 	51
+  --param=loop-interchange-max-num-stmts= 	64
+  --param=loop-interchange-stride-ratio= 	2
+  --param=loop-invariant-max-bbs-in-loop= 	10000
+  --param=loop-max-datarefs-for-datadeps= 	1000
+  --param=loop-versioning-max-inner-insns= 	200
+  --param=loop-versioning-max-outer-insns= 	100
+  --param=lra-inheritance-ebb-probability-cutoff=<0,100> 	40
+  --param=lra-max-considered-reload-pseudos= 	500
+  --param=lto-max-partition=  		1000000
+  --param=lto-max-streaming-parallelism=<1,65536> 	32
+  --param=lto-min-partition=  		10000
+  --param=lto-partitions=<1,65536> 		128
+  --param=max-average-unrolled-insns= 	80
+  --param=max-combine-insns=<2,4> 		4
+  --param=max-completely-peel-loop-nest-depth= 	8
+  --param=max-completely-peel-times= 	16
+  --param=max-completely-peeled-insns= 	200
+  --param=max-crossjump-edges= 		100
+  --param=max-cse-insns=      		1000
+  --param=max-cse-path-length=<1,65536> 		10
+  --param=max-cselib-memory-locations= 	500
+  --param=max-debug-marker-count= 	100000
+  --param=max-delay-slot-insn-search= 	100
+  --param=max-delay-slot-live-search= 	333
+  --param=max-dse-active-local-stores= 	5000
+  --param=max-early-inliner-iterations= 	1
+  --param=max-fields-for-field-sensitive= 	0
+  --param=max-find-base-term-values= 	200
+  --param=max-fsm-thread-path-insns=<1,999999> 	100
+  --param=max-gcse-insertion-ratio= 	20
+  --param=max-gcse-memory=    		131072
+  --param=max-goto-duplication-insns= 	8
+  --param=max-grow-copy-bb-insns= 	8
+  --param=max-hoist-depth=    		30
+  --param=max-inline-functions-called-once-insns= 	4000
+  --param=max-inline-functions-called-once-loop-depth= 	6
+  --param=max-inline-insns-auto= 	15
+  --param=max-inline-insns-recursive-auto= 	450
+  --param=max-inline-insns-recursive= 	450
+  --param=max-inline-insns-single= 	70
+  --param=max-inline-insns-size= 	0
+  --param=max-inline-insns-small= 	0
+  --param=max-inline-recursive-depth-auto= 	8
+  --param=max-inline-recursive-depth= 	8
+  --param=max-isl-operations= 		350000
+  --param=max-iterations-computation-cost= 	10
+  --param=max-iterations-to-track= 	1000
+  --param=max-jump-thread-duplication-stmts= 	15
+  --param=max-jump-thread-paths=<1,65536> 	64
+  --param=max-last-value-rtl= 		10000
+  --param=max-loop-header-insns= 	20
+  --param=max-modulo-backtrack-attempts= 	40
+  --param=max-partial-antic-length= 	100
+  --param=max-peel-branches=  		32
+  --param=max-peel-times=     		16
+  --param=max-peeled-insns=   		100
+  --param=max-pending-list-length= 	32
+  --param=max-pipeline-region-blocks= 	15
+  --param=max-pipeline-region-insns= 	200
+  --param=max-pow-sqrt-depth=<1,32> 		5
+  --param=max-predicted-iterations=<0,65536> 	100
+  --param=max-reload-search-insns= 	100
+  --param=max-rtl-if-conversion-insns=<0,99> 	10
+  --param=max-rtl-if-conversion-predictable-cost=<0,200> 	20
+  --param=max-rtl-if-conversion-unpredictable-cost=<0,200> 	40
+  --param=max-sched-extend-regions-iters= 	0
+  --param=max-sched-insn-conflict-delay=<1,10> 	3
+  --param=max-sched-ready-insns=<1,65536> 	100
+  --param=max-sched-region-blocks= 	10
+  --param=max-sched-region-insns= 	100
+  --param=max-slsr-cand-scan=<1,999999> 		50
+  --param=max-speculative-devirt-maydefs= 	50
+  --param=max-ssa-name-query-depth=<1,10> 	3
+  --param=max-store-chains-to-track=<1,65536> 	64
+  --param=max-stores-to-merge=<2,65536> 		64
+  --param=max-stores-to-sink= 		2
+  --param=max-stores-to-track=<2,1048576> 		1024
+  --param=max-tail-merge-comparisons= 	10
+  --param=max-tail-merge-iterations= 	2
+  --param=max-tracked-strlens= 		10000
+  --param=max-tree-if-conversion-phi-args=<2,65536> 	4
+  --param=max-unroll-times=   		8
+  --param=max-unrolled-insns= 		200
+  --param=max-unswitch-depth=<1,50> 		50
+  --param=max-unswitch-insns= 		50
+  --param=max-variable-expansions-in-unroller= 	1
+  --param=max-vartrack-expr-depth= 	12
+  --param=max-vartrack-reverse-op-size= 	50
+  --param=max-vartrack-size=  		50000000
+  --param=min-crossjump-insns=<1,65536> 		5
+  --param=min-inline-recursive-probability= 	10
+  --param=min-insn-to-prefetch-ratio= 	9
+  --param=min-loop-cond-split-prob=<0,100> 	30
+  --param=min-nondebug-insn-uid= 	0
+  --param=min-pagesize=       		4096
+  --param=min-size-for-stack-sharing= 	32
+  --param=min-spec-prob=      		40
+  --param=min-vect-loop-bound= 		0
+  --param=modref-max-accesses= 		16
+  --param=modref-max-adjustments=<0,254> 	8
+  --param=modref-max-bases=   		32
+  --param=modref-max-depth=<1,65536> 		256
+  --param=modref-max-escape-points= 	256
+  --param=modref-max-refs=    		16
+  --param=modref-max-tests=   		64
+  --param=openacc-kernels=[decompose|parloops] 	parloops
+  --param=openacc-privatization=[quiet|noisy] 	quiet
+  --param=parloops-chunk-size= 		0
+  --param=parloops-min-per-thread=<2,65536> 	100
+  --param=parloops-schedule=[static|dynamic|guided|auto|runtime] 	static
+  --param=partial-inlining-entry-probability=<0,100> 	70
+  --param=predictable-branch-outcome=<0,50> 	2
+  --param=prefetch-dynamic-strides=<0,1> 	1
+  --param=prefetch-latency=   		200
+  --param=prefetch-min-insn-to-mem-ratio= 	3
+  --param=prefetch-minimum-stride= 	-1
+  --param=profile-func-internal-id=<0,1> 	0
+  --param=ranger-debug=       		none
+  --param=ranger-logical-depth=<1,999> 	6
+  --param=ranger-recompute-depth=<1,100> 	5
+  --param=relation-block-limit=<0,9999> 	200
+  --param=rpo-vn-max-loop-depth=<2,65536> 	7
+  --param=sccvn-max-alias-queries-per-access= 	1000
+  --param=scev-max-expr-complexity= 	10
+  --param=scev-max-expr-size= 		100
+  --param=sched-autopref-queue-depth= 	0
+  --param=sched-mem-true-dep-cost= 	1
+  --param=sched-pressure-algorithm=<1,2> 	2
+  --param=sched-spec-prob-cutoff=<0,100> 	40
+  --param=sched-state-edge-prob-cutoff=<0,100> 	10
+  --param=selsched-insns-to-rename= 	2
+  --param=selsched-max-lookahead= 	50
+  --param=selsched-max-sched-times=<1,65536> 	2
+  --param=simultaneous-prefetches= 	3
+  --param=sink-frequency-threshold=<0,100> 	75
+  --param=sms-dfa-history=<0,16> 		0
+  --param=sms-loop-average-count-threshold= 	0
+  --param=sms-max-ii-factor=<1,16> 		2
+  --param=sms-min-sc=<1,2>    		2
+  --param=sra-max-propagations= 	32
+  --param=sra-max-scalarization-size-Osize= 	0
+  --param=sra-max-scalarization-size-Ospeed= 	0
+  --param=ssa-name-def-chain-limit= 	512
+  --param=ssp-buffer-size=<1,65536> 		8
+  --param=stack-clash-protection-guard-size=<12,30> 	16
+  --param=stack-clash-protection-probe-interval=<10,16> 	16
+  --param=store-merging-allow-unaligned=<0,1> 	1
+  --param=store-merging-max-size=<1,65536> 	65536
+  --param=switch-conversion-max-branch-ratio=<1,65536> 	8
+  --param=threader-debug=     		none
+  --param=tm-max-aggregate-size= 	9
+  --param=tracer-dynamic-coverage-feedback=<0,100> 	95
+  --param=tracer-dynamic-coverage=<0,100> 	75
+  --param=tracer-max-code-growth= 	100
+  --param=tracer-min-branch-probability-feedback=<0,100> 	80
+  --param=tracer-min-branch-probability=<0,100> 	50
+  --param=tracer-min-branch-ratio=<0,100> 	10
+  --param=tree-reassoc-width= 		0
+  --param=tsan-distinguish-volatile=<0,1> 	0
+  --param=tsan-instrument-func-entry-exit=<0,1> 	1
+  --param=uninit-control-dep-attempts=<1,65536> 	1000
+  --param=uninit-max-chain-len=<1,128> 	8
+  --param=uninit-max-num-chains=<1,128> 	8
+  --param=uninlined-function-insns=<0,1000000> 	2
+  --param=uninlined-function-time=<0,1000000> 	0
+  --param=uninlined-thunk-insns=<0,1000000> 	2
+  --param=uninlined-thunk-time=<0,1000000> 	2
+  --param=unlikely-bb-count-fraction= 	20
+  --param=unroll-jam-max-unroll= 	4
+  --param=unroll-jam-min-percent=<0,100> 	1
+  --param=use-after-scope-direct-emission-threshold= 	256
+  --param=use-canonical-types=<0,1> 		1
+  --param=vect-epilogues-nomask=<0,1> 	1
+  --param=vect-induction-float=<0,1> 	1
+  --param=vect-inner-loop-cost-factor=<1,10000> 	50
+  --param=vect-max-layout-candidates= 	32
+  --param=vect-max-peeling-for-alignment=<0,64> 	-1
+  --param=vect-max-version-for-alias-checks= 	10
+  --param=vect-max-version-for-alignment-checks= 	6
+  --param=vect-partial-vector-usage=<0,2> 	2
+
+The following options control compiler warning messages:
+  -W                          		-Wextra
+  -Waggregate-return          		[disabled]
+  -Waggressive-loop-optimizations 	[enabled]
+  -Wanalyzer-allocation-size  		[enabled]
+  -Wanalyzer-deref-before-check 	[enabled]
+  -Wanalyzer-double-fclose    		[enabled]
+  -Wanalyzer-double-free      		[enabled]
+  -Wanalyzer-exposure-through-output-file 	[enabled]
+  -Wanalyzer-exposure-through-uninit-copy 	[enabled]
+  -Wanalyzer-fd-access-mode-mismatch 	[enabled]
+  -Wanalyzer-fd-double-close  		[enabled]
+  -Wanalyzer-fd-leak          		[enabled]
+  -Wanalyzer-fd-phase-mismatch 		[enabled]
+  -Wanalyzer-fd-type-mismatch 		[enabled]
+  -Wanalyzer-fd-use-after-close 	[enabled]
+  -Wanalyzer-fd-use-without-check 	[enabled]
+  -Wanalyzer-file-leak        		[enabled]
+  -Wanalyzer-free-of-non-heap 		[enabled]
+  -Wanalyzer-imprecise-fp-arithmetic 	[enabled]
+  -Wanalyzer-infinite-recursion 	[enabled]
+  -Wanalyzer-jump-through-null 		[enabled]
+  -Wanalyzer-malloc-leak      		[enabled]
+  -Wanalyzer-mismatching-deallocation 	[enabled]
+  -Wanalyzer-null-argument    		[enabled]
+  -Wanalyzer-null-dereference 		[enabled]
+  -Wanalyzer-out-of-bounds    		[enabled]
+  -Wanalyzer-possible-null-argument 	[enabled]
+  -Wanalyzer-possible-null-dereference 	[enabled]
+  -Wanalyzer-putenv-of-auto-var 	[enabled]
+  -Wanalyzer-shift-count-negative 	[enabled]
+  -Wanalyzer-shift-count-overflow 	[enabled]
+  -Wanalyzer-stale-setjmp-buffer 	[enabled]
+  -Wanalyzer-tainted-allocation-size 	[enabled]
+  -Wanalyzer-tainted-array-index 	[enabled]
+  -Wanalyzer-tainted-assertion 		[enabled]
+  -Wanalyzer-tainted-divisor  		[enabled]
+  -Wanalyzer-tainted-offset   		[enabled]
+  -Wanalyzer-tainted-size     		[enabled]
+  -Wanalyzer-too-complex      		[disabled]
+  -Wanalyzer-unsafe-call-within-signal-handler 	[enabled]
+  -Wanalyzer-use-after-free   		[enabled]
+  -Wanalyzer-use-of-pointer-in-stale-stack-frame 	[enabled]
+  -Wanalyzer-use-of-uninitialized-value 	[enabled]
+  -Wanalyzer-va-arg-type-mismatch 	[enabled]
+  -Wanalyzer-va-list-exhausted 		[enabled]
+  -Wanalyzer-va-list-leak     		[enabled]
+  -Wanalyzer-va-list-use-after-va-end 	[enabled]
+  -Wanalyzer-write-to-const   		[enabled]
+  -Wanalyzer-write-to-string-literal 	[enabled]
+  -Warray-bounds=<0,2>        		0
+  -Wattribute-alias           		-Wattribute-alias=1
+  -Wattribute-alias=<0,2>     		1
+  -Wattribute-warning         		[enabled]
+  -Wattributes                		[enabled]
+  -Wcannot-profile            		[enabled]
+  -Wcast-align                		[disabled]
+  -Wcast-align=strict         		[disabled]
+  -Wcomplain-wrong-lang       		[enabled]
+  -Wcoverage-invalid-line-number 	[enabled]
+  -Wcoverage-mismatch         		[enabled]
+  -Wdeprecated-declarations   		[enabled]
+  -Wdisabled-optimization     		[disabled]
+  -Wframe-larger-than=<byte-size> 	9223372036854775807 bytes
+  -Wfree-nonheap-object       		[enabled]
+  -Whsa                       		[ignored]
+  -Wimplicit-fallthrough=<0,5> 		0
+  -Winline                    		[disabled]
+  -Winvalid-memory-model      		[enabled]
+  -Wlarger-than=<byte-size>   		9223372036854775807 bytes
+  -Wlto-type-mismatch         		[enabled]
+  -Wmissing-profile           		[enabled]
+  -Wno-frame-larger-than      		-Wframe-larger-than=18446744073709551615EiB
+  -Wno-larger-than            		-Wlarger-than=18446744073709551615EiB
+  -Wno-stack-usage            		-Wstack-usage=18446744073709551615EiB
+  -Wnull-dereference          		[disabled]
+  -Wodr                       		[enabled]
+  -Woverflow                  		[enabled]
+  -Wpacked                    		[disabled]
+  -Wpadded                    		[disabled]
+  -Wreturn-local-addr         		[enabled]
+  -Wshadow                    		[disabled]
+  -Wshadow=compatible-local   		[disabled]
+  -Wshadow=global             		-Wshadow
+  -Wshadow=local              		[disabled]
+  -Wstack-protector           		[disabled]
+  -Wstack-usage=<byte-size>   		9223372036854775807 bytes
+  -Wstrict-aliasing           		
+  -Wstrict-overflow           		
+  -Wsuggest-attribute=cold    		[disabled]
+  -Wsuggest-attribute=const   		[disabled]
+  -Wsuggest-attribute=malloc  		[disabled]
+  -Wsuggest-attribute=noreturn 		[disabled]
+  -Wsuggest-attribute=pure    		[disabled]
+  -Wsuggest-final-methods     		[disabled]
+  -Wsuggest-final-types       		[disabled]
+  -Wswitch-unreachable        		[enabled]
+  -Wtrampolines               		[disabled]
+  -Wtrivial-auto-var-init     		[disabled]
+  -Wtsan                      		[enabled]
+  -Wtype-limits               		[disabled]
+  -Wunreachable-code          		[ignored]
+  -Wunsafe-loop-optimizations 		[ignored]
+  -Wunused-but-set-parameter  		[disabled]
+  -Wunused-but-set-variable   		[disabled]
+  -Wunused-function           		[disabled]
+  -Wunused-label              		[disabled]
+  -Wunused-value              		[disabled]
+  -Wuse-after-free            		[disabled]
+  -Wuse-after-free=<0,3>      		0
+  -Wvector-operation-performance 	[disabled]
+
+The following options control optimizations:
+  -O<number>                  		
+  -Ofast                      		
+  -Og                         		
+  -Os                         		
+  -Oz                         		
+  -faggressive-loop-optimizations 	[enabled]
+  -falign-functions           		[disabled]
+  -falign-jumps               		[disabled]
+  -falign-labels              		[disabled]
+  -falign-loops               		[disabled]
+  -fallocation-dce            		[enabled]
+  -fallow-store-data-races    		[disabled]
+  -fassociative-math          		[disabled]
+  -fasynchronous-unwind-tables 		[enabled]
+  -fauto-inc-dec              		[enabled]
+  -fbit-tests                 		[enabled]
+  -fbranch-count-reg          		[disabled]
+  -fbranch-probabilities      		[disabled]
+  -fcaller-saves              		[disabled]
+  -fcode-hoisting             		[disabled]
+  -fcombine-stack-adjustments 		[disabled]
+  -fcompare-elim              		[disabled]
+  -fconserve-stack            		[disabled]
+  -fcprop-registers           		[disabled]
+  -fcrossjumping              		[disabled]
+  -fcse-follow-jumps          		[disabled]
+  -fcx-fortran-rules          		[disabled]
+  -fcx-limited-range          		[disabled]
+  -fdce                       		[enabled]
+  -fdefer-pop                 		[disabled]
+  -fdelayed-branch            		[disabled]
+  -fdelete-dead-exceptions    		[disabled]
+  -fdelete-null-pointer-checks 		
+  -fdevirtualize              		[disabled]
+  -fdevirtualize-speculatively 		[disabled]
+  -fdse                       		[disabled]
+  -fearly-inlining            		[enabled]
+  -fexcess-precision=[fast|standard|16] 	[default]
+  -fexpensive-optimizations   		[disabled]
+  -ffinite-loops              		[disabled]
+  -ffinite-math-only          		[disabled]
+  -ffloat-store               		[disabled]
+  -fforward-propagate         		[disabled]
+  -ffp-contract=[off|on|fast] 		fast
+  -ffp-int-builtin-inexact    		[enabled]
+  -ffunction-cse              		[enabled]
+  -fgcse                      		[disabled]
+  -fgcse-after-reload         		[disabled]
+  -fgcse-las                  		[disabled]
+  -fgcse-lm                   		[enabled]
+  -fgcse-sm                   		[disabled]
+  -fgraphite                  		[disabled]
+  -fgraphite-identity         		[disabled]
+  -fguess-branch-probability  		[disabled]
+  -fharden-compares           		[disabled]
+  -fharden-conditional-branches 	[disabled]
+  -fhoist-adjacent-loads      		[disabled]
+  -fif-conversion             		[disabled]
+  -fif-conversion2            		[disabled]
+  -findirect-inlining         		[disabled]
+  -finline                    		[enabled]
+  -finline-atomics            		[enabled]
+  -finline-functions          		[disabled]
+  -finline-functions-called-once 	[disabled]
+  -finline-small-functions    		[disabled]
+  -fipa-bit-cp                		[disabled]
+  -fipa-cp                    		[disabled]
+  -fipa-cp-clone              		[disabled]
+  -fipa-icf                   		[disabled]
+  -fipa-icf-functions         		[disabled]
+  -fipa-icf-variables         		[disabled]
+  -fipa-modref                		[disabled]
+  -fipa-profile               		[disabled]
+  -fipa-pta                   		[disabled]
+  -fipa-pure-const            		[disabled]
+  -fipa-ra                    		[disabled]
+  -fipa-reference             		[disabled]
+  -fipa-reference-addressable 		[disabled]
+  -fipa-sra                   		[disabled]
+  -fipa-stack-alignment       		[enabled]
+  -fipa-strict-aliasing       		[enabled]
+  -fipa-vrp                   		[disabled]
+  -fira-algorithm=[CB|priority] 	CB
+  -fira-hoist-pressure        		[enabled]
+  -fira-loop-pressure         		[disabled]
+  -fira-region=[one|all|mixed] 		one
+  -fira-share-save-slots      		[enabled]
+  -fira-share-spill-slots     		[enabled]
+  -fisolate-erroneous-paths-attribute 	[disabled]
+  -fisolate-erroneous-paths-dereference 	[disabled]
+  -fivopts                    		[enabled]
+  -fjump-tables               		[enabled]
+  -flifetime-dse              		[enabled]
+  -flive-patching=[inline-only-static|inline-clone] 	[default]
+  -flive-range-shrinkage      		[disabled]
+  -floop-interchange          		[disabled]
+  -floop-nest-optimize        		[disabled]
+  -floop-parallelize-all      		[disabled]
+  -floop-unroll-and-jam       		[disabled]
+  -flra-remat                 		[disabled]
+  -fmath-errno                		[enabled]
+  -fmodulo-sched              		[disabled]
+  -fmodulo-sched-allow-regmoves 	[disabled]
+  -fmove-loop-invariants      		[disabled]
+  -fmove-loop-stores          		[disabled]
+  -fnon-call-exceptions       		[disabled]
+  -fomit-frame-pointer        		[enabled]
+  -fopenmp-target-simd-clone= 		none
+  -fopt-info                  		[disabled]
+  -foptimize-sibling-calls    		[disabled]
+  -foptimize-strlen           		[disabled]
+  -fpack-struct               		[disabled]
+  -fpack-struct=<number>      		
+  -fpartial-inlining          		[disabled]
+  -fpatchable-function-entry= 		
+  -fpeel-loops                		[disabled]
+  -fpeephole                  		[enabled]
+  -fpeephole2                 		[disabled]
+  -fplt                       		[enabled]
+  -fpredictive-commoning      		[disabled]
+  -fprefetch-loop-arrays      		
+  -fprofile-partial-training  		[disabled]
+  -fprofile-reorder-functions 		[disabled]
+  -freciprocal-math           		[disabled]
+  -free                       		[disabled]
+  -freg-struct-return         		[enabled]
+  -frename-registers          		[disabled]
+  -freorder-blocks            		[disabled]
+  -freorder-blocks-algorithm=[simple|stc] 	simple
+  -freorder-blocks-and-partition 	[disabled]
+  -freorder-functions         		[disabled]
+  -frerun-cse-after-loop      		[disabled]
+  -freschedule-modulo-scheduled-loops 	[disabled]
+  -frounding-math             		[disabled]
+  -fsave-optimization-record  		[disabled]
+  -fsched-critical-path-heuristic 	[enabled]
+  -fsched-dep-count-heuristic 		[enabled]
+  -fsched-group-heuristic     		[enabled]
+  -fsched-interblock          		[enabled]
+  -fsched-last-insn-heuristic 		[enabled]
+  -fsched-pressure            		[disabled]
+  -fsched-rank-heuristic      		[enabled]
+  -fsched-spec                		[enabled]
+  -fsched-spec-insn-heuristic 		[enabled]
+  -fsched-spec-load           		[disabled]
+  -fsched-spec-load-dangerous 		[disabled]
+  -fsched-stalled-insns       		[disabled]
+  -fsched-stalled-insns-dep   		[enabled]
+  -fsched-stalled-insns-dep=<number> 	
+  -fsched-stalled-insns=<number> 	
+  -fsched2-use-superblocks    		[disabled]
+  -fschedule-fusion           		[enabled]
+  -fschedule-insns            		[disabled]
+  -fschedule-insns2           		[disabled]
+  -fsection-anchors           		[disabled]
+  -fsel-sched-pipelining      		[disabled]
+  -fsel-sched-pipelining-outer-loops 	[disabled]
+  -fsel-sched-reschedule-pipelined 	[disabled]
+  -fselective-scheduling      		[disabled]
+  -fselective-scheduling2     		[disabled]
+  -fsemantic-interposition    		[enabled]
+  -fshrink-wrap               		[disabled]
+  -fshrink-wrap-separate      		[enabled]
+  -fsignaling-nans            		[disabled]
+  -fsigned-zeros              		[enabled]
+  -fsimd-cost-model=[unlimited|dynamic|cheap|very-cheap] 	unlimited
+  -fsingle-precision-constant 		[disabled]
+  -fsplit-ivs-in-unroller     		[enabled]
+  -fsplit-loops               		[disabled]
+  -fsplit-paths               		[disabled]
+  -fsplit-wide-types          		[disabled]
+  -fsplit-wide-types-early    		[disabled]
+  -fssa-backprop              		[enabled]
+  -fssa-phiopt                		[disabled]
+  -fstack-check=[no|generic|specific] 	
+  -fstack-clash-protection    		[disabled]
+  -fstack-protector           		[disabled]
+  -fstack-protector-all       		[disabled]
+  -fstack-protector-explicit  		[disabled]
+  -fstack-protector-strong    		[disabled]
+  -fstack-reuse=[all|named_vars|none] 	all
+  -fstdarg-opt                		[enabled]
+  -fstore-merging             		[disabled]
+  -fstrict-aliasing           		[disabled]
+  -fstrict-volatile-bitfields 		[enabled]
+  -fthread-jumps              		[disabled]
+  -ftoplevel-reorder          		[enabled]
+  -ftracer                    		[disabled]
+  -ftrapping-math             		[enabled]
+  -ftrapv                     		[disabled]
+  -ftree-bit-ccp              		[disabled]
+  -ftree-builtin-call-dce     		[disabled]
+  -ftree-ccp                  		[disabled]
+  -ftree-ch                   		[disabled]
+  -ftree-coalesce-vars        		[disabled]
+  -ftree-copy-prop            		[disabled]
+  -ftree-cselim               		[disabled]
+  -ftree-dce                  		[disabled]
+  -ftree-dominator-opts       		[disabled]
+  -ftree-dse                  		[disabled]
+  -ftree-forwprop             		[enabled]
+  -ftree-fre                  		[disabled]
+  -ftree-loop-distribute-patterns 	[disabled]
+  -ftree-loop-distribution    		[disabled]
+  -ftree-loop-if-convert      		
+  -ftree-loop-im              		[enabled]
+  -ftree-loop-ivcanon         		[enabled]
+  -ftree-loop-optimize        		[enabled]
+  -ftree-loop-vectorize       		[disabled]
+  -ftree-lrs                  		[disabled]
+  -ftree-parallelize-loops=<number> 	1
+  -ftree-partial-pre          		[disabled]
+  -ftree-phiprop              		[enabled]
+  -ftree-pre                  		[disabled]
+  -ftree-pta                  		[disabled]
+  -ftree-reassoc              		[enabled]
+  -ftree-scev-cprop           		[enabled]
+  -ftree-sink                 		[disabled]
+  -ftree-slp-vectorize        		[disabled]
+  -ftree-slsr                 		[disabled]
+  -ftree-sra                  		[disabled]
+  -ftree-switch-conversion    		[disabled]
+  -ftree-tail-merge           		[disabled]
+  -ftree-ter                  		[disabled]
+  -ftree-vectorize            		[disabled]
+  -ftree-vrp                  		[disabled]
+  -ftrivial-auto-var-init=[uninitialized|pattern|zero] 	uninitialized
+  -funconstrained-commons     		[disabled]
+  -funreachable-traps         		[disabled]
+  -funroll-all-loops          		[disabled]
+  -funroll-loops              		[disabled]
+  -funsafe-math-optimizations 		[disabled]
+  -funswitch-loops            		[disabled]
+  -funwind-tables             		[enabled]
+  -fvar-tracking              		[disabled]
+  -fvar-tracking-assignments  		[disabled]
+  -fvar-tracking-assignments-toggle 	[disabled]
+  -fvar-tracking-uninit       		[disabled]
+  -fvariable-expansion-in-unroller 	[disabled]
+  -fvect-cost-model=[unlimited|dynamic|cheap|very-cheap] 	[default]
+  -fversion-loops-for-strides 		[disabled]
+  -fvpt                       		[disabled]
+  -fweb                       		[disabled]
+  -fwrapv                     		[disabled]
+  -fwrapv-pointer             		[disabled]
+  -gstatement-frontiers       		[disabled]
+  -mlow-precision-div         		[disabled]
+  -mlow-precision-recip-sqrt  		[disabled]
+  -mlow-precision-sqrt        		[disabled]
+
+The following options are target specific:
+  -mabi=                      		lp64
+  -march=                     		
+  -mbig-endian                		[disabled]
+  -mbionic                    		[disabled]
+  -mbranch-protection=        		
+  -mcmodel=                   		small
+  -mcpu=                      		
+  -mfix-cortex-a53-835769     		[enabled]
+  -mfix-cortex-a53-843419     		[enabled]
+  -mgeneral-regs-only         		[disabled]
+  -mglibc                     		[enabled]
+  -mharden-sls=               		
+  -mlittle-endian             		[enabled]
+  -mmusl                      		[disabled]
+  -momit-leaf-frame-pointer   		[enabled]
+  -moutline-atomics           		[enabled]
+  -moverride=<string>         		
+  -mpc-relative-literal-loads 		[enabled]
+  -msign-return-address=      		none
+  -mstack-protector-guard-offset= 	
+  -mstack-protector-guard-reg= 		
+  -mstack-protector-guard=    		global
+  -mstrict-align              		[disabled]
+  -msve-vector-bits=<number>  		scalable
+  -mtls-dialect=              		desc
+  -mtls-size=                 		24
+  -mtrack-speculation         		[disabled]
+  -mtune=                     		
+  -muclibc                    		[disabled]
+
+  Known AArch64 ABIs (for use with the -mabi= option):
+    ilp32 lp64
+
+  Supported AArch64 return address signing scope (for use with -msign-return-address= option):
+    all non-leaf none
+
+  The code model option names for -mcmodel:
+    large small tiny
+
+  Valid arguments to -mstack-protector-guard=:
+    global sysreg
+
+  The possible SVE vector lengths:
+    1024 128 2048 256 512 scalable
+
+  The possible TLS dialects:
+    desc trad
+
+The following options are language-independent:
+  --help                      		[enabled]
+  --help=<class>              		
+  --target-help               		
+  -Wattributes=               		
+  -Werror=                    		
+  -Wfatal-errors              		[disabled]
+  -aux-info <file>            		
+  -dumpbase <file>            		
+  -dumpbase-ext               		
+  -dumpdir <dir>              		
+  -fPIC                       		[disabled]
+  -fPIE                       		[disabled]
+  -fabi-version=              		0
+  -fanalyzer                  		[disabled]
+  -fanalyzer-call-summaries   		[disabled]
+  -fanalyzer-checker=         		
+  -fanalyzer-feasibility      		[enabled]
+  -fanalyzer-fine-grained     		[disabled]
+  -fanalyzer-show-duplicate-count 	[disabled]
+  -fanalyzer-state-merge      		[enabled]
+  -fanalyzer-state-purge      		[enabled]
+  -fanalyzer-suppress-followups 	[enabled]
+  -fanalyzer-transitivity     		[disabled]
+  -fanalyzer-undo-inlining    		[enabled]
+  -fanalyzer-verbose-edges    		[disabled]
+  -fanalyzer-verbose-state-changes 	[disabled]
+  -fanalyzer-verbosity=       		2
+  -fargument-alias            		[ignored]
+  -fargument-noalias          		[ignored]
+  -fargument-noalias-anything 		[ignored]
+  -fargument-noalias-global   		[ignored]
+  -fasan-shadow-offset=<number> 	
+  -fauto-profile              		[disabled]
+  -fauto-profile=             		
+  -fbranch-target-load-optimize 	[ignored]
+  -fbranch-target-load-optimize2 	[ignored]
+  -fbtr-bb-exclusive          		[ignored]
+  -fcall-saved-<register>     		
+  -fcall-used-<register>      		
+  -fcallgraph-info            		[disabled]
+  -fcallgraph-info=           		
+  -fcanon-prefix-map          		
+  -fcf-protection=[full|branch|return|none|check] 	none
+  -fcheck-data-deps           		[ignored]
+  -fcheck-new                 		[disabled]
+  -fchecking                  		[disabled]
+  -fchecking=                 		0
+  -fcommon                    		[disabled]
+  -fcompare-debug-second      		[disabled]
+  -fcompare-debug[=<opts>]    		
+  -fcse-skip-blocks           		[ignored]
+  -fdata-sections             		[disabled]
+  -fdbg-cnt-list              		[disabled]
+  -fdbg-cnt=<counter>[:<lower_limit1>-]<upper_limit1>[:<lower_limit2>-<upper_limit2>:...][,<counter>:...] 	
+  -fdebug-prefix-map=<old>=<new> 	
+  -fdebug-types-section       		[disabled]
+  -fdevirtualize-at-ltrans    		[disabled]
+  -fdiagnostics-color=[never|always|auto] 	never
+  -fdiagnostics-column-origin=<number> 	
+  -fdiagnostics-column-unit=[display|byte] 	
+  -fdiagnostics-escape-format=[unicode|bytes] 	
+  -fdiagnostics-format=[text|sarif-stderr|sarif-file|json|json-stderr|json-file] 	
+  -fdiagnostics-generate-patch 		[disabled]
+  -fdiagnostics-minimum-margin-width= 	6
+  -fdiagnostics-parseable-fixits 	[disabled]
+  -fdiagnostics-path-format=  		inline-events
+  -fdiagnostics-plain-output  		
+  -fdiagnostics-show-caret    		[enabled]
+  -fdiagnostics-show-cwe      		[enabled]
+  -fdiagnostics-show-labels   		[enabled]
+  -fdiagnostics-show-line-numbers 	[enabled]
+  -fdiagnostics-show-location=[once|every-line] 	
+  -fdiagnostics-show-option   		[enabled]
+  -fdiagnostics-show-path-depths 	[disabled]
+  -fdiagnostics-show-rules    		[enabled]
+  -fdiagnostics-urls=[never|always|auto] 	auto
+  -fdisable-[tree|rtl|ipa]-<pass>=range1+range2 	
+  -fdump-<type>               		
+  -fdump-analyzer             		[disabled]
+  -fdump-analyzer-callgraph   		[disabled]
+  -fdump-analyzer-exploded-graph 	[disabled]
+  -fdump-analyzer-exploded-nodes 	[disabled]
+  -fdump-analyzer-exploded-nodes-2 	[disabled]
+  -fdump-analyzer-exploded-nodes-3 	[disabled]
+  -fdump-analyzer-exploded-paths 	[disabled]
+  -fdump-analyzer-feasibility 		[disabled]
+  -fdump-analyzer-json        		[disabled]
+  -fdump-analyzer-state-purge 		[disabled]
+  -fdump-analyzer-stderr      		[disabled]
+  -fdump-analyzer-supergraph  		[disabled]
+  -fdump-analyzer-untracked   		[disabled]
+  -fdump-final-insns=filename 		
+  -fdump-go-spec=filename     		
+  -fdump-internal-locations   		[disabled]
+  -fdump-noaddr               		[disabled]
+  -fdump-passes               		[disabled]
+  -fdump-unnumbered           		[disabled]
+  -fdump-unnumbered-links     		[disabled]
+  -fdwarf2-cfi-asm            		[enabled]
+  -feliminate-dwarf2-dups     		[ignored]
+  -feliminate-unused-debug-symbols 	[enabled]
+  -feliminate-unused-debug-types 	[enabled]
+  -femit-class-debug-always   		[disabled]
+  -fenable-[tree|rtl|ipa]-<pass>=range1+range2 	
+  -ffat-lto-objects           		[disabled]
+  -ffile-prefix-map=<old>=<new> 	
+  -ffixed-<register>          		
+  -fforce-addr                		[ignored]
+  -ffunction-sections         		[disabled]
+  -fgnu-tm                    		[disabled]
+  -fgnu-unique                		[enabled]
+  -fident                     		[enabled]
+  -finhibit-size-directive    		[disabled]
+  -finline-limit=<number>     		
+  -finstrument-functions      		[disabled]
+  -finstrument-functions-exclude-file-list=filename,... 	
+  -finstrument-functions-exclude-function-list=name,... 	
+  -finstrument-functions-once 		[disabled]
+  -fipa-cp-alignment          		[ignored]
+  -fipa-matrix-reorg          		[ignored]
+  -fipa-struct-reorg          		[ignored]
+  -fira-verbose=<number>      		5
+  -fkeep-inline-functions     		[disabled]
+  -fkeep-static-consts        		[enabled]
+  -fkeep-static-functions     		[disabled]
+  -flarge-source-files        		[disabled]
+  -fleading-underscore        		
+  -floop-block                		-floop-nest-optimize
+  -floop-flatten              		[ignored]
+  -floop-optimize             		[ignored]
+  -floop-strip-mine           		-floop-nest-optimize
+  -flto                       		
+  -flto-compression-level=<0,19> 		-1
+  -flto-odr-type-merging      		[ignored]
+  -flto-partition=            		balanced
+  -flto-report                		[disabled]
+  -flto-report-wpa            		[disabled]
+  -flto=                      		
+  -fmax-errors=<number>       		0
+  -fmem-report                		[disabled]
+  -fmem-report-wpa            		[disabled]
+  -fmerge-all-constants       		[disabled]
+  -fmerge-constants           		[disabled]
+  -fmerge-debug-strings       		[enabled]
+  -fmessage-length=<number>   		
+  -fmultiflags                		
+  -foffload-abi=[lp64|ilp32]  		
+  -foffload-options=<targets>=<options> 	
+  -fopt-info[-<type>=filename] 		
+  -foptimize-register-move    		[ignored]
+  -fpcc-struct-return         		[disabled]
+  -fpermitted-flt-eval-methods=[c11|ts-18661] 	[default]
+  -fpic                       		[disabled]
+  -fpie                       		[disabled]
+  -fplugin-arg-<name>-<key>[=<value>] 	
+  -fplugin=                   		
+  -fpost-ipa-mem-report       		[disabled]
+  -fpre-ipa-mem-report        		[disabled]
+  -fprofile                   		[disabled]
+  -fprofile-abs-path          		[disabled]
+  -fprofile-arcs              		[disabled]
+  -fprofile-correction        		[disabled]
+  -fprofile-dir=              		
+  -fprofile-exclude-files=    		
+  -fprofile-filter-files=     		
+  -fprofile-generate          		
+  -fprofile-generate=         		
+  -fprofile-info-section      		
+  -fprofile-info-section=     		
+  -fprofile-note=             		
+  -fprofile-prefix-map=<old>=<new> 	
+  -fprofile-prefix-path=      		
+  -fprofile-report            		[disabled]
+  -fprofile-reproducible=[serial|parallel-runs|multithreaded] 	serial
+  -fprofile-update=[single|atomic|prefer-atomic] 	single
+  -fprofile-use               		[disabled]
+  -fprofile-use=              		
+  -fprofile-values            		[disabled]
+  -frandom-seed=<string>      		
+  -frecord-gcc-switches       		[disabled]
+  -fregmove                   		[ignored]
+  -freport-bug                		[disabled]
+  -frerun-loop-opt            		[ignored]
+  -fsanitize-coverage=        		[default]
+  -fsanitize-recover          		
+  -fsanitize-recover=         		
+  -fsanitize-sections=<sec1,sec2,...> 	
+  -fsanitize-trap=            		
+  -fsanitize-undefined-trap-on-error 	-fsanitize-trap
+  -fsanitize=                 		
+  -fsched-verbose=<number>    		1
+  -fsched2-use-traces         		[ignored]
+  -fsee                       		[ignored]
+  -fshow-column               		[enabled]
+  -fsplit-stack               		
+  -fstack-check               		-fstack-check=specific
+  -fstack-limit-register=<register> 	
+  -fstack-limit-symbol=<name> 		
+  -fstack-usage               		[disabled]
+  -fstrength-reduce           		[ignored]
+  -fstrict-overflow           		
+  -fsync-libcalls             		[enabled]
+  -fsyntax-only               		[disabled]
+  -ftabstop=                  		
+  -ftest-coverage             		[disabled]
+  -ftime-report               		[disabled]
+  -ftime-report-details       		[disabled]
+  -ftls-model=[global-dynamic|local-dynamic|initial-exec|local-exec] 	global-
+                              dynamic
+  -ftrampolines               		[disabled]
+  -ftree-coalesce-inlined-vars 		[ignored]
+  -ftree-copyrename           		[ignored]
+  -ftree-loop-if-convert-stores 	[ignored]
+  -ftree-loop-linear          		-floop-nest-optimize
+  -ftree-salias               		[ignored]
+  -ftree-store-ccp            		[ignored]
+  -ftree-store-copy-prop      		[ignored]
+  -ftree-vect-loop-version    		[ignored]
+  -ftree-vectorizer-verbose=  		
+  -funit-at-a-time            		[enabled]
+  -funsafe-loop-optimizations 		[ignored]
+  -fuse-ld=bfd                		
+  -fuse-ld=gold               		
+  -fuse-ld=lld                		
+  -fuse-ld=mold               		
+  -fvect-cost-model           		-fvect-cost-model=dynamic
+  -fverbose-asm               		[disabled]
+  -fvisibility=[default|internal|hidden|protected] 	default
+  -fvtable-verify=            		none
+  -fvtv-counts                		[disabled]
+  -fvtv-debug                 		[disabled]
+  -fwhole-program             		[disabled]
+  -fzee                       		[ignored]
+  -fzero-call-used-regs=      		
+  -fzero-initialized-in-bss   		[enabled]
+  -g                          		
+  -gas-loc-support            		[disabled]
+  -gas-locview-support        		[disabled]
+  -gbtf                       		
+  -gcoff                      		
+  -gcoff1                     		
+  -gcoff2                     		
+  -gcoff3                     		
+  -gcolumn-info               		[enabled]
+  -gctf                       		
+  -gdescribe-dies             		[disabled]
+  -gdwarf                     		
+  -gdwarf-                    		5
+  -gdwarf32                   		[enabled]
+  -gdwarf64                   		[disabled]
+  -ggdb                       		
+  -ggnu-pubnames              		[disabled]
+  -ginline-points             		[disabled]
+  -ginternal-reset-location-views 	[enabled]
+  -gno-pubnames               		[disabled]
+  -gpubnames                  		[disabled]
+  -grecord-gcc-switches       		[enabled]
+  -gsplit-dwarf               		[disabled]
+  -gstabs                     		
+  -gstabs+                    		
+  -gstrict-dwarf              		[disabled]
+  -gtoggle                    		[disabled]
+  -gvariable-location-views   		[disabled]
+  -gvms                       		
+  -gxcoff                     		
+  -gxcoff+                    		
+  -gz                         		
+  -gz=<format>                		
+  -imultiarch <dir>           		
+  -iplugindir=<dir>           		
+  -p                          		[disabled]
+  -pedantic-errors            		[disabled]
+  -quiet                      		[disabled]
+  -version                    		[disabled]
+

--- a/corpus/lto-dump/13.3.0/meta.toml
+++ b/corpus/lto-dump/13.3.0/meta.toml
@@ -1,0 +1,22 @@
+# From issue 102 item 1. `-C` and `-CC` are adjacent rows both described
+# "[disabled]", a description repeated 505 times in this one document.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "lto-dump"
+version = "13.3.0"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["lto-dump", "--help"]
+stdout = "help.txt"
+
+[contract]
+must_keep_separate = [["-C", "-CC"]]
+
+[xfail]
+broken = true
+reason = "-C and -CC collapse onto one entity. Unlike the other issue 102 item 1 tools, this pair is not fused by description equality: -CC is single-dash-long shaped, so the single-dash-long repair reads -CC as a longer spelling of -C. A fix needs that repair to refuse a candidate whose own row exists separately in the same option table."

--- a/corpus/mkfs.bfs/2.39.3/expected.snap
+++ b/corpus/mkfs.bfs/2.39.3/expected.snap
@@ -1,0 +1,77 @@
+name: mkfs.bfs
+usage:
+- 'Usage: mkfs.bfs [options] device [block-count]'
+flags:
+- spellings:
+  - -N
+  - --inodes
+  value_name: NUM
+  value_kind: Required
+  description: specify desired number of inodes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --vname
+  value_name: NAME
+  value_kind: Required
+  description: specify volume name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -F
+  - --fname
+  value_name: NAME
+  value_kind: Required
+  description: specify file system name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -v
+  - --verbose
+  description: explain what is being done
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -c
+  description: this option is silently ignored
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -l
+  description: this option is silently ignored
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --lock
+  value_name: <mode>
+  value_kind: Optional
+  description: use exclusive device lock (yes, no or nonblock)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  - --help
+  description: display this help
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --version
+  description: display version
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/mkfs.bfs/2.39.3/help.txt
+++ b/corpus/mkfs.bfs/2.39.3/help.txt
@@ -1,0 +1,16 @@
+Usage: mkfs.bfs [options] device [block-count]
+
+Make an SCO bfs filesystem.
+
+Options:
+ -N, --inodes=NUM    specify desired number of inodes
+ -V, --vname=NAME    specify volume name
+ -F, --fname=NAME    specify file system name
+ -v, --verbose       explain what is being done
+ -c                  this option is silently ignored
+ -l                  this option is silently ignored
+ --lock[=<mode>]     use exclusive device lock (yes, no or nonblock)
+ -h, --help          display this help
+ -V, --version       display version
+
+For more details see mkfs.bfs(8).

--- a/corpus/mkfs.bfs/2.39.3/meta.toml
+++ b/corpus/mkfs.bfs/2.39.3/meta.toml
@@ -1,0 +1,18 @@
+# From issue 102 item 1. `-c` and `-l` are adjacent rows both described
+# "this option is silently ignored".
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "mkfs.bfs"
+version = "2.39.3"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["mkfs.bfs", "--help"]
+stdout = "help.txt"
+
+[contract]
+must_keep_separate = [["-c", "-l"]]

--- a/corpus/resolvconf/255.4/expected.snap
+++ b/corpus/resolvconf/255.4/expected.snap
@@ -1,0 +1,73 @@
+name: resolvconf
+usage:
+- resolvconf -a INTERFACE < FILE
+- resolvconf -d INTERFACE
+positionals:
+- name: FILE
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -h
+  - --help
+  description: Show this help
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --version
+  description: Show package version
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -a
+  description: Register per-interface DNS server and domain data
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  description: Unregister per-interface DNS server and domain data
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -f
+  description: Ignore if specified interface does not exist
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -x
+  description: Send DNS traffic preferably over this interface
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -I
+  - -i
+  - -l
+  - -R
+  - -r
+  - -v
+  - -V
+  - --enable-updates
+  - --disable-updates
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --updates-are-enabled
+  value_name: .
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/sysctl/4.0.4/expected.snap
+++ b/corpus/sysctl/4.0.4/expected.snap
@@ -1,0 +1,145 @@
+name: sysctl
+usage:
+- 'Usage:'
+- ' sysctl [options] [variable[=value] ...]'
+flags:
+- spellings:
+  - -a
+  - --all
+  description: display all variables
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -A
+  description: alias of -a
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -X
+  description: alias of -a
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --deprecated
+  description: include deprecated parameters to listing
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --dry-run
+  description: Print the key and values but do not write
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -b
+  - --binary
+  description: print value without new line
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -e
+  - --ignore
+  description: ignore unknown variables errors
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -N
+  - --names
+  description: print variable names without values
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -n
+  - --values
+  description: print only values of the given variable(s)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -p
+  - --load
+  value_name: <file>
+  value_kind: Optional
+  description: read values from file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -f
+  description: alias of -p
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --system
+  description: read values from all system directories
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -r
+  - --pattern
+  value_name: <expression>
+  value_kind: Required
+  description: select setting that match expression
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -q
+  - --quiet
+  description: do not echo variable set
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -w
+  - --write
+  description: enable writing a value to variable
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  description: does nothing
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -x
+  description: does nothing
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  description: alias of -h
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  - --help
+  description: display this help and exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --version
+  description: output version information and exit
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/sysctl/4.0.4/help.txt
+++ b/corpus/sysctl/4.0.4/help.txt
@@ -1,0 +1,29 @@
+
+Usage:
+ sysctl [options] [variable[=value] ...]
+
+Options:
+  -a, --all            display all variables
+  -A                   alias of -a
+  -X                   alias of -a
+      --deprecated     include deprecated parameters to listing
+      --dry-run        Print the key and values but do not write
+  -b, --binary         print value without new line
+  -e, --ignore         ignore unknown variables errors
+  -N, --names          print variable names without values
+  -n, --values         print only values of the given variable(s)
+  -p, --load[=<file>]  read values from file
+  -f                   alias of -p
+      --system         read values from all system directories
+  -r, --pattern <expression>
+                       select setting that match expression
+  -q, --quiet          do not echo variable set
+  -w, --write          enable writing a value to variable
+  -o                   does nothing
+  -x                   does nothing
+  -d                   alias of -h
+
+ -h, --help     display this help and exit
+ -V, --version  output version information and exit
+
+For more details see sysctl(8).

--- a/corpus/sysctl/4.0.4/meta.toml
+++ b/corpus/sysctl/4.0.4/meta.toml
@@ -1,0 +1,19 @@
+# From issue 102 item 1. `-A`/`-X` are two independent legacy shims for a
+# third flag, both described "alias of -a", and `-o`/`-x` both "does
+# nothing". Neither pair is an alias of the other.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "sysctl"
+version = "4.0.4"
+platform = "ubuntu-24.04"
+captured_with = "mandible 0.6.1"
+
+[[capture]]
+argv = ["sysctl", "--help"]
+stdout = "help.txt"
+
+[contract]
+must_keep_separate = [["-A", "-X"], ["-o", "-x"]]

--- a/corpus/zgrep/1.12/expected.snap
+++ b/corpus/zgrep/1.12/expected.snap
@@ -1,0 +1,44 @@
+name: zgrep
+description: Look for instances of PATTERN in the input FILEs, using their uncompressed contents if they are compressed.
+usage:
+- 'Usage: /usr/bin/zgrep [OPTION]... [-e] PATTERN [FILE]...'
+positionals:
+- name: PATTERN
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: FILE
+  variadic: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - --exclude
+  - --exclude-from
+  - --exclude-dir
+  - --include
+  - --null
+  value_name: (-Z),
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --null-data
+  value_name: (-z),
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -e
+  provenance:
+    sources:
+    - help-text-synopsis
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/xtask/src/corpus/contract.rs
+++ b/xtask/src/corpus/contract.rs
@@ -155,6 +155,8 @@ pub(crate) fn contract_weakened_lines(current: &[Fixture], baseline: &[Fixture])
             }
         }
 
+        lines.extend(new_field_weakened_lines(&base.label, b, n));
+
         let base_xfail = base.meta.xfail.as_ref().is_some_and(|x| x.broken);
         let now_xfail = now.meta.xfail.as_ref().is_some_and(|x| x.broken);
         if !base_xfail && now_xfail {
@@ -164,6 +166,60 @@ pub(crate) fn contract_weakened_lines(current: &[Fixture], baseline: &[Fixture])
             ));
         }
     }
+    lines
+}
+
+/// The weakening checks for the three fields added alongside
+/// `must_keep_separate`, `must_attach_choices` and `must_describe` — split
+/// out of [`contract_weakened_lines`] to keep that function under the
+/// workspace's line-count lint.
+fn new_field_weakened_lines(label: &str, b: &ContractMeta, n: &ContractMeta) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    // `must_keep_separate`: a dropped group retires the only statement
+    // that its spellings never fused, exactly the reasoning
+    // `must_not_contain_flags` above already carries for its own negative
+    // claim.
+    let dropped_groups: Vec<String> = b
+        .must_keep_separate
+        .iter()
+        .filter(|group| !n.must_keep_separate.iter().any(|g| g == *group))
+        .map(|group| format!("{group:?}"))
+        .collect();
+    if !dropped_groups.is_empty() {
+        lines.push(format!(
+            "CONTRACT WEAKENED: {label} must_keep_separate (dropped: {})",
+            dropped_groups.join(", ")
+        ));
+    }
+
+    for (flag, base_choices) in &b.must_attach_choices {
+        let now_choices = n.must_attach_choices.get(flag);
+        let missing: Vec<&str> = base_choices
+            .iter()
+            .filter(|c| !now_choices.is_some_and(|cs| cs.iter().any(|x| x == *c)))
+            .map(String::as_str)
+            .collect();
+        if !missing.is_empty() {
+            lines.push(format!(
+                "CONTRACT WEAKENED: {label} must_attach_choices[{flag:?}] (dropped: {})",
+                missing.join(", ")
+            ));
+        }
+    }
+
+    // `must_describe`: only flagged when the assertion disappears
+    // entirely, mirroring `expected_framework`'s own rule — a changed
+    // expected substring has no natural stronger/weaker ordering, so only
+    // its outright removal is reported.
+    for flag in b.must_describe.keys() {
+        if !n.must_describe.contains_key(flag) {
+            lines.push(format!(
+                "CONTRACT WEAKENED: {label} must_describe[{flag:?}] (assertion removed)"
+            ));
+        }
+    }
+
     lines
 }
 
@@ -195,15 +251,19 @@ pub(crate) fn check_contract(
 /// report reads the same shape whether the failure is "wrong tree" or "no
 /// tree".
 ///
-/// `must_not_contain_flags` is deliberately absent from this list. Every
-/// field above is a positive claim, which a missing tree trivially breaks
-/// — "the tool has --paginate" cannot hold of no tree. A negative claim is
-/// the opposite: "no root flag is spelled X" is *satisfied* by a tree with
-/// no flags at all, so reporting it here would announce a violation of a
-/// promise that in fact holds, which is a false positive in the one place
-/// this runner's authority comes from. A fixture that produced no root
-/// still fails loudly — on its snapshot, and on every positive field it
-/// set.
+/// `must_not_contain_flags` and `must_keep_separate` are deliberately
+/// absent from this list. Every field above is a positive claim, which a
+/// missing tree trivially breaks — "the tool has --paginate" cannot hold
+/// of no tree. A negative claim is the opposite: "no root flag is spelled
+/// X" is *satisfied* by a tree with no flags at all, so reporting it here
+/// would announce a violation of a promise that in fact holds, which is a
+/// false positive in the one place this runner's authority comes from.
+/// `must_keep_separate` is negative the same way — "these spellings never
+/// fused" holds vacuously when none of them exist to fuse. `must_attach_choices`
+/// and `must_describe` are positive claims ("this flag exists and carries
+/// this"), so a missing root fails them exactly as it fails
+/// `must_contain_flags`. A fixture that produced no root still fails
+/// loudly — on its snapshot, and on every positive field it set.
 fn check_contract_missing_root(contract: &ContractMeta) -> Vec<ContractFailure> {
     let mut failures = Vec::new();
     if contract.expected_framework.is_some() {
@@ -241,6 +301,14 @@ fn check_contract_missing_root(contract: &ContractMeta) -> Vec<ContractFailure> 
         failures.push(ContractFailure(
             "must_contain_env_vars: no root produced".into(),
         ));
+    }
+    if !contract.must_attach_choices.is_empty() {
+        failures.push(ContractFailure(
+            "must_attach_choices: no root produced".into(),
+        ));
+    }
+    if !contract.must_describe.is_empty() {
+        failures.push(ContractFailure("must_describe: no root produced".into()));
     }
     failures
 }
@@ -311,6 +379,33 @@ fn check_contract_scalar_fields(
             "must_not_contain_flags: present {}",
             present_forbidden.join(", ")
         )));
+    }
+
+    // The other negative-claim shape: not "this spelling was invented",
+    // but "these spellings, which really exist, must not have been folded
+    // onto one entity" — the alias-run fold's own failure mode. Each group
+    // is checked independently; one `ContractFailure` per group that
+    // actually collapsed, naming the group and which of its spellings
+    // share an entity.
+    for group in &contract.must_keep_separate {
+        let mut by_entity: std::collections::BTreeMap<usize, Vec<&str>> =
+            std::collections::BTreeMap::new();
+        for spelling in group {
+            if let Some(idx) = resolve_flag_entity(root, spelling) {
+                by_entity.entry(idx).or_default().push(spelling.as_str());
+            }
+        }
+        let collapsed: Vec<String> = by_entity
+            .into_values()
+            .filter(|spellings| spellings.len() > 1)
+            .map(|spellings| spellings.join(", "))
+            .collect();
+        if !collapsed.is_empty() {
+            failures.push(ContractFailure(format!(
+                "must_keep_separate: {group:?} collapsed onto one entity: {}",
+                collapsed.join("; ")
+            )));
+        }
     }
 
     failures
@@ -388,6 +483,53 @@ fn check_contract_collection_fields(
         }
     }
 
+    for (flag_spec, wanted_choices) in &contract.must_attach_choices {
+        match root
+            .flags()
+            .find(|f| entity_matches_flag_spec(f, flag_spec))
+        {
+            None => failures.push(ContractFailure(format!(
+                "must_attach_choices[{flag_spec:?}]: flag not present"
+            ))),
+            Some(entity) => {
+                let missing: Vec<&str> = wanted_choices
+                    .iter()
+                    .filter(|c| !entity.choices.iter().any(|ch| &ch.name == *c))
+                    .map(|s| s.as_str())
+                    .collect();
+                if !missing.is_empty() {
+                    failures.push(ContractFailure(format!(
+                        "must_attach_choices[{flag_spec:?}]: missing {}",
+                        missing.join(", ")
+                    )));
+                }
+            }
+        }
+    }
+
+    for (flag_spec, expected_text) in &contract.must_describe {
+        match root
+            .flags()
+            .find(|f| entity_matches_flag_spec(f, flag_spec))
+        {
+            None => failures.push(ContractFailure(format!(
+                "must_describe[{flag_spec:?}]: flag not present"
+            ))),
+            Some(entity) => {
+                let actual = entity.description.as_ref().map_or("", |t| t.as_str());
+                let actual_collapsed = collapse_whitespace(actual);
+                let expected_collapsed = collapse_whitespace(expected_text);
+                if !actual_collapsed.contains(&expected_collapsed) {
+                    failures.push(ContractFailure(format!(
+                        "must_describe[{flag_spec:?}]: expected description to contain {:?}, got {:?}",
+                        expected_collapsed,
+                        truncate_for_display(&actual_collapsed, 120)
+                    )));
+                }
+            }
+        }
+    }
+
     failures
 }
 
@@ -433,6 +575,14 @@ fn extraction_result_stub(root: CommandNode) -> mandible_extract::ExtractionResu
 /// --help`), so a contract asserting `-?` must still find it once `-h`
 /// claims the canonical slot.
 fn flag_present(node: &CommandNode, spec: &str) -> bool {
+    node.flags().any(|f| entity_matches_flag_spec(f, spec))
+}
+
+/// The single-entity half of [`flag_present`]'s matching rule, split out
+/// so [`resolve_flag_entity`] can find *which* entity a spelling resolves
+/// to (for `must_keep_separate`) rather than only whether any entity
+/// matches.
+fn entity_matches_flag_spec(entity: &Entity, spec: &str) -> bool {
     if let Some(long) = spec.strip_prefix("--") {
         // Long-*like*, matching `Entity::long`'s own shape rule exactly
         // (never narrowed to `Dashes::Double` alone): two dashes, or one
@@ -440,25 +590,50 @@ fn flag_present(node: &CommandNode, spec: &str) -> bool {
         // (`ptargrep`'s own `-message`, `Dashes::Single`, four letters)
         // must still satisfy a `--message` contract entry the way
         // `Entity::long()` always considered it to.
-        node.flags().any(|f| {
-            f.spellings.iter().any(|s| {
-                (matches!(s.dashes, Dashes::Double)
-                    || (matches!(s.dashes, Dashes::Single) && s.name.chars().count() > 1))
-                    && s.name == long
-            })
+        entity.spellings.iter().any(|s| {
+            (matches!(s.dashes, Dashes::Double)
+                || (matches!(s.dashes, Dashes::Single) && s.name.chars().count() > 1))
+                && s.name == long
         })
     } else if let Some(short) = spec.strip_prefix('-') {
         short.chars().next().is_some_and(|c| {
-            node.flags().any(|f| {
-                f.spellings.iter().any(|s| {
-                    matches!(s.dashes, Dashes::Single)
-                        && s.name.chars().count() == 1
-                        && s.name.starts_with(c)
-                })
+            entity.spellings.iter().any(|s| {
+                matches!(s.dashes, Dashes::Single)
+                    && s.name.chars().count() == 1
+                    && s.name.starts_with(c)
             })
         })
     } else {
-        node.flags()
-            .any(|f| f.spellings.iter().any(|s| s.name == spec))
+        entity.spellings.iter().any(|s| s.name == spec)
     }
+}
+
+/// Which root flag entity (by index into `node.flags()`'s own iteration
+/// order) a spelling resolves to, or `None` if nothing matches — the
+/// building block `must_keep_separate` needs to tell "two spellings match
+/// two different entities" apart from "two spellings match the same
+/// entity", which mere presence (`flag_present`) cannot distinguish.
+fn resolve_flag_entity(node: &CommandNode, spec: &str) -> Option<usize> {
+    node.flags()
+        .enumerate()
+        .find(|(_, f)| entity_matches_flag_spec(f, spec))
+        .map(|(i, _)| i)
+}
+
+/// Truncate `s` to at most `max` chars for a readable failure message,
+/// appending `"..."` when truncated.
+fn truncate_for_display(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{truncated}...")
+    }
+}
+
+/// Collapse runs of whitespace to a single space and trim the ends —
+/// `must_describe`'s comparison rule, applied to both sides, since a
+/// description wraps and a fixture author's TOML value may too.
+fn collapse_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/xtask/src/corpus/mod.rs
+++ b/xtask/src/corpus/mod.rs
@@ -21,7 +21,8 @@
 //! - (b) `[contract]`: `expected_framework`, `min_status`,
 //!   `min_subcommands`, `must_contain_flags`, `must_contain_flags_by_path`,
 //!   `must_contain_positionals`, `must_contain_modifiers`,
-//!   `must_not_contain_flags` ([`check_contract`]).
+//!   `must_not_contain_flags`, `must_keep_separate`, `must_attach_choices`,
+//!   `must_describe` ([`check_contract`]).
 //! - (c) Strict xfail: an `[xfail]` fixture whose snapshot and contract
 //!   both pass fails the run — the bug is fixed, promote it
 //!   (`corpus/README.md`'s lifecycle rules).
@@ -158,6 +159,32 @@ pub(crate) struct ContractMeta {
     /// reported, unlike every positive field above.
     #[serde(default)]
     must_not_contain_flags: Vec<String>,
+    /// Spelling groups that must resolve to *distinct* root-flag entities
+    /// — the other shape a negative claim can take, guarding against the
+    /// alias-run fold merging unrelated flags onto one multi-spelling
+    /// entity (a reverted defect: an earlier fold merged rows on
+    /// description equality and fused unrelated flags, e.g. `-w` and
+    /// `-X`). Each inner list names spellings that must not all resolve
+    /// to the same entity; matched the way `must_contain_flags` matches,
+    /// root only. A tree with no root satisfies this vacuously, the same
+    /// reasoning as `must_not_contain_flags`.
+    #[serde(default)]
+    must_keep_separate: Vec<Vec<String>>,
+    /// A root flag's choice values it must carry, keyed by the flag's own
+    /// spelling (matched the way `must_contain_flags` matches). A positive
+    /// claim: the flag must exist and its `Entity::choices` must include
+    /// every named value, so a choices block that attached to the wrong
+    /// flag is checkable instead of only visible in a snapshot diff.
+    #[serde(default)]
+    must_attach_choices: std::collections::BTreeMap<String, Vec<String>>,
+    /// A root flag's rendered description must contain this text, keyed
+    /// by the flag's own spelling (matched the way `must_contain_flags`
+    /// matches). Substring match after collapsing runs of whitespace on
+    /// both sides to a single space (descriptions wrap); case-sensitive.
+    /// Issue #102 item 5: makes description recovery checkable instead of
+    /// guarded only by the snapshot.
+    #[serde(default)]
+    must_describe: std::collections::BTreeMap<String, String>,
     /// Which dimensions of this fixture's tree a human actually verified
     /// before blessing it — machine-readable replacement for the
     /// "SCOPE OF REVIEW" prose comment (`git show c9bfe76`). Not itself a
@@ -991,6 +1018,186 @@ must_not_contain_flags = ["{forbidden}"]
                 );
             }
         }
+    }
+
+    /// `must_keep_separate` in both directions: two spellings that resolve
+    /// to two different entities pass; two spellings folded onto one
+    /// entity fail, naming the group and the spellings that collapsed.
+    /// Built by hand rather than through a real fold, since this is the
+    /// exact defect an earlier alias-run fold caused (`-w`/`-X` fused by a
+    /// description-equality merge) — the check must catch it regardless of
+    /// how the fold happens.
+    #[test]
+    fn must_keep_separate_names_the_group_and_spellings_that_collapsed() {
+        let contract = ContractMeta {
+            must_keep_separate: vec![
+                vec!["-w".into(), "-X".into()],
+                vec!["-C".into(), "-CC".into()],
+            ],
+            ..ContractMeta::default()
+        };
+
+        // Two entities, one spelling each: nothing collapsed.
+        let mut root = CommandNode::new("tool", Provenance::single(Source::HelpText));
+        root.entities.push(Entity::flag_short(
+            'w',
+            Provenance::single(Source::HelpText),
+        ));
+        root.entities.push(Entity::flag_short(
+            'X',
+            Provenance::single(Source::HelpText),
+        ));
+        assert!(check_contract(&contract, Some(&root)).is_empty());
+
+        // `-w` and `-X` folded onto one multi-spelling entity: reported,
+        // naming the group and the two spellings that share it. `-C`/`-CC`
+        // never even resolve here, so that group is silent.
+        let mut fused = CommandNode::new("tool", Provenance::single(Source::HelpText));
+        let mut fused_entity = Entity::flag_short('w', Provenance::single(Source::HelpText));
+        fused_entity.spellings.push(Spelling::short('X'));
+        fused.entities.push(fused_entity);
+        assert_eq!(
+            check_contract(&contract, Some(&fused))
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["must_keep_separate: [\"-w\", \"-X\"] collapsed onto one entity: -w, -X"]
+        );
+
+        // A spelling absent from the tree entirely never collapses with
+        // anything — the group is silent unless two of its spellings both
+        // resolved to the same entity.
+        let solo_only = ContractMeta {
+            must_keep_separate: vec![vec!["-w".into(), "-Z".into()]],
+            ..ContractMeta::default()
+        };
+        let mut solo = CommandNode::new("tool", Provenance::single(Source::HelpText));
+        solo.entities.push(Entity::flag_short(
+            'w',
+            Provenance::single(Source::HelpText),
+        ));
+        assert!(check_contract(&solo_only, Some(&solo)).is_empty());
+
+        // No root at all is a negative claim, satisfied vacuously — same
+        // reasoning as `must_not_contain_flags`.
+        assert!(check_contract(&contract, None).is_empty());
+    }
+
+    /// `must_attach_choices` in both directions: the flag missing, the
+    /// flag present but missing a choice value, and the flag carrying
+    /// every named value.
+    #[test]
+    fn must_attach_choices_names_the_flag_or_the_missing_values() {
+        let mut choices = std::collections::BTreeMap::new();
+        choices.insert(
+            "--warnings".to_string(),
+            vec!["gnu".to_string(), "obsolete".to_string()],
+        );
+        let contract = ContractMeta {
+            must_attach_choices: choices,
+            ..ContractMeta::default()
+        };
+
+        // Flag absent entirely.
+        let mut root = CommandNode::new("tool", Provenance::single(Source::HelpText));
+        assert_eq!(
+            check_contract(&contract, Some(&root))
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["must_attach_choices[\"--warnings\"]: flag not present"]
+        );
+
+        // Flag present, but its choices don't carry either named value.
+        let mut warnings = Entity::flag_long("warnings", Provenance::single(Source::HelpText));
+        warnings.choices.push(mandible_core::Choice::bare("gnu"));
+        root.entities.push(warnings);
+        assert_eq!(
+            check_contract(&contract, Some(&root))
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["must_attach_choices[\"--warnings\"]: missing obsolete"]
+        );
+
+        // Both values attached: clean.
+        root.entities
+            .iter_mut()
+            .find(|e| e.spellings.iter().any(|s| s.name == "warnings"))
+            .unwrap()
+            .choices
+            .push(mandible_core::Choice::bare("obsolete"));
+        assert!(check_contract(&contract, Some(&root)).is_empty());
+
+        // No root at all fails this positive claim exactly as
+        // `must_contain_flags` fails.
+        assert_eq!(
+            check_contract(&contract, None)
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["must_attach_choices: no root produced"]
+        );
+    }
+
+    /// `must_describe` in both directions, plus the whitespace-collapsing
+    /// rule (a wrapped description) and the truncated mismatch message.
+    #[test]
+    fn must_describe_names_the_flag_or_shows_expected_vs_actual() {
+        let mut describe = std::collections::BTreeMap::new();
+        describe.insert(
+            "--target".to_string(),
+            "the triple to build for".to_string(),
+        );
+        let contract = ContractMeta {
+            must_describe: describe,
+            ..ContractMeta::default()
+        };
+
+        // Flag absent entirely.
+        let mut root = CommandNode::new("tool", Provenance::single(Source::HelpText));
+        assert_eq!(
+            check_contract(&contract, Some(&root))
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["must_describe[\"--target\"]: flag not present"]
+        );
+
+        // Flag present, description doesn't contain the expected text.
+        let mut target = Entity::flag_long("target", Provenance::single(Source::HelpText));
+        target.description = Some(mandible_core::Text::sanitize("build for this host only"));
+        root.entities.push(target);
+        assert_eq!(
+            check_contract(&contract, Some(&root))
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "must_describe[\"--target\"]: expected description to contain \"the triple to build for\", got \"build for this host only\""
+            ]
+        );
+
+        // A wrapped description collapses to the same text a fixture
+        // author would have typed on one line.
+        root.entities
+            .iter_mut()
+            .find(|e| e.spellings.iter().any(|s| s.name == "target"))
+            .unwrap()
+            .description = Some(mandible_core::Text::sanitize(
+            "set   the triple\nto build for   and stop",
+        ));
+        assert!(check_contract(&contract, Some(&root)).is_empty());
+
+        // No root at all fails this positive claim exactly as
+        // `must_contain_flags` fails.
+        assert_eq!(
+            check_contract(&contract, None)
+                .iter()
+                .map(|f| f.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["must_describe: no root produced"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds three fixture contract fields, `must_keep_separate`, `must_attach_choices`
and `must_describe`, and turns issue 102 items 1 to 3 into eight fixtures.

A known defect belongs in the corpus as a falsifiable assertion, not as a
bullet in an issue.

Five of the eight are passing guards rather than xfails: `as`, `sysctl`,
`mkfs.bfs` and `llvm-size` keep their look-alike short flags separate today,
and `cp` attaches its `--backup` choices. Running the contracts decided that,
not reasoning about the withdrawn fold. `lto-dump` is the one item 1 pair that
does collapse, by a different mechanism, and is xfail.
