### PR TITLE
extract: read a dash-led paragraph wrap as prose, not a flag row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ once it reaches a published 0.1.0 release.
 
 - `cargo xtask audit contribute` walks a contributor through auditing mandible against their own installed tools — login, a random 20-tool draw excluding anything already audited, review, and a verdict file ready to submit (CONTRIBUTING.md §2).
 
+### Fixed
+
+- `mandible zgrep`/`mandible resolvconf` no longer show fabricated flags mined from a prose sentence that hard-wraps onto a dash-led word at its own paragraph's indent: the wrap now reads as a continuation of the sentence, which is folded into the node description instead.
+
 ## [0.6.1] - 2026-09-01
 
 ### Fixed

--- a/corpus/resolvconf/255.4/expected.snap
+++ b/corpus/resolvconf/255.4/expected.snap
@@ -1,4 +1,5 @@
 name: resolvconf
+description: 'This is a compatibility alias for the resolvectl(1) tool, providing native command line compatibility with the resolvconf(8) tool of various Linux distributions and BSD systems. Some options supported by other implementations are not supported and are ignored: -m, -p, -u. Various options supported by other implementations are not supported and will cause the invocation to fail: -I, -i, -l, -R, -r, -v, -V, --enable-updates, --disable-updates, --updates-are-enabled.'
 usage:
 - resolvconf -a INTERFACE < FILE
 - resolvconf -d INTERFACE
@@ -43,26 +44,6 @@ flags:
 - spellings:
   - -x
   description: Send DNS traffic preferably over this interface
-  provenance:
-    sources:
-    - help-text
-- spellings:
-  - -I
-  - -i
-  - -l
-  - -R
-  - -r
-  - -v
-  - -V
-  - --enable-updates
-  - --disable-updates
-  provenance:
-    sources:
-    - help-text
-- spellings:
-  - --updates-are-enabled
-  value_name: .
-  value_kind: Required
   provenance:
     sources:
     - help-text

--- a/corpus/resolvconf/255.4/meta.toml
+++ b/corpus/resolvconf/255.4/meta.toml
@@ -20,14 +20,14 @@ stdout = "help.txt"
 expected_framework = "generic"
 
 # resolvconf explicitly says these cause the invocation to fail, i.e. it
-# does not support them. Both are fabricated because the sentence naming
-# them wraps mid-list onto a line starting with a dash-led word, and that
-# wrap is read as a new flag row.
+# does not support them. Both were fabricated because the sentence naming
+# them wrapped mid-list onto a line starting with a dash-led word, read as
+# a new flag row until docs/shapes.md S-027 fixed it.
 must_not_contain_flags = ["-I", "--enable-updates"]
 
-[xfail]
-broken = true
-reason = "the sentence 'Various options ... will cause the invocation to fail:' wraps onto a line starting with '-I, -i, -l, -R, -r, -v, -V, --enable-updates, ...', a dash-led word, and that wrap is read as the start of a new row instead of a continuation of the previous line, fabricating -I and --enable-updates as real resolvconf flags. The C3 whitespace-continuation rules do not reach this shape."
+# The real option table, so containment of the wrapped-prose paragraph can
+# never be bought by losing the rows above it.
+must_contain_flags = ["--help", "--version", "-a", "-d", "-f", "-x"]
 
 # Maintainer, checking this build by hand: "similar single line flags
 # getting detected as aliases", verdict wrong. Machine classification:

--- a/corpus/zgrep/1.12/expected.snap
+++ b/corpus/zgrep/1.12/expected.snap
@@ -1,5 +1,5 @@
 name: zgrep
-description: Look for instances of PATTERN in the input FILEs, using their uncompressed contents if they are compressed.
+description: 'Look for instances of PATTERN in the input FILEs, using their uncompressed contents if they are compressed. OPTIONs are the same as for ''grep'', except that the following ''grep'' options are not supported: --dereference-recursive (-R), --directories (-d), --exclude, --exclude-from, --exclude-dir, --include, --null (-Z), --null-data (-z), and --recursive (-r).'
 usage:
 - 'Usage: /usr/bin/zgrep [OPTION]... [-e] PATTERN [FILE]...'
 positionals:
