### PR TITLE
Soft-wrap the detail pane's USAGE section at the pane width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ once it reaches a published 0.1.0 release.
 
 - `mandible zgrep`/`mandible resolvconf` no longer show fabricated flags mined from a prose sentence that hard-wraps onto a dash-led word at its own paragraph's indent: the wrap now reads as a continuation of the sentence, which is folded into the node description instead.
 - A usage-line operand written with the repetition dots glued to its name (`[file...]`, `file...`) now reaches the tree repeatable, matching the same operand written with a space before the dots (docs/shapes.md S-101).
+- The detail pane's USAGE section soft-wraps at the pane width instead of forcing horizontal scroll (`mandible sg_luns`, `mandible tar`); the raw `--help` view still scrolls.
 
 ## [0.6.1] - 2026-09-01
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1578,21 +1578,27 @@ pane.
    top-left; a remembered position clamps to the extent the view has when
    restored; changing the selected node clears both views' memory.
 9. Preformatted content scrolls horizontally instead of wrapping; prose
-   does not. The raw `--help` view (`t`) and a node's USAGE synopsis lines
-   are the tool author's own layout. `h`/`l`/`←`/`→` scroll that content
-   when the detail pane has focus, clamped to the widest line, with a
-   marker in the border when more content sits off that edge. The summary,
-   description, and flag list keep wrapping to pane width as everywhere
-   else. Governed by `[ui] horizontal_scroll` in
-   `~/.config/mandible/config.toml`, default `true`.
-10. `horizontal_scroll = false` wraps every view; it never clips. A
-    preformatted line wider than the pane continues onto the next row
-    instead of ending at the border, in the raw view and the `unparsed`
-    fallback included, without being reflowed: a fitting line arrives byte
-    for byte, a row keeps its internal spacing, the cut prefers a
-    whitespace boundary and falls back to a character boundary only when a
-    token has none, and a continuation row carries the line's own leading
-    indent.
+   does not. The raw `--help` view (`t`) and the `unparsed` fallback are
+   the tool author's own layout, so they scroll. `h`/`l`/`←`/`→` scroll
+   that content when the detail pane has focus, clamped to the widest
+   line, with a marker in the border when more content sits off that
+   edge. A node's USAGE synopsis soft-wraps at the pane width instead of
+   scrolling. The parser already joins a usage that wrapped over several
+   physical lines into one logical line, so a rendered USAGE line is
+   mandible's own reconstruction, not the tool author's own layout (§16).
+   USAGE, the summary, description, and flag list all keep wrapping to
+   pane width. `[ui] horizontal_scroll` in
+   `~/.config/mandible/config.toml`, default `true`, governs only the raw
+   view and the `unparsed` fallback.
+10. `horizontal_scroll = false` wraps the raw view and the `unparsed`
+    fallback; it never clips. A preformatted line wider than the pane
+    continues onto the next row instead of ending at the border, without
+    being reflowed: a fitting line arrives byte for byte, a row keeps its
+    internal spacing, the cut prefers a whitespace boundary and falls back
+    to a character boundary only when a token has none, and a continuation
+    row carries the line's own leading indent. USAGE wraps at every
+    setting of this toggle already, under rule 9's own word-wrap instead
+    of this mechanism.
 11. Empty and degraded states are designed, not incidental. A node whose
     children are still being extracted shows a subtle spinner row; a tool
     where only Tier B fired shows the confidence in the footer; a tool no
@@ -1609,8 +1615,10 @@ so a `char`-count truncation overflows the border by one cell per wide
 character. Mandible's own layout and the tool's own raw text place the
 same flag at unrelated coordinates, which is why the parsed and raw views
 never share scroll state. Wrapping preformatted content reflows spacing
-that was part of its meaning, since the raw view and USAGE lines are the
-tool author's own layout.
+that was part of its meaning, since the raw view is the tool author's own
+layout. A rendered USAGE line is not: the parser already joined a usage
+that wrapped over several physical lines into one logical line, so it is
+mandible's own reconstruction and soft-wraps instead (§16).
 
 **Implemented in.** `mandible-tui/src/render/mod.rs`,
 `mandible-tui/src/sanitize.rs`, `mandible-tui/src/tree.rs`.
@@ -1864,12 +1872,13 @@ sections.
       rendering its label alone at column 0 directly beneath the header.
       A divider later in the same section keeps both.
 15. Descriptions always wrap. Sections are mandible's own layout, so
