### PR TITLE
detector: wrapped-prose-row-boundary and unparsed-tail-operand

### DIFF
--- a/audit/submissions/sadigaxund/4.toml
+++ b/audit/submissions/sadigaxund/4.toml
@@ -58,6 +58,8 @@ tool = "bashbug"
 stratum = "ok"
 verdict = "incomplete"
 note = "missing 'bug-report-email-address' flag. in my screen the usage line is missing one character that wraps that flag, the closing square character, might that be the cause?"
+families = ["unparsed-positional"]
+families_derived = true
 
 [[entry]]
 tool = "btrfs"
@@ -236,6 +238,8 @@ tool = "lessecho"
 stratum = "ok"
 verdict = "incomplete"
 note = "is it missing positional 'file' argument?"
+families = ["unparsed-positional"]
+families_derived = true
 
 [[entry]]
 tool = "llvm-jitlink-executor-18"
@@ -485,6 +489,8 @@ tool = "vim.basic"
 stratum = "ok"
 verdict = "incomplete"
 note = "i believe it shows '--' as positional arg"
+families = ["unparsed-positional"]
+families_derived = true
 
 [[entry]]
 tool = "wall"

--- a/corpus/bashbug/audit-seed4/meta.toml
+++ b/corpus/bashbug/audit-seed4/meta.toml
@@ -30,3 +30,7 @@ must_contain_positionals = ["bug-report-email-address"]
 [xfail]
 broken = true
 reason = "missing 'bug-report-email-address' flag. in my screen the usage line is missing one character that wraps that flag, the closing square character, might that be the cause?"
+
+# Fleet count: the unparsed-tail-operand detector fires on 194 tools
+# (194 flags) across a full-PATH sweep of 2318 tools, 2026-09-02. Calibrated
+# and passing: 3 of 3 labelled members detected, 0 false alarms on seed 4.

--- a/corpus/lessecho/audit-seed4/meta.toml
+++ b/corpus/lessecho/audit-seed4/meta.toml
@@ -27,3 +27,7 @@ must_contain_positionals = ["file"]
 [xfail]
 broken = true
 reason = "is it missing positional 'file' argument?"
+
+# Fleet count: the unparsed-tail-operand detector fires on 194 tools
+# (194 flags) across a full-PATH sweep of 2318 tools, 2026-09-02. Calibrated
+# and passing: 3 of 3 labelled members detected, 0 false alarms on seed 4.

--- a/corpus/resolvconf/255.4/meta.toml
+++ b/corpus/resolvconf/255.4/meta.toml
@@ -28,3 +28,9 @@ must_not_contain_flags = ["-I", "--enable-updates"]
 [xfail]
 broken = true
 reason = "the sentence 'Various options ... will cause the invocation to fail:' wraps onto a line starting with '-I, -i, -l, -R, -r, -v, -V, --enable-updates, ...', a dash-led word, and that wrap is read as the start of a new row instead of a continuation of the previous line, fabricating -I and --enable-updates as real resolvconf flags. The C3 whitespace-continuation rules do not reach this shape."
+
+# Fleet count: the wrapped-prose-row-boundary detector fires on 21 tools
+# (26 flags) across a full-PATH sweep of 2318 tools, 2026-09-02. The number
+# is NOT quotable as calibrated: no tool carrying this family has a human
+# audit verdict, so recall is unevaluable and only the false-alarm half was
+# checked (0 of 30 labelled-correct fixtures).

--- a/corpus/vim.basic/audit-seed4/meta.toml
+++ b/corpus/vim.basic/audit-seed4/meta.toml
@@ -29,3 +29,7 @@ must_contain_positionals = ["file"]
 [xfail]
 broken = true
 reason = "i believe it shows '--' as positional arg"
+
+# Fleet count: the unparsed-tail-operand detector fires on 194 tools
+# (194 flags) across a full-PATH sweep of 2318 tools, 2026-09-02. Calibrated
+# and passing: 3 of 3 labelled members detected, 0 false alarms on seed 4.

--- a/corpus/zgrep/1.12/meta.toml
+++ b/corpus/zgrep/1.12/meta.toml
@@ -27,3 +27,9 @@ must_not_contain_flags = ["--exclude", "--null-data"]
 [xfail]
 broken = true
 reason = "the sentence listing unsupported grep options wraps onto a line starting with '--null-data (-z), and --recursive (-r).', a dash-led word, and that wrap is read as the start of a new row instead of a continuation of the previous line, fabricating --exclude and --null-data as real zgrep flags. The C3 whitespace-continuation rules do not reach this shape."
+
+# Fleet count: the wrapped-prose-row-boundary detector fires on 21 tools
+# (26 flags) across a full-PATH sweep of 2318 tools, 2026-09-02. The number
+# is NOT quotable as calibrated: no tool carrying this family has a human
+# audit verdict, so recall is unevaluable and only the false-alarm half was
+# checked (0 of 30 labelled-correct fixtures).

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -492,7 +492,10 @@ entry's `tools` field and nothing else. It does not get a new entry.
   case. dpkg's own cross-reference sentence is contained by the
   wrapped-prose-region remedy (S-011); zgrep, resolvconf and jpackage remain
   open.
-- fleet: not measured, 2026-08-31
+- fleet: detector fires on 21 tools, 26 flags, over a 2318-tool sweep,
+  2026-09-02. Not quotable as calibrated: no tool carrying this family has
+  a human audit verdict, so recall is unevaluable and only the false-alarm
+  half was checked, 0 of 30 labelled-correct fixtures.
 
 ### S-028: smaller unshipped defects
 
@@ -716,7 +719,9 @@ entry's `tools` field and nothing else. It does not get a new entry.
   not extracted as a positional; the tree currently carries no positionals at
   all for these tools even though the operand is real and documented. Open
   defect.
-- fleet: not measured
+- fleet: detector fires on 194 tools, 194 flags, over a 2318-tool sweep,
+  2026-09-02. Calibrated and passing: 3 of 3 labelled members detected,
+  0 false alarms on seed 4.
 
 ### S-042: BNF production heading sharing its own row (iproute2 family)
 

--- a/mandible-core/src/audit.rs
+++ b/mandible-core/src/audit.rs
@@ -513,6 +513,22 @@ pub const DEFECT_FAMILIES: &[DefectFamily] = &[
         meaning: "a positional operand in the usage line (`<destination>`, `pid`) is never \
                   extracted — the IR has nowhere to put it",
     },
+    // Added for atlas S-027 (`corpus/zgrep/1.12/`, `corpus/resolvconf/255.4/`,
+    // both `[xfail]`). Checked against `wrong-stream` and `unmodeled-help-
+    // shape` first and neither fits: `wrong-stream` is about reading the
+    // wrong *stream* entirely, and this defect reads the right stream and
+    // misreads one physical line within it; `unmodeled-help-shape` is
+    // explicitly a catch-all for five unrelated layouts the grammar has no
+    // model for at all (see that family's own comment), while this shape
+    // has one precise, checkable rule (`xtask::wrapped_prose`) rather than
+    // being a symptom standing in for several dispositions.
+    DefectFamily {
+        name: "wrapped-prose-row-boundary",
+        meaning: "a description written as ordinary running prose (no option table, no \
+                  indentation) wraps onto a physical line that happens to begin with a dash-led \
+                  word, and the grammar reads that continuation as the start of a new flag row, \
+                  fabricating a flag out of prose rather than out of any real option list",
+    },
     // NOT ONE DEFECT, AND NO DETECTOR WAS BUILT. This is the vaguest label
     // in the manifest — its own `meaning` below is a list of five unrelated
     // layouts, which is the tell — and reading the six labelled tools'

