### PR TITLE
extract: recognize the glued repetition marker in usage synopses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ once it reaches a published 0.1.0 release.
 ### Fixed
 
 - `mandible zgrep`/`mandible resolvconf` no longer show fabricated flags mined from a prose sentence that hard-wraps onto a dash-led word at its own paragraph's indent: the wrap now reads as a continuation of the sentence, which is folded into the node description instead.
+- A usage-line operand written with the repetition dots glued to its name (`[file...]`, `file...`) now reaches the tree repeatable, matching the same operand written with a space before the dots (docs/shapes.md S-101).
 
 ## [0.6.1] - 2026-09-01
 

--- a/corpus/aarch64-linux-gnu-dwp/2.42/expected.snap
+++ b/corpus/aarch64-linux-gnu-dwp/2.42/expected.snap
@@ -1,0 +1,60 @@
+name: aarch64-linux-gnu-dwp
+usage:
+- 'Usage: aarch64-linux-gnu-dwp [options] [file...]'
+positionals:
+- name: file
+  variadic: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -h
+  - --help
+  description: Print this help message
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -e
+  - --exec
+  value_name: EXE
+  value_kind: Required
+  description: Get list of dwo files from EXE (defaults output to EXE.dwp)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  - --output
+  value_name: FILE
+  value_kind: Required
+  description: Set output dwp file name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -v
+  - --verbose
+  description: Verbose output
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --verify-only
+  description: Verify output file against exec file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --version
+  description: Print version number
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/aarch64-linux-gnu-dwp/2.42/meta.toml
+++ b/corpus/aarch64-linux-gnu-dwp/2.42/meta.toml
@@ -24,13 +24,5 @@ stdout = "help.txt"
 [contract]
 expected_framework = "generic"
 
-# The name half already passes. The `...` suffix is the half that fails:
-# the operand reaches the tree as `file` and is not repeatable.
+# The operand reaches the tree named `file` and repeatable. See S-101.
 must_contain_positionals = ["file..."]
-
-[xfail]
-broken = true
-reason = "the usage line writes its operand as `[file...]`, with the repetition dots glued to the name and no space between them. The operand reaches the tree named `file` and not repeatable, so the marker the tool printed is rendered nowhere. The same line written `[file ...]` parses repeatable, which is what `bc` does."
-
-# Fleet count: none. No detector models this shape yet, so the count is
-# unmeasured rather than zero.

--- a/corpus/pastebinit/1.6.2/expected.snap
+++ b/corpus/pastebinit/1.6.2/expected.snap
@@ -9,6 +9,7 @@ usage:
 - 'Usage:  pastebinit [OPTION...] [FILE...]'
 positionals:
 - name: FILE
+  variadic: true
   provenance:
     sources:
     - help-text

--- a/corpus/pastebinit/audit-seed2/expected.snap
+++ b/corpus/pastebinit/audit-seed2/expected.snap
@@ -9,6 +9,7 @@ usage:
 - 'Usage:  pastebinit [OPTION...] [FILE...]'
 positionals:
 - name: FILE
+  variadic: true
   provenance:
     sources:
     - help-text

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1644,13 +1644,12 @@ entry's `tools` field and nothing else. It does not get a new entry.
       Usage: aarch64-linux-gnu-dwp [options] [file...]
       usage: bc [options] [file ...]
 - tools: aarch64-linux-gnu-dwp, dwp, demandoc, lsattr, lsinitramfs
-- handling: An operand written with the repetition dots attached to its name loses the
-  marker. The operand reaches the tree named `file` and not repeatable. The
-  same operand written with a space before the dots comes out repeatable,
-  which is what the second line above does. Open defect, recorded by
-  `corpus/aarch64-linux-gnu-dwp/2.42`.
-- fleet: no detector. Five tools checked by hand and all five lose the marker,
-  2026-09-03. The two control tools written with a space keep it.
+- handling: A shared predicate marks an operand repeatable when it ends in two or
+  more dots after trimming a trailing `]` or `)`. It backs both the main
+  positional loop and the tail-operand recovery path. The operand reaches the
+  tree named `file` and repeatable, matching `corpus/aarch64-linux-gnu-dwp/2.42`.
+- fleet: 11 tools gained the marker in a direct before/after diff over captured bytes,
+  2026-09-03. Zero tools changed any other way and zero of 38 checked controls moved.
 
 ### S-102: one spelling documented on two rows, folded before display
 

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -281,6 +281,17 @@ pub(super) fn primary_synopsis_lines(
         .collect()
 }
 
