### PR TITLE
fix(help_text): stop self-similar help at any ancestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- pnpm 11.22.0's `audit → signatures → signatures → …` tree no longer repeats until the warmer's node cap: the generic self-similar-help guard now compares exact selected output with every strict command-path ancestor for the same resolved binary and current root generation instead of the root alone, while identical siblings, different binaries, merely similar documents, and stale pre-refresh probes remain independent; its auxiliary history is bounded to 4,096 documents and 8 MiB of selected-text payload.
+
 - `mandible ar`'s descriptions no longer start with a stray `- ` on some rows and not others: `ar` writes ` - ` as the column separator on every row of its tables, and the parser stripped it only on rows whose name overran the column (`--target=BFDNAME - specify …`) while leaving it on aligned rows (`--thin       - make a thin archive`, `@<file>      - read options from <file>`), so one table rendered two ways; a lone `-` token opening the description side is now stripped whichever way the column was found, in every tool with that table style.
 
 - `mandible ffplay`'s `-? topic` row keeps the space between spelling and value again: the argfile sigil's glued rendering (`@<file>`) keyed on "first character is not alphanumeric", which also matches the dashed short `-?` — harmless while `-?` carried no value, wrong the moment the value recovery above gave it one — and the sigil test now requires a dashless spelling (`Dashes::None`), which no short or long flag has and the argfile `@` does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
-- pnpm 11.22.0's `audit → signatures → signatures → …` tree no longer repeats until the warmer's node cap: the generic self-similar-help guard now compares exact selected output with every strict command-path ancestor for the same resolved binary and current root generation instead of the root alone, while identical siblings, different binaries, merely similar documents, and stale pre-refresh probes remain independent; its auxiliary history is bounded to 4,096 documents and 8 MiB of selected-text payload.
+- `mandible pnpm` no longer repeats the `audit signatures` help until the node cap: help identical to any ancestor command path now stops the fan-out (issue #114).
 
 - `mandible ar`'s descriptions no longer start with a stray `- ` on some rows and not others: `ar` writes ` - ` as the column separator on every row of its tables, and the parser stripped it only on rows whose name overran the column (`--target=BFDNAME - specify …`) while leaving it on aligned rows (`--thin       - make a thin archive`, `@<file>      - read options from <file>`), so one table rendered two ways; a lone `-` token opening the description side is now stripped whichever way the column was found, in every tool with that table style.
 

--- a/corpus/pnpm/11.22.0/audit-help.txt
+++ b/corpus/pnpm/11.22.0/audit-help.txt
@@ -1,0 +1,40 @@
+Version 11.22.0
+Usage: pnpm audit [options]
+       pnpm audit signatures [options]
+
+Checks for known security issues with the installed packages.
+
+Commands:
+      signatures           Verify ECDSA registry signatures for installed
+                           packages from registries that provide signing keys at
+                           /-/npm/v1/keys.
+
+Options:
+      --audit-level <severity>  Only print advisories with severity greater than
+                                or equal to one of the following:
+                                info|low|moderate|high|critical. Default: low
+  -D, --dev                     Only audit "devDependencies"
+      --fix [method]            Fix the audited vulnerabilities using the
+                                specified method: "override" or "update".
+                                "override" adds overrides to the package.json
+                                file in order to force non-vulnerable versions
+                                of the dependencies. "update" attempts to update
+                                the vulnerable packages in the lockfile to
+                                non-vulnerable versions. If no method is
+                                specified, "override" is used by default.
+      --ignore <vulnerability>  Ignore a vulnerability by its GitHub advisory ID
+                                (e.g. GHSA-xxxx-xxxx-xxxx)
+      --ignore-registry-errors  Use exit code 0 if the registry responds with an
+                                error. Useful when audit checks are used in CI.
+                                A build should not fail because the registry has
+                                issues.
+      --ignore-unfixable        Ignore all vulnerabilities for which no fix
+                                exists
+  -i, --interactive             Show vulnerabilities and select which ones to
+                                fix interactively
+      --json                    Output audit report in JSON format
+      --no-optional             Don't audit "optionalDependencies"
+  -P, --prod                    Only audit "dependencies" and
+                                "optionalDependencies"
+
+Visit https://pnpm.io/11.x/cli/audit for documentation about this command.

--- a/corpus/pnpm/11.22.0/help.txt
+++ b/corpus/pnpm/11.22.0/help.txt
@@ -1,0 +1,47 @@
+Version 11.22.0
+Usage: pnpm [command] [flags]
+       pnpm [ -h | --help | -v | --version ]
+
+These are common pnpm commands used in various situations, use 'pnpm help -a' to list all commands
+
+Manage your dependencies:
+      add                  Installs a package and any packages that it depends
+                           on. By default, any new package is installed as a
+                           prod dependency
+   i, install              Install all dependencies for a project
+  ln, link                 Connect the local project to another one
+  rm, remove               Removes packages from node_modules and from the
+                           project's package.json
+      unlink               Unlinks a package. Like yarn unlink but pnpm
+                           re-installs the dependency after removing the
+                           external link
+  up, update               Updates packages to their latest version based on the
+                           specified range
+
+Review your dependencies:
+      audit                Checks for known security issues with the installed
+                           packages
+  ls, list                 Print all the versions of packages that are
+                           installed, as well as their dependencies, in a
+                           tree-structure
+      outdated             Check for outdated packages
+      why                  Shows all packages that depend on the specified
+                           package
+
+Run your scripts:
+      create               Create a project from a "create-*" or "@foo/create-*"
+                           starter kit
+      dlx                  Fetches a package from the registry without
+                           installing it as a dependency, hot loads it, and runs
+                           whatever default command binary it exposes
+      exec                 Executes a shell command in scope of a project
+      run                  Runs a defined package script
+
+Other:
+   c, config               Manage the pnpm configuration files
+      init                 Create a package.json file
+      publish              Publishes a package to the registry
+      stage                Stage packages for publishing
+
+Options:
+  -r, --recursive          Run the command for each project in the workspace.

--- a/corpus/pnpm/11.22.0/meta.toml
+++ b/corpus/pnpm/11.22.0/meta.toml
@@ -1,0 +1,71 @@
+# Two defects live here, and only one of them is the fan-out this fixture was
+# captured for.
+#
+# 1. The fan-out (issue #114, docs/shapes.md S-079). `pnpm audit --help` and
+#    `pnpm audit signatures --help` return the same 2,251 bytes, and the
+#    document lists a real `signatures` command. Read literally, that gives
+#    `audit signatures signatures ...` without end. Both argv below therefore
+#    point at one capture file: the bytes are identical, and a second copy
+#    would only be a file to keep in sync. No `[contract]` field states the
+#    claim that matters here, which is that the `audit signatures` node has no
+#    subcommands and is complete. The contract can assert a subcommand's flags
+#    by path and a subcommand floor at the root, and neither says a named node
+#    is an empty, known-complete leaf. That claim is pinned by the unit test
+#    `mandible-extract/src/help_text/mod.rs::tests::
+#    a_descendant_probe_identical_to_its_non_root_ancestor_does_not_fan_out`.
+#
+# 2. The root parse, which is wrong independently of the fan-out. pnpm groups
+#    its 18 root commands under four prose headings and writes the aliased ones
+#    with a leading short column (`i, install`, `ln, link`, `rm, remove`,
+#    `up, update`, `ls, list`, `c, config`). The parser reports 8 subcommands:
+#    add, audit, create, dlx, exec, package, run, tree-structure. Every aliased
+#    row is dropped, and so are the unaliased rows under them: unlink,
+#    outdated, why, init, publish, stage. Worse, `package` and `tree-structure`
+#    are inventions, both read off wrapped description lines. `tree-structure`
+#    is the last word of the `ls, list` description, alone on its own
+#    continuation line; `package` opens a continuation line under `why`. The
+#    tool documents neither as a command.
+#
+#    `min_subcommands` below states the omission half. There is no field for
+#    the invention half at this level: `must_not_contain_flags` is the one
+#    negative claim a contract can make and it is scoped to root flags, so it
+#    cannot say `package` and `tree-structure` are not commands. Those two
+#    names are named here instead.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "pnpm"
+version = "11.22.0"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8)"
+
+[[capture]]
+argv = ["pnpm", "--help"]
+stdout = "help.txt"
+
+[[capture]]
+argv = ["pnpm", "audit", "--help"]
+stdout = "audit-help.txt"
+
+# The same bytes as the entry above, which is the defect.
+[[capture]]
+argv = ["pnpm", "audit", "signatures", "--help"]
+stdout = "audit-help.txt"
+
+[contract]
+# pnpm's help is hand-rolled, so Tier A' fingerprints nothing.
+expected_framework = "generic"
+
+# The tool documents 18 root commands. The parser reports 8, two of which it
+# invented. This floor is the omission half of the root defect.
+min_subcommands = 18
+
+# The one root flag pnpm lists under `Options:`.
+must_contain_flags = ["--recursive"]
+
+[xfail]
+broken = true
+reason = "the root command table is misread: the six aliased rows and the six rows under them are dropped, and `package` and `tree-structure` are invented from wrapped description lines"
+issue = "https://github.com/AS-FOSS/mandible/issues/114"