--- a/xtask/src/coverage/aggregate.rs
+++ b/xtask/src/coverage/aggregate.rs
@@ -158,6 +158,23 @@ pub struct Aggregate {
     pub repeated_char_tools: usize,
     /// Real flags lost to those misreads, fleet-wide — one per misread.
     pub repeated_char_flags: usize,
+    /// Tools with at least one [`crate::wrapped_prose`] fabrication — a
+    /// dash-led continuation line, at the same indent as an unfinished
+    /// sentence above it, whose own leading spelling reached the tree as a
+    /// flag (atlas S-027). **Not gated**, same reasoning as every brand-new
+    /// detector count above: no fleet-wide baseline exists yet, and neither
+    /// ground-truth tool (`zgrep`, `resolvconf`) has a reviewed audit
+    /// verdict yet either (spec §13.1b, §13.1e).
+    pub wrapped_prose_tools: usize,
+    /// Real flags fabricated by that shape, fleet-wide — one per
+    /// fabrication line.
+    pub wrapped_prose_flags: usize,
+    /// Tools with at least one [`crate::tail_operand`] finding — a usage
+    /// line's own trailing operand token that never became a positional
+    /// (atlas S-041). **Not gated**, same reasoning as above.
+    pub tail_operand_tools: usize,
+    /// Real operands lost to that shape, fleet-wide — one per finding.
+    pub tail_operand_flags: usize,
 }
 
 /// Compute aggregate stats over `rows`.