-    nothing in them is ever clipped or horizontally scrolled; `[ui]
-    horizontal_scroll` governs only content whose layout is not ours (the
-    raw view, verbatim USAGE synopsis lines, the `unparsed` fallback,
-    which reaches the pane by the same path as the raw view). A
-    description's preserved line breaks (§4.1) wrap too, each logical
-    line wrapped on its own at its own indent.
+    nothing in them is ever clipped or horizontally scrolled. USAGE is
+    mandible's own reconstruction too (§9 rule 9) and wraps the same way.
+    `[ui] horizontal_scroll` governs only content whose layout is not ours
+    (the raw view, the `unparsed` fallback, which reaches the pane by the
+    same path as the raw view). A description's preserved line breaks
+    (§4.1) wrap too, each logical line wrapped on its own at its own
+    indent.
 
 **Why.** A label in a different shade or weight from the line running out
 of it reads as two unrelated marks sharing a row, which is why a group
@@ -2690,6 +2699,20 @@ only as a zero-confidence fallback, which never touches a tool that already
 parsed. [M-14]'s reading wins. A tool whose only good documentation is a man
 page stays shallow in the tree, and that is a stated limit rather than a bug
 to chase.
+
+**USAGE soft-wraps at the pane width instead of scrolling horizontally
+(2026-09-03).** Shown `mandible sg_luns`, the maintainer asked "should we
+leave as original? or should we not let usage line go out of view in parse
+mode?". §9 rule 9
+named a node's USAGE synopsis as preformatted, tool-author layout, on the
+same footing as the raw `--help` view. That footing does not hold: the
+parser joins a usage that wrapped over several physical lines in the
+tool's own output into one logical line, so the rendered USAGE line is
+mandible's own reconstruction, not the author's layout. `sg_luns` wraps
+its usage over three physical lines plus an `or` alternative over two
+more, and the parser joins each into one line before mandible ever draws
+it. The raw `--help` view and the `unparsed` fallback keep their existing
+horizontal scroll; only USAGE moved.
 
 ### Deferred, with the reason each is not simply undone
 