--- a/docs/design.md
+++ b/docs/design.md
@@ -3265,6 +3265,44 @@ any of these as current.
   it never fires for a genuinely distinct subcommand's genuinely distinct
   help text, corpus fixtures included.
 
+  **Extended on 2026-09-02 after issue #114 exposed the same mechanism
+  below the root.** pnpm 11.22.0 on Windows 11 returned one 2,251-byte,
+  LF-only stdout document (stderr empty, exit 0) for each of `pnpm audit
+  --help`, `pnpm audit signatures --help`, and `pnpm audit signatures
+  signatures --help`; that document contains a real `Commands:` row named
+  `signatures`. Its 2,305-byte root document is different. The original
+  root-only equality guard therefore stopped `systemctl`/`llvm-ar` root
+  echoes but could not stop `audit → signatures → signatures → …`: every
+  repeated descendant differed from the cached root while exactly matching
+  its nearest non-root ancestor.
+
+  The generalized invariant remains exact and local: selected help for a
+  command path is compared only with its strict path ancestors, only for the
+  same resolved binary, and only in the extraction generation established
+  by that binary's latest root probe. A match takes the existing M-19
+  verbatim/known-complete path. Siblings and unrelated paths are never
+  compared, similar-but-not-identical text still parses normally, and a
+  convention-discovered command rebased onto another executable has a
+  separate history. The history is mutex-protected because background and
+  UI fills share the tier; beginning a root probe clears that binary's
+  descendants and advances its generation before execution, so a failed
+  refresh cannot retain stale entries and an old in-flight probe cannot
+  reinsert one after `Warmer::reset`.
+
+  This comparison history is itself bounded rather than multiplying the
+  8 MiB combined probe-output allowance by the 4,096-node warmer ceiling.
+  Across all resolved binaries, one tier retains at most 4,096 selected
+  documents and 8 MiB of their UTF-8 payload, plus at most 4,096 per-binary
+  history records. Distinct leaf documents are retained because admission
+  occurs before parsing establishes whether they have children; an exact
+  ancestor repetition is not inserted again. Identical siblings remain two
+  path-local entries. A root probe removes only that resolved binary's
+  documents from both the per-binary map and global accounting before it
+  advances that binary's generation; other binaries remain valid. Dropping
+  the tier releases everything. If either admission budget is exhausted,
+  the current node follows the same conservative verbatim/known-complete
+  path, so bounded memory cannot reopen an untracked fan-out.
+
 - **[M-21] Metric-design incidents and the defect-family detector fixes**
   (2026-08 batch, seed-2 audit of 94 tools). Five incidents produced §13.1b's
   five rules: [M-10]'s fabricated `tar` nodes inflated `%described`; [M-16]'s

--- a/docs/design.md
+++ b/docs/design.md
@@ -3261,47 +3261,18 @@ any of these as current.
 
   The full workspace test suite (584 tests, two more than the 582 this
   investigation started from) and all 6 corpus fixtures stayed green
-  throughout — the guard is keyed on exact byte equality to the root, so
-  it never fires for a genuinely distinct subcommand's genuinely distinct
+  throughout — that guard was keyed on exact equality with the root, so
+  it never fired for a genuinely distinct subcommand's genuinely distinct
   help text, corpus fixtures included.
 
-  **Extended on 2026-09-02 after issue #114 exposed the same mechanism
-  below the root.** pnpm 11.22.0 on Windows 11 returned one 2,251-byte,
-  LF-only stdout document (stderr empty, exit 0) for each of `pnpm audit
-  --help`, `pnpm audit signatures --help`, and `pnpm audit signatures
-  signatures --help`; that document contains a real `Commands:` row named
-  `signatures`. Its 2,305-byte root document is different. The original
-  root-only equality guard therefore stopped `systemctl`/`llvm-ar` root
-  echoes but could not stop `audit → signatures → signatures → …`: every
-  repeated descendant differed from the cached root while exactly matching
-  its nearest non-root ancestor.
-
-  The generalized invariant remains exact and local: selected help for a
-  command path is compared only with its strict path ancestors, only for the
-  same resolved binary, and only in the extraction generation established
-  by that binary's latest root probe. A match takes the existing M-19
-  verbatim/known-complete path. Siblings and unrelated paths are never
-  compared, similar-but-not-identical text still parses normally, and a
-  convention-discovered command rebased onto another executable has a
-  separate history. The history is mutex-protected because background and
-  UI fills share the tier; beginning a root probe clears that binary's
-  descendants and advances its generation before execution, so a failed
-  refresh cannot retain stale entries and an old in-flight probe cannot
-  reinsert one after `Warmer::reset`.
-
-  This comparison history is itself bounded rather than multiplying the
-  8 MiB combined probe-output allowance by the 4,096-node warmer ceiling.
-  Across all resolved binaries, one tier retains at most 4,096 selected
-  documents and 8 MiB of their UTF-8 payload, plus at most 4,096 per-binary
-  history records. Distinct leaf documents are retained because admission
-  occurs before parsing establishes whether they have children; an exact
-  ancestor repetition is not inserted again. Identical siblings remain two
-  path-local entries. A root probe removes only that resolved binary's
-  documents from both the per-binary map and global accounting before it
-  advances that binary's generation; other binaries remain valid. Dropping
-  the tier releases everything. If either admission budget is exhausted,
-  the current node follows the same conservative verbatim/known-complete
-  path, so bounded memory cannot reopen an untracked fan-out.
+  The guard compares a command path's selected help with its strict path
+  ancestors for the same resolved binary in the current root generation.
+  A match degrades that node to verbatim with an empty, known-complete
+  child list. Siblings, unrelated paths, other resolved binaries, and
+  merely similar documents never match. The history keeps a hash and a
+  length for each path, so an exact repetition is a hash match. It holds
+  at most 4,096 documents and at most 4,096 resolved binary histories. A
+  full history records nothing and the node parses normally.
 
 - **[M-21] Metric-design incidents and the defect-family detector fixes**
   (2026-08 batch, seed-2 audit of 94 tools). Five incidents produced §13.1b's

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1282,26 +1282,18 @@ entry's `tools` field and nothing else. It does not get a new entry.
       no verbatim excerpt in source
 - tools: systemctl, llvm-ar, pnpm
 - handling: Some tools permute --help to the front of their own argument processing