@@ -228,6 +245,10 @@ pub(super) fn compute_aggregate(rows: &[Row]) -> Aggregate {
         .filter(|r| r.repeated_char_misread_count > 0)
         .count();
     let repeated_char_flags: usize = rows.iter().map(|r| r.repeated_char_misread_count).sum();
+    let wrapped_prose_tools = rows.iter().filter(|r| r.wrapped_prose_count > 0).count();
+    let wrapped_prose_flags: usize = rows.iter().map(|r| r.wrapped_prose_count).sum();
+    let tail_operand_tools = rows.iter().filter(|r| r.tail_operand_count > 0).count();
+    let tail_operand_flags: usize = rows.iter().map(|r| r.tail_operand_count).sum();
 
     let mut framework_counts: BTreeMap<String, usize> = BTreeMap::new();
     for row in rows {
@@ -263,6 +284,10 @@ pub(super) fn compute_aggregate(rows: &[Row]) -> Aggregate {
         single_dash_split_flags,
         repeated_char_tools,
         repeated_char_flags,
+        wrapped_prose_tools,
+        wrapped_prose_flags,
+        tail_operand_tools,
+        tail_operand_flags,
     }
 }
 
@@ -291,7 +316,7 @@ pub(super) fn detection_rate_pct(aggregate: &Aggregate) -> f64 {
 /// `coverage-scoreboard.txt`).
 pub(super) fn aggregate_footer_line(aggregate: &Aggregate) -> String {
     format!(
-        "# aggregate: pct_flags_with_text={:.2} no_tier_count={} suspicious_count={} verbatim_count={} incomplete_count={} man_shaped_count={} zero_flag_ok_count={} misattribution_suspect_tools={} misattribution_column_aligned_tools={} existence_fabrication_tools={} bundle_collapse_tools={} bundle_destroyed_flags={} alternation_defect_tools={} alternation_defect_flags={} command_table_tools={} single_dash_split_tools={} single_dash_split_flags={} repeated_char_tools={} repeated_char_flags={} total={} described_flags={:.4} describable_flags={:.4} total_flags={}\n",
+        "# aggregate: pct_flags_with_text={:.2} no_tier_count={} suspicious_count={} verbatim_count={} incomplete_count={} man_shaped_count={} zero_flag_ok_count={} misattribution_suspect_tools={} misattribution_column_aligned_tools={} existence_fabrication_tools={} bundle_collapse_tools={} bundle_destroyed_flags={} alternation_defect_tools={} alternation_defect_flags={} command_table_tools={} single_dash_split_tools={} single_dash_split_flags={} repeated_char_tools={} repeated_char_flags={} wrapped_prose_tools={} wrapped_prose_flags={} tail_operand_tools={} tail_operand_flags={} total={} described_flags={:.4} describable_flags={:.4} total_flags={}\n",
         aggregate.pct_flags_with_text,
         aggregate.no_tier_count,
         aggregate.suspicious_count,
@@ -311,6 +336,10 @@ pub(super) fn aggregate_footer_line(aggregate: &Aggregate) -> String {
         aggregate.single_dash_split_flags,
         aggregate.repeated_char_tools,
         aggregate.repeated_char_flags,
+        aggregate.wrapped_prose_tools,
+        aggregate.wrapped_prose_flags,
+        aggregate.tail_operand_tools,
+        aggregate.tail_operand_flags,
         aggregate.total,
         aggregate.described_flags,
         aggregate.describable_flags,
@@ -398,6 +427,13 @@ pub fn parse_aggregate_footer(scoreboard: &str) -> Option<Aggregate> {
     let mut single_dash_split_flags = 0usize;
     let mut repeated_char_tools = 0usize;
     let mut repeated_char_flags = 0usize;
+    // Same reasoning again, brand new field (this task): a scoreboard
+    // written before the wrapped-prose-row-boundary / unparsed-tail-operand
+    // detectors existed carries neither key.
+    let mut wrapped_prose_tools = 0usize;
+    let mut wrapped_prose_flags = 0usize;
+    let mut tail_operand_tools = 0usize;
+    let mut tail_operand_flags = 0usize;
     for field in line.trim_start_matches("# aggregate:").split_whitespace() {
         let (key, value) = field.split_once('=')?;
         match key {
@@ -435,6 +471,10 @@ pub fn parse_aggregate_footer(scoreboard: &str) -> Option<Aggregate> {
             "single_dash_split_flags" => single_dash_split_flags = value.parse::<usize>().ok()?,
             "repeated_char_tools" => repeated_char_tools = value.parse::<usize>().ok()?,
             "repeated_char_flags" => repeated_char_flags = value.parse::<usize>().ok()?,
+            "wrapped_prose_tools" => wrapped_prose_tools = value.parse::<usize>().ok()?,
+            "wrapped_prose_flags" => wrapped_prose_flags = value.parse::<usize>().ok()?,
+            "tail_operand_tools" => tail_operand_tools = value.parse::<usize>().ok()?,
+            "tail_operand_flags" => tail_operand_flags = value.parse::<usize>().ok()?,
             "described_flags" => described_flags = value.parse::<f64>().ok()?,
             "describable_flags" => describable_flags = value.parse::<f64>().ok()?,
             "total_flags" => total_flags = value.parse::<usize>().ok()?,
@@ -468,6 +508,10 @@ pub fn parse_aggregate_footer(scoreboard: &str) -> Option<Aggregate> {
         single_dash_split_flags,
         repeated_char_tools,
         repeated_char_flags,
+        wrapped_prose_tools,
+        wrapped_prose_flags,
+        tail_operand_tools,
+        tail_operand_flags,
     })
 }
 

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -198,6 +198,10 @@ fn row(tool: &str, flags: usize, pct_flags_with_text: Option<f64>, status: &'sta
         single_dash_samples: Vec::new(),
         repeated_char_misread_count: 0,
         repeated_char_samples: Vec::new(),
+        wrapped_prose_count: 0,
+        wrapped_prose_samples: Vec::new(),
+        tail_operand_count: 0,
+        tail_operand_samples: Vec::new(),
         status,
         fingerprint: fingerprint::ToolFingerprint::default(),
     }

--- a/xtask/src/coverage/render_markdown.rs
+++ b/xtask/src/coverage/render_markdown.rs
@@ -75,6 +75,24 @@ fn repeated_char_sample_section_markdown(rows: &[Row]) -> String {
     )
 }
 
+/// Markdown twin of [`wrapped_prose_sample_lines_text`].
+fn wrapped_prose_sample_section_markdown(rows: &[Row]) -> String {
+    sample_section_markdown(
+        rows.iter().flat_map(|r| r.wrapped_prose_samples.iter()),
+        "\n**Wrapped-prose-row-boundary fabrications** (sample — see \
+         `xtask/src/wrapped_prose.rs`):\n\n| sample |\n|---|\n",
+    )
+}
+
+/// Markdown twin of [`tail_operand_sample_lines_text`].
+fn tail_operand_sample_section_markdown(rows: &[Row]) -> String {
+    sample_section_markdown(
+        rows.iter().flat_map(|r| r.tail_operand_samples.iter()),
+        "\n**Unparsed-tail-operand findings** (sample — see \
+         `xtask/src/tail_operand.rs`):\n\n| sample |\n|---|\n",
+    )
+}
+
 /// The shared body of the two markdown sections above.
 fn sample_section_markdown<'a>(samples: impl Iterator<Item = &'a String>, heading: &str) -> String {
     let samples: Vec<&String> = samples.take(SPLIT_SAMPLE_LIMIT).collect();
@@ -231,6 +249,19 @@ pub(super) fn render_markdown(rows: &[Row], aggregate: &Aggregate) -> String {
         aggregate.repeated_char_tools, aggregate.repeated_char_flags,
     ));
     out.push_str(&format!(
+        "**Wrapped-prose-row-boundary fabrications:** {} tool(s) whose own leading spelling was \
+         fabricated into a flag when a description wrapped onto a dash-led continuation line \
+         (atlas S-027), {} line(s) fleet-wide — not calibratable against a reviewed audit \
+         verdict yet, see `xtask/src/wrapped_prose.rs`.\n\n",
+        aggregate.wrapped_prose_tools, aggregate.wrapped_prose_flags,
+    ));
+    out.push_str(&format!(
+        "**Unparsed-tail-operand findings:** {} tool(s) whose usage line's own trailing operand \
+         token never became a positional (atlas S-041), {} operand(s) fleet-wide — see \
+         `xtask/src/tail_operand.rs`.\n\n",
+        aggregate.tail_operand_tools, aggregate.tail_operand_flags,
+    ));
+    out.push_str(&format!(
         "**Framework detection:** {}/{} tools ({:.1}%).\n",
         aggregate.framework_detected_count,
         aggregate.total,
@@ -249,6 +280,8 @@ pub(super) fn render_markdown(rows: &[Row], aggregate: &Aggregate) -> String {
     out.push_str(&alternation_sample_section_markdown(rows));
     out.push_str(&single_dash_sample_section_markdown(rows));
     out.push_str(&repeated_char_sample_section_markdown(rows));
+    out.push_str(&wrapped_prose_sample_section_markdown(rows));
+    out.push_str(&tail_operand_sample_section_markdown(rows));
     // The same machine-readable footer the text format carries, wrapped in
     // an HTML comment so it stays invisible when rendered but parseable by
     // whatever recombines shards. Without it a sharded markdown run could

--- a/xtask/src/coverage/render_text.rs
+++ b/xtask/src/coverage/render_text.rs
@@ -178,6 +178,23 @@ pub(super) struct Row {
     /// A few of this row's own misreads, pre-formatted, capped per row
     /// ([`SPLIT_SAMPLES_PER_ROW`]).
     pub(super) repeated_char_samples: Vec<String>,
+    /// [`crate::wrapped_prose`]'s own measurement: count of this tool's
+    /// physical lines whose own leading spelling was fabricated into a flag
+    /// because a description wrapped mid-sentence onto a dash-led
+    /// continuation line (atlas S-027). **Not gated**, same reasoning as
+    /// every brand-new detector count above: no fleet-wide baseline exists
+    /// yet (spec §13.1b).
+    pub(super) wrapped_prose_count: usize,
+    /// A few of this row's own fabrications, pre-formatted, mirroring
+    /// [`Self::repeated_char_samples`].
+    pub(super) wrapped_prose_samples: Vec<String>,
+    /// [`crate::tail_operand`]'s own measurement: count of this tool's
+    /// usage-line trailing operand tokens that never became a positional
+    /// (atlas S-041). **Not gated**, same reasoning as above.
+    pub(super) tail_operand_count: usize,
+    /// A few of this row's own findings, pre-formatted, mirroring
+    /// [`Self::wrapped_prose_samples`].
+    pub(super) tail_operand_samples: Vec<String>,
     pub(super) status: &'static str,
     /// This tool's field-level fingerprint (WS2 part 2,
     /// [`crate::transition`]'s per-tool diff): enough for `sweep-diff` to
@@ -321,6 +338,8 @@ pub(super) fn render_text(rows: &[Row], aggregate: &Aggregate) -> String {
     out.push_str(&alternation_sample_lines_text(rows));
     out.push_str(&single_dash_sample_lines_text(rows));
     out.push_str(&repeated_char_sample_lines_text(rows));
+    out.push_str(&wrapped_prose_sample_lines_text(rows));
+    out.push_str(&tail_operand_sample_lines_text(rows));
     out.push_str(&fingerprint_lines(rows));
     out
 }
@@ -516,6 +535,23 @@ fn repeated_char_sample_lines_text(rows: &[Row]) -> String {
     sample_lines_text(
         rows.iter().flat_map(|r| r.repeated_char_samples.iter()),
         "# repeated-char-flag misreads (sample — judge the false-positive rate yourself):\n",
+    )
+}
+
+/// Twin of [`single_dash_sample_lines_text`] for [`crate::wrapped_prose`].
+fn wrapped_prose_sample_lines_text(rows: &[Row]) -> String {
+    sample_lines_text(
+        rows.iter().flat_map(|r| r.wrapped_prose_samples.iter()),
+        "# wrapped-prose-row-boundary fabrications (sample — judge the false-positive rate \
+         yourself):\n",
+    )
+}
+
+/// Twin of [`single_dash_sample_lines_text`] for [`crate::tail_operand`].
+fn tail_operand_sample_lines_text(rows: &[Row]) -> String {
+    sample_lines_text(
+        rows.iter().flat_map(|r| r.tail_operand_samples.iter()),
+        "# unparsed-tail-operand findings (sample — judge the false-positive rate yourself):\n",
     )
 }
 

--- a/xtask/src/coverage/score.rs
+++ b/xtask/src/coverage/score.rs
@@ -11,6 +11,9 @@ use crate::existence;
 use crate::misattribution::{self, RecordingProbe};
 use crate::repeated_char;
 use crate::single_dash_long;
+use crate::tail_operand;
+use crate::wrapped_prose;
+use mandible_core::CommandNode;
 use mandible_extract::{default_tiers_with_probe, resolve_tool, ExtractionResult, Runner};
 use std::sync::Arc;
 use std::time::Instant;
@@ -42,6 +45,11 @@ const ALTERNATION_SAMPLES_PER_ROW: usize = 3;
 /// mirrors [`BUNDLE_SAMPLES_PER_ROW`]. Shared by both families; read from
 /// the same capture pass.
 const SPLIT_SAMPLES_PER_ROW: usize = 3;
+
+/// Cap on how many of one tool's own [`crate::wrapped_prose`] fabrications
+/// or [`crate::tail_operand`] findings feed their fleet-wide sample
+/// sections — mirrors [`SPLIT_SAMPLES_PER_ROW`].
+const FAMILY_DETECTOR_SAMPLES_PER_ROW: usize = 3;
 
 pub(super) fn score_one(tool: &str) -> Row {
     let start = Instant::now();
@@ -172,36 +180,16 @@ pub(super) fn score_one(tool: &str) -> Row {
     };
     // The two remaining families of the three that share the `short &&
     // !long && value_name` fingerprint, read off the same capture on the
-    // same pass and costing the same zero additional subprocess spawns.
-    let (single_dash_split_count, single_dash_samples) =
-        match (probe.root_help_text(), result.root.as_ref()) {
-            (Some(raw), Some(root)) if !raw.trim().is_empty() => {
-                let report = single_dash_long::detect(&raw, root);
-                let samples = report
-                    .splits
-                    .iter()
-                    .take(SPLIT_SAMPLES_PER_ROW)
-                    .map(format_single_dash_sample)
-                    .collect();
-                (report.split_count(), samples)
-            }
-            _ => (0, Vec::new()),
-        };
-    let (repeated_char_misread_count, repeated_char_samples) =
-        match (probe.root_help_text(), result.root.as_ref()) {
-            (Some(raw), Some(root)) if !raw.trim().is_empty() => {
-                let report = repeated_char::detect(&raw, root);
-                let samples = report
-                    .misreads
-                    .iter()
-                    .take(SPLIT_SAMPLES_PER_ROW)
-                    .map(format_repeated_char_sample)
-                    .collect();
-                (report.misread_count(), samples)
-            }
-            _ => (0, Vec::new()),
-        };
-
+    // same pass and costing the same zero additional subprocess spawns —
+    // see `split_family_counts`.
+    let (
+        single_dash_split_count,
+        single_dash_samples,
+        repeated_char_misread_count,
+        repeated_char_samples,
+    ) = split_family_counts(probe.root_help_text(), result.root.as_ref());
+    let (wrapped_prose_count, wrapped_prose_samples, tail_operand_count, tail_operand_samples) =
+        family_detector_counts(probe.root_help_text(), result.root.as_ref());
     Row {
         tool: tool.to_string(),
         tiers: tiers_label,
@@ -229,6 +217,10 @@ pub(super) fn score_one(tool: &str) -> Row {
         single_dash_samples,
         repeated_char_misread_count,
         repeated_char_samples,
+        wrapped_prose_count,
+        wrapped_prose_samples,
+        tail_operand_count,
+        tail_operand_samples,
         status: status.label,
         fingerprint: build_fingerprint(result.root.as_ref()),
     }
@@ -296,6 +288,90 @@ fn format_repeated_char_sample(misread: &repeated_char::Misread) -> String {
     format!(
         "{}: {:?} read as {} carrying its own letter as a value",
         misread.path, misread.token, misread.spelling,
+    )
+}
+
+/// One wrapped-prose-row-boundary fabrication, rendered as a single audit-
+/// section line.
+fn format_wrapped_prose_sample(finding: &wrapped_prose::Finding) -> String {
+    format!(
+        "{:?} fabricated from the line {:?}",
+        finding.flag, finding.line
+    )
+}
+
+/// One unparsed-tail-operand finding, rendered as a single audit-section
+/// line.
+fn format_tail_operand_sample(finding: &tail_operand::Finding) -> String {
+    format!(
+        "{:?} never became a positional, from {:?}",
+        finding.operand, finding.usage_line
+    )
+}
+
+/// [`wrapped_prose::detect`] and [`tail_operand::detect`], run over one
+/// tool's already-captured text and tree — split out of [`score_one`]
+/// purely to keep that function under clippy's line-count lint.
+/// [`single_dash_long::detect`] and [`repeated_char::detect`], the other
+/// two families sharing the `short && !long && value_name` fingerprint —
+/// split out of [`score_one`] for the same line-count reason as
+/// [`family_detector_counts`].
+fn split_family_counts(
+    raw: Option<String>,
+    root: Option<&CommandNode>,
+) -> (usize, Vec<String>, usize, Vec<String>) {
+    let (Some(raw), Some(root)) = (raw, root) else {
+        return (0, Vec::new(), 0, Vec::new());
+    };
+    if raw.trim().is_empty() {
+        return (0, Vec::new(), 0, Vec::new());
+    }
+    let sd = single_dash_long::detect(&raw, root);
+    let sd_samples = sd
+        .splits
+        .iter()
+        .take(SPLIT_SAMPLES_PER_ROW)
+        .map(format_single_dash_sample)
+        .collect();
+    let rc = repeated_char::detect(&raw, root);
+    let rc_samples = rc
+        .misreads
+        .iter()
+        .take(SPLIT_SAMPLES_PER_ROW)
+        .map(format_repeated_char_sample)
+        .collect();
+    (sd.split_count(), sd_samples, rc.misread_count(), rc_samples)
+}
+
+fn family_detector_counts(
+    raw: Option<String>,
+    root: Option<&CommandNode>,
+) -> (usize, Vec<String>, usize, Vec<String>) {
+    let (Some(raw), Some(root)) = (raw, root) else {
+        return (0, Vec::new(), 0, Vec::new());
+    };
+    if raw.trim().is_empty() {
+        return (0, Vec::new(), 0, Vec::new());
+    }
+    let wp = wrapped_prose::detect(&raw, root);
+    let wp_samples = wp
+        .findings
+        .iter()
+        .take(FAMILY_DETECTOR_SAMPLES_PER_ROW)
+        .map(format_wrapped_prose_sample)
+        .collect();
+    let to = tail_operand::detect(&raw, root);
+    let to_samples = to
+        .findings
+        .iter()
+        .take(FAMILY_DETECTOR_SAMPLES_PER_ROW)
+        .map(format_tail_operand_sample)
+        .collect();
+    (
+        wp.finding_count(),
+        wp_samples,
+        to.finding_count(),
+        to_samples,
     )
 }
 

--- a/xtask/src/detector/detectors_misc.rs
+++ b/xtask/src/detector/detectors_misc.rs
@@ -347,3 +347,101 @@ impl Detector for RepeatedCharFlag {
         crate::repeated_char::self_checks()
     }
 }
+
+/// `wrapped-prose-row-boundary` (`crate::wrapped_prose`, atlas S-027): a
+/// description written as running prose wraps onto a physical line that
+/// begins with a dash-led word, and the grammar reads that continuation as
+/// the start of a new flag row.
+///
+/// Not calibratable against the seed-2/seed-4 labelled sets today — its two
+/// ground-truth fixtures (`zgrep`, `resolvconf`) sit in the audit queue,
+/// unreviewed — so `family()` still returns `Some`, and `detector
+/// calibrate` against either seed reports 0/0 while still checking no fire
+/// on a `correct`-judged tool. The fleet-wide claim rests on the hand-built
+/// self-checks (`crate::wrapped_prose::self_checks`) alone.
+pub(crate) struct WrappedProseRowBoundary;
+
+impl Detector for WrappedProseRowBoundary {
+    fn name(&self) -> &'static str {
+        "wrapped-prose-row-boundary"
+    }
+    fn family(&self) -> Option<&'static str> {
+        Some("wrapped-prose-row-boundary")
+    }
+    fn describes(&self) -> &'static str {
+        "a physical line beginning with a dash-led word, at the same indent as an unfinished \
+         sentence above it and with no aligned description column of its own, whose own leading \
+         spelling reached the tree as a flag"
+    }
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        crate::wrapped_prose::detect(evidence.raw, evidence.root)
+            .findings
+            .iter()
+            .map(|f| format!("{:?} fabricated from the line {:?}", f.flag, f.line))
+            .collect()
+    }
+    fn scope(&self) -> Scope {
+        Scope {
+            claim: "a continuation line's OWN leading spelling only — a second dash-led spelling \
+                    the same row-merge pulls from mid-line (resolvconf's real `--enable-updates`, \
+                    read off the middle of the `-I` line) is out of reach; see this detector's \
+                    own module doc comment",
+            known_exclusions: &[],
+        }
+    }
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        crate::wrapped_prose::self_checks()
+    }
+}
+
+/// A second `unparsed-positional` detector, narrower than
+/// [`crate::detector::UnparsedArgparsePositional`] and reaching a disjoint
+/// shape: a usage line's own trailing operand token (bracketed or bare,
+/// atlas S-041), rather than argparse's `positional arguments:` heading.
+///
+/// Calibratable against `audit-seed4` (`--seed 4 --fixture-version
+/// audit-seed4`), where all three of its ground-truth tools
+/// (`bashbug`, `lessecho`, `vim.basic`) are labelled — `vim.basic` also
+/// carries the label under seed 2 (`audit-seed2`, `k1 = true`), so a
+/// default-seed run exercises it too, alongside every seed-2 `correct`
+/// verdict as a false-alarm check.
+pub(crate) struct UnparsedTailOperand;
+
+impl Detector for UnparsedTailOperand {
+    fn name(&self) -> &'static str {
+        "unparsed-tail-operand"
+    }
+    fn family(&self) -> Option<&'static str> {
+        Some("unparsed-positional")
+    }
+    fn describes(&self) -> &'static str {
+        "a usage line's own last token group is not flag-shaped once its brackets are stripped \
+         (a real operand name, not a placeholder), and the root has no positionals at all"
+    }
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        crate::tail_operand::detect(evidence.raw, evidence.root)
+            .findings
+            .iter()
+            .map(|f| {
+                format!(
+                    "{:?} never became a positional, from the usage line {:?}",
+                    f.operand, f.usage_line
+                )
+            })
+            .collect()
+    }
+    fn scope(&self) -> Scope {
+        Scope {
+            claim: "lowercase-led operand names in the usage line's own trailing token group, \
+                    where every earlier group is itself a flag or a flag-list placeholder \
+                    (`arguments`, `options`) only; an ALL-CAPS metavariable tail (`FILE`, \
+                    `PATTERN`) and a usage line naming multiple bare operands \
+                    (`infont intable outfont`) are both deliberately out of reach — see this \
+                    detector's own module doc comment",
+            known_exclusions: &[],
+        }
+    }
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        crate::tail_operand::self_checks()
+    }
+}