--- a/mandible-tui/src/render/detail_pane/mod.rs
+++ b/mandible-tui/src/render/detail_pane/mod.rs
@@ -426,7 +426,12 @@ fn build_lines(
 ) -> BuiltLines {
     let mut lines = Vec::new();
     let mut target_flag_line = None;
-    let mut clip_rows: Vec<(usize, bool, bool)> = Vec::new();
+    // Every list section wraps to pane width and never clips (spec §9.3
+    // rule 15); USAGE now soft-wraps too (spec §9 rule 9), so
+    // nothing in the parsed view ever produces a clipped row any more.
+    // The field stays on [`BuiltLines`] because [`render`] still threads it
+    // through to [`draw_clip_marker_rails`] the same way the raw view does.
+    let clip_rows: Vec<(usize, bool, bool)> = Vec::new();
     let mut rows: Vec<EntryRow> = Vec::new();
     // Reset every frame so a node with no USAGE doesn't keep the previous
     // node's extent and draw a stale overflow marker.
@@ -494,39 +499,18 @@ fn build_lines(
         // apart from its prose.
         let indent = "  ";
         let forms = usage_forms(&node.name, &node.usage);
-        if app.horizontal_scroll_enabled {
-            // A synopsis is preformatted — spacing inside it is part of
-            // its meaning, so spec §9 has it scroll rather than wrap. One
-            // `Line` per usage form, never re-flowed; `h`/`l` reveal the rest instead
-            // of the old greedy word-wrap eating it into a ragged block.
-            let usage_lines: Vec<String> = forms
-                .iter()
-                .map(|(pad, text)| format!("{indent}{}{text}", " ".repeat(*pad)))
-                .collect();
-            let max_width = usage_lines
-                .iter()
-                .map(|line| display_width(line))
-                .max()
-                .unwrap_or(0);
-            app.set_detail_hextent(max_width, width);
-            let hoffset = app.clamped_detail_hscroll();
-            for line in usage_lines {
-                let (built, left, right) = hscroll_line(&line, hoffset, width);
-                if left || right {
-                    clip_rows.push((lines.len(), left, right));
-                }
-                lines.push(built);
-            }
-        } else {
-            // Wrapping mode keeps the same left edge for a form's own
-            // continuation rows, so a form that has to wrap still reads as
-            // one form rather than drifting back to the block indent.
-            for (pad, text) in &forms {
-                let lead = format!("{indent}{}", " ".repeat(*pad));
-                let avail = width.saturating_sub(display_width(&lead)).max(1);
-                for chunk in wrap_words(text, avail) {
-                    lines.push(Line::from(format!("{lead}{chunk}")));
-                }
+        // A rendered USAGE line is mandible's own reconstruction, not the
+        // tool author's layout: the parser already joined a usage that
+        // wrapped over several physical lines into one logical line, so it
+        // soft-wraps at the pane width in both modes instead of forcing
+        // horizontal scroll (spec §9 rule 9). Continuation rows
+        // keep the form's own left edge, so a form that has to wrap still
+        // reads as one form rather than drifting back to the block indent.
+        for (pad, text) in &forms {
+            let lead = format!("{indent}{}", " ".repeat(*pad));
+            let avail = width.saturating_sub(display_width(&lead)).max(1);
+            for chunk in wrap_words(text, avail) {
+                lines.push(Line::from(format!("{lead}{chunk}")));
             }
         }
     }
@@ -3346,6 +3330,81 @@ mod tests {
         );
     }
 
+    /// End-to-end for the `sg_luns` repro: a USAGE form wider than the pane
+    /// wraps onto a second row at the pane width, the continuation row
+    /// keeps the form's own left edge, and no horizontal clip marker
+    /// reaches the screen for it, on a real `TestBackend` frame (spec §9
+    /// rule 9).
+    #[test]
+    fn usage_form_wraps_on_screen_with_no_clip_marker() {
+        use crate::app::App;
+        use ratatui::backend::TestBackend;
+        use ratatui::buffer::Buffer;
+        use ratatui::Terminal;
+
+        fn frame_of(app: &App) -> Buffer {
+            let backend = TestBackend::new(80, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    let area = frame.area();
+                    render(frame, area, app);
+                })
+                .unwrap();
+            terminal.backend().buffer().clone()
+        }
+
+        let mut root = CommandNode::new("sg_luns", Provenance::single(Source::HelpText));
+        root.usage = vec![Text::sanitize_preserving_layout(
+            "Usage: sg_luns [--alpha] [--brief] [--decode] [--hex] [--inhex=FN] [--lu_cong] [--maxlen=LEN] [--quiet] [--raw] [--readonly] [--select=SR] [--verbose] [--version] [DEVICE]",
+        )];
+        let app = App::new("sg_luns".to_string(), root);
+
+        let buffer = frame_of(&app);
+        let rows: Vec<String> = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect();
+        let usage_heading = rows
+            .iter()
+            .position(|r| r.contains("USAGE"))
+            .expect("USAGE heading should render");
+        let first = &rows[usage_heading + 1];
+        let second = &rows[usage_heading + 2];
+        assert!(
+            first.contains("sg_luns [--alpha]"),
+            "the first usage row should start the form: {first:?}"
+        );
+        assert!(
+            second
+                .trim_matches(|c: char| c == '│' || c.is_whitespace())
+                .starts_with("[--"),
+            "the form must wrap onto a second row instead of scrolling off screen: {second:?}"
+        );
+        // Border, then one padding column, then content (`Padding::horizontal(1)`).
+        let content_indent_of = |s: &str| s.chars().skip(2).take_while(|c| *c == ' ').count();
+        assert_eq!(
+            content_indent_of(first),
+            content_indent_of(second),
+            "the continuation row must keep the form's own left edge: {first:?} / {second:?}"
+        );
+        // No clip marker (draw_clip_marker_rails' literal "<"/">") anywhere
+        // on the two USAGE rows, in the padding gutter or the text itself.
+        assert!(!first.contains('<') && !first.contains('>'), "{first:?}");
+        assert!(!second.contains('<') && !second.contains('>'), "{second:?}");
+        // No horizontal-scroll overflow affordance on the pane's top
+        // border either — USAGE no longer contributes any hextent.
+        let top_border = &rows[0];
+        assert!(
+            !top_border.contains(app.glyphs.more_right)
+                && !top_border.contains(app.glyphs.more_left),
+            "the detail pane must show no horizontal-scroll affordance: {top_border:?}"
+        );
+    }
+
     /// Every form's rendered padding, for a tool's own synopsis block.
     fn pads(name: &str, forms: &[&str]) -> Vec<usize> {
         let usage: Vec<Text> = forms
@@ -3617,69 +3676,77 @@ mod tests {
     /// somewhere in the rendered lines, and never emit an ellipsis in its
     /// place.
     ///
-    /// Pinned with the horizontal-scroll toggle explicitly **off**: this is
-    /// the pre-existing wrapping behavior, and `horizontal_scroll = false`
-    /// (spec: the config toggle for this feature) must reproduce it
-    /// exactly. The toggle **on** has its own test below, where the same
-    /// token stays on one unwrapped line instead.
+    /// USAGE soft-wraps at the pane width in both `[ui] horizontal_scroll`
+    /// states (spec §9 rule 9): a rendered USAGE line is
+    /// mandible's own reconstruction of a synopsis the parser already
+    /// joined from several physical lines, not the tool author's layout,
+    /// so the toggle that governs the raw view's preformatted text no
+    /// longer governs this one.
     #[test]
-    fn build_lines_wraps_rather_than_truncates_a_long_usage_token_with_scroll_disabled() {
+    fn build_lines_wraps_rather_than_truncates_a_long_usage_token() {
         let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
         let long_url = "https://registry.example.com/v2/org/repo/blobs/uploads/deadbeefcafefeed0123456789abcdef0123456789abcdef0123456789abcd";
         node.usage = vec![Text::sanitize(long_url)];
 
-        let mut app = test_app();
-        app.horizontal_scroll_enabled = false;
-        let built = build_lines(
-            &node,
-            false,
-            46,
-            style::Palette::extended(),
-            None,
-            crate::glyphs::UNICODE,
-            &app,
-        );
-        // Every usage line carries its own 2-space block indent (see the
-        // USAGE section of `build_lines`) — strip it per line before
-        // rejoining so adjacent chunks of the broken token reassemble
-        // without a spurious gap between them.
-        let joined: String = built
-            .lines
-            .iter()
-            .map(text_of)
-            .map(|t| t.trim_start().to_string())
-            .collect();
-        // The chunks concatenate back to the original token exactly, so
-        // the whole URL — not just a fragment of it — must appear intact
-        // somewhere in the rendered output.
-        assert!(
-            joined.contains(long_url),
-            "token was lost, not wrapped: {joined:?}"
-        );
-        assert!(
-            !joined.contains('…'),
-            "an over-long token must never be ellipsis-truncated: {joined:?}"
-        );
-        assert!(
-            built.lines.len() > 1,
-            "with scrolling disabled the long token should still wrap across lines: {:?}",
-            built.lines.iter().map(text_of).collect::<Vec<_>>()
-        );
+        for toggle in [false, true] {
+            let mut app = test_app();
+            app.horizontal_scroll_enabled = toggle;
+            let built = build_lines(
+                &node,
+                false,
+                46,
+                style::Palette::extended(),
+                None,
+                crate::glyphs::UNICODE,
+                &app,
+            );
+            // Every usage line carries its own 2-space block indent (see the
+            // USAGE section of `build_lines`) — strip it per line before
+            // rejoining so adjacent chunks of the broken token reassemble
+            // without a spurious gap between them.
+            let joined: String = built
+                .lines
+                .iter()
+                .map(text_of)
+                .map(|t| t.trim_start().to_string())
+                .collect();
+            // The chunks concatenate back to the original token exactly, so
+            // the whole URL — not just a fragment of it — must appear intact
+            // somewhere in the rendered output.
+            assert!(
+                joined.contains(long_url),
+                "token was lost, not wrapped ({toggle}): {joined:?}"
+            );
+            assert!(
+                !joined.contains('…'),
+                "an over-long token must never be ellipsis-truncated ({toggle}): {joined:?}"
+            );
+            assert!(
+                built.lines.len() > 1,
+                "the long token should wrap across lines ({toggle}): {:?}",
+                built.lines.iter().map(text_of).collect::<Vec<_>>()
+            );
+            assert!(
+                built.clip_rows.is_empty(),
+                "USAGE must never contribute a horizontal clip marker ({toggle})"
+            );
+        }
     }
 
-    /// The toggle **on** (the default): a USAGE synopsis is preformatted
-    /// and must stay on one line rather than being greedily word-wrapped,
-    /// with `h`/`l` revealing the rest instead (spec §9: preformatted
-    /// detail-pane content scrolls rather than wraps).
+    /// A usage form wider than the pane soft-wraps onto a second row at the
+    /// pane width instead of forcing horizontal scroll (spec §9 rule 9).
+    /// The continuation row keeps the form's own left edge — the block
+    /// indent plus the form's own pad, same as the first row — and no clip
+    /// marker is recorded for it. Regression fixture: `sg_luns`.
     #[test]
-    fn usage_synopsis_stays_on_one_line_when_horizontal_scroll_is_enabled() {
-        let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
-        let long_url = "https://registry.example.com/v2/org/repo/blobs/uploads/deadbeefcafefeed0123456789abcdef0123456789abcdef0123456789abcd";
-        node.usage = vec![Text::sanitize(long_url)];
+    fn usage_form_wraps_at_pane_width_with_continuation_keeping_its_own_left_edge() {
+        let mut node = CommandNode::new("sg_luns", Provenance::single(Source::HelpText));
+        node.usage = vec![Text::sanitize(
+            "sg_luns [--alpha] [--brief] [--decode] [--hex] [--inhex=FN] [--lu_cong] [--maxlen=LEN] [--quiet] [--raw] [--readonly] [--select=SR] [--verbose] [--version] [DEVICE]",
+        )];
 
-        let app = test_app();
-        assert!(app.horizontal_scroll_enabled, "default is on");
         let width = 46;
+        let app = test_app();
         let built = build_lines(
             &node,
             false,
@@ -3689,76 +3756,67 @@ mod tests {
             crate::glyphs::UNICODE,
             &app,
         );
-        // Unscrolled, the line shows a `width`-column prefix of the
-        // synopsis — the rest reachable with `l`, never reflowed onto a
-        // second line the way the disabled path wraps it.
-        let usage_lines: Vec<&Line> = built
-            .lines
-            .iter()
-            .filter(|l| text_of(l).trim_start().starts_with("url https"))
-            .collect();
-        assert_eq!(
-            usage_lines.len(),
-            1,
-            "a preformatted synopsis must not be split across lines: {:?}",
-            built.lines.iter().map(text_of).collect::<Vec<_>>()
-        );
-        let shown = text_of(usage_lines[0]);
-        // The clip marker lives in the padding gutter (see
-        // `draw_clip_marker_rails`), never inside the text, so the line
-        // itself is a clean unbroken prefix at full width.
-        assert!(
-            long_url.starts_with(shown.trim_start().trim_start_matches("url ")),
-            "the visible portion must be an unbroken prefix of the real synopsis: {shown:?}"
-        );
-        assert!(
-            display_width(&shown) <= width,
-            "must not overflow the pane and rely on Paragraph::Wrap to save it: {shown:?}"
-        );
-    }
-
-    /// Scrolling right trims preformatted USAGE content from the left —
-    /// the same offset the affordance in the border reflects — while
-    /// leaving everything else (here, nothing else on this node) alone.
-    /// Two-pass, matching how a real frame works: the first pass tells
-    /// `App` how wide the content is (`set_detail_hextent`), only after
-    /// which a scroll key has something to clamp against.
-    #[test]
-    fn usage_synopsis_scrolls_horizontally_when_enabled() {
-        let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
-        let long_url = "x".repeat(200);
-        node.usage = vec![Text::sanitize(&long_url)];
-
-        let mut app = test_app();
-        let _ = build_lines(
-            &node,
-            false,
-            46,
-            style::Palette::extended(),
-            None,
-            crate::glyphs::UNICODE,
-            &app,
-        );
-        app.detail_hscroll_right();
-        app.detail_hscroll_right();
-        let built = build_lines(
-            &node,
-            false,
-            46,
-            style::Palette::extended(),
-            None,
-            crate::glyphs::UNICODE,
-            &app,
-        );
-        let usage_line = built
+        let usage_lines: Vec<String> = built
             .lines
             .iter()
             .map(text_of)
-            .find(|t| t.contains('x'))
-            .expect("usage line should still be present");
+            .skip_while(|t| !t.contains("USAGE"))
+            .skip(1)
+            .take_while(|t| !t.trim().is_empty())
+            .collect();
         assert!(
-            !usage_line.trim_start().starts_with("url xxxx"),
-            "the line should have scrolled past its own start: {usage_line:?}"
+            usage_lines.len() > 1,
+            "an over-wide form must wrap onto a second row: {usage_lines:?}"
         );
+        for line in &usage_lines {
+            assert!(display_width(line) <= width, "row overruns: {line:?}");
+        }
+        let indent_of = |s: &str| s.len() - s.trim_start().len();
+        assert_eq!(
+            indent_of(&usage_lines[0]),
+            indent_of(&usage_lines[1]),
+            "continuation row must keep the form's own left edge: {usage_lines:?}"
+        );
+        assert!(
+            built.clip_rows.is_empty(),
+            "a wrapped USAGE row must never be marked clipped: {:?}",
+            built.clip_rows
+        );
+    }
+
+    /// A usage form that already fits the pane renders unchanged: one row,
+    /// byte for byte, in both `[ui] horizontal_scroll` states (spec §9 rule
+    /// 9).
+    #[test]
+    fn usage_form_that_fits_the_pane_is_unchanged() {
+        let mut node = CommandNode::new("url", Provenance::single(Source::HelpText));
+        node.usage = vec![Text::sanitize("url [-h] <command> [args]")];
+
+        let width = 46;
+        for toggle in [false, true] {
+            let mut app = test_app();
+            app.horizontal_scroll_enabled = toggle;
+            let built = build_lines(
+                &node,
+                false,
+                width,
+                style::Palette::extended(),
+                None,
+                crate::glyphs::UNICODE,
+                &app,
+            );
+            let usage_lines: Vec<String> = built
+                .lines
+                .iter()
+                .map(text_of)
+                .filter(|t| t.contains("url [-h]"))
+                .collect();
+            assert_eq!(
+                usage_lines,
+                vec!["  url [-h] <command> [args]".to_string()],
+                "a fitting form must render byte for byte ({toggle})"
+            );
+            assert!(built.clip_rows.is_empty());
+        }
     }
 }

--- a/mandible-tui/tests/border_integrity.rs
+++ b/mandible-tui/tests/border_integrity.rs
@@ -427,17 +427,19 @@ fn ascii_glyph_set_renders_a_pure_ascii_frame() {
     }
 }
 
-/// A node whose USAGE synopsis is wider than the pane: the horizontal-scroll
-/// overflow affordance (spec §9: preformatted detail-pane content scrolls
-/// rather than wraps) must show a right-pointing marker while
-/// unscrolled, switch to a left-pointing one once fully scrolled right, and
-/// — the point of testing it here rather than only in `detail_pane`'s own
-/// unit tests — never disturb any of the border cells `assert_border_intact`
-/// checks strictly (left/right/bottom edges, all four corners).
+/// A node whose only content is a degraded `unparsed` fallback wider than
+/// the pane: the horizontal-scroll overflow affordance (spec §9: the raw
+/// `--help` view and the `unparsed` fallback scroll rather than wrap; USAGE
+/// soft-wraps instead, so it can no longer exercise this affordance) must
+/// show a right-pointing marker while unscrolled, switch to a
+/// left-pointing one once fully scrolled right, and — the point of testing
+/// it here rather than only in `detail_pane`'s own unit tests — never
+/// disturb any of the border cells `assert_border_intact` checks strictly
+/// (left/right/bottom edges, all four corners).
 #[test]
 fn detail_pane_hscroll_affordance_marks_overflow_without_corrupting_the_border() {
-    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
-    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+    let mut root = CommandNode::new("wide", Provenance::with_confidence(Source::HelpText, 0.0));
+    root.unparsed = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
 
     let mut app = App::new("wide".to_string(), root);
     app.focus = mandible_tui::Focus::Detail;
@@ -499,11 +501,13 @@ fn detail_pane_hscroll_affordance_marks_overflow_without_corrupting_the_border()
 /// once scrolled, a `<` in its first — while a short line beside it stays
 /// untouched. The contrast between marked and unmarked neighbors is the
 /// point: the pane-border affordance says "somewhere there's more", the
-/// per-line marker says "this line".
+/// per-line marker says "this line". Exercised through `unparsed`, not
+/// USAGE: USAGE soft-wraps unconditionally now and never carries a clip
+/// marker any more.
 #[test]
 fn hscroll_clip_markers_mark_only_the_clipped_lines() {
-    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
-    root.usage = vec![
+    let mut root = CommandNode::new("wide", Provenance::with_confidence(Source::HelpText, 0.0));
+    root.unparsed = vec![
         Text::sanitize("wide -a"),
         Text::sanitize(&format!("wide {}", "x".repeat(200))),
     ];
@@ -568,13 +572,15 @@ fn hscroll_clip_markers_mark_only_the_clipped_lines() {
 /// deliberate choice documented on `draw_hscroll_affordance` itself: even
 /// though `h`/`l`/`←`/`→` only reach the detail pane's scroll while it is
 /// focused, a marker that disappeared with the tree focused would let a
-/// USAGE line clip silently until the reader happened to `Tab` over, which
-/// is the worse failure. Pinned here so a future change to that decision is
-/// a deliberate edit to this test, not a silent regression.
+/// preformatted line clip silently until the reader happened to `Tab` over,
+/// which is the worse failure. Pinned here so a future change to that
+/// decision is a deliberate edit to this test, not a silent regression.
+/// Exercised through `unparsed`, not USAGE: USAGE soft-wraps
+/// unconditionally now and can no longer overflow the pane.
 #[test]
 fn detail_pane_hscroll_affordance_shows_even_with_the_tree_focused() {
-    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
-    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+    let mut root = CommandNode::new("wide", Provenance::with_confidence(Source::HelpText, 0.0));
+    root.unparsed = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
 
     let mut app = App::new("wide".to_string(), root);
     app.focus = mandible_tui::Focus::Tree;
@@ -604,10 +610,12 @@ fn detail_pane_hscroll_affordance_shows_even_with_the_tree_focused() {
 /// The ASCII glyph set's affordance markers (`<`/`>`) are what actually
 /// reach the screen under `MANDIBLE_ASCII=1` — the Unicode arrows above are
 /// exactly the kind of glyph this project refuses to rely on everywhere.
+/// Exercised through `unparsed`; see the note on the focus test above for
+/// why USAGE no longer serves this purpose.
 #[test]
 fn detail_pane_hscroll_affordance_uses_the_ascii_glyphs() {
-    let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));
-    root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
+    let mut root = CommandNode::new("wide", Provenance::with_confidence(Source::HelpText, 0.0));
+    root.unparsed = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
 
     let mut app = App::new("wide".to_string(), root);
     app.focus = mandible_tui::Focus::Detail;
@@ -643,8 +651,9 @@ fn detail_pane_hscroll_affordance_uses_the_ascii_glyphs() {
 
 /// The config toggle off must reproduce today's rendering exactly: no
 /// affordance marker anywhere on the detail pane's border, even for a node
-/// whose USAGE is far wider than the pane — because with the toggle off
-/// that content wraps instead of overflowing, so there is nothing to mark.
+/// whose USAGE is far wider than the pane — USAGE soft-wraps
+/// unconditionally (spec §9 rule 9), so there is nothing to mark in either
+/// toggle state.
 #[test]
 fn detail_pane_hscroll_affordance_absent_when_the_config_toggle_is_off() {
     let mut root = CommandNode::new("wide", Provenance::single(Source::HelpText));

--- a/mandible-tui/tests/detail_scroll_memory.rs
+++ b/mandible-tui/tests/detail_scroll_memory.rs
@@ -10,8 +10,11 @@
 //! after every key.
 //!
 //! The fixture is deliberately asymmetric — a long flag list against a
-//! longer raw text, a wide synopsis against wider raw lines — so no
-//! assertion can pass because the two views happen to agree.
+//! longer raw text — so no vertical assertion can pass because the two
+//! views happen to agree. The parsed view has no horizontal extent of its
+//! own any more (spec §9 rule 9: USAGE soft-wraps instead of
+//! scrolling), so the horizontal axis is exercised through the raw view
+//! only, against the parsed view's fixed zero.
 
 use mandible_core::{CommandNode, Entity, EntityKind, Provenance, Source, Spelling, Text};
 use mandible_tui::app::{App, RawHelp};
@@ -49,9 +52,11 @@ fn detail_rows(app: &App) -> Vec<String> {
     rows
 }
 
-/// A node with far more flags than fit the pane, and a synopsis far wider
-/// than it — the parsed view needs both extents to be nonzero before it
-/// can have a position worth remembering.
+/// A node with far more flags than fit the pane, so the parsed view has a
+/// vertical position worth remembering. The synopsis is wider than the
+/// pane too, kept only to exercise USAGE's own soft-wrap (spec §9 rule 9)
+/// elsewhere; it no longer gives the parsed view anything horizontal to
+/// scroll.
 fn parsed_node() -> CommandNode {
     let mut node = CommandNode::new(TOOL, Provenance::single(Source::HelpText));
     node.description = Some(Text::sanitize("Search for PATTERNS in each FILE."));
@@ -161,17 +166,22 @@ fn each_view_returns_to_its_own_line() {
     );
 }
 
-/// The horizontal offset is remembered per view on the same terms: the
-/// parsed view's synopsis column and the raw view's column are separate
-/// numbers, each restored exactly.
+/// The horizontal offset is remembered per view on the same terms: the raw
+/// view's column is its own number, restored exactly. The parsed view has
+/// no horizontal extent left to scroll (spec §9 rule 9): USAGE
+/// soft-wraps now, and nothing else in the parsed view ever supported
+/// horizontal scroll, so scrolling it right is a no-op that must not leak
+/// into the raw view's own column.
 #[test]
 fn each_view_returns_to_its_own_column() {
     let mut app = app_with_raw(60);
 
     scroll_right(&mut app, 3);
-    let parsed_column = app.clamped_detail_hscroll();
-    let parsed_screen = detail_rows(&app);
-    assert!(parsed_column > 0, "the synopsis is wider than the pane");
+    assert_eq!(
+        app.clamped_detail_hscroll(),
+        0,
+        "the parsed view has nothing left to scroll horizontally"
+    );
 
     app.toggle_raw_mode();
     assert_eq!(
@@ -182,21 +192,13 @@ fn each_view_returns_to_its_own_column() {
     scroll_right(&mut app, 7);
     let raw_column = app.clamped_detail_hscroll();
     let raw_screen = detail_rows(&app);
-    assert_ne!(
-        raw_column, parsed_column,
-        "the two columns must differ here"
-    );
+    assert!(raw_column > 0, "the raw text is wider than the pane");
 
     app.toggle_raw_mode();
     assert_eq!(
         app.clamped_detail_hscroll(),
-        parsed_column,
-        "the parsed view must return to its own column"
-    );
-    assert_eq!(
-        detail_rows(&app),
-        parsed_screen,
-        "the parsed view came back at a different column"
+        0,
+        "the raw view's column must not leak into the parsed view"
     );
 
     app.toggle_raw_mode();
@@ -213,7 +215,11 @@ fn each_view_returns_to_its_own_column() {
 }
 
 /// Movement in one view never moves the other's stored position, however
-/// far it goes — including past the other view's whole extent.
+/// far it goes — including past the other view's whole extent. The parsed
+/// view's own `scroll_right` is a no-op (spec §9 rule 9: USAGE
+/// soft-wraps now, so the parsed view has no horizontal extent), which is
+/// itself part of what this test pins: it must stay at zero rather than
+/// picking up the raw view's travel.
 #[test]
 fn scrolling_one_view_leaves_the_others_position_alone() {
     let mut app = app_with_raw(120);
@@ -221,6 +227,7 @@ fn scrolling_one_view_leaves_the_others_position_alone() {
     scroll_down(&mut app, 4);
     scroll_right(&mut app, 2);
     let parsed_place = (app.clamped_detail_scroll(), app.clamped_detail_hscroll());
+    assert_eq!(parsed_place.1, 0, "precondition: nothing to scroll to");
     let parsed_screen = detail_rows(&app);
 
     app.toggle_raw_mode();
@@ -257,23 +264,20 @@ fn a_first_visit_to_a_view_starts_at_the_top_left() {
     app.toggle_raw_mode();
     assert_ne!(parsed_top, raw_top);
 
-    // Take the parsed view far from its top on both axes; the raw view has
+    // Take the parsed view far from its top on its one remaining axis; the
+    // parsed view has no horizontal extent to scroll any more (spec §9
+    // rule 9: USAGE soft-wraps now), so only the vertical
+    // position is worth carrying across the toggle here. The raw view has
     // never been scrolled for this node.
     let mut app = app_with_raw(60);
     scroll_down(&mut app, 14);
-    scroll_right(&mut app, 5);
-    assert!(app.clamped_detail_scroll() > 0 && app.clamped_detail_hscroll() > 0);
+    assert!(app.clamped_detail_scroll() > 0);
 
     app.toggle_raw_mode();
     assert_eq!(
         app.clamped_detail_scroll(),
         0,
         "an unvisited view must not be seeded from the other view's line"
-    );
-    assert_eq!(
-        app.clamped_detail_hscroll(),
-        0,
-        "an unvisited view must not be seeded from the other view's column"
     );
     assert_eq!(
         detail_rows(&app),


### PR DESCRIPTION
A long usage line no longer forces horizontal scroll: USAGE wraps to the pane width in both `[ui] horizontal_scroll` states. The raw `--help` view and the `unparsed` fallback still scroll, because those are the tool author's own layout and a joined usage line is mandible's reconstruction.

See it yourself:

    mandible sg_luns    # both usage forms now wrap into view, no `>` clip marker
    mandible tar        # already fitted, unchanged byte for byte
    mandible find       # was clipped, now wraps

`git diff --stat main -- corpus` is empty.