+/// A trailing run of two or more dots marks a synopsis token repeatable:
+/// `[FILE...]` and `FILE...` both count, since the marker sits inside a
+/// closing bracket exactly as often as outside one. A lone trailing dot is
+/// ordinary sentence punctuation, never a marker, so the minimum is two. See
+/// S-101 and both call sites, [`extract_positionals`] and
+/// [`recover_primary_tail_operand`].
+fn token_marks_repetition(token: &str) -> bool {
+    let trimmed = token.trim_end_matches(|c| c == ']' || c == ')');
+    trimmed.len() - trimmed.trim_end_matches('.').len() >= 2
+}
+
 /// `usage_lines`: every physical line of the recovered usage block, in
 /// source order. `primary_lines`: [`primary_synopsis_lines`]'s pick of
 /// which of them (by index) make up the tool's primary invocation form —
@@ -335,11 +346,11 @@ pub(super) fn extract_positionals(
                 // yield `name`, not `name>=<value` from stripping only the
                 // token's very last `>`.
                 match stripped.find('>') {
-                    Some(end) => (stripped[..end].to_string(), token.ends_with("...")),
+                    Some(end) => (stripped[..end].to_string(), token_marks_repetition(token)),
                     None => continue,
                 }
             } else if cleaned.chars().all(|c| c.is_uppercase() || c == '_') && cleaned.len() > 1 {
-                (cleaned.to_string(), token.ends_with("..."))
+                (cleaned.to_string(), token_marks_repetition(token))
             } else {
                 continue;
             };
@@ -488,8 +499,13 @@ fn recover_primary_tail_operand(
     }
     let last = groups.last()?;
     let stripped = last.trim_matches(|c| c == '[' || c == ']');
-    let word = stripped.split_whitespace().next()?;
-    let word = word.trim_end_matches('.');
+    let raw_word = stripped.split_whitespace().next()?;
+    // A dots-glued word (`file...`) marks repetition itself, same as the
+    // separate trailing ellipsis-only group handled above. See S-101.
+    if token_marks_repetition(raw_word) {
+        repeatable = true;
+    }
+    let word = raw_word.trim_end_matches('.');
     if word.is_empty() || word.starts_with('-') || is_option_list_placeholder(word) {
         return None;
     }