--- a/xtask/src/detector/mod.rs
+++ b/xtask/src/detector/mod.rs
@@ -633,6 +633,8 @@ pub fn registry() -> Vec<Box<dyn Detector>> {
         Box::new(RepeatedCharFlag),
         Box::new(ExistenceOracle),
         Box::new(MisattributionOracle),
+        Box::new(WrappedProseRowBoundary),
+        Box::new(UnparsedTailOperand),
     ]
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,7 +24,9 @@ mod residue;
 mod rng;
 mod single_dash_long;
 mod status;
+mod tail_operand;
 mod transition;
+mod wrapped_prose;
 
 use clap::{Parser, Subcommand};
 use coverage::ScoreFormat;

--- a/xtask/src/tail_operand.rs
+++ b/xtask/src/tail_operand.rs
@@ -1,0 +1,396 @@
+//! The `unparsed-positional` tail-operand detector (atlas S-041): a usage
+//! line's own last operand token never becomes a positional entity, so the
+//! root reports zero positionals while its synopsis names one.
+//!
+//! Fixtures: `corpus/bashbug/audit-seed4/`, `corpus/lessecho/audit-seed4/`,
+//! `corpus/vim.basic/audit-seed4/`. Shape detail in `docs/shapes.md` S-041.
+
+use mandible_core::CommandNode;
+
+pub struct Finding {
+    /// The operand name lifted from the usage line's own tail, e.g.
+    /// `"file"`.
+    pub operand: String,
+    /// The usage line it came from, verbatim.
+    pub usage_line: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    pub fn finding_count(&self) -> usize {
+        self.findings.len()
+    }
+}
+
+/// The first physical line that looks like a usage synopsis (`usage:` or
+/// `Usage:`, anywhere at the start of the line's own trimmed text).
+fn first_usage_line(raw: &str) -> Option<&str> {
+    raw.lines()
+        .find(|l| l.trim_start().to_ascii_lowercase().starts_with("usage:"))
+}
+
+/// `s` cut at the first run of `gap` or more consecutive spaces — the
+/// description column boundary a real usage line's inline trailing prose
+/// (vim.basic's `edit specified file(s)`) sits behind. Char-indexed
+/// throughout, never a raw byte slice, so a non-ASCII description cannot
+/// panic this on a boundary that isn't a char boundary.
+fn cut_before_wide_gap(s: &str, gap: usize) -> &str {
+    let mut run = 0usize;
+    let mut run_start = None;
+    for (i, c) in s.char_indices() {
+        if c == ' ' {
+            if run == 0 {
+                run_start = Some(i);
+            }
+            run += 1;
+            if run >= gap {
+                return &s[..run_start.unwrap()];
+            }
+        } else {
+            run = 0;
+        }
+    }
+    s
+}
+
+/// Split `s` into whitespace-delimited groups, treating a `[...]` span as
+/// one group even when it contains internal spaces (`"[file ..]"` stays
+/// one token, matching how a synopsis's own bracket notation groups an
+/// optional clause). Unmatched brackets degrade gracefully: once opened, a
+/// group simply runs to the next matching close or the end of the string.
+fn group_tokens(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut depth = 0i32;
+    for c in s.chars() {
+        match c {
+            '[' => {
+                depth += 1;
+                cur.push(c);
+            }
+            ']' => {
+                depth = (depth - 1).max(0);
+                cur.push(c);
+            }
+            c if c.is_whitespace() && depth == 0 => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+/// A lowercase word standing in for the tool's own flag list collectively
+/// (`[arguments]`, `[options]`) rather than naming a real operand — the
+/// same "stand-in, not an argument anyone passes" shape
+/// `crate::existence`'s operand check already recognizes for `OPTION`-style
+/// placeholders, spelled lowercase here because that's how a synopsis like
+/// vim.basic's `[arguments]` writes it. Checked case-insensitively so
+/// `[Options]` reads the same as `[options]`.
+fn is_flag_list_placeholder(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "options" | "option" | "opts" | "args" | "arguments" | "flags"
+    )
+}
+
+/// Whether `group` (brackets stripped) is something other than a real
+/// operand: a `-`-led flag/flag-cluster, or [`is_flag_list_placeholder`].
+fn is_flag_or_placeholder(stripped: &str) -> bool {
+    stripped.starts_with('-') || is_flag_list_placeholder(stripped)
+}
+
+/// The usage line's own trailing operand, or `None` when the last token is
+/// flag-shaped, a flag-list placeholder, elliptical-only, empty, not
+/// lowercase-led, or when any group *before* it is something other than a
+/// flag or a flag-list placeholder.
+///
+/// The last condition is load-bearing: without it calibration fired on
+/// `apt-extracttemplates` and `psfaddtable`, whose usage lines are several
+/// bare operands rather than flags plus one trailing operand. That is a
+/// different shape and this detector does not claim it.
+fn tail_operand(usage_line: &str) -> Option<String> {
+    let lower = usage_line.to_ascii_lowercase();
+    let idx = lower.find("usage:")?;
+    let after = &usage_line[idx + "usage:".len()..];
+    let before_desc =
+        cut_before_wide_gap(after, mandible_extract::help_text::MIN_COLUMN_GAP_SPACES);
+    let mut groups = group_tokens(before_desc.trim());
+    if groups.len() < 2 {
+        return None;
+    }
+    groups.remove(0); // the program name itself
+    while let Some(last) = groups.last() {
+        let stripped = last.trim_matches(|c| c == '[' || c == ']');
+        if !stripped.is_empty() && stripped.chars().all(|c| c == '.') {
+            groups.pop();
+        } else {
+            break;
+        }
+    }
+    let last = groups.last()?;
+    let stripped = last.trim_matches(|c| c == '[' || c == ']');
+    let word = stripped.split_whitespace().next()?;
+    let word = word.trim_end_matches('.');
+    if word.is_empty() || word.starts_with('-') || is_flag_list_placeholder(word) {
+        return None;
+    }
+    let mut chars = word.chars();
+    let first = chars.next()?;
+    if !first.is_ascii_lowercase() {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+        return None;
+    }
+    for earlier in &groups[..groups.len() - 1] {
+        let earlier_stripped = earlier.trim_matches(|c| c == '[' || c == ']');
+        if !is_flag_or_placeholder(earlier_stripped) {
+            return None;
+        }
+    }
+    Some(word.to_string())
+}
+
+pub fn detect(raw: &str, root: &CommandNode) -> Report {
+    if root.positionals().next().is_some() {
+        // Already recovered — whatever else this tool's TUI shows, the
+        // tree itself is not missing this operand.
+        return Report {
+            findings: Vec::new(),
+        };
+    }
+    let Some(usage_line) = first_usage_line(raw) else {
+        return Report {
+            findings: Vec::new(),
+        };
+    };
+    let Some(operand) = tail_operand(usage_line) else {
+        return Report {
+            findings: Vec::new(),
+        };
+    };
+    Report {
+        findings: vec![Finding {
+            operand,
+            usage_line: usage_line.to_string(),
+        }],
+    }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use crate::detector::{Expect, SelfCheck};
+use mandible_core::{Entity, Provenance, Source};
+
+/// `bashbug --help`'s real first two lines, byte-exact
+/// (`corpus/bashbug/audit-seed4/help.txt`).
+pub(crate) const BASHBUG_USAGE: &str =
+    "Usage: /usr/bin/bashbug [--help] [--version] [bug-report-email-address]\n";
+
+/// `lessecho --help`'s real stderr usage line, byte-exact
+/// (`corpus/lessecho/audit-seed4/help.stderr.txt`).
+pub(crate) const LESSECHO_USAGE: &str =
+    "usage: lessecho [-ox] [-cx] [-pn] [-dn] [-mx] [-nn] [-ex] [-fn] [-a] file ...\n";
+
+/// `vim.basic --help`'s real first usage line, byte-exact
+/// (`corpus/vim.basic/audit-seed4/help.txt`).
+pub(crate) const VIM_USAGE: &str =
+    "Usage: vim [arguments] [file ..]       edit specified file(s)\n";
+
+fn flag(long: Option<&str>, short: Option<char>) -> Entity {
+    Entity::flag_spelled(
+        short,
+        long.map(|s| s.to_string()),
+        false,
+        false,
+        Provenance::single(Source::HelpText),
+    )
+}
+
+fn node_with_flags(name: &str, flags: Vec<Entity>) -> CommandNode {
+    let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
+    root.set_entities_of(mandible_core::EntityKind::Flag, flags);
+    root
+}
+
+fn node_with_positional(name: &str, positional: &str) -> CommandNode {
+    let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
+    let mut p = Entity::positional(positional, Provenance::single(Source::HelpText));
+    p.required = true;
+    root.set_entities_of(mandible_core::EntityKind::Positional, vec![p]);
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "bashbug's own bytes, operand dropped",
+            why: "the defect itself: `[bug-report-email-address]` is the usage line's own \
+                  trailing bracketed operand, and the root has zero positionals",
+            expect: Expect::Fires(1),
+            raw: BASHBUG_USAGE.to_string(),
+            root: node_with_flags(
+                "bashbug",
+                vec![flag(Some("help"), None), flag(Some("version"), None)],
+            ),
+        },
+        SelfCheck {
+            name: "lessecho's own bytes, bare trailing operand dropped",
+            why: "the same shape without brackets: `file ...` is bare and required, not \
+                  optional, and the tail-token rule must reach it exactly the same way",
+            expect: Expect::Fires(1),
+            raw: LESSECHO_USAGE.to_string(),
+            root: node_with_flags(
+                "lessecho",
+                vec![
+                    flag(None, Some('o')),
+                    flag(None, Some('c')),
+                    flag(None, Some('p')),
+                    flag(None, Some('d')),
+                    flag(None, Some('m')),
+                    flag(None, Some('n')),
+                    flag(None, Some('e')),
+                    flag(None, Some('f')),
+                    flag(None, Some('a')),
+                ],
+            ),
+        },
+        SelfCheck {
+            name: "vim.basic's own bytes, operand dropped behind inline prose",
+            why: "the hardest of the three: `[file ..]` sits before a trailing inline \
+                  description on the same physical line, and the description-column cut must \
+                  land in the right place for the tail group to still be `[file ..]` and not \
+                  a fragment of the description",
+            expect: Expect::Fires(1),
+            raw: VIM_USAGE.to_string(),
+            root: node_with_flags(
+                "vim.basic",
+                vec![flag(None, Some('v')), flag(None, Some('e'))],
+            ),
+        },
+        SelfCheck {
+            name: "lessecho's operand, already recovered",
+            why: "the positional-present gate: once the tree carries `file` as a real \
+                  positional, the same raw bytes must go silent — whatever the TUI shows \
+                  elsewhere is not this detector's concern",
+            expect: Expect::Silent,
+            raw: LESSECHO_USAGE.to_string(),
+            root: node_with_positional("lessecho", "file"),
+        },
+        SelfCheck {
+            name: "a usage line ending in a flag, not an operand",
+            why: "the nearest real false positive: the last bracket group is flag-shaped \
+                  (`[-h]`) once its own brackets are stripped, so there is no operand to claim \
+                  and the detector must find none",
+            expect: Expect::Silent,
+            raw: "Usage: prog [-v] [-h]\n".to_string(),
+            root: node_with_flags("prog", vec![flag(None, Some('v')), flag(None, Some('h'))]),
+        },
+        SelfCheck {
+            name: "an ALL-CAPS metavariable tail, deliberately out of scope",
+            why: "the declared scope limit: an upper-case-led operand (`FILE`) is easy to \
+                  confuse with a flag's own value-name convention, so this detector requires a \
+                  lowercase-led name and stays silent here on purpose, not by accident",
+            expect: Expect::Silent,
+            raw: "Usage: prog [OPTION]... FILE\n".to_string(),
+            root: node_with_flags("prog", vec![]),
+        },
+        SelfCheck {
+            name: "multiple bare operands, not one flag-list-plus-tail",
+            why: "the false alarm calibration actually found: `apt-extracttemplates`'s \
+                  `Usage: apt-extracttemplates file1 [file2 ...]` ends in an operand-shaped tail \
+                  too, but `file1` earlier on the line is *also* bare and non-flag — this is a \
+                  multiple-bare-operand usage line, a genuinely different (and harder) shape than \
+                  a flag list with one operand tacked on the end, and the earlier-groups gate \
+                  must keep it out",
+            expect: Expect::Silent,
+            raw: "Usage: apt-extracttemplates file1 [file2 ...]\n".to_string(),
+            root: node_with_flags("apt-extracttemplates", vec![]),
+        },
+        SelfCheck {
+            name: "a flag-list placeholder as the tail, not a real operand",
+            why: "the other false alarm calibration found: `rust-lldb`'s \
+                  `USAGE: lldb [options]` ends in `options`, a stand-in for the tool's own flag \
+                  list (the same shape `[arguments]` is in vim.basic's true positive), not a \
+                  real operand — must stay silent on the word itself, not just when it is a \
+                  *preceding* group",
+            expect: Expect::Silent,
+            raw: "USAGE: lldb [options]\n".to_string(),
+            root: node_with_flags("lldb", vec![]),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_bashbugs_bracketed_tail_operand() {
+        let root = node_with_flags(
+            "bashbug",
+            vec![flag(Some("help"), None), flag(Some("version"), None)],
+        );
+        let report = detect(BASHBUG_USAGE, &root);
+        assert_eq!(report.finding_count(), 1);
+        assert_eq!(report.findings[0].operand, "bug-report-email-address");
+    }
+
+    #[test]
+    fn finds_lessechos_bare_tail_operand() {
+        let root = node_with_flags("lessecho", vec![flag(None, Some('a'))]);
+        let report = detect(LESSECHO_USAGE, &root);
+        assert_eq!(report.finding_count(), 1);
+        assert_eq!(report.findings[0].operand, "file");
+    }
+
+    #[test]
+    fn finds_vims_tail_operand_behind_inline_prose() {
+        let root = node_with_flags("vim.basic", vec![flag(None, Some('v'))]);
+        let report = detect(VIM_USAGE, &root);
+        assert_eq!(report.finding_count(), 1);
+        assert_eq!(report.findings[0].operand, "file");
+    }
+
+    #[test]
+    fn stays_silent_once_the_positional_is_recovered() {
+        let root = node_with_positional("lessecho", "file");
+        assert_eq!(detect(LESSECHO_USAGE, &root).finding_count(), 0);
+    }
+
+    #[test]
+    fn stays_silent_on_a_flag_shaped_tail() {
+        let root = node_with_flags("prog", vec![flag(None, Some('h'))]);
+        assert_eq!(detect("Usage: prog [-v] [-h]\n", &root).finding_count(), 0);
+    }
+
+    #[test]
+    fn every_self_check_holds() {
+        for case in self_checks() {
+            let expected = match case.expect {
+                Expect::Fires(n) => n,
+                Expect::Silent => 0,
+            };
+            let report = detect(&case.raw, &case.root);
+            assert_eq!(
+                report.finding_count(),
+                expected,
+                "{}: expected {} finding(s)",
+                case.name,
+                expected
+            );
+        }
+    }
+}

--- a/xtask/src/wrapped_prose.rs
+++ b/xtask/src/wrapped_prose.rs
@@ -1,0 +1,382 @@
+//! The `wrapped-prose-row-boundary` detector (atlas S-027): a description
+//! wraps onto a line beginning with a dash-led word, and the grammar reads
+//! that continuation as a new flag row, fabricating a flag out of prose.
+//!
+//! Fixtures: `corpus/zgrep/1.12/`, `corpus/resolvconf/255.4/`.
+//! The discriminator and its cost are in `docs/shapes.md` S-027.
+
+use mandible_core::{CommandNode, Entity};
+
+/// One physical line whose leading spelling reached the tree as a
+/// fabricated flag.
+pub struct Finding {
+    /// The fabricated spelling, e.g. `"--exclude"`.
+    pub flag: String,
+    /// The physical line it was lifted from, verbatim.
+    pub line: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    pub fn finding_count(&self) -> usize {
+        self.findings.len()
+    }
+}
+
+/// Widest run of consecutive ASCII spaces anywhere in `line`.
+fn widest_space_run(line: &str) -> usize {
+    let mut widest = 0usize;
+    let mut run = 0usize;
+    for c in line.chars() {
+        if c == ' ' {
+            run += 1;
+            widest = widest.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    widest
+}
+
+/// `node`'s own flag spellings (`-x`, `--long`), recursively — a
+/// fabrication from this shape can in principle land anywhere the raw text
+/// reaches, not only at the root.
+fn tree_has_spelling(node: &CommandNode, spelling: &str) -> bool {
+    node.flags().any(|f| entity_matches(f, spelling))
+        || node
+            .subcommands
+            .iter()
+            .any(|c| tree_has_spelling(c, spelling))
+}
+
+fn entity_matches(entity: &Entity, spelling: &str) -> bool {
+    if let Some(long) = entity.long() {
+        if spelling == format!("--{long}") {
+            return true;
+        }
+    }
+    if let Some(short) = entity.short() {
+        if spelling == format!("-{short}") {
+            return true;
+        }
+    }
+    false
+}
+
+/// The candidate line's own leading spelling, stripped of trailing
+/// punctuation a comma-separated prose list glues on (`"--exclude,"` ->
+/// `"--exclude"`), or `None` when the first token isn't dash-led at all.
+fn leading_spelling(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let token = trimmed.split_whitespace().next()?;
+    let spelling = token.trim_end_matches(|c: char| !(c.is_ascii_alphanumeric() || c == '-'));
+    if spelling.starts_with('-') && spelling.len() > 1 {
+        Some(spelling)
+    } else {
+        None
+    }
+}
+
+pub fn detect(raw: &str, root: &CommandNode) -> Report {
+    let mut findings = Vec::new();
+    let lines: Vec<&str> = raw.lines().collect();
+    for i in 1..lines.len() {
+        let cur = lines[i];
+        let prev = lines[i - 1];
+        if prev.trim().is_empty() || cur.trim().is_empty() {
+            // A blank separator means `cur` opens a new paragraph, not a
+            // continuation of `prev` — out of this shape entirely.
+            continue;
+        }
+        let Some(spelling) = leading_spelling(cur) else {
+            continue;
+        };
+        if prev.trim_start().starts_with('-') {
+            // Gate 2 (see module doc comment): the previous line is itself
+            // a dash-led row, so `cur` is just the next entry of an
+            // ordinary table, not prose wrapping into one.
+            continue;
+        }
+        let cur_indent = cur.len() - cur.trim_start().len();
+        let prev_indent = prev.len() - prev.trim_start().len();
+        if cur_indent != prev_indent {
+            continue;
+        }
+        if prev.trim_end().ends_with('.') {
+            continue;
+        }
+        if widest_space_run(cur) >= mandible_extract::help_text::MIN_COLUMN_GAP_SPACES {
+            continue;
+        }
+        if tree_has_spelling(root, spelling) {
+            findings.push(Finding {
+                flag: spelling.to_string(),
+                line: cur.to_string(),
+            });
+        }
+    }
+    Report { findings }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use crate::detector::{Expect, SelfCheck};
+use mandible_core::{Provenance, Source};
+
+/// `zgrep --help`'s real bytes, byte-exact
+/// (`corpus/zgrep/1.12/help.txt`).
+pub(crate) const ZGREP_HELP: &str = "\
+Usage: /usr/bin/zgrep [OPTION]... [-e] PATTERN [FILE]...
+Look for instances of PATTERN in the input FILEs, using their
+uncompressed contents if they are compressed.
+
+OPTIONs are the same as for 'grep', except that the following 'grep'
+options are not supported: --dereference-recursive (-R), --directories (-d),
+--exclude, --exclude-from, --exclude-dir, --include, --null (-Z),
+--null-data (-z), and --recursive (-r).
+
+Report bugs to <bug-gzip@gnu.org>.
+";
+
+/// `resolvconf --help`'s real bytes, byte-exact
+/// (`corpus/resolvconf/255.4/help.txt`).
+pub(crate) const RESOLVCONF_HELP: &str = "\
+resolvconf -a INTERFACE < FILE
+resolvconf -d INTERFACE
+
+Register DNS server and domain configuration with systemd-resolved.
+
+  -h --help     Show this help
+     --version  Show package version
+  -a            Register per-interface DNS server and domain data
+  -d            Unregister per-interface DNS server and domain data
+  -f            Ignore if specified interface does not exist
+  -x            Send DNS traffic preferably over this interface
+
+This is a compatibility alias for the resolvectl(1) tool, providing native
+command line compatibility with the resolvconf(8) tool of various Linux
+distributions and BSD systems. Some options supported by other implementations
+are not supported and are ignored: -m, -p, -u. Various options supported by other
+implementations are not supported and will cause the invocation to fail:
+-I, -i, -l, -R, -r, -v, -V, --enable-updates, --disable-updates,
+--updates-are-enabled.
+
+See the resolvectl(1) man page for details.
+";
+
+fn flag_node(long: Option<&str>, short: Option<char>) -> Entity {
+    Entity::flag_spelled(
+        short,
+        long.map(|s| s.to_string()),
+        false,
+        false,
+        Provenance::single(Source::HelpText),
+    )
+}
+
+fn node_with_flags(name: &str, flags: Vec<Entity>) -> CommandNode {
+    let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
+    root.set_entities_of(mandible_core::EntityKind::Flag, flags);
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "zgrep's own bytes, the paragraph's first misread line",
+            why: "the defect itself: the sentence listing unsupported grep options wraps onto a \
+                  dash-led line and that line's own leading spelling (`--exclude`) reached the \
+                  tree. The sentence actually wraps a second time (`--null-data`), but that \
+                  second wrap's own predecessor is itself dash-led — gate 2 silences it along \
+                  with every real table row, a deliberate lower bound (see module doc comment)",
+            expect: Expect::Fires(1),
+            raw: ZGREP_HELP.to_string(),
+            root: node_with_flags(
+                "zgrep",
+                vec![
+                    flag_node(Some("exclude"), None),
+                    flag_node(Some("null-data"), None),
+                ],
+            ),
+        },
+        SelfCheck {
+            name: "resolvconf's own bytes, one prose fabrication amid a real table",
+            why: "the same shape beside a genuine, correctly-parsed option table: the six real \
+                  flags must not be mistaken for more of the same defect, and only the wrapped \
+                  sentence's own leading spelling (`-I`) is in this detector's declared reach — \
+                  `--enable-updates`, pulled from mid-line on the same wrap, is a real second \
+                  fabrication this detector does not claim (see module doc comment)",
+            expect: Expect::Fires(1),
+            raw: RESOLVCONF_HELP.to_string(),
+            root: node_with_flags(
+                "resolvconf",
+                vec![
+                    flag_node(Some("help"), Some('h')),
+                    flag_node(Some("version"), None),
+                    flag_node(None, Some('a')),
+                    flag_node(None, Some('d')),
+                    flag_node(None, Some('f')),
+                    flag_node(None, Some('x')),
+                    flag_node(None, Some('I')),
+                ],
+            ),
+        },
+        SelfCheck {
+            name: "a genuine aligned two-row option table",
+            why: "the nearest real false positive: two dash-led rows at the same indent, each \
+                  with a wide description-column gap — the column-gap gate is what keeps this \
+                  silent, since the indent-equality and open-sentence gates alone would not",
+            expect: Expect::Silent,
+            raw: "\
+Register DNS server and domain configuration with systemd-resolved.
+
+  -a            Register per-interface DNS server and domain data
+  -d            Unregister per-interface DNS server and domain data
+"
+            .to_string(),
+            root: node_with_flags(
+                "resolvconf",
+                vec![flag_node(None, Some('a')), flag_node(None, Some('d'))],
+            ),
+        },
+        SelfCheck {
+            name: "a deeper-indented continuation (C3's own territory)",
+            why: "a continuation line indented past its entry is the ordinary whitespace- \
+                  continuation shape C3 already reads correctly — this detector's indent- \
+                  equality gate must leave it alone even when the row's own flag is real and in \
+                  the tree",
+            expect: Expect::Silent,
+            raw: "\
+  -x            Send DNS traffic preferably over
+                -this interface, deliberately dash-led
+"
+            .to_string(),
+            root: node_with_flags("prog", vec![flag_node(None, Some('x'))]),
+        },
+        SelfCheck {
+            name: "a new sentence after a completed one",
+            why: "the previous physical line ends with a period, so the next line is a fresh \
+                  sentence rather than a wrap-in-progress — must stay silent even though its \
+                  leading token happens to spell a flag genuinely in the tree",
+            expect: Expect::Silent,
+            raw: "\
+This tool exits zero on success.
+-1 is returned on every other outcome.
+"
+            .to_string(),
+            root: node_with_flags("prog", vec![flag_node(None, Some('1'))]),
+        },
+        SelfCheck {
+            name: "wall's real table, a ragged description column mid-list",
+            why: "the false alarm calibration actually found: `--timeout <timeout>` is one \
+                  character longer than its neighbours, so its own row's gap narrows to a single \
+                  space — gate 5 alone would misread it as prose. Gate 2 is what actually saves \
+                  it: the row directly above is itself dash-led, so this can never be a wrap out \
+                  of prose",
+            expect: Expect::Silent,
+            raw: "\
+Options:
+ -g, --group <group>     only send message to group
+ -n, --nobanner          do not print banner, works only for root
+ -t, --timeout <timeout> write timeout in seconds
+"
+            .to_string(),
+            root: node_with_flags(
+                "wall",
+                vec![
+                    flag_node(Some("group"), Some('g')),
+                    flag_node(Some("nobanner"), Some('n')),
+                    flag_node(Some("timeout"), Some('t')),
+                ],
+            ),
+        },
+        SelfCheck {
+            name: "a tab-indented option list with no wide gap at all",
+            why: "the other false alarm calibration found: every row's own gap (one tab) is \
+                  under the column-gap threshold, and the heading above the list is real prose \
+                  (`General arguments:`) — the same surface shape as a genuine wrapped-prose \
+                  paragraph. Gate 2 is again what saves it: the second and later rows are each \
+                  preceded by another dash-led row",
+            expect: Expect::Silent,
+            raw: "\
+General arguments:
+
+-i <input file>
+-l List all supported pastebins
+"
+            .to_string(),
+            root: node_with_flags(
+                "pastebinit",
+                vec![flag_node(None, Some('i')), flag_node(None, Some('l'))],
+            ),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_zgreps_first_wrapped_prose_fabrication() {
+        let root = node_with_flags(
+            "zgrep",
+            vec![
+                flag_node(Some("exclude"), None),
+                flag_node(Some("null-data"), None),
+            ],
+        );
+        let report = detect(ZGREP_HELP, &root);
+        assert_eq!(report.finding_count(), 1);
+        assert_eq!(report.findings[0].flag, "--exclude");
+    }
+
+    #[test]
+    fn stays_silent_on_walls_ragged_description_column() {
+        let raw = " -g, --group <group>     only send message to group\n \
+                    -n, --nobanner          do not print banner, works only for root\n \
+                    -t, --timeout <timeout> write timeout in seconds\n";
+        let root = node_with_flags(
+            "wall",
+            vec![
+                flag_node(Some("group"), Some('g')),
+                flag_node(Some("nobanner"), Some('n')),
+                flag_node(Some("timeout"), Some('t')),
+            ],
+        );
+        assert_eq!(detect(raw, &root).finding_count(), 0);
+    }
+
+    #[test]
+    fn stays_silent_on_a_genuine_aligned_option_table() {
+        let raw = "  -a            Register\n  -d            Unregister\n";
+        let root = node_with_flags(
+            "prog",
+            vec![flag_node(None, Some('a')), flag_node(None, Some('d'))],
+        );
+        assert_eq!(detect(raw, &root).finding_count(), 0);
+    }
+
+    #[test]
+    fn every_self_check_holds() {
+        for case in self_checks() {
+            let expected = match case.expect {
+                Expect::Fires(n) => n,
+                Expect::Silent => 0,
+            };
+            let report = detect(&case.raw, &case.root);
+            assert_eq!(
+                report.finding_count(),
+                expected,
+                "{}: expected {} finding(s)",
+                case.name,
+                expected
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds the `wrapped-prose-row-boundary` and `unparsed-tail-operand` family
detectors and records each family's fleet count in its fixtures and the atlas.

A family's calibrated count is what decides whether it earns a grammar fix or
stays an xfail.

`unparsed-tail-operand` is calibrated and passing: 3 of 3 labelled members
detected, 0 misses, 0 false alarms on seed 4. It fires on 194 tools across a
full-PATH sweep of 2318. `wrapped-prose-row-boundary` fires on 21 tools and is
**not** quotable as calibrated: no tool carrying it has a human verdict, so
recall is unevaluable and only the false-alarm half was checked.