@@ -14,24 +14,6 @@ positionals:
     sources:
     - help-text
 flags:
-- spellings:
-  - --exclude
-  - --exclude-from
-  - --exclude-dir
-  - --include
-  - --null
-  value_name: (-Z),
-  value_kind: Required
-  provenance:
-    sources:
-    - help-text
-- spellings:
-  - --null-data
-  value_name: (-z),
-  value_kind: Required
-  provenance:
-    sources:
-    - help-text
 - spellings:
   - -e
   provenance:

--- a/corpus/zgrep/1.12/meta.toml
+++ b/corpus/zgrep/1.12/meta.toml
@@ -19,14 +19,10 @@ stdout = "help.txt"
 [contract]
 expected_framework = "generic"
 
-# zgrep has neither flag. Both are fabricated because the sentence listing
-# unsupported grep options wraps mid-list onto a line starting with a
-# dash-led word, and that wrap is read as a new flag row.
+# zgrep has neither flag. Both were fabricated because the sentence listing
+# unsupported grep options wrapped mid-list onto a line starting with a
+# dash-led word, read as a new flag row until docs/shapes.md S-027 fixed it.
 must_not_contain_flags = ["--exclude", "--null-data"]
-
-[xfail]
-broken = true
-reason = "the sentence listing unsupported grep options wraps onto a line starting with '--null-data (-z), and --recursive (-r).', a dash-led word, and that wrap is read as the start of a new row instead of a continuation of the previous line, fabricating --exclude and --null-data as real zgrep flags. The C3 whitespace-continuation rules do not reach this shape."
 
 # Maintainer, checking this build by hand: "positionals part is fine, but
 # the same bad parse we encountered earlier where all flags are on the same

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -487,11 +487,13 @@ entry's `tools` field and nothing else. It does not get a new entry.
       -e, --control, -x, --extract, -f, --field,
       ... on archives (type dpkg-deb --help).
 - tools: zgrep, resolvconf, jpackage, dpkg
-- handling: A description that wraps onto a line starting with a dash-led word is read
-  as the next flag row. The C3 whitespace-continuation rules do not reach this
-  case. dpkg's own cross-reference sentence is contained by the
-  wrapped-prose-region remedy (S-011); zgrep, resolvconf and jpackage remain
-  open.
+- handling: A dash-led line at its paragraph's own indent now reads as prose, not a
+  flag row, when the previous physical line is non-blank, not sentence-final,
+  and prose, and the candidate carries no description column. The rule
+  cascades, so a comma list wrapping across several dash-led lines reads as
+  one continuation. dpkg's hanging-indent wrap stays on the separate S-011
+  remedy. The recovered paragraph is appended to the node description so the
+  sentence still reaches the tree.
 - fleet: detector fires on 21 tools, 26 flags, over a 2318-tool sweep,
   2026-09-03. Quotable as calibrated: zgrep and resolvconf now carry human
   verdicts, the detector fires on both, and it stays silent on all 39

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -252,16 +252,32 @@ pub(super) fn wrapped_prose_region_end(lines: &[&str], head: usize) -> Option<us
     (end > head + 1).then_some(end)
 }
 
+/// True when `line`'s [`find_multi_space_gap`] is real column alignment,
+/// not two spaces after a full stop — ordinary sentence spacing some help
+/// text still uses (coreutils `nice`'s `... current niceness.  Niceness
+/// values range from`). A gap immediately after `.`/`!`/`?` is sentence
+/// spacing; anything else (jinfo's gap after `>`, nvim's gap after `>`) is
+/// a genuine column.
+fn has_description_column(line: &str) -> bool {
+    let Some(col) = find_multi_space_gap(line) else {
+        return false;
+    };
+    !line
+        .get(..col)
+        .and_then(|s| s.trim_end().chars().next_back())
+        .is_some_and(|c| matches!(c, '.' | '!' | '?'))
+}
+
 /// True when `lines[idx]` is a dash-led line continuing the prose above it,