-  regardless of what precedes it, so a subcommand probe comes back
-  byte-identical to help already returned for an ancestor command path.
-  Reading that as the current node's own children turns a harmless command
-  list into an unbounded recursive re-probe. The first implementation compared
-  only with the cached root and stopped root echoes (`systemctl`, `llvm-ar`),
-  but pnpm's root differs while `audit signatures --help` repeats `audit
-  --help`. Whenever selected help exactly matches any strict path ancestor for
-  the same resolved binary and current root generation, the node degrades to
-  verbatim with an empty, known-complete child list instead of cascading
-  further. Siblings, unrelated paths, different binaries and merely similar
-  documents remain independent; equality is byte-for-byte after the normal
-  stdout/stderr and long/short-help selection, never normalized similarity.
-  The auxiliary history is capped across all binaries at 4,096 documents and
-  8 MiB of selected-text payload. Exact ancestor repetitions are not inserted
-  twice; on admission exhaustion the current node takes the same bounded,
-  complete-verbatim path instead of reopening recursive discovery. A root
-  probe frees and advances only its resolved binary's history.
+  regardless of what precedes it, so a probe comes back identical to help already
+  returned for an ancestor command path. Reading that as the node's own children
+  turns a harmless command list into an unbounded recursive re-probe. Whenever
+  selected help repeats a strict path ancestor for the same resolved binary and
+  current root generation, that node degrades to verbatim with an empty,
+  known-complete child list instead of cascading further. Siblings, unrelated
+  paths, other binaries and merely similar documents stay independent. The
+  history keeps a hash and a length for each path, holds at most 4,096 documents,
+  and records nothing once full, in which case the node parses normally.
 - fleet: one live incident starved the UI thread for over 45 seconds on a 4-core
-  machine; pnpm 11.22.0's non-root repetition reproduced on Windows 11 on
-  2026-09-02, not otherwise fleet-measured
+  machine; pnpm 11.22.0 repeats its `audit` help below the root, reproduced
+  2026-09-03, not otherwise fleet-measured
 
 ### S-080: truncation confession (tool names its own missing content)
 

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1280,17 +1280,28 @@ entry's `tools` field and nothing else. It does not get a new entry.
 - id: S-079
 - looks like: |
       no verbatim excerpt in source
-- tools: systemctl, llvm-ar
+- tools: systemctl, llvm-ar, pnpm
 - handling: Some tools permute --help to the front of their own argument processing
   regardless of what precedes it, so a subcommand probe comes back
-  byte-identical to the tool's own root help text. Reading that as the
-  subcommand's own children turns a harmless command list into an unbounded
-  recursive re-probe. Whenever a subcommand probe returns exactly the same
-  bytes as the cached root text, that node degrades to verbatim with an empty,
-  known-complete child list instead of cascading further, keyed on
-  byte-for-byte equality, never similarity.
+  byte-identical to help already returned for an ancestor command path.
+  Reading that as the current node's own children turns a harmless command
+  list into an unbounded recursive re-probe. The first implementation compared
+  only with the cached root and stopped root echoes (`systemctl`, `llvm-ar`),
+  but pnpm's root differs while `audit signatures --help` repeats `audit
+  --help`. Whenever selected help exactly matches any strict path ancestor for
+  the same resolved binary and current root generation, the node degrades to
+  verbatim with an empty, known-complete child list instead of cascading
+  further. Siblings, unrelated paths, different binaries and merely similar
+  documents remain independent; equality is byte-for-byte after the normal
+  stdout/stderr and long/short-help selection, never normalized similarity.
+  The auxiliary history is capped across all binaries at 4,096 documents and
+  8 MiB of selected-text payload. Exact ancestor repetitions are not inserted
+  twice; on admission exhaustion the current node takes the same bounded,
+  complete-verbatim path instead of reopening recursive discovery. A root
+  probe frees and advances only its resolved binary's history.
 - fleet: one live incident starved the UI thread for over 45 seconds on a 4-core
-  machine, not otherwise dated
+  machine; pnpm 11.22.0's non-root repetition reproduced on Windows 11 on
+  2026-09-02, not otherwise fleet-measured
 
 ### S-080: truncation confession (tool names its own missing content)
 

--- a/mandible-extract/src/help_text/mod.rs
+++ b/mandible-extract/src/help_text/mod.rs
@@ -76,7 +76,7 @@ pub use grammar::looks_like_bracket_flag_row;
 pub use sections::is_option_list_placeholder;
 
 use crate::errors::ExtractError;
-use crate::exec::{ExecOutput, InertArgv, LiveProbe, Probe};
+use crate::exec::{ExecOutput, InertArgv, LiveProbe, Probe, MAX_OUTPUT_BYTES};
 use crate::framework::{self, Framework};
 use crate::resolve::ResolvedTool;
 use crate::tier::{ExtractionTier, NodeHints};
@@ -98,6 +98,19 @@ const EXTRACT_TIMEOUT: Duration = Duration::from_secs(10);
 /// and scroll.
 const MAX_UNPARSED_LINES: usize = 4096;
 
+/// Maximum selected-help payload retained solely for ancestor comparison.
+/// One live probe already has this combined stdout/stderr ceiling; keeping
+/// no more than the same amount across the session prevents the auxiliary
+/// history from multiplying that per-probe allowance by the warmer's node
+/// budget. Parsed [`CommandNode`] data is not counted here.
+const MAX_RETAINED_HELP_BYTES: usize = MAX_OUTPUT_BYTES;
+
+/// Maximum number of selected documents — and, independently, resolved
+/// binary histories — held by one tier. Mirrors the background warmer's
+/// 4,096-node safety ceiling without coupling the extractor crate to the
+/// application crate. Bytes usually reach their tighter bound first.
+const MAX_RETAINED_HELP_DOCUMENTS: usize = 4096;
+
 /// Tier B: parses `<tool> [<path>...] --help` (falling back to `-h`) via a
 /// layout-driven section parser and a small `winnow` flag-spec grammar.
 pub struct HelpTextTier {
@@ -106,20 +119,76 @@ pub struct HelpTextTier {
     /// replay frozen bytes through this exact parsing pipeline with zero
     /// subprocesses (the corpus regression harness's seam).
     probe: Arc<dyn Probe>,
-    /// Each tool's root `--help` text, keyed by its resolved binary path,
-    /// remembered the first time [`Self::extract_node`] probes the root —
-    /// see that method's doc comment for why: it is the baseline a later
-    /// subcommand probe is checked against to catch the self-similar-
-    /// fan-out hazard.
+    /// Each tool's selected help text by command path, keyed first by its
+    /// resolved binary path and scoped to that binary's current extraction
+    /// generation. See [`Self::record_selected_text`] for the invariant:
+    /// only strict path ancestors are candidates for the self-similar-
+    /// fan-out guard.
     ///
     /// A `Mutex` because `fill_node` is called concurrently from the
     /// background warm pool (`mandible/src/background.rs`) as well as the
     /// UI thread; a plain `RefCell` would not be `Sync`. Lives for the
     /// tier's lifetime, which is the whole session — one `Runner` (and so
-    /// one set of tiers) is built once per `mandible` invocation and
-    /// targets exactly one tool for that invocation's lifetime, refresh
-    /// (`r`) included, so the cache never needs to be evicted.
-    root_text: Mutex<HashMap<PathBuf, Arc<str>>>,
+    /// one set of tiers) is built once per `mandible` invocation, refresh
+    /// (`r`) included. A fresh root probe advances the generation and
+    /// clears that binary's paths; the generation token also stops an
+    /// in-flight probe from the discarded tree re-inserting stale text.
+    selected_text: Mutex<SelectedTextHistory>,
+}
+
+/// All selected-help history owned by one tier. Payload accounting is
+/// global so many convention-discovered binaries cannot each claim a full
+/// byte allowance; generations and path maps remain per resolved binary.
+struct SelectedTextHistory {
+    by_tool: HashMap<PathBuf, ToolHelpHistory>,
+    retained_documents: usize,
+    retained_bytes: usize,
+    limits: HelpHistoryLimits,
+}
+
+/// Selected help documents observed for one resolved binary during one
+/// extraction generation. `by_path` is keyed by the words after argv[0];
+/// the empty path is therefore the binary's root document.
+#[derive(Default)]
+struct ToolHelpHistory {
+    generation: u64,
+    by_path: HashMap<Vec<String>, Arc<str>>,
+    retained_bytes: usize,
+}
+
+#[derive(Clone, Copy)]
+struct HelpHistoryLimits {
+    binaries: usize,
+    documents: usize,
+    bytes: usize,
+}
+
+impl Default for SelectedTextHistory {
+    fn default() -> Self {
+        Self {
+            by_tool: HashMap::new(),
+            retained_documents: 0,
+            retained_bytes: 0,
+            limits: HelpHistoryLimits {
+                binaries: MAX_RETAINED_HELP_DOCUMENTS,
+                documents: MAX_RETAINED_HELP_DOCUMENTS,
+                bytes: MAX_RETAINED_HELP_BYTES,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HelpProbeGeneration {
+    Tracked(u64),
+    Untracked,
+    CapacityExhausted,
+}
+
+enum SelectedTextDecision {
+    Continue,
+    RepeatedAncestor,
+    CapacityExhausted,
 }
 
 impl Default for HelpTextTier {
@@ -135,8 +204,136 @@ impl HelpTextTier {
     pub fn new(probe: Arc<dyn Probe>) -> Self {
         Self {
             probe,
-            root_text: Mutex::new(HashMap::new()),
+            selected_text: Mutex::new(SelectedTextHistory::default()),
         }
+    }
+
+    /// Snapshot the binary's extraction generation immediately before a
+    /// probe. A root probe starts a new generation *before* executing so a
+    /// failed refresh cannot leave descendant text from the discarded tree
+    /// eligible for comparison.
+    fn begin_help_probe(&self, tool_path: &Path, words: &[String]) -> HelpProbeGeneration {
+        let Ok(mut cache) = self.selected_text.lock() else {
+            return HelpProbeGeneration::Untracked;
+        };
+        if words.is_empty() {
+            if !cache.by_tool.contains_key(tool_path) {
+                if cache.by_tool.len() >= cache.limits.binaries {
+                    return HelpProbeGeneration::CapacityExhausted;
+                }
+                cache
+                    .by_tool
+                    .insert(tool_path.to_path_buf(), ToolHelpHistory::default());
+            }
+
+            let (cleared_documents, cleared_bytes, generation) = {
+                let history = cache
+                    .by_tool
+                    .get_mut(tool_path)
+                    .expect("the binary history was found or inserted above");
+                let cleared_documents = history.by_path.len();
+                let cleared_bytes = history.retained_bytes;
+                history.generation = history.generation.wrapping_add(1);
+                history.by_path.clear();
+                history.retained_bytes = 0;
+                (cleared_documents, cleared_bytes, history.generation)
+            };
+            cache.retained_documents = cache.retained_documents.saturating_sub(cleared_documents);
+            cache.retained_bytes = cache.retained_bytes.saturating_sub(cleared_bytes);
+            HelpProbeGeneration::Tracked(generation)
+        } else {
+            cache
+                .by_tool
+                .get(tool_path)
+                .map(|history| HelpProbeGeneration::Tracked(history.generation))
+                .unwrap_or(HelpProbeGeneration::Untracked)
+        }
+    }
+
+    /// Record one selected document if its probe still belongs to the
+    /// current generation, reporting when it is byte-for-byte identical to
+    /// a strict path ancestor for the same resolved binary.
+    ///
+    /// The full path is deliberately excluded from the comparison: a
+    /// repeated probe of one node is not evidence of recursion. Unrelated
+    /// and sibling paths are excluded by construction, and a root probe's
+    /// generation reset prevents stale descendants from crossing refresh.
+    /// A repeated ancestor is never inserted again. Distinct documents are
+    /// admitted only while both the entry and byte budgets have room; on
+    /// exhaustion the caller degrades the current node to a complete
+    /// verbatim leaf, preserving bounded and deterministic behavior.
+    fn record_selected_text(
+        &self,
+        tool_path: &Path,
+        words: &[String],
+        generation: HelpProbeGeneration,
+        raw: &str,
+    ) -> SelectedTextDecision {
+        let generation = match generation {
+            HelpProbeGeneration::Tracked(generation) => generation,
+            HelpProbeGeneration::Untracked => return SelectedTextDecision::Continue,
+            HelpProbeGeneration::CapacityExhausted => {
+                return SelectedTextDecision::CapacityExhausted;
+            }
+        };
+        let Ok(mut cache) = self.selected_text.lock() else {
+            return SelectedTextDecision::Continue;
+        };
+        let Some(history) = cache.by_tool.get(tool_path) else {
+            return SelectedTextDecision::Continue;
+        };
+        if history.generation != generation {
+            return SelectedTextDecision::Continue;
+        }
+
+        // A same-generation re-probe replaces this path. Remove its old
+        // value before either matching or admission so a changed result can
+        // never remain eligible as stale ancestor text.
+        let removed_bytes = {
+            let history = cache
+                .by_tool
+                .get_mut(tool_path)
+                .expect("the generation check found this binary history");
+            let removed_bytes = history.by_path.remove(words).map(|document| document.len());
+            if let Some(removed_bytes) = removed_bytes {
+                history.retained_bytes = history.retained_bytes.saturating_sub(removed_bytes);
+            }
+            removed_bytes
+        };
+        if let Some(removed_bytes) = removed_bytes {
+            cache.retained_documents = cache.retained_documents.saturating_sub(1);
+            cache.retained_bytes = cache.retained_bytes.saturating_sub(removed_bytes);
+        }
+
+        let history = cache
+            .by_tool
+            .get(tool_path)
+            .expect("the generation check found this binary history");
+        let repeats_ancestor = (0..words.len()).any(|prefix_len| {
+            history
+                .by_path
+                .get(&words[..prefix_len])
+                .is_some_and(|ancestor| ancestor.as_ref() == raw)
+        });
+        if repeats_ancestor {
+            return SelectedTextDecision::RepeatedAncestor;
+        }
+
+        if cache.retained_documents >= cache.limits.documents
+            || raw.len() > cache.limits.bytes.saturating_sub(cache.retained_bytes)
+        {
+            return SelectedTextDecision::CapacityExhausted;
+        }
+
+        let history = cache
+            .by_tool
+            .get_mut(tool_path)
+            .expect("the generation check found this binary history");
+        history.by_path.insert(words.to_vec(), Arc::from(raw));
+        history.retained_bytes += raw.len();
+        cache.retained_documents += 1;
+        cache.retained_bytes += raw.len();
+        SelectedTextDecision::Continue
     }
 }
 
@@ -164,35 +361,27 @@ impl ExtractionTier for HelpTextTier {
     ) -> Result<CommandNode, ExtractError> {
         let tool_path = tool.path.as_ref().ok_or(ExtractError::ToolNotFound)?;
         let words: Vec<String> = path.iter().skip(1).cloned().collect();
+        let generation = self.begin_help_probe(tool_path, &words);
         let (raw, _argv_display, confession) =
             probe_help_text_confession_aware(self.probe.as_ref(), tool_path, &words, hints)?;
         let node_name = path.last().cloned().unwrap_or_else(|| tool.name.clone());
 
-        if words.is_empty() {
-            // This probe is the root: cache its text as the baseline
-            // later subcommand probes compare against. Always
-            // overwritten so a refresh re-baselines.
-            if let Ok(mut cache) = self.root_text.lock() {
-                cache.insert(tool_path.clone(), Arc::from(raw.as_str()));
-            }
-        } else if let Ok(cache) = self.root_text.lock() {
-            // Self-similar fan-out (spec M-19): a subcommand probe that
-            // returns bytes identical to the cached root text degrades to
-            // verbatim with no children, rather than re-reading the
-            // root's own command table as this subcommand's own.
-            // Keyed on output equality, never on tool name (same
-            // discipline as M-16's man-page check). See docs/shapes.md
-            // S-079.
-            if let Some(root_raw) = cache.get(tool_path) {
-                if root_raw.as_ref() == raw.as_str() {
-                    let detected_framework = framework::identify_from_artifact(tool)
-                        .or_else(|| framework::identify_from_help_text(&raw))
-                        .map(|f| f.name().to_string());
-                    let mut node = verbatim_node(&node_name, &raw, detected_framework);
-                    node.confession = confession;
-                    return Ok(node);
-                }
-            }
+        // Self-similar fan-out (spec M-19, docs/shapes.md S-079): a node
+        // whose selected help is identical to any strict ancestor for the
+        // same resolved binary and extraction generation degrades to
+        // verbatim with no children. Exact equality is the authority;
+        // neither tool/command names nor unrelated paths participate.
+        let history_decision = self.record_selected_text(tool_path, &words, generation, &raw);
+        if matches!(
+            history_decision,
+            SelectedTextDecision::RepeatedAncestor | SelectedTextDecision::CapacityExhausted
+        ) {
+            let detected_framework = framework::identify_from_artifact(tool)
+                .or_else(|| framework::identify_from_help_text(&raw))
+                .map(|f| f.name().to_string());
+            let mut node = verbatim_node(&node_name, &raw, detected_framework);
+            node.confession = confession;
+            return Ok(node);
         }
 
         // Detection order per spec §7 Tier A′: free artifact scan first
@@ -1486,6 +1675,648 @@ mod tests {
             !child.unparsed.is_empty(),
             "the raw text must still be available to the verbatim ('t') \
              view even though nothing was promoted to structure"
+        );
+    }
+
+    /// Issue #114's measured pnpm shape extends M-19/S-079 by one level:
+    /// the root document is distinct, but `audit signatures --help`
+    /// repeats `audit --help` byte for byte.  The first real `signatures`
+    /// row stays visible under `audit`; only the repeated descendant must
+    /// stop, while retaining the exact selected document as verbatim text.
+    #[test]
+    fn a_descendant_probe_identical_to_its_non_root_ancestor_does_not_fan_out() {
+        let root_raw =
+            "Usage: pnpm [command] [flags]\n\nCommands:\n  audit   Check installed packages\n";
+        let audit_raw = "Usage: pnpm audit [options]\n       pnpm audit signatures [options]\n\nCommands:\n  signatures   Verify registry signatures\n\nOptions:\n  --json       Output JSON\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["audit".to_string(), "--help".to_string()],
+                exec_output(audit_raw),
+            ),
+            (
+                vec![
+                    "audit".to_string(),
+                    "signatures".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(audit_raw),
+            ),
+        ]);
+        let tier = HelpTextTier::new(std::sync::Arc::new(transcript));
+        let tool = crate::resolve::ResolvedTool {
+            name: "pnpm".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/pnpm")),
+            version: None,
+        };
+
+        let root = tier
+            .extract_node(&tool, &["pnpm".to_string()], ATTESTED)
+            .expect("the transcript covers the root argv");
+        assert_eq!(
+            root.subcommands
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["audit"],
+            "the distinct root document must still expose audit"
+        );
+
+        let audit = tier
+            .extract_node(&tool, &["pnpm".to_string(), "audit".to_string()], ATTESTED)
+            .expect("the transcript covers audit --help");
+        assert_eq!(
+            audit
+                .subcommands
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["signatures"],
+            "the first real signatures row must remain visible"
+        );
+
+        let repeated = tier
+            .extract_node(
+                &tool,
+                &[
+                    "pnpm".to_string(),
+                    "audit".to_string(),
+                    "signatures".to_string(),
+                ],
+                ATTESTED,
+            )
+            .expect("the transcript covers audit signatures --help");
+        assert!(
+            repeated.subcommands.is_empty(),
+            "a document identical to a strict non-root ancestor must not \
+             expose that ancestor's children again: {:?}",
+            repeated
+                .subcommands
+                .iter()
+                .map(|node| &node.name)
+                .collect::<Vec<_>>()
+        );
+        assert!(repeated.children_filled, "the repeated level is complete");
+        assert_eq!(
+            repeated
+                .unparsed
+                .iter()
+                .map(Text::as_str)
+                .collect::<Vec<_>>(),
+            audit_raw.lines().collect::<Vec<_>>(),
+            "the selected help must remain available verbatim"
+        );
+        let cache = tier
+            .selected_text
+            .lock()
+            .expect("the selected-help history lock is healthy");
+        assert_eq!(cache.retained_documents, 2);
+        assert_eq!(cache.retained_bytes, root_raw.len() + audit_raw.len());
+        assert_eq!(
+            cache
+                .by_tool
+                .get(Path::new("/replayed/pnpm"))
+                .expect("pnpm has one current history")
+                .by_path
+                .len(),
+            2,
+            "the repeated signatures leaf must not retain a duplicate"
+        );
+    }
+
+    /// Every strict prefix participates, not just the root and the nearest
+    /// parent: `gamma` repeats `alpha` while differing from both `beta` and
+    /// the root.
+    #[test]
+    fn a_descendant_matching_a_non_nearest_non_root_ancestor_does_not_fan_out() {
+        let root_raw = "Usage: widget COMMAND\n\nCommands:\n  alpha   Alpha branch\n";
+        let alpha_raw = "Usage: widget alpha COMMAND\n\nCommands:\n  beta   A real beta command\n";
+        let beta_raw =
+            "Usage: widget alpha beta COMMAND\n\nCommands:\n  gamma   A real gamma command\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["alpha".to_string(), "--help".to_string()],
+                exec_output(alpha_raw),
+            ),
+            (
+                vec![
+                    "alpha".to_string(),
+                    "beta".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(beta_raw),
+            ),
+            (
+                vec![
+                    "alpha".to_string(),
+                    "beta".to_string(),
+                    "gamma".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(alpha_raw),
+            ),
+        ]);
+        let tier = HelpTextTier::new(Arc::new(transcript));
+        let tool = crate::resolve::ResolvedTool {
+            name: "widget".to_string(),
+            path: Some(PathBuf::from("/replayed/widget")),
+            version: None,
+        };
+
+        tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+            .expect("the root transcript is present");
+        tier.extract_node(
+            &tool,
+            &["widget".to_string(), "alpha".to_string()],
+            ATTESTED,
+        )
+        .expect("the alpha transcript is present");
+        tier.extract_node(
+            &tool,
+            &[
+                "widget".to_string(),
+                "alpha".to_string(),
+                "beta".to_string(),
+            ],
+            ATTESTED,
+        )
+        .expect("the beta transcript is present");
+
+        let gamma = tier
+            .extract_node(
+                &tool,
+                &[
+                    "widget".to_string(),
+                    "alpha".to_string(),
+                    "beta".to_string(),
+                    "gamma".to_string(),
+                ],
+                ATTESTED,
+            )
+            .expect("the gamma transcript is present");
+        assert_ne!(alpha_raw, root_raw);
+        assert_ne!(alpha_raw, beta_raw);
+        assert!(gamma.children_filled);
+        assert!(gamma.subcommands.is_empty());
+        assert_eq!(
+            gamma.unparsed.iter().map(Text::as_str).collect::<Vec<_>>(),
+            alpha_raw.lines().collect::<Vec<_>>()
+        );
+    }
+
+    /// Equality is meaningful only along one command path. Two siblings
+    /// may legitimately share a generated help template; seeing the first
+    /// must not globally suppress the second.
+    #[test]
+    fn identical_sibling_help_is_parsed_normally_for_both_paths() {
+        let root_raw =
+            "Usage: widget COMMAND\n\nCommands:\n  left    Left branch\n  right   Right branch\n";
+        let sibling_raw =
+            "Usage: widget branch COMMAND\n\nCommands:\n  nested   A real nested command\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["left".to_string(), "--help".to_string()],
+                exec_output(sibling_raw),
+            ),
+            (
+                vec!["right".to_string(), "--help".to_string()],
+                exec_output(sibling_raw),
+            ),
+        ]);
+        let tier = HelpTextTier::new(std::sync::Arc::new(transcript));
+        let tool = crate::resolve::ResolvedTool {
+            name: "widget".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/widget")),
+            version: None,
+        };
+
+        tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+            .expect("the transcript covers the root argv");
+        for sibling in ["left", "right"] {
+            let node = tier
+                .extract_node(
+                    &tool,
+                    &["widget".to_string(), sibling.to_string()],
+                    ATTESTED,
+                )
+                .unwrap_or_else(|error| panic!("{sibling} probe failed: {error}"));
+            assert_eq!(
+                node.subcommands
+                    .iter()
+                    .map(|child| child.name.as_str())
+                    .collect::<Vec<_>>(),
+                ["nested"],
+                "sibling equality must not suppress {sibling}"
+            );
+        }
+    }
+
+    /// Path prefixes are scoped by the resolved executable, not merely by
+    /// their spelling. Convention-discovered commands can rebase onto a
+    /// different binary while retaining the same remaining words.
+    #[test]
+    fn identical_help_from_a_different_resolved_binary_is_not_an_ancestor_match() {
+        let root_raw = "Usage: widget COMMAND\n\nCommands:\n  branch   A real branch\n";
+        let branch_raw =
+            "Usage: widget branch COMMAND\n\nCommands:\n  nested   A real nested command\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["branch".to_string(), "--help".to_string()],
+                exec_output(branch_raw),
+            ),
+            (
+                vec![
+                    "branch".to_string(),
+                    "leaf".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(branch_raw),
+            ),
+        ]);
+        let tier = HelpTextTier::new(std::sync::Arc::new(transcript));
+        let first = crate::resolve::ResolvedTool {
+            name: "first".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/first")),
+            version: None,
+        };
+        let second = crate::resolve::ResolvedTool {
+            name: "second".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/second")),
+            version: None,
+        };
+
+        // Interleave the two binary histories: a cache lacking the outer
+        // binary key sees `first`'s `branch` as `second`'s path prefix.
+        tier.extract_node(&second, &["second".to_string()], ATTESTED)
+            .expect("the transcript covers second's root");
+        tier.extract_node(&first, &["first".to_string()], ATTESTED)
+            .expect("the transcript covers first's root");
+        tier.extract_node(
+            &first,
+            &["first".to_string(), "branch".to_string()],
+            ATTESTED,
+        )
+        .expect("the transcript covers first's branch");
+
+        let second_descendant = tier
+            .extract_node(
+                &second,
+                &[
+                    "second".to_string(),
+                    "branch".to_string(),
+                    "leaf".to_string(),
+                ],
+                ATTESTED,
+            )
+            .expect("the transcript covers second's descendant");
+        assert_eq!(
+            second_descendant
+                .subcommands
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["nested"],
+            "text from another resolved binary must not suppress this path"
+        );
+    }
+
+    /// A convention-rebased binary starts its own root generation. Doing
+    /// so between an ancestor and descendant probe for another binary must
+    /// neither clear that ancestor nor invalidate its generation token.
+    #[test]
+    fn probing_another_binarys_root_does_not_reset_this_binarys_ancestors() {
+        let root_raw = "Usage: widget COMMAND\n\nCommands:\n  branch   A real branch\n";
+        let branch_raw = "Usage: widget branch COMMAND\n\nCommands:\n  leaf   A repeated child\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["branch".to_string(), "--help".to_string()],
+                exec_output(branch_raw),
+            ),
+            (
+                vec![
+                    "branch".to_string(),
+                    "leaf".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(branch_raw),
+            ),
+        ]);
+        let tier = HelpTextTier::new(Arc::new(transcript));
+        let first = crate::resolve::ResolvedTool {
+            name: "first".to_string(),
+            path: Some(PathBuf::from("/replayed/first")),
+            version: None,
+        };
+        let second = crate::resolve::ResolvedTool {
+            name: "second".to_string(),
+            path: Some(PathBuf::from("/replayed/second")),
+            version: None,
+        };
+
+        tier.extract_node(&first, &["first".to_string()], ATTESTED)
+            .expect("first's root establishes its generation");
+        tier.extract_node(
+            &first,
+            &["first".to_string(), "branch".to_string()],
+            ATTESTED,
+        )
+        .expect("first's ancestor is retained");
+        tier.extract_node(&second, &["second".to_string()], ATTESTED)
+            .expect("second's rebased root establishes only its generation");
+
+        {
+            let cache = tier
+                .selected_text
+                .lock()
+                .expect("the selected-help history lock is healthy");
+            let first_history = cache
+                .by_tool
+                .get(Path::new("/replayed/first"))
+                .expect("first's history survives second's root");
+            let second_history = cache
+                .by_tool
+                .get(Path::new("/replayed/second"))
+                .expect("second has an independent history");
+            assert_eq!(first_history.generation, 1);
+            assert_eq!(second_history.generation, 1);
+            assert!(first_history
+                .by_path
+                .contains_key(&["branch".to_string()][..]));
+        }
+
+        let repeated = tier
+            .extract_node(
+                &first,
+                &[
+                    "first".to_string(),
+                    "branch".to_string(),
+                    "leaf".to_string(),
+                ],
+                ATTESTED,
+            )
+            .expect("first's descendant still sees first's ancestor");
+        assert!(repeated.children_filled);
+        assert!(repeated.subcommands.is_empty());
+        assert_eq!(
+            repeated
+                .unparsed
+                .iter()
+                .map(Text::as_str)
+                .collect::<Vec<_>>(),
+            branch_raw.lines().collect::<Vec<_>>()
+        );
+    }
+
+    /// If retaining another distinct document would exceed the bounded
+    /// history payload, extraction fails closed at that node: raw help is
+    /// kept on the node, but no untracked children are allowed to fan out.
+    #[test]
+    fn exhausted_help_history_budget_degrades_to_a_complete_verbatim_leaf() {
+        let root_raw = "Usage: widget COMMAND\n\nCommands:\n  child   A real child\n";
+        let child_raw =
+            "Usage: widget child COMMAND\n\nCommands:\n  nested   A real nested command\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["child".to_string(), "--help".to_string()],
+                exec_output(child_raw),
+            ),
+        ]);
+        let selected_text = SelectedTextHistory {
+            limits: HelpHistoryLimits {
+                binaries: 2,
+                documents: 2,
+                bytes: root_raw.len(),
+            },
+            ..SelectedTextHistory::default()
+        };
+        let tier = HelpTextTier {
+            probe: Arc::new(transcript),
+            selected_text: Mutex::new(selected_text),
+        };
+        let tool = crate::resolve::ResolvedTool {
+            name: "widget".to_string(),
+            path: Some(PathBuf::from("/replayed/widget")),
+            version: None,
+        };
+
+        tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+            .expect("the root fills the configured byte budget exactly");
+        let child = tier
+            .extract_node(
+                &tool,
+                &["widget".to_string(), "child".to_string()],
+                ATTESTED,
+            )
+            .expect("budget exhaustion is a safe degradation, not an error");
+        assert!(child.children_filled);
+        assert!(child.subcommands.is_empty());
+        assert_eq!(
+            child.unparsed.iter().map(Text::as_str).collect::<Vec<_>>(),
+            child_raw.lines().collect::<Vec<_>>()
+        );
+
+        let cache = tier
+            .selected_text
+            .lock()
+            .expect("the selected-help history lock is healthy");
+        assert_eq!(cache.retained_documents, 1);
+        assert_eq!(cache.retained_bytes, root_raw.len());
+    }
+
+    /// Re-extracting a binary's root starts a new extraction generation.
+    /// A descendant recorded for the discarded tree must no longer count
+    /// as an ancestor until that path is probed again in the new tree.
+    #[test]
+    fn root_reextraction_discards_descendant_help_from_the_old_generation() {
+        let root_raw = "Usage: widget COMMAND\n\nCommands:\n  audit   Inspect things\n";
+        let audit_raw =
+            "Usage: widget audit COMMAND\n\nCommands:\n  signatures   Inspect signatures\n";
+        let transcript = crate::exec::Transcript::new([
+            (vec!["--help".to_string()], exec_output(root_raw)),
+            (
+                vec!["audit".to_string(), "--help".to_string()],
+                exec_output(audit_raw),
+            ),
+            (
+                vec![
+                    "audit".to_string(),
+                    "signatures".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(audit_raw),
+            ),
+        ]);
+        let tier = HelpTextTier::new(std::sync::Arc::new(transcript));
+        let tool = crate::resolve::ResolvedTool {
+            name: "widget".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/widget")),
+            version: None,
+        };
+
+        tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+            .expect("the transcript covers the first root probe");
+        tier.extract_node(
+            &tool,
+            &["widget".to_string(), "audit".to_string()],
+            ATTESTED,
+        )
+        .expect("the old generation records audit");
+        tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+            .expect("the transcript covers the refreshed root probe");
+
+        let descendant = tier
+            .extract_node(
+                &tool,
+                &[
+                    "widget".to_string(),
+                    "audit".to_string(),
+                    "signatures".to_string(),
+                ],
+                ATTESTED,
+            )
+            .expect("the transcript covers the descendant probe");
+        assert_eq!(
+            descendant
+                .subcommands
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["signatures"],
+            "discarded-generation ancestor text must not suppress this node"
+        );
+        assert!(descendant.unparsed.is_empty());
+    }
+
+    /// A reset can land while an old background fill is blocked in its
+    /// subprocess. Clearing the map at the new root is insufficient if the
+    /// old fill can insert after that clear; its pre-probe generation token
+    /// must make the late result ineligible for both recording and matching.
+    #[test]
+    fn an_inflight_old_generation_probe_cannot_reinsert_stale_descendant_help() {
+        #[derive(Default)]
+        struct GateState {
+            child_started: bool,
+            release_child: bool,
+        }
+
+        struct BlockingProbe {
+            gate: Arc<(Mutex<GateState>, std::sync::Condvar)>,
+            root: crate::exec::ExecOutput,
+            child: crate::exec::ExecOutput,
+        }
+
+        impl Probe for BlockingProbe {
+            fn run(
+                &self,
+                tool_path: &Path,
+                argv: &InertArgv,
+                _timeout: Duration,
+            ) -> Result<crate::exec::ExecOutput, crate::exec::ExecError> {
+                let args = argv.args();
+                let words: Vec<&str> = args.iter().map(String::as_str).collect();
+                if words == ["audit", "--help"] {
+                    let (lock, wake) = &*self.gate;
+                    let mut state = lock.lock().unwrap_or_else(|error| error.into_inner());
+                    state.child_started = true;
+                    wake.notify_all();
+                    while !state.release_child {
+                        state = wake.wait(state).unwrap_or_else(|error| error.into_inner());
+                    }
+                }
+                match words.as_slice() {
+                    ["--help"] => Ok(self.root.clone()),
+                    ["audit", "--help"] | ["audit", "signatures", "--help"] => {
+                        Ok(self.child.clone())
+                    }
+                    _ => Err(crate::exec::ExecError::TranscriptMiss {
+                        tool: tool_path.display().to_string(),
+                        argv: args,
+                    }),
+                }
+            }
+        }
+
+        let root_raw = "Usage: widget COMMAND\n\nCommands:\n  audit   Inspect things\n";
+        let audit_raw =
+            "Usage: widget audit COMMAND\n\nCommands:\n  signatures   Inspect signatures\n";
+        let gate = Arc::new((Mutex::new(GateState::default()), std::sync::Condvar::new()));
+        let probe = BlockingProbe {
+            gate: Arc::clone(&gate),
+            root: exec_output(root_raw),
+            child: exec_output(audit_raw),
+        };
+        let tier = Arc::new(HelpTextTier::new(Arc::new(probe)));
+        let tool = crate::resolve::ResolvedTool {
+            name: "widget".to_string(),
+            path: Some(std::path::PathBuf::from("/replayed/widget")),
+            version: None,
+        };
+
+        tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+            .expect("the first root probe establishes a generation");
+        std::thread::scope(|scope| {
+            let old_tier = Arc::clone(&tier);
+            let old_tool = tool.clone();
+            let old_fill = scope.spawn(move || {
+                old_tier.extract_node(
+                    &old_tool,
+                    &["widget".to_string(), "audit".to_string()],
+                    ATTESTED,
+                )
+            });
+
+            let (lock, wake) = &*gate;
+            let state = lock.lock().unwrap_or_else(|error| error.into_inner());
+            let (mut state, timeout) = wake
+                .wait_timeout_while(state, Duration::from_secs(5), |state| !state.child_started)
+                .unwrap_or_else(|error| error.into_inner());
+            if timeout.timed_out() {
+                state.release_child = true;
+                wake.notify_all();
+                drop(state);
+                panic!("the old-generation child probe never reached its gate");
+            }
+            drop(state);
+
+            // This is `r`: the fresh root advances and clears the binary's
+            // history while the old child is still in flight.
+            tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
+                .expect("the refreshed root probe succeeds");
+
+            let mut state = lock.lock().unwrap_or_else(|error| error.into_inner());
+            state.release_child = true;
+            wake.notify_all();
+            drop(state);
+            old_fill
+                .join()
+                .expect("the old fill thread must not panic")
+                .expect("the old probe itself still returns normally");
+        });
+
+        let descendant = tier
+            .extract_node(
+                &tool,
+                &[
+                    "widget".to_string(),
+                    "audit".to_string(),
+                    "signatures".to_string(),
+                ],
+                ATTESTED,
+            )
+            .expect("the descendant probe is recorded in the new generation");
+        assert_eq!(
+            descendant
+                .subcommands
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect::<Vec<_>>(),
+            ["signatures"],
+            "the late old-generation audit result must not suppress this node"
         );
     }
 

--- a/mandible-extract/src/help_text/mod.rs
+++ b/mandible-extract/src/help_text/mod.rs
@@ -76,12 +76,13 @@ pub use grammar::looks_like_bracket_flag_row;
 pub use sections::is_option_list_placeholder;
 
 use crate::errors::ExtractError;
-use crate::exec::{ExecOutput, InertArgv, LiveProbe, Probe, MAX_OUTPUT_BYTES};
+use crate::exec::{ExecOutput, InertArgv, LiveProbe, Probe};
 use crate::framework::{self, Framework};
 use crate::resolve::ResolvedTool;
 use crate::tier::{ExtractionTier, NodeHints};
 use mandible_core::{Authority, CommandNode, Confession, Provenance, Source, Text};
 use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -98,17 +99,10 @@ const EXTRACT_TIMEOUT: Duration = Duration::from_secs(10);
 /// and scroll.
 const MAX_UNPARSED_LINES: usize = 4096;
 
-/// Maximum selected-help payload retained solely for ancestor comparison.
-/// One live probe already has this combined stdout/stderr ceiling; keeping
-/// no more than the same amount across the session prevents the auxiliary
-/// history from multiplying that per-probe allowance by the warmer's node
-/// budget. Parsed [`CommandNode`] data is not counted here.
-const MAX_RETAINED_HELP_BYTES: usize = MAX_OUTPUT_BYTES;
-
 /// Maximum number of selected documents — and, independently, resolved
 /// binary histories — held by one tier. Mirrors the background warmer's
 /// 4,096-node safety ceiling without coupling the extractor crate to the
-/// application crate. Bytes usually reach their tighter bound first.
+/// application crate.
 const MAX_RETAINED_HELP_DOCUMENTS: usize = 4096;
 
 /// Tier B: parses `<tool> [<path>...] --help` (falling back to `-h`) via a
@@ -136,13 +130,12 @@ pub struct HelpTextTier {
     selected_text: Mutex<SelectedTextHistory>,
 }
 
-/// All selected-help history owned by one tier. Payload accounting is
+/// All selected-help history owned by one tier. Document accounting is
 /// global so many convention-discovered binaries cannot each claim a full
-/// byte allowance; generations and path maps remain per resolved binary.
+/// document allowance; generations and path maps remain per resolved binary.
 struct SelectedTextHistory {
     by_tool: HashMap<PathBuf, ToolHelpHistory>,
     retained_documents: usize,
-    retained_bytes: usize,
     limits: HelpHistoryLimits,
 }
 
@@ -152,15 +145,34 @@ struct SelectedTextHistory {
 #[derive(Default)]
 struct ToolHelpHistory {
     generation: u64,
-    by_path: HashMap<Vec<String>, Arc<str>>,
-    retained_bytes: usize,
+    by_path: HashMap<Vec<String>, HelpFingerprint>,
+}
+
+/// A selected document's identity for ancestor comparison: a hash of its
+/// bytes plus its length, not the text itself. Two documents match only
+/// when both fields are equal, so the history never has to retain the raw
+/// help text just to compare it later.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct HelpFingerprint {
+    hash: u64,
+    len: usize,
+}
+
+impl HelpFingerprint {
+    fn of(raw: &str) -> Self {
+        let mut hasher = DefaultHasher::new();
+        raw.as_bytes().hash(&mut hasher);
+        Self {
+            hash: hasher.finish(),
+            len: raw.len(),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
 struct HelpHistoryLimits {
     binaries: usize,
     documents: usize,
-    bytes: usize,
 }
 
 impl Default for SelectedTextHistory {
@@ -168,11 +180,9 @@ impl Default for SelectedTextHistory {
         Self {
             by_tool: HashMap::new(),
             retained_documents: 0,
-            retained_bytes: 0,
             limits: HelpHistoryLimits {
                 binaries: MAX_RETAINED_HELP_DOCUMENTS,
                 documents: MAX_RETAINED_HELP_DOCUMENTS,
-                bytes: MAX_RETAINED_HELP_BYTES,
             },
         }
     }
@@ -182,13 +192,11 @@ impl Default for SelectedTextHistory {
 enum HelpProbeGeneration {
     Tracked(u64),
     Untracked,
-    CapacityExhausted,
 }
 
 enum SelectedTextDecision {
     Continue,
     RepeatedAncestor,
-    CapacityExhausted,
 }
 
 impl Default for HelpTextTier {
@@ -219,27 +227,24 @@ impl HelpTextTier {
         if words.is_empty() {
             if !cache.by_tool.contains_key(tool_path) {
                 if cache.by_tool.len() >= cache.limits.binaries {
-                    return HelpProbeGeneration::CapacityExhausted;
+                    return HelpProbeGeneration::Untracked;
                 }
                 cache
                     .by_tool
                     .insert(tool_path.to_path_buf(), ToolHelpHistory::default());
             }
 
-            let (cleared_documents, cleared_bytes, generation) = {
+            let (cleared_documents, generation) = {
                 let history = cache
                     .by_tool
                     .get_mut(tool_path)
                     .expect("the binary history was found or inserted above");
                 let cleared_documents = history.by_path.len();
-                let cleared_bytes = history.retained_bytes;
                 history.generation = history.generation.wrapping_add(1);
                 history.by_path.clear();
-                history.retained_bytes = 0;
-                (cleared_documents, cleared_bytes, history.generation)
+                (cleared_documents, history.generation)
             };
             cache.retained_documents = cache.retained_documents.saturating_sub(cleared_documents);
-            cache.retained_bytes = cache.retained_bytes.saturating_sub(cleared_bytes);
             HelpProbeGeneration::Tracked(generation)
         } else {
             cache
@@ -251,17 +256,16 @@ impl HelpTextTier {
     }
 
     /// Record one selected document if its probe still belongs to the
-    /// current generation, reporting when it is byte-for-byte identical to
-    /// a strict path ancestor for the same resolved binary.
+    /// current generation, reporting when its fingerprint (spec M-19) is
+    /// equal to a strict path ancestor's for the same resolved binary.
     ///
     /// The full path is deliberately excluded from the comparison: a
     /// repeated probe of one node is not evidence of recursion. Unrelated
     /// and sibling paths are excluded by construction, and a root probe's
     /// generation reset prevents stale descendants from crossing refresh.
-    /// A repeated ancestor is never inserted again. Distinct documents are
-    /// admitted only while both the entry and byte budgets have room; on
-    /// exhaustion the caller degrades the current node to a complete
-    /// verbatim leaf, preserving bounded and deterministic behavior.
+    /// A repeated ancestor is never inserted again. When the document cap
+    /// is already full, nothing is recorded and the node still parses
+    /// normally; a full history never forces verbatim degradation.
     fn record_selected_text(
         &self,
         tool_path: &Path,
@@ -272,9 +276,6 @@ impl HelpTextTier {
         let generation = match generation {
             HelpProbeGeneration::Tracked(generation) => generation,
             HelpProbeGeneration::Untracked => return SelectedTextDecision::Continue,
-            HelpProbeGeneration::CapacityExhausted => {
-                return SelectedTextDecision::CapacityExhausted;
-            }
         };
         let Ok(mut cache) = self.selected_text.lock() else {
             return SelectedTextDecision::Continue;
@@ -289,22 +290,18 @@ impl HelpTextTier {
         // A same-generation re-probe replaces this path. Remove its old
         // value before either matching or admission so a changed result can
         // never remain eligible as stale ancestor text.
-        let removed_bytes = {
+        let removed = {
             let history = cache
                 .by_tool
                 .get_mut(tool_path)
                 .expect("the generation check found this binary history");
-            let removed_bytes = history.by_path.remove(words).map(|document| document.len());
-            if let Some(removed_bytes) = removed_bytes {
-                history.retained_bytes = history.retained_bytes.saturating_sub(removed_bytes);
-            }
-            removed_bytes
+            history.by_path.remove(words)
         };
-        if let Some(removed_bytes) = removed_bytes {
+        if removed.is_some() {
             cache.retained_documents = cache.retained_documents.saturating_sub(1);
-            cache.retained_bytes = cache.retained_bytes.saturating_sub(removed_bytes);
         }
 
+        let fingerprint = HelpFingerprint::of(raw);
         let history = cache
             .by_tool
             .get(tool_path)
@@ -313,26 +310,22 @@ impl HelpTextTier {
             history
                 .by_path
                 .get(&words[..prefix_len])
-                .is_some_and(|ancestor| ancestor.as_ref() == raw)
+                .is_some_and(|ancestor| *ancestor == fingerprint)
         });
         if repeats_ancestor {
             return SelectedTextDecision::RepeatedAncestor;
         }
 
-        if cache.retained_documents >= cache.limits.documents
-            || raw.len() > cache.limits.bytes.saturating_sub(cache.retained_bytes)
-        {
-            return SelectedTextDecision::CapacityExhausted;
+        if cache.retained_documents >= cache.limits.documents {
+            return SelectedTextDecision::Continue;
         }
 
         let history = cache
             .by_tool
             .get_mut(tool_path)
             .expect("the generation check found this binary history");
-        history.by_path.insert(words.to_vec(), Arc::from(raw));
-        history.retained_bytes += raw.len();
+        history.by_path.insert(words.to_vec(), fingerprint);
         cache.retained_documents += 1;
-        cache.retained_bytes += raw.len();
         SelectedTextDecision::Continue
     }
 }
@@ -367,15 +360,14 @@ impl ExtractionTier for HelpTextTier {
         let node_name = path.last().cloned().unwrap_or_else(|| tool.name.clone());
 
         // Self-similar fan-out (spec M-19, docs/shapes.md S-079): a node
-        // whose selected help is identical to any strict ancestor for the
-        // same resolved binary and extraction generation degrades to
-        // verbatim with no children. Exact equality is the authority;
-        // neither tool/command names nor unrelated paths participate.
+        // whose selected help fingerprints as identical to any strict
+        // ancestor for the same resolved binary and extraction generation
+        // degrades to verbatim with no children. The history keeps a hash
+        // and a length rather than the text, so an exact-ancestor match is
+        // a hash match; neither tool/command names nor unrelated paths
+        // participate.
         let history_decision = self.record_selected_text(tool_path, &words, generation, &raw);
-        if matches!(
-            history_decision,
-            SelectedTextDecision::RepeatedAncestor | SelectedTextDecision::CapacityExhausted
-        ) {
+        if matches!(history_decision, SelectedTextDecision::RepeatedAncestor) {
             let detected_framework = framework::identify_from_artifact(tool)
                 .or_else(|| framework::identify_from_help_text(&raw))
                 .map(|f| f.name().to_string());
@@ -1771,14 +1763,23 @@ mod tests {
             .lock()
             .expect("the selected-help history lock is healthy");
         assert_eq!(cache.retained_documents, 2);
-        assert_eq!(cache.retained_bytes, root_raw.len() + audit_raw.len());
+        let pnpm_history = &cache
+            .by_tool
+            .get(Path::new("/replayed/pnpm"))
+            .expect("pnpm has one current history")
+            .by_path;
         assert_eq!(
-            cache
-                .by_tool
-                .get(Path::new("/replayed/pnpm"))
-                .expect("pnpm has one current history")
-                .by_path
-                .len(),
+            pnpm_history.get(&Vec::<String>::new()).copied(),
+            Some(HelpFingerprint::of(root_raw)),
+            "the root fingerprint must match a fresh hash of the root text"
+        );
+        assert_eq!(
+            pnpm_history.get(&vec!["audit".to_string()]).copied(),
+            Some(HelpFingerprint::of(audit_raw)),
+            "the audit fingerprint must match a fresh hash of the audit text"
+        );
+        assert_eq!(
+            pnpm_history.len(),
             2,
             "the repeated signatures leaf must not retain a duplicate"
         );
@@ -2071,26 +2072,35 @@ mod tests {
         );
     }
 
-    /// If retaining another distinct document would exceed the bounded
-    /// history payload, extraction fails closed at that node: raw help is
-    /// kept on the node, but no untracked children are allowed to fan out.
+    /// A full document history records nothing more and never degrades a
+    /// node to verbatim: with a cap of one document, the third distinct
+    /// document still parses its own children normally.
     #[test]
-    fn exhausted_help_history_budget_degrades_to_a_complete_verbatim_leaf() {
+    fn a_full_help_history_still_parses_the_next_document() {
         let root_raw = "Usage: widget COMMAND\n\nCommands:\n  child   A real child\n";
         let child_raw =
             "Usage: widget child COMMAND\n\nCommands:\n  nested   A real nested command\n";
+        let nested_raw =
+            "Usage: widget child nested COMMAND\n\nCommands:\n  leaf   A real leaf command\n";
         let transcript = crate::exec::Transcript::new([
             (vec!["--help".to_string()], exec_output(root_raw)),
             (
                 vec!["child".to_string(), "--help".to_string()],
                 exec_output(child_raw),
             ),
+            (
+                vec![
+                    "child".to_string(),
+                    "nested".to_string(),
+                    "--help".to_string(),
+                ],
+                exec_output(nested_raw),
+            ),
         ]);
         let selected_text = SelectedTextHistory {
             limits: HelpHistoryLimits {
                 binaries: 2,
-                documents: 2,
-                bytes: root_raw.len(),
+                documents: 1,
             },
             ..SelectedTextHistory::default()
         };
@@ -2105,27 +2115,35 @@ mod tests {
         };
 
         tier.extract_node(&tool, &["widget".to_string()], ATTESTED)
-            .expect("the root fills the configured byte budget exactly");
-        let child = tier
+            .expect("the root fills the configured document cap exactly");
+        tier.extract_node(
+            &tool,
+            &["widget".to_string(), "child".to_string()],
+            ATTESTED,
+        )
+        .expect("a full history is not an error");
+        let nested = tier
             .extract_node(
                 &tool,
-                &["widget".to_string(), "child".to_string()],
+                &[
+                    "widget".to_string(),
+                    "child".to_string(),
+                    "nested".to_string(),
+                ],
                 ATTESTED,
             )
-            .expect("budget exhaustion is a safe degradation, not an error");
-        assert!(child.children_filled);
-        assert!(child.subcommands.is_empty());
-        assert_eq!(
-            child.unparsed.iter().map(Text::as_str).collect::<Vec<_>>(),
-            child_raw.lines().collect::<Vec<_>>()
+            .expect("a full history is not an error");
+        assert!(
+            !nested.subcommands.is_empty(),
+            "the third document must still parse normally, not degrade to verbatim"
         );
+        assert!(nested.unparsed.is_empty());
 
         let cache = tier
             .selected_text
             .lock()
             .expect("the selected-help history lock is healthy");
         assert_eq!(cache.retained_documents, 1);
-        assert_eq!(cache.retained_bytes, root_raw.len());
     }
 
     /// Re-extracting a binary's root starts a new extraction generation.


### PR DESCRIPTION
## Summary

- extend the existing self-similar help guard from root-only equality to every strict command-path ancestor
- keep repeated help as a complete verbatim leaf instead of exposing the same children again
- scope comparison history by resolved binary and extraction generation
- bound retained comparison history to 4,096 documents / 8 MiB total
- prevent stale in-flight probes from crossing a root refresh

## Evidence

Issue #114 reported an apparently endless:

`audit → signatures → signatures → …`

tree with pnpm 11.22.0 on macOS.

I reproduced the underlying behavior independently on Windows 11 with an isolated pnpm 11.22.0:

- `pnpm --help` → distinct root document
- `pnpm audit --help` → 2,251-byte stdout document
- `pnpm audit signatures --help` → byte-identical to `audit --help`
- `pnpm audit signatures signatures --help` → byte-identical again
- all three exit 0 with empty stderr

The repeated audit document contains a real `Commands:` entry named `signatures`.

Mandible therefore correctly discovers the first `signatures`, probes it, receives its parent's help again, rediscovers `signatures`, and continues warming the same shape.

The existing M-19/S-079 protection only compared descendant help with the root document. Here the root differs, while a non-root ancestor repeats exactly.

## Fix

Selected help is now remembered per resolved binary, command path, and extraction generation.

A node is treated as self-similar only when its selected help is byte-for-byte identical to one of its strict ancestors in that same binary and generation.

Identical siblings, unrelated paths, different resolved binaries, and merely similar documents remain independent.

Repeated documents are not retained again. The auxiliary history is bounded to 4,096 documents and 8 MiB of selected-text payload; if admission is exhausted, the current node conservatively becomes a complete verbatim leaf rather than reopening untracked fan-out.

## Regression coverage

Added production-path Transcript coverage for:

- the pnpm non-root ancestor repetition
- repetition against a non-nearest ancestor
- identical siblings
- separate resolved binaries, including an intervening root probe
- merely similar ancestor output
- root refresh generation reset
- stale concurrent probes finishing after refresh

The original root-identical M-19 regression remains covered.

## Verification

- focused self-similar-help tests: 11/11 pass
- corpus: 123 fixtures, 114 ok, 9 expected xfails, 0 unexpected failures
- workspace suite: 1,539 / 1,542 pass
- remaining 3 failures are the already documented WSL namespace/passwordless-sudo environment limitations
- formatting: pass
- focused Clippy: pass
- `git diff --check`: pass

Closes #114.