@@ -2586,5 +2602,83 @@ mod tests {
     fn a_wrapped_multi_line_primary_entry_gains_no_tail_positional() {
         let parsed = parse("Usage: widget [-a] [-b] \\\n              tail\n");
         assert!(parsed.positionals.is_empty(), "{:?}", parsed.positionals);
+    }
+
+    // --- S-101: the glued repetition marker ---
+
+    /// `token_marks_repetition` itself, the shared predicate used at both
+    /// call sites ([`extract_positionals`] and
+    /// [`recover_primary_tail_operand`]).
+    #[test]
+    fn token_marks_repetition_predicate() {
+        // Glued dots behind a closing bracket: dwp's own shape.
+        assert!(token_marks_repetition("[file...]"));
+        assert!(token_marks_repetition("[FILE...]"));
+        // Glued dots with no bracket at all: lsinitramfs's own shape.
+        assert!(token_marks_repetition("initramfs-file..."));
+        // Spaced dots (a separate token, existing behaviour elsewhere) do
+        // not themselves end in a dot run once isolated.
+        assert!(!token_marks_repetition("file"));
+        // A single trailing dot is ordinary sentence punctuation, never a
+        // marker.
+        assert!(!token_marks_repetition("file."));
+        assert!(!token_marks_repetition("[file.]"));
+        // No trailing dots at all.
+        assert!(!token_marks_repetition("[file]"));
+    }
+
+    /// dwp's own bytes (atlas S-101, `corpus/aarch64-linux-gnu-dwp/2.42`):
+    /// the repetition dots are glued to the operand name, inside the
+    /// closing bracket, and must still mark it repeatable.
+    #[test]
+    fn glued_dots_after_a_bracket_mark_repetition() {
+        let parsed = parse("Usage: aarch64-linux-gnu-dwp [options] [file...]\n");
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["file"], "{names:?}");
+        assert!(parsed.positionals[0].repeatable);
+    }
+
+    /// lsinitramfs's own bytes: glued dots with no bracket at all.
+    #[test]
+    fn glued_dots_with_no_bracket_mark_repetition() {
+        let parsed = parse("Usage: lsinitramfs [-l] initramfs-file...\n");
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["initramfs-file"], "{names:?}");
+        assert!(parsed.positionals[0].repeatable);
+    }
+
+    /// A single trailing dot on the tail operand must never be read as the
+    /// repetition marker: it is ordinary sentence punctuation.
+    #[test]
+    fn a_single_trailing_dot_does_not_mark_repetition() {
+        let parsed = parse("Usage: widget [-a] file.\n");
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["file"], "{names:?}");
+        assert!(!parsed.positionals[0].repeatable);
+    }
+
+    /// `[OPTION...]` is an option-list placeholder, not an operand, glued
+    /// dots or not: it must never become a positional at all.
+    #[test]
+    fn an_option_list_placeholder_with_glued_dots_is_never_a_positional() {
+        let parsed = parse("Usage: widget [OPTION...] FILE\n");
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["FILE"], "{names:?}");
     }
 }

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -288,7 +288,7 @@ pub(super) fn primary_synopsis_lines(
 /// S-101 and both call sites, [`extract_positionals`] and
 /// [`recover_primary_tail_operand`].
 fn token_marks_repetition(token: &str) -> bool {
-    let trimmed = token.trim_end_matches(|c| c == ']' || c == ')');
+    let trimmed = token.trim_end_matches([']', ')']);
     trimmed.len() - trimmed.trim_end_matches('.').len() >= 2
 }
 


### PR DESCRIPTION
A usage-line operand written with the repetition dots glued to its name (`[file...]`) now reaches the tree repeatable, matching what the parser already did for the spaced spelling (`[file ...]`). One shared predicate backs both the main positional loop and the tail-operand recovery path, so the two entry points cannot disagree about the same operand.

`aarch64-linux-gnu-dwp` moves from `[xfail]` to passing. `pastebinit`'s two snapshots each gain exactly one `variadic: true` line and nothing else.

### Measurement

`xtask sweep-diff` is structurally unable to see this change. `FlagFingerprint` records `has_description`, `description_hash`, `choices_hash` and `value_name`, and `xtask/src/coverage/fingerprint.rs` carries no repeatability field at all, so a repeatability fix reports zero gains and zero losses whatever it does.

It was measured by replaying frozen captures through both parsers, which spawns no subprocess. The scratch corpus holds 242 fixtures: 200 tools whose captured usage line carries a glued-dots operand, and 42 controls written with a space before the dots. 11 tools gained the marker, 0 tools changed in any other way, and 0 controls moved. Every gain was checked against that tool's own usage line:

| tool | operand | usage line |
|---|---|---|
| `aarch64-linux-gnu-dwp` | `file` | `Usage: /usr/bin/aarch64-linux-gnu-dwp [options] [file...]` |
| `catman` | `SECTION` | `Usage: catman [OPTION...] [SECTION...]` |
| `demandoc` | `files` | `usage: demandoc [-w] [files...]` |
| `iconv` | `FILE` | `Usage: iconv [OPTION...] [FILE...]` |
| `iconvconfig` | `DIR` | `Usage: iconvconfig [OPTION...] [DIR...]` |
| `jq` | `JSON_TEXTS` | `Usage: /usr/bin/jq [options] --jsonargs <jq filter> [JSON_TEXTS...]` |
| `lsattr` | `files` | `Usage: /usr/bin/lsattr [-RVadlpv] [files...]` |
| `lsinitramfs` | `initramfs-file` | `Usage: lsinitramfs [-l] initramfs-file...` |
| `mokutil` | `ARGS` | `Usage: mokutil OPTIONS [ARGS...]` |
| `nsenter` | `argument` | `Usage: nsenter [options] [<program> [<argument>...]]` |
| `pastebinit` | `FILE` | `Usage: pastebinit [OPTION...] [FILE...]` |

### See it yourself

```console
$ cargo build --release
$ ./target/release/mandible aarch64-linux-gnu-dwp
$ ./target/release/mandible pastebinit
$ cargo run -p xtask -- corpus --show aarch64-linux-gnu-dwp/2.42
```

Both tools show their operand as `file...` and `FILE...` under `POSITIONALS`. Before this change each showed a bare `file` and `FILE`, losing the marker the tool printed.