-/// not opening a new flag row (atlas S-027). Same-indent counterpart of
-/// [`wrapped_prose_region_end`]. Gates: prev non-blank, not sentence-final,
-/// prose (cascades: an already-accepted predecessor counts as prose too)
-/// and past [`MIN_PROSE_SENTENCE_WORDS`] when not itself dash-led (tar's
-/// four-word `*This* tar defaults to:` opens real rows, not a wrap), prev
-/// and cur both carry no description column (jinfo's, nvim's real rows),
-/// same indent, and cur is not itself a self-described row — see
-/// [`super::flag_rows::entry_row_carries_own_description`] (e2scrub's
-/// colon-separated `-n: Show ...`).
+/// not a new flag row (atlas S-027). Gates: prev non-blank, not
+/// sentence-final, not bracketed usage/synopsis grammar (memhog's `memhog
+/// [-fFILE] [-rNUM] [-H] size[kmg] ...` reads 7 "words" by count alone),
+/// prose (cascades) and past [`MIN_PROSE_SENTENCE_WORDS`] when not itself
+/// dash-led (tar's `*This* tar defaults to:`), prev has no
+/// [`has_description_column`] (jinfo's, nvim's real rows), cur has no
+/// [`find_multi_space_gap`], same indent as prev, and cur does not already
+/// self-describe — [`super::flag_rows::entry_row_carries_own_description`]
+/// (e2scrub's colon-separated `-n: Show ...`).
 pub(super) fn is_wrapped_prose_continuation(lines: &[&str], idx: usize) -> bool {
     if idx == 0 {
         return false;
@@ -278,7 +294,10 @@ pub(super) fn is_wrapped_prose_continuation(lines: &[&str], idx: usize) -> bool 
     if prev.trim_end().ends_with(['.', '!', '?']) {
         return false;
     }
-    if find_multi_space_gap(prev).is_some() {
+    if prev.contains(['[', ']']) {
+        return false;
+    }
+    if has_description_column(prev) {
         return false;
     }
     if find_multi_space_gap(cur).is_some() {

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -267,23 +267,26 @@ pub(super) fn is_wrapped_prose_continuation(lines: &[&str], idx: usize) -> bool 
     }
     let cur = lines[idx];
     let prev = lines[idx - 1];
+    // Cheap, non-recursive gates first: most candidates fail one of these
+    // (a real option row's own description column, most of all), so the
+    // recursive cascade below only ever runs on a line that already cleared
+    // every gate that doesn't need it. See AGENTS.md §3.11.
     if prev.trim().is_empty() {
         return false;
     }
     if prev.trim_end().ends_with(['.', '!', '?']) {
         return false;
     }
-    if prev.trim_start().starts_with('-') {
-        if !is_wrapped_prose_continuation(lines, idx - 1) {
-            return false;
-        }
-    } else if prev.split_whitespace().count() < MIN_PROSE_SENTENCE_WORDS {
-        return false;
-    }
     if find_multi_space_gap(cur).is_some() {
         return false;
     }
-    leading_whitespace(cur) == leading_whitespace(prev)
+    if leading_whitespace(cur) != leading_whitespace(prev) {
+        return false;
+    }
+    if prev.trim_start().starts_with('-') {
+        return is_wrapped_prose_continuation(lines, idx - 1);
+    }
+    prev.split_whitespace().count() >= MIN_PROSE_SENTENCE_WORDS
 }
 
 /// The full prose paragraph a rescued wrapped-prose continuation at

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -252,15 +252,16 @@ pub(super) fn wrapped_prose_region_end(lines: &[&str], head: usize) -> Option<us
     (end > head + 1).then_some(end)
 }
 
-/// True when `lines[idx]` is a dash-led line continuing the prose above it
-/// rather than opening a new flag row (atlas S-027,
-/// `corpus/zgrep/1.12`, `corpus/resolvconf/255.4`). Same-indent counterpart
-/// of [`wrapped_prose_region_end`]. Gates: prev line non-blank, not
-/// sentence-final, prose (cascades — a predecessor this rule already
-/// accepted counts as prose too) and at least [`MIN_PROSE_SENTENCE_WORDS`]
-/// long when not itself dash-led (tar's four-word `*This* tar defaults to:`
-/// introduces real flag rows, not a wrap), cur has no description column,
-/// cur's indent equals prev's.
+/// True when `lines[idx]` is a dash-led line continuing the prose above it,
+/// not opening a new flag row (atlas S-027). Same-indent counterpart of
+/// [`wrapped_prose_region_end`]. Gates: prev non-blank, not sentence-final,
+/// prose (cascades: an already-accepted predecessor counts as prose too)
+/// and past [`MIN_PROSE_SENTENCE_WORDS`] when not itself dash-led (tar's
+/// four-word `*This* tar defaults to:` opens real rows, not a wrap), prev
+/// and cur both carry no description column (jinfo's, nvim's real rows),
+/// same indent, and cur is not itself a self-described row — see
+/// [`super::flag_rows::entry_row_carries_own_description`] (e2scrub's
+/// colon-separated `-n: Show ...`).
 pub(super) fn is_wrapped_prose_continuation(lines: &[&str], idx: usize) -> bool {
     if idx == 0 {
         return false;
@@ -277,10 +278,16 @@ pub(super) fn is_wrapped_prose_continuation(lines: &[&str], idx: usize) -> bool 
     if prev.trim_end().ends_with(['.', '!', '?']) {
         return false;
     }
+    if find_multi_space_gap(prev).is_some() {
+        return false;
+    }
     if find_multi_space_gap(cur).is_some() {
         return false;
     }
     if leading_whitespace(cur) != leading_whitespace(prev) {
+        return false;
+    }
+    if super::flag_rows::entry_row_carries_own_description(cur) {
         return false;
     }
     if prev.trim_start().starts_with('-') {

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -252,6 +252,72 @@ pub(super) fn wrapped_prose_region_end(lines: &[&str], head: usize) -> Option<us
     (end > head + 1).then_some(end)
 }
 
+/// True when `lines[idx]` is a dash-led line continuing the prose above it
+/// rather than opening a new flag row (atlas S-027,
+/// `corpus/zgrep/1.12`, `corpus/resolvconf/255.4`). Same-indent counterpart
+/// of [`wrapped_prose_region_end`]. Gates: prev line non-blank, not
+/// sentence-final, prose (cascades — a predecessor this rule already
+/// accepted counts as prose too) and at least [`MIN_PROSE_SENTENCE_WORDS`]
+/// long when not itself dash-led (tar's four-word `*This* tar defaults to:`
+/// introduces real flag rows, not a wrap), cur has no description column,
+/// cur's indent equals prev's.
+pub(super) fn is_wrapped_prose_continuation(lines: &[&str], idx: usize) -> bool {
+    if idx == 0 {
+        return false;
+    }
+    let cur = lines[idx];
+    let prev = lines[idx - 1];
+    if prev.trim().is_empty() {
+        return false;
+    }
+    if prev.trim_end().ends_with(['.', '!', '?']) {
+        return false;
+    }
+    if prev.trim_start().starts_with('-') {
+        if !is_wrapped_prose_continuation(lines, idx - 1) {
+            return false;
+        }
+    } else if prev.split_whitespace().count() < MIN_PROSE_SENTENCE_WORDS {
+        return false;
+    }
+    if find_multi_space_gap(cur).is_some() {
+        return false;
+    }
+    leading_whitespace(cur) == leading_whitespace(prev)
+}
+
+/// The full prose paragraph a rescued wrapped-prose continuation at
+/// `flag_line_idx` belongs to (S-027): back to the blank line above it (or
+/// the document start), forward through every line
+/// [`is_wrapped_prose_continuation`] still accepts, up to the next blank
+/// line. Returns the index just past the paragraph and its text, physical
+/// lines trimmed and joined by single spaces — so the sentence the
+/// fabricated flags were mined from still reaches the description instead
+/// of vanishing with them (AGENTS.md §3.9).
+pub(super) fn wrapped_prose_paragraph(lines: &[&str], flag_line_idx: usize) -> (usize, String) {
+    let mut start = flag_line_idx;
+    while start > 0 && !lines[start - 1].trim().is_empty() {
+        start -= 1;
+    }
+    let mut end = flag_line_idx + 1;
+    while end < lines.len() {
+        let line = lines[end];
+        if line.trim().is_empty() {
+            break;
+        }
+        if looks_like_flag_start(line.trim_start()) && !is_wrapped_prose_continuation(lines, end) {
+            break;
+        }
+        end += 1;
+    }
+    let text = lines[start..end]
+        .iter()
+        .map(|l| l.trim())
+        .collect::<Vec<_>>()
+        .join(" ");
+    (end, text)
+}
+
 /// True when `heading` may open the obscured-marker whole-region fence
 /// (`obscured_ignorable_indent`). [`is_ignorable_heading`] alone is too
 /// loose for a whole-region trigger: a mid-document `Report bugs to

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -1246,6 +1246,21 @@ fn scan_entries(
         // current line already looks like a flag entry, so it is scanned
         // in place. See S-052.
         if looks_like_flag_start(line.trim_start()) {
+            // Not a new row at all: a hard-wrapped prose sentence landed on
+            // a dash-led word at its paragraph's own indent (zgrep's
+            // excluded-options list, resolvconf's unsupported-options
+            // list). The whole paragraph is recovered into the
+            // description instead of being mined as fabricated flags. See
+            // docs/shapes.md S-027.
+            if is_wrapped_prose_continuation(lines, i) {
+                let (end, text) = wrapped_prose_paragraph(lines, i);
+                st.result.description = Some(match st.result.description.take() {
+                    Some(d) => format!("{d} {text}"),
+                    None => text,
+                });
+                i = end;
+                continue;
+            }
             // The row may still be one `split_shared_heading_rows`
             // recovered from a `:=` production the engine never
             // revisited as a heading — dcb and vdpa's `OPTIONS` row.


### PR DESCRIPTION
`mandible zgrep` and `mandible resolvconf` no longer show flags mined from a prose sentence that hard-wraps onto a dash-led word at its own paragraph indent. The wrap reads as a continuation now, and the recovered sentence is folded into the node description, so every word the tool printed still reaches the reader.

Both fixtures move from `[xfail]` to passing. `resolvconf` also gains `must_contain_flags` over its real option table, so containment of the paragraph can never be bought by losing the rows above it.

### Measurement

A full-PATH sweep before and after: 2264 tools, 2264 matched, 0 appeared, 0 disappeared, 19 excluded near the 10s cap. No tool gained a flag. 16 flags went across 12 tools, and each one was checked against that tool's captured bytes and confirmed fabricated:

| tools | what went |
|---|---|
| `resolvconf`, `zgrep`, `zegrep`, `zfgrep` | the target shape, 8 flags mined from the two unsupported-options sentences |
| `sg_luns`, `sg_stream_ctl`, `sg_zone` | a bare descriptionless synopsis duplicate of a row that survives byte-identical |
| `grub-mkrescue` | `-a`, mined from the prose line ``-as mkisofs -help'.`` |
| `nice` | `-2`, mined from the prose "-20 (most favorable...)" |
| `jshell`, `rst-buildhtml`, `rstpep2html` | a fabricated duplicate entity sharing the real entity's spelling |

`ntfssecaudit`, `pdb3` and `pdb3.12` move from low-confidence to ok.

Four regressions were found during review and fixed before this branch was accepted: `jinfo`, `nvim`, `e2scrub` and `memhog` all left the loss list again. The three later commits are those fixes.

### See it yourself

```console
$ cargo build --release
$ ./target/release/mandible zgrep
$ ./target/release/mandible resolvconf
$ cargo run -p xtask -- corpus --show zgrep/1.12
$ cargo run -p xtask -- corpus --show resolvconf/255.4
```

`zgrep` shows one flag, `-e`, and its node description now carries the whole unsupported-options sentence. Before this change it showed `--exclude/--exclude-from/--exclude-dir/--include/--null` with value name `(-Z),` and `--null-data` with value name `(-z),`. `resolvconf` shows its six real flags and drops the nine-spelling `-I/-i/-l/...` entity and `--updates-are-enabled`.
