### PR TITLE
Read a ragged-indent command table (pnpm's root parse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+### Fixed
+
+- A command table's short-alias-comma rows (`i, install`) and the descriptions wrapping off their neighbors no longer drop the whole table or invent commands from wrapped text (`mandible pnpm`, docs/shapes.md S-103, S-104).
+
 ## [0.7.0] - 2026-09-05
 
 ### Added

--- a/corpus/pnpm/11.22.0/expected.snap
+++ b/corpus/pnpm/11.22.0/expected.snap
@@ -1,0 +1,304 @@
+name: pnpm
+description: Version 11.22.0
+usage:
+- 'Usage: pnpm [command] [flags]'
+- '       pnpm [ -h | --help | -v | --version ]'
+flags:
+- spellings:
+  - -r
+  - --recursive
+  description: Run the command for each project in the workspace.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  provenance:
+    sources:
+    - help-text-synopsis
+- spellings:
+  - --help
+  provenance:
+    sources:
+    - help-text-synopsis
+- spellings:
+  - -v
+  provenance:
+    sources:
+    - help-text-synopsis
+- spellings:
+  - --version
+  provenance:
+    sources:
+    - help-text-synopsis
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true
+subcommands:
+- name: add
+  summary: Installs a package and any packages that it depends on. By default, any new package is installed as a prod dependency
+  group: 'Manage your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: install
+  aliases:
+  - i
+  summary: Install all dependencies for a project
+  group: 'Manage your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: link
+  aliases:
+  - ln
+  summary: Connect the local project to another one
+  group: 'Manage your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: remove
+  aliases:
+  - rm
+  summary: Removes packages from node_modules and from the project's package.json
+  group: 'Manage your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: unlink
+  summary: Unlinks a package. Like yarn unlink but pnpm re-installs the dependency after removing the external link
+  group: 'Manage your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: update
+  aliases:
+  - up
+  summary: Updates packages to their latest version based on the specified range
+  group: 'Manage your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: audit
+  summary: Checks for known security issues with the installed packages
+  description: Version 11.22.0
+  usage:
+  - 'Usage: pnpm audit [options]'
+  - '       pnpm audit signatures [options]'
+  flags:
+  - spellings:
+    - --audit-level
+    value_name: <severity>
+    value_kind: Required
+    description: 'Only print advisories with severity greater than or equal to one of the following: info|low|moderate|high|critical. Default: low'
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - -D
+    - --dev
+    description: Only audit "devDependencies"
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - --fix
+    value_name: method
+    value_kind: Optional
+    description: 'Fix the audited vulnerabilities using the specified method: "override" or "update". "override" adds overrides to the package.json file in order to force non-vulnerable versions of the dependencies. "update" attempts to update the vulnerable packages in the lockfile to non-vulnerable versions. If no method is specified, "override" is used by default.'
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - --ignore
+    value_name: <vulnerability>
+    value_kind: Required
+    description: Ignore a vulnerability by its GitHub advisory ID (e.g. GHSA-xxxx-xxxx-xxxx)
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - --ignore-registry-errors
+    description: Use exit code 0 if the registry responds with an error. Useful when audit checks are used in CI. A build should not fail because the registry has issues.
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - --ignore-unfixable
+    description: Ignore all vulnerabilities for which no fix exists
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - -i
+    - --interactive
+    description: Show vulnerabilities and select which ones to fix interactively
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - --json
+    description: Output audit report in JSON format
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - --no-optional
+    description: Don't audit "optionalDependencies"
+    provenance:
+      sources:
+      - help-text
+  - spellings:
+    - -P
+    - --prod
+    description: Only audit "dependencies" and "optionalDependencies"
+    provenance:
+      sources:
+      - help-text
+  group: 'Review your dependencies:'
+  provenance:
+    sources:
+    - help-text
+    confidence: 0.5
+  children_filled: true
+  heading_attested: true
+  subcommands:
+  - name: signatures
+    summary: Verify ECDSA registry signatures for installed packages from registries that provide signing keys at /-/npm/v1/keys.
+    group: 'Commands:'
+    provenance:
+      sources:
+      - help-text
+      confidence: 0.0
+    children_filled: true
+    heading_attested: true
+    unparsed:
+    - Version 11.22.0
+    - 'Usage: pnpm audit [options]'
+    - '       pnpm audit signatures [options]'
+    - ''
+    - Checks for known security issues with the installed packages.
+    - ''
+    - 'Commands:'
+    - '      signatures           Verify ECDSA registry signatures for installed'
+    - '                           packages from registries that provide signing keys at'
+    - '                           /-/npm/v1/keys.'
+    - ''
+    - 'Options:'
+    - '      --audit-level <severity>  Only print advisories with severity greater than'
+    - '                                or equal to one of the following:'
+    - '                                info|low|moderate|high|critical. Default: low'
+    - '  -D, --dev                     Only audit "devDependencies"'
+    - '      --fix [method]            Fix the audited vulnerabilities using the'
+    - '                                specified method: "override" or "update".'
+    - '                                "override" adds overrides to the package.json'
+    - '                                file in order to force non-vulnerable versions'
+    - '                                of the dependencies. "update" attempts to update'
+    - '                                the vulnerable packages in the lockfile to'
+    - '                                non-vulnerable versions. If no method is'
+    - '                                specified, "override" is used by default.'
+    - '      --ignore <vulnerability>  Ignore a vulnerability by its GitHub advisory ID'
+    - '                                (e.g. GHSA-xxxx-xxxx-xxxx)'
+    - '      --ignore-registry-errors  Use exit code 0 if the registry responds with an'
+    - '                                error. Useful when audit checks are used in CI.'
+    - '                                A build should not fail because the registry has'
+    - '                                issues.'
+    - '      --ignore-unfixable        Ignore all vulnerabilities for which no fix'
+    - '                                exists'
+    - '  -i, --interactive             Show vulnerabilities and select which ones to'
+    - '                                fix interactively'
+    - '      --json                    Output audit report in JSON format'
+    - '      --no-optional             Don''t audit "optionalDependencies"'
+    - '  -P, --prod                    Only audit "dependencies" and'
+    - '                                "optionalDependencies"'
+    - ''
+    - Visit https://pnpm.io/11.x/cli/audit for documentation about this command.
+- name: list
+  aliases:
+  - ls
+  summary: Print all the versions of packages that are installed, as well as their dependencies, in a tree-structure
+  group: 'Review your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: outdated
+  summary: Check for outdated packages
+  group: 'Review your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: why
+  summary: Shows all packages that depend on the specified package
+  group: 'Review your dependencies:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: create
+  summary: Create a project from a "create-*" or "@foo/create-*" starter kit
+  group: 'Run your scripts:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: dlx
+  summary: Fetches a package from the registry without installing it as a dependency, hot loads it, and runs whatever default command binary it exposes
+  group: 'Run your scripts:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: exec
+  summary: Executes a shell command in scope of a project
+  group: 'Run your scripts:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: run
+  summary: Runs a defined package script
+  group: 'Run your scripts:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: config
+  aliases:
+  - c
+  summary: Manage the pnpm configuration files
+  group: 'Other:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: init
+  summary: Create a package.json file
+  group: 'Other:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: publish
+  summary: Publishes a package to the registry
+  group: 'Other:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: stage
+  summary: Stage packages for publishing
+  group: 'Other:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true

--- a/corpus/pnpm/11.22.0/expected.snap
+++ b/corpus/pnpm/11.22.0/expected.snap
@@ -180,47 +180,7 @@ subcommands:
       confidence: 0.0
     children_filled: true
     heading_attested: true
-    unparsed:
-    - Version 11.22.0
-    - 'Usage: pnpm audit [options]'
-    - '       pnpm audit signatures [options]'
-    - ''
-    - Checks for known security issues with the installed packages.
-    - ''
-    - 'Commands:'
-    - '      signatures           Verify ECDSA registry signatures for installed'
-    - '                           packages from registries that provide signing keys at'
-    - '                           /-/npm/v1/keys.'
-    - ''
-    - 'Options:'
-    - '      --audit-level <severity>  Only print advisories with severity greater than'
-    - '                                or equal to one of the following:'
-    - '                                info|low|moderate|high|critical. Default: low'
-    - '  -D, --dev                     Only audit "devDependencies"'
-    - '      --fix [method]            Fix the audited vulnerabilities using the'
-    - '                                specified method: "override" or "update".'
-    - '                                "override" adds overrides to the package.json'
-    - '                                file in order to force non-vulnerable versions'
-    - '                                of the dependencies. "update" attempts to update'
-    - '                                the vulnerable packages in the lockfile to'
-    - '                                non-vulnerable versions. If no method is'
-    - '                                specified, "override" is used by default.'
-    - '      --ignore <vulnerability>  Ignore a vulnerability by its GitHub advisory ID'
-    - '                                (e.g. GHSA-xxxx-xxxx-xxxx)'
-    - '      --ignore-registry-errors  Use exit code 0 if the registry responds with an'
-    - '                                error. Useful when audit checks are used in CI.'
-    - '                                A build should not fail because the registry has'
-    - '                                issues.'
-    - '      --ignore-unfixable        Ignore all vulnerabilities for which no fix'
-    - '                                exists'
-    - '  -i, --interactive             Show vulnerabilities and select which ones to'
-    - '                                fix interactively'
-    - '      --json                    Output audit report in JSON format'
-    - '      --no-optional             Don''t audit "optionalDependencies"'
-    - '  -P, --prod                    Only audit "dependencies" and'
-    - '                                "optionalDependencies"'
-    - ''
-    - Visit https://pnpm.io/11.x/cli/audit for documentation about this command.
+    same_as_ancestor: true
 - name: list
   aliases:
   - ls

--- a/corpus/pnpm/11.22.0/meta.toml
+++ b/corpus/pnpm/11.22.0/meta.toml
@@ -1,5 +1,7 @@
-# Two defects live here, and only one of them is the fan-out this fixture was
-# captured for.
+# Two defects lived here, and only one of them is the fan-out this fixture
+# was captured for. The root-parse defect (item 2 below, atlas S-103/S-104)
+# is fixed; the fan-out (item 1) is not and is unrelated — do not weaken or
+# remove anything about it while touching this file for a different reason.
 #
 # 1. The fan-out (issue #114, docs/shapes.md S-079). `pnpm audit --help` and
 #    `pnpm audit signatures --help` return the same 2,251 bytes, and the
@@ -14,23 +16,20 @@
 #    `mandible-extract/src/help_text/mod.rs::tests::
 #    a_descendant_probe_identical_to_its_non_root_ancestor_does_not_fan_out`.
 #
-# 2. The root parse, which is wrong independently of the fan-out. pnpm groups
-#    its 18 root commands under four prose headings and writes the aliased ones
-#    with a leading short column (`i, install`, `ln, link`, `rm, remove`,
-#    `up, update`, `ls, list`, `c, config`). The parser reports 8 subcommands:
-#    add, audit, create, dlx, exec, package, run, tree-structure. Every aliased
-#    row is dropped, and so are the unaliased rows under them: unlink,
-#    outdated, why, init, publish, stage. Worse, `package` and `tree-structure`
-#    are inventions, both read off wrapped description lines. `tree-structure`
-#    is the last word of the `ls, list` description, alone on its own
-#    continuation line; `package` opens a continuation line under `why`. The
-#    tool documents neither as a command.
-#
-#    `min_subcommands` below states the omission half. There is no field for
-#    the invention half at this level: `must_not_contain_flags` is the one
-#    negative claim a contract can make and it is scoped to root flags, so it
-#    cannot say `package` and `tree-structure` are not commands. Those two
-#    names are named here instead.
+# 2. FIXED. pnpm groups its 18 root commands under four prose headings and
+#    writes six of them with a leading short-alias column (`i, install`,
+#    `ln, link`, `rm, remove`, `up, update`, `ls, list`, `c, config`), which
+#    ragged-indents those rows against their unaliased siblings. The generic
+#    layout parser used one fixed indent baseline per block and read a run of
+#    such rows as one giant misdetected heading, dropping every aliased row
+#    and every unaliased row after it, and inventing two commands
+#    (`tree-structure`, `package`) from the wrapped description lines that
+#    landed inside that misdetected heading's own block. Fixed in
+#    `mandible-extract/src/help_text/sections/{mod,scan}.rs`
+#    (`scan_ragged_command_run`/`try_ragged_command_row`), gated on the
+#    document already being in a command-listing context. Detectors:
+#    `ragged-command-table` (`unparsed-subcommand` shape E, atlas S-104) and
+#    `wrapped-command-continuation-as-subcommand` (atlas S-103).
 
 [bless]
 provenance = "agent"
@@ -58,27 +57,14 @@ stdout = "audit-help.txt"
 # pnpm's help is hand-rolled, so Tier A' fingerprints nothing.
 expected_framework = "generic"
 
-# The tool documents 18 root commands. The parser reports 8, two of which it
-# invented. This floor is the omission half of the root defect.
+# All 18 documented root commands now reach the tree.
 min_subcommands = 18
 
 # The one root flag pnpm lists under `Options:`.
 must_contain_flags = ["--recursive"]
 
-# Fleet counts for this shape, measured on a full-PATH sweep of 2,264 tools.
-# A candidate fix lives on the branch `r3/pnpm-command-table` and is not
-# merged, because it does not clear the admission bar. Sweep-diff against the
-# pre-fix sweep reports zero flag losses, zero flag gains and one field-level
-# gain, so the fix demonstrably helps two tools: pnpm itself, and
-# fail2ban-client, which recovers five real subcommands. The bar is five
-# tools. The two detectors written for this shape report 145 tools
-# (ragged-command-table) and 1 tool (wrapped-command-continuation-as-
-# subcommand), and neither count is quotable: both are dominated by the
-# detectors' own false positives, which is why both are reported and not
-# gated. Neither detector has a labelled member in the audit manifest, so
-# neither has passed calibration either.
-
-[xfail]
-broken = true
-reason = "the root command table is misread: the six aliased rows and the six rows under them are dropped, and `package` and `tree-structure` are invented from wrapped description lines"
-issue = "https://github.com/AS-FOSS/mandible/issues/114"
+# Root command tree and every root flag checked against the raw capture,
+# row by row, before blessing (corpus/README.md's bless workflow). Prose
+# (descriptions/summaries) was read as part of that same row-by-row check
+# but is not separately re-verified here, so it stays out of the claim.
+verdict_scope = ["flags", "subcommands"]

--- a/docs/design.md
+++ b/docs/design.md
@@ -2797,6 +2797,16 @@ parser change follows. Snap launchers are a hazard class worth naming.
 like redo of things we already did." No busybox fixture, no busybox
 family, and no busybox count follow from this decision.
 
+**The ragged-command-table fix ships below the five-tool bar
+(2026-09-06).** `AGENTS.md` §3.1 sets five tools fleet-wide as the bar a
+new parser heuristic must clear. `scan_ragged_command_row` and
+`scan_ragged_command_run` (docs/shapes.md S-103, S-104) move two: pnpm
+itself and fail2ban-client. The maintainer ruled it ships anyway, as a
+recorded exception, since the alternative is dropping pnpm's whole root
+command table and inventing two commands from wrapped text. Both
+families are ratcheted at zero fleet-wide the same way a repaired family
+above the bar is.
+
 ### Deferred, with the reason each is not simply undone
 
 **Sub-case (b) of the `-h` fallback is unmeasured and must stay that way until

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1805,6 +1805,55 @@ entry's `tools` field and nothing else. It does not get a new entry.
   member); not gated (the merge half it argues for is invisible to this
   same sweep, so a gate here would ratchet a number the fix cannot move).
 
+### S-103: a command's wrapped description invents a subcommand
+
+- id: S-103
+- looks like: |
+        ls, list                 Print all the versions of packages that are
+                                 installed, as well as their dependencies, in a
+                                 tree-structure
+- tools: pnpm
+- handling: A command's description wraps onto a physical line with no column of
+  its own. The generic layout parser's heading fallback misreads an earlier
+  ragged-indent row as a section heading (see S-104), and the orphaned
+  continuation's own leading word then reads as a fresh subcommand.
+  `scan_ragged_command_run` recognizes the owning row directly, before the
+  heading fallback ever sees it, so the continuation folds into that row's
+  description instead of becoming a node. Fixed. The fix moves 2 tools
+  fleet-wide, below the five-tool bar in AGENTS.md §3.1; shipped as a
+  recorded exception (docs/design.md §16).
+- fleet: 0 after the fix (pnpm's 2 inventions, `tree-structure` and `package`,
+  both gone), 2026-09-03. The `wrapped-command-continuation-as-subcommand`
+  detector's own fleet-wide count is reported, not gated: a full sweep found
+  1 unrelated tool it also fires on, not yet excluded by a declared scope.
+
+### S-104: a short-alias prefix ragged-indents a command table's rows
+
+- id: S-104
+- looks like: |
+        add                  Installs a package and any packages that it depends
+     i, install              Install all dependencies for a project
+    ln, link                 Connect the local project to another one
+- tools: pnpm
+- handling: A command table's rows carry an optional short-alias-comma prefix
+  (`i, install`), which sits at a shallower indent than the unaliased rows
+  around it. The generic layout parser's block scanners key a row-vs-
+  continuation decision on one fixed indent baseline per block, which cannot
+  admit both indents at once: the shallower row never opens a block and is
+  dropped, and the deeper siblings after it get swallowed by the heading
+  fallback (see S-103). `scan_ragged_command_row`/`scan_ragged_command_run`
+  recognize each row directly, one physical line at a time, gated on the
+  document already being in a command-listing context and on a run of 2+
+  such rows in strict adjacency. Fixed. The fix moves 2 tools fleet-wide,
+  below the five-tool bar in AGENTS.md §3.1; shipped as a recorded exception
+  (docs/design.md §16).
+- fleet: 0 after the fix (pnpm's 12 aliased-and-sibling rows all recovered:
+  `i, install`, `ln, link`, `rm, remove`, `unlink`, `up, update`, `ls, list`,
+  `outdated`, `why`, `c, config`, `init`, `publish`, `stage`), 2026-09-03. The
+  `ragged-command-table` detector's own fleet-wide count is reported, not
+  gated: a full sweep found it also fires on 144 tools whose "missing
+  command" is really an unrelated bullet or reference list, not this shape.
+
 ### S-105: one-space description column on a pipe-joined alias row
 
 - id: S-105

--- a/mandible-core/src/audit.rs
+++ b/mandible-core/src/audit.rs
@@ -502,11 +502,23 @@ pub const DEFECT_FAMILIES: &[DefectFamily] = &[
     // names B, C and D as declared exclusions with a witness line each (see
     // `xtask/src/commandtable.rs`). A zero count for that detector therefore
     // means shape A is repaired — it does NOT mean this family is done.
+    //
+    // A fifth grammar, found outside the seed-2 set (`corpus/pnpm/11.22.0/`,
+    // `[xfail]` until fixed — the tool is not one of seed-2's 8 labelled
+    // members, so it does not change that count):
+    //
+    //   E  ragged alias-column table          pnpm                          FIXED
+    //      (`  i, install   desc` beside `      add   desc`, an optional
+    //      short-alias prefix ragged-indenting some rows but not others)
+    //
+    // `xtask`'s `ragged-command-table` detector claims shape E only. Its
+    // own fleet count is ratchet-gated at zero the same way shape A's is.
     DefectFamily {
         name: "unparsed-subcommand",
         meaning: "subcommand names are plainly present in the help text but no child node is \
-                  produced for them — four unrelated grammars share this label; see the comment \
-                  above, only shape A (the dash-separated command table) is fixed",
+                  produced for them — five unrelated grammars share this label; see the comment \
+                  above, only shapes A and E (the dash-separated and ragged alias-column command \
+                  tables) are fixed",
     },
     DefectFamily {
         name: "unparsed-positional",
@@ -613,6 +625,22 @@ pub const DEFECT_FAMILIES: &[DefectFamily] = &[
         meaning: "a flag's value spec is two or more glued optional groups (`-V[N][fname]`) \
                   reaching the tree folded into one space-joined name instead of the source's \
                   own bracket spelling",
+    },
+    // Added for atlas S-103 (`corpus/pnpm/11.22.0/`, fixed).
+    // A sibling of `wrapped-prose-row-boundary` above, not the same family:
+    // that one requires the continuation's own leading spelling to start
+    // with `-` (it fires only inside a flag table) and reads the invented
+    // entry as a flag; this one requires no dash at all (subcommand names
+    // never carry one) and reads it as a subcommand, gated on the document
+    // already being in a command-listing context rather than on any table
+    // shape of its own. Distinct grammars, same underlying mistake —
+    // a continuation line with no aligned column of its own is read as a
+    // fresh table row.
+    DefectFamily {
+        name: "wrapped-command-continuation-as-subcommand",
+        meaning: "a command's description wraps onto a physical line with no column of its own, \
+                  and the grammar reads that continuation's own leading word as a new subcommand \
+                  — inventing a command out of prose rather than out of any real command list",
     },
     // NOT ONE DEFECT, AND NO DETECTOR WAS BUILT. This is the vaguest label
     // in the manifest — its own `meaning` below is a list of five unrelated

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -730,10 +730,39 @@ fn emit_command_table(inp: &BodyInput, h: &Heading, mut i: usize, st: &mut BodyS
         i = end;
         st.command_mode = true;
         st.in_ignorable_section = false;
+        st.command_group = heading_can_name_a_group(heading).then(|| heading.to_string());
         let (seen, clean) = emit_subcommands(heading, entries, st.result);
         st.total_entries += seen;
         st.clean_entries += clean;
         return i;
+    }
+
+    // A ragged-indent command table (docs/shapes.md S-103, S-104) gets
+    // first refusal here too, not only from `scan_entries`'s own
+    // leftover-row dispatch: pnpm's `Other:` heading opens directly on
+    // an aliased row (`c, config`), so [`bare_block_end`]'s fixed-floor
+    // block never truncates early the way it does for a *later* ragged
+    // row, and the whole section — `c, config`, `init`, `publish`,
+    // `stage` — reaches [`scan_bare_block`] as one block whose baseline
+    // then folds every unaliased sibling into `c, config`'s own
+    // description, which is then dropped whole for failing the name-
+    // shape test (the comma). Gated the same way `allow_dash_separator`
+    // is, so it never fires outside a heading already known to name
+    // commands.
+    if (recognized || st.command_mode) && !is_declared_non_command {
+        let group = heading_can_name_a_group(heading).then(|| heading.to_string());
+        if let Some((end, nodes)) = scan_ragged_command_run(lines, i, group.as_deref()) {
+            i = end;
+            st.command_mode = true;
+            st.in_ignorable_section = false;
+            st.command_group = group;
+            st.total_entries += nodes.len();
+            st.clean_entries += nodes.len();
+            for node in nodes {
+                st.result.try_push_subcommand(node);
+            }
+            return i;
+        }
     }
 
     let (end, entries) = scan_bare_block(lines, i, heading_indent, allow_dash_separator);
@@ -763,6 +792,7 @@ fn emit_command_table(inp: &BodyInput, h: &Heading, mut i: usize, st: &mut BodyS
         if recognized {
             st.in_ignorable_section = false;
         }
+        st.command_group = heading_can_name_a_group(heading).then(|| heading.to_string());
         let (seen, clean) = emit_subcommands(heading, entries, st.result);
         st.total_entries += seen;
         st.clean_entries += clean;
@@ -1009,6 +1039,7 @@ fn emit_heading_block(
             i = end;
             st.command_mode = false;
             st.in_ignorable_section = false;
+            st.command_group = heading_can_name_a_group(heading).then(|| heading.to_string());
             let (seen, clean) = emit_subcommands(heading, entries, st.result);
             st.total_entries += seen;
             st.clean_entries += clean;
@@ -1153,6 +1184,7 @@ fn emit_flush_heading(
             i = end;
             st.command_mode = true;
             st.in_ignorable_section = false;
+            st.command_group = heading_can_name_a_group(heading).then(|| heading.to_string());
             let (seen, clean) = emit_subcommands(heading, entries, st.result);
             st.total_entries += seen;
             st.clean_entries += clean;
@@ -1180,6 +1212,14 @@ struct BodyScan<'a> {
     obscured_ignorable_indent: Option<(usize, bool)>,
     total_entries: usize,
     clean_entries: usize,
+    /// The most recent real heading whose block became subcommands
+    /// (`emit_subcommands`'s own `group` argument, mirrored here), so
+    /// `scan_ragged_command_run`'s directly-emitted nodes carry the same
+    /// group a sibling row reached through the ordinary block scanners
+    /// would. Best-effort only: `None` when no such heading has been seen
+    /// yet, and never consulted by anything but that one call site. See
+    /// docs/shapes.md S-103, S-104.
+    command_group: Option<String>,
 }
 
 fn scan_entries(
@@ -1241,6 +1281,7 @@ fn scan_entries(
         obscured_ignorable_indent,
         total_entries: 0usize,
         clean_entries: 0usize,
+        command_group: None,
     };
     while i < lines.len() {
         let line = lines[i];
@@ -1317,6 +1358,29 @@ fn scan_entries(
                     st.command_mode = false;
                     continue;
                 }
+            }
+        }
+
+        // A run of ragged-indent command-table rows: a short-alias prefix
+        // (`i, install`) ragged-indents some rows against their unaliased
+        // siblings, which defeats every fixed-indent block scanner below
+        // and, left to the heading fallback, invents a command from a
+        // wrapped description. Recognized directly first. Gated on
+        // `st.command_group` too, not just `st.command_mode`, so an
+        // inherited chain with no real command heading behind it
+        // (`mysqlslap`'s flush-left settings table, S-092) never fires.
+        // See docs/shapes.md S-103, S-104; corpus/pnpm/11.22.0.
+        if st.command_mode && st.command_group.is_some() && !st.in_ignorable_section {
+            if let Some((end, nodes)) =
+                scan_ragged_command_run(lines, i, st.command_group.as_deref())
+            {
+                i = end;
+                st.total_entries += nodes.len();
+                st.clean_entries += nodes.len();
+                for node in nodes {
+                    st.result.try_push_subcommand(node);
+                }
+                continue;
             }
         }
 

--- a/mandible-extract/src/help_text/sections/scan.rs
+++ b/mandible-extract/src/help_text/sections/scan.rs
@@ -1338,6 +1338,218 @@ Usage: mytool [OPTIONS]\n\nEnvironment overrides:\n  -e, --env-file FILE   load 
     }
 }
 
+/// Fewest characters allowed on the left side of a comma before it stops
+/// reading as a short alias: pnpm's own aliased root commands are all 1 or
+/// 2 letters (`i`, `ln`, `rm`, `up`, `ls`, `c`). Kept small deliberately —
+/// a wider bound risks reading an unrelated two-word row as an alias pair.
+/// See docs/shapes.md S-104.
+const MAX_RAGGED_ALIAS_CHARS: usize = 3;
+
+/// A short-alias prefix on a ragged command row's own name field (`"i,
+/// install"`, `"ln, link"`): pnpm's own convention for its 6 aliased root
+/// commands. Returns `(primary, Some(alias))` when the text splits on one
+/// comma into two [`is_command_name_shaped`] tokens, the left one at most
+/// [`MAX_RAGGED_ALIAS_CHARS`] characters and strictly shorter than the
+/// right — otherwise `(name, None)` unchanged, which also covers the
+/// ordinary unaliased case (`"add"`, `"init"`). See docs/shapes.md S-104.
+fn split_ragged_alias_prefix(name: &str) -> (&str, Option<&str>) {
+    let Some((left, right)) = name.split_once(',') else {
+        return (name, None);
+    };
+    let (left, right) = (left.trim(), right.trim());
+    if is_command_name_shaped(left)
+        && is_command_name_shaped(right)
+        && left.chars().count() <= MAX_RAGGED_ALIAS_CHARS
+        && left.chars().count() < right.chars().count()
+    {
+        (right, Some(left))
+    } else {
+        (name, None)
+    }
+}
+
+/// One ragged-indent command-table row: a bare or short-alias-prefixed
+/// name, its own description-column gap, and a gap-free description (no
+/// further [`find_multi_space_gap`] — refuses `less --help`'s packed
+/// key-binding rows). Folds its own deeper-indented, gap-free
+/// continuations. Called only under `st.command_mode`, and only ever
+/// accepted in a run of [`MIN_RAGGED_RUN`]+ via [`scan_ragged_command_run`].
+/// See docs/shapes.md S-103, S-104; corpus/pnpm/11.22.0.
+fn try_ragged_command_row(
+    lines: &[&str],
+    start: usize,
+    group: Option<&str>,
+) -> Option<(usize, CommandNode)> {
+    let line = *lines.get(start)?;
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || looks_like_flag_start(trimmed) {
+        return None;
+    }
+    let gap = find_description_gap(line)?;
+    let (name_field, desc) = split_at_column(line, Some(gap));
+    let name_field = name_field.trim();
+    if name_field.is_empty() {
+        return None;
+    }
+    let desc = desc.trim().to_string();
+    if desc.is_empty() || find_multi_space_gap(&desc).is_some() {
+        return None;
+    }
+    let (primary, alias) = split_ragged_alias_prefix(name_field);
+    if !is_command_name_shaped(primary) {
+        return None;
+    }
+
+    let row_indent = leading_whitespace(line);
+    let mut end = start + 1;
+    let mut full_desc = desc;
+    while end < lines.len() {
+        let cont = lines[end];
+        if cont.trim().is_empty() {
+            break;
+        }
+        if leading_whitespace(cont) <= row_indent {
+            break;
+        }
+        if find_description_gap(cont).is_some() || looks_like_flag_start(cont.trim_start()) {
+            break;
+        }
+        full_desc.push(' ');
+        full_desc.push_str(cont.trim());
+        end += 1;
+    }
+
+    let mut node = CommandNode::new(primary, Provenance::single(Source::HelpText));
+    if let Some(alias) = alias {
+        node.aliases.push(alias.to_string());
+    }
+    node.summary = non_empty_text(&full_desc);
+    node.group = group.map(str::to_string);
+    node.children_filled = false;
+    node.heading_attested = true;
+    Some((end, node))
+}
+
+/// Shortest run of [`try_ragged_command_row`] matches, in strict physical
+/// adjacency, admitted as a real command table rather than noise — see
+/// that function's own doc comment, gate 3.
+const MIN_RAGGED_RUN: usize = 2;
+
+/// Every [`try_ragged_command_row`] match starting at `lines[start]`,
+/// requiring immediate adjacency (each row starts exactly where the
+/// previous one's own span, continuations included, ended — no blank line
+/// and no non-matching line between them) and at least [`MIN_RAGGED_RUN`]
+/// of them. `None` on a lone match or no match at all; the caller then
+/// falls through to the ordinary heading/block scanners exactly as if
+/// this function did not exist. See docs/shapes.md S-103, S-104.
+pub(super) fn scan_ragged_command_run(
+    lines: &[&str],
+    start: usize,
+    group: Option<&str>,
+) -> Option<(usize, Vec<CommandNode>)> {
+    let mut nodes = Vec::new();
+    let mut i = start;
+    while let Some((end, node)) = try_ragged_command_row(lines, i, group) {
+        nodes.push(node);
+        i = end;
+    }
+    // `timedatectl`'s `Commands:` block mixes bare-name rows this grammar
+    // reads (`status`, `show`) with rows carrying a trailing operand
+    // (`set-time TIME`) it does not — and does not claim to (that operand
+    // is no part of any command name). A run that stops mid-block, on a
+    // non-blank line it simply does not recognize, must decline whole
+    // rather than return a partial result and abandon everything after
+    // it: the caller has no other path back to those rows once this one
+    // returns. Accepted only when the run reaches a real boundary —
+    // end of input or a blank line — the same signal `bare_block_end`
+    // reads a block's own end from.
+    let reached_boundary = i >= lines.len() || lines[i].trim().is_empty();
+    (nodes.len() >= MIN_RAGGED_RUN && reached_boundary).then_some((i, nodes))
+}
+
+#[cfg(test)]
+mod ragged_command_row_tests {
+    use super::*;
+
+    #[test]
+    fn an_alias_prefixed_row_yields_its_primary_name_and_alias() {
+        let lines = ["   i, install              Install all dependencies for a project"];
+        let (end, node) = try_ragged_command_row(&lines, 0, None).unwrap();
+        assert_eq!(end, 1);
+        assert_eq!(node.name, "install");
+        assert_eq!(node.aliases, vec!["i".to_string()]);
+        assert_eq!(
+            node.summary.as_ref().unwrap().as_str(),
+            "Install all dependencies for a project"
+        );
+    }
+
+    #[test]
+    fn an_unaliased_row_folds_its_own_continuation() {
+        let lines = [
+            "      unlink               Unlinks a package. Like yarn unlink but pnpm",
+            "                           re-installs the dependency after removing the",
+            "                           external link",
+        ];
+        let (end, node) = try_ragged_command_row(&lines, 0, None).unwrap();
+        assert_eq!(end, 3);
+        assert_eq!(node.name, "unlink");
+        assert!(node.aliases.is_empty());
+        assert_eq!(
+            node.summary.as_ref().unwrap().as_str(),
+            "Unlinks a package. Like yarn unlink but pnpm re-installs the dependency after \
+             removing the external link"
+        );
+    }
+
+    /// The `less` false positive this detector must never fire on: a
+    /// key-binding row whose own first 2+-space gap lands right after a
+    /// single letter, exactly the way a real row's name field would, but
+    /// whose "description" is itself another aligned column.
+    #[test]
+    fn a_packed_multi_column_reference_row_is_refused() {
+        let lines = ["  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines)."];
+        assert!(try_ragged_command_row(&lines, 0, None).is_none());
+    }
+
+    #[test]
+    fn a_row_with_no_description_gap_is_refused() {
+        let lines = ["  bareword"];
+        assert!(try_ragged_command_row(&lines, 0, None).is_none());
+    }
+
+    #[test]
+    fn a_flag_row_is_never_read_as_a_command_row() {
+        let lines = ["  -x, --example         An ordinary flag, not a command"];
+        assert!(try_ragged_command_row(&lines, 0, None).is_none());
+    }
+
+    /// pnpm's own ragged run: a shallower aliased row beside two deeper
+    /// unaliased ones, admitted together because the run has 3 members.
+    #[test]
+    fn a_run_of_ragged_rows_is_admitted_together() {
+        let lines = [
+            "   i, install              Install all dependencies for a project",
+            "  ln, link                 Connect the local project to another one",
+            "      unlink               Unlinks a package.",
+        ];
+        let (end, nodes) = scan_ragged_command_run(&lines, 0, Some("Manage:")).unwrap();
+        assert_eq!(end, 3);
+        let names: Vec<&str> = nodes.iter().map(|n| n.name.as_str()).collect();
+        assert_eq!(names, vec!["install", "link", "unlink"]);
+        assert!(nodes.iter().all(|n| n.group.as_deref() == Some("Manage:")));
+    }
+
+    /// `less`'s lone `v` row: it passes every single-row gate on its own,
+    /// but the row before it (`s _f_i_l_e`) is not a match, so the run
+    /// never reaches [`MIN_RAGGED_RUN`] and nothing is emitted.
+    #[test]
+    fn a_lone_matching_row_is_not_a_run() {
+        let lines = ["  v                    Edit the current file with $VISUAL or $EDITOR."];
+        assert!(scan_ragged_command_run(&lines, 0, None).is_none());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/xtask/src/coverage/aggregate.rs
+++ b/xtask/src/coverage/aggregate.rs
@@ -181,6 +181,19 @@ pub struct Aggregate {
     /// fleet-wide)`, in registration order. **Not gated** — the calibration
     /// precondition (spec §13.1e) has not passed yet for any of the seven.
     pub vim_family: Vec<(&'static str, usize, usize)>,
+    /// Tools with at least one [`crate::ragged_command_table`] finding — a
+    /// run of ragged-indent command-table rows (`unparsed-subcommand`
+    /// shape E, atlas S-104) whose primary name never reaches the tree.
+    pub ragged_command_tools: usize,
+    /// Real commands lost to that shape, fleet-wide — one per finding.
+    pub ragged_command_flags: usize,
+    /// Tools with at least one [`crate::wrapped_command_continuation`]
+    /// finding — a command's description wrapping onto a bare
+    /// continuation line read as a fresh subcommand (atlas S-103).
+    pub wrapped_command_tools: usize,
+    /// Fabricated subcommands from that shape, fleet-wide — one per
+    /// finding.
+    pub wrapped_command_flags: usize,
 }
 
 /// Compute aggregate stats over `rows`.
@@ -256,6 +269,10 @@ pub(super) fn compute_aggregate(rows: &[Row]) -> Aggregate {
     let tail_operand_tools = rows.iter().filter(|r| r.tail_operand_count > 0).count();
     let tail_operand_flags: usize = rows.iter().map(|r| r.tail_operand_count).sum();
     let vim_family = compute_vim_family(rows);
+    let ragged_command_tools = rows.iter().filter(|r| r.ragged_command_count > 0).count();
+    let ragged_command_flags: usize = rows.iter().map(|r| r.ragged_command_count).sum();
+    let wrapped_command_tools = rows.iter().filter(|r| r.wrapped_command_count > 0).count();
+    let wrapped_command_flags: usize = rows.iter().map(|r| r.wrapped_command_count).sum();
 
     let mut framework_counts: BTreeMap<String, usize> = BTreeMap::new();
     for row in rows {
@@ -296,6 +313,10 @@ pub(super) fn compute_aggregate(rows: &[Row]) -> Aggregate {
         tail_operand_tools,
         tail_operand_flags,
         vim_family,
+        ragged_command_tools,
+        ragged_command_flags,
+        wrapped_command_tools,
+        wrapped_command_flags,
     }
 }
 
@@ -358,7 +379,7 @@ pub(super) fn detection_rate_pct(aggregate: &Aggregate) -> f64 {
 /// `coverage-scoreboard.txt`).
 pub(super) fn aggregate_footer_line(aggregate: &Aggregate) -> String {
     format!(
-        "# aggregate: pct_flags_with_text={:.2} no_tier_count={} suspicious_count={} verbatim_count={} incomplete_count={} man_shaped_count={} zero_flag_ok_count={} misattribution_suspect_tools={} misattribution_column_aligned_tools={} existence_fabrication_tools={} bundle_collapse_tools={} bundle_destroyed_flags={} alternation_defect_tools={} alternation_defect_flags={} command_table_tools={} single_dash_split_tools={} single_dash_split_flags={} repeated_char_tools={} repeated_char_flags={} wrapped_prose_tools={} wrapped_prose_flags={} tail_operand_tools={} tail_operand_flags={} vim_family={} total={} described_flags={:.4} describable_flags={:.4} total_flags={}\n",
+        "# aggregate: pct_flags_with_text={:.2} no_tier_count={} suspicious_count={} verbatim_count={} incomplete_count={} man_shaped_count={} zero_flag_ok_count={} misattribution_suspect_tools={} misattribution_column_aligned_tools={} existence_fabrication_tools={} bundle_collapse_tools={} bundle_destroyed_flags={} alternation_defect_tools={} alternation_defect_flags={} command_table_tools={} single_dash_split_tools={} single_dash_split_flags={} repeated_char_tools={} repeated_char_flags={} wrapped_prose_tools={} wrapped_prose_flags={} tail_operand_tools={} tail_operand_flags={} vim_family={} ragged_command_tools={} ragged_command_flags={} wrapped_command_tools={} wrapped_command_flags={} total={} described_flags={:.4} describable_flags={:.4} total_flags={}\n",
         aggregate.pct_flags_with_text,
         aggregate.no_tier_count,
         aggregate.suspicious_count,
@@ -383,6 +404,10 @@ pub(super) fn aggregate_footer_line(aggregate: &Aggregate) -> String {
         aggregate.tail_operand_tools,
         aggregate.tail_operand_flags,
         encode_vim_family(&aggregate.vim_family),
+        aggregate.ragged_command_tools,
+        aggregate.ragged_command_flags,
+        aggregate.wrapped_command_tools,
+        aggregate.wrapped_command_flags,
         aggregate.total,
         aggregate.described_flags,
         aggregate.describable_flags,
@@ -539,6 +564,10 @@ pub fn parse_aggregate_footer(scoreboard: &str) -> Option<Aggregate> {
     // written before the seven vim-family detectors existed carries no such
     // key.
     let mut vim_family: Vec<(&'static str, usize, usize)> = Vec::new();
+    let mut ragged_command_tools = 0usize;
+    let mut ragged_command_flags = 0usize;
+    let mut wrapped_command_tools = 0usize;
+    let mut wrapped_command_flags = 0usize;
     for field in line.trim_start_matches("# aggregate:").split_whitespace() {
         let (key, value) = field.split_once('=')?;
         match key {
@@ -581,6 +610,10 @@ pub fn parse_aggregate_footer(scoreboard: &str) -> Option<Aggregate> {
             "tail_operand_tools" => tail_operand_tools = value.parse::<usize>().ok()?,
             "tail_operand_flags" => tail_operand_flags = value.parse::<usize>().ok()?,
             "vim_family" => vim_family = decode_vim_family(value),
+            "ragged_command_tools" => ragged_command_tools = value.parse::<usize>().ok()?,
+            "ragged_command_flags" => ragged_command_flags = value.parse::<usize>().ok()?,
+            "wrapped_command_tools" => wrapped_command_tools = value.parse::<usize>().ok()?,
+            "wrapped_command_flags" => wrapped_command_flags = value.parse::<usize>().ok()?,
             "described_flags" => described_flags = value.parse::<f64>().ok()?,
             "describable_flags" => describable_flags = value.parse::<f64>().ok()?,
             "total_flags" => total_flags = value.parse::<usize>().ok()?,
@@ -619,6 +652,10 @@ pub fn parse_aggregate_footer(scoreboard: &str) -> Option<Aggregate> {
         tail_operand_tools,
         tail_operand_flags,
         vim_family,
+        ragged_command_tools,
+        ragged_command_flags,
+        wrapped_command_tools,
+        wrapped_command_flags,
     })
 }
 

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -203,6 +203,10 @@ fn row(tool: &str, flags: usize, pct_flags_with_text: Option<f64>, status: &'sta
         tail_operand_count: 0,
         tail_operand_samples: Vec::new(),
         vim_family: Vec::new(),
+        ragged_command_count: 0,
+        ragged_command_samples: Vec::new(),
+        wrapped_command_count: 0,
+        wrapped_command_samples: Vec::new(),
         status,
         fingerprint: fingerprint::ToolFingerprint::default(),
     }

--- a/xtask/src/coverage/render_markdown.rs
+++ b/xtask/src/coverage/render_markdown.rs
@@ -120,6 +120,24 @@ fn vim_family_sample_section_markdown(rows: &[Row]) -> String {
     out
 }
 
+/// Markdown twin of [`ragged_command_sample_lines_text`].
+fn ragged_command_sample_section_markdown(rows: &[Row]) -> String {
+    sample_section_markdown(
+        rows.iter().flat_map(|r| r.ragged_command_samples.iter()),
+        "\n**Ragged-command-table findings** (sample — see \
+         `xtask/src/ragged_command_table.rs`):\n\n| sample |\n|---|\n",
+    )
+}
+
+/// Markdown twin of [`wrapped_command_sample_lines_text`].
+fn wrapped_command_sample_section_markdown(rows: &[Row]) -> String {
+    sample_section_markdown(
+        rows.iter().flat_map(|r| r.wrapped_command_samples.iter()),
+        "\n**Wrapped-command-continuation-as-subcommand findings** (sample — see \
+         `xtask/src/wrapped_command_continuation.rs`):\n\n| sample |\n|---|\n",
+    )
+}
+
 /// The shared body of the two markdown sections above.
 fn sample_section_markdown<'a>(samples: impl Iterator<Item = &'a String>, heading: &str) -> String {
     let samples: Vec<&String> = samples.take(SPLIT_SAMPLE_LIMIT).collect();
@@ -298,6 +316,18 @@ pub(super) fn render_markdown(rows: &[Row], aggregate: &Aggregate) -> String {
         out.push('\n');
     }
     out.push_str(&format!(
+        "**Ragged-command-table findings:** {} tool(s) whose ragged-indent command-table row \
+         never reached the tree (atlas S-104, `unparsed-subcommand` shape E), {} command(s) \
+         fleet-wide — see `xtask/src/ragged_command_table.rs`.\n\n",
+        aggregate.ragged_command_tools, aggregate.ragged_command_flags,
+    ));
+    out.push_str(&format!(
+        "**Wrapped-command-continuation-as-subcommand findings:** {} tool(s) with a fabricated \
+         subcommand from a bare continuation line (atlas S-103), {} command(s) fleet-wide — see \
+         `xtask/src/wrapped_command_continuation.rs`.\n\n",
+        aggregate.wrapped_command_tools, aggregate.wrapped_command_flags,
+    ));
+    out.push_str(&format!(
         "**Framework detection:** {}/{} tools ({:.1}%).\n",
         aggregate.framework_detected_count,
         aggregate.total,
@@ -319,6 +349,8 @@ pub(super) fn render_markdown(rows: &[Row], aggregate: &Aggregate) -> String {
     out.push_str(&wrapped_prose_sample_section_markdown(rows));
     out.push_str(&tail_operand_sample_section_markdown(rows));
     out.push_str(&vim_family_sample_section_markdown(rows));
+    out.push_str(&ragged_command_sample_section_markdown(rows));
+    out.push_str(&wrapped_command_sample_section_markdown(rows));
     // The same machine-readable footer the text format carries, wrapped in
     // an HTML comment so it stays invisible when rendered but parseable by
     // whatever recombines shards. Without it a sharded markdown run could

--- a/xtask/src/coverage/render_text.rs
+++ b/xtask/src/coverage/render_text.rs
@@ -200,6 +200,22 @@ pub(super) struct Row {
     /// family, in registration order. One field rather than seven
     /// repeated ones — see `crate::coverage::score::vim_family_counts`.
     pub(super) vim_family: Vec<(&'static str, usize, Vec<String>)>,
+    /// [`crate::ragged_command_table`]'s own measurement: count of this
+    /// tool's ragged-indent command-table rows whose primary name never
+    /// reached the tree (atlas S-104). Ratchet-gated at zero once the
+    /// generic-layout fix lands. See `mandible-core/src/audit.rs`'s
+    /// `unparsed-subcommand` comment.
+    pub(super) ragged_command_count: usize,
+    /// A few of this row's own findings, pre-formatted, mirroring
+    /// [`Self::tail_operand_samples`].
+    pub(super) ragged_command_samples: Vec<String>,
+    /// [`crate::wrapped_command_continuation`]'s own measurement: count of
+    /// this tool's fabricated subcommands from a bare continuation line
+    /// (atlas S-103). Ratchet-gated at zero once the fix lands.
+    pub(super) wrapped_command_count: usize,
+    /// A few of this row's own findings, pre-formatted, mirroring
+    /// [`Self::ragged_command_samples`].
+    pub(super) wrapped_command_samples: Vec<String>,
     pub(super) status: &'static str,
     /// This tool's field-level fingerprint (WS2 part 2,
     /// [`crate::transition`]'s per-tool diff): enough for `sweep-diff` to
@@ -346,6 +362,8 @@ pub(super) fn render_text(rows: &[Row], aggregate: &Aggregate) -> String {
     out.push_str(&wrapped_prose_sample_lines_text(rows));
     out.push_str(&tail_operand_sample_lines_text(rows));
     out.push_str(&vim_family_sample_lines_text(rows));
+    out.push_str(&ragged_command_sample_lines_text(rows));
+    out.push_str(&wrapped_command_sample_lines_text(rows));
     out.push_str(&fingerprint_lines(rows));
     out
 }
@@ -588,6 +606,24 @@ fn vim_family_sample_lines_text(rows: &[Row]) -> String {
         ));
     }
     out
+}
+
+/// Twin of [`single_dash_sample_lines_text`] for [`crate::ragged_command_table`].
+fn ragged_command_sample_lines_text(rows: &[Row]) -> String {
+    sample_lines_text(
+        rows.iter().flat_map(|r| r.ragged_command_samples.iter()),
+        "# ragged-command-table findings (sample — judge the false-positive rate yourself):\n",
+    )
+}
+
+/// Twin of [`single_dash_sample_lines_text`] for
+/// [`crate::wrapped_command_continuation`].
+fn wrapped_command_sample_lines_text(rows: &[Row]) -> String {
+    sample_lines_text(
+        rows.iter().flat_map(|r| r.wrapped_command_samples.iter()),
+        "# wrapped-command-continuation-as-subcommand findings (sample — judge the false-positive \
+         rate yourself):\n",
+    )
 }
 
 /// The shared body of the two functions above: up to [`SPLIT_SAMPLE_LIMIT`]

--- a/xtask/src/coverage/score.rs
+++ b/xtask/src/coverage/score.rs
@@ -9,9 +9,11 @@ use crate::alternation;
 use crate::bundling;
 use crate::existence;
 use crate::misattribution::{self, RecordingProbe};
+use crate::ragged_command_table;
 use crate::repeated_char;
 use crate::single_dash_long;
 use crate::tail_operand;
+use crate::wrapped_command_continuation;
 use crate::wrapped_prose;
 use mandible_core::CommandNode;
 use mandible_extract::{default_tiers_with_probe, resolve_tool, ExtractionResult, Runner};
@@ -191,6 +193,12 @@ pub(super) fn score_one(tool: &str) -> Row {
     let (wrapped_prose_count, wrapped_prose_samples, tail_operand_count, tail_operand_samples) =
         family_detector_counts(probe.root_help_text(), result.root.as_ref());
     let vim_family = vim_family_counts(probe.root_help_text(), result.root.as_ref());
+    let (
+        ragged_command_count,
+        ragged_command_samples,
+        wrapped_command_count,
+        wrapped_command_samples,
+    ) = ragged_family_detector_counts(probe.root_help_text(), result.root.as_ref());
     Row {
         tool: tool.to_string(),
         tiers: tiers_label,
@@ -223,6 +231,10 @@ pub(super) fn score_one(tool: &str) -> Row {
         tail_operand_count,
         tail_operand_samples,
         vim_family,
+        ragged_command_count,
+        ragged_command_samples,
+        wrapped_command_count,
+        wrapped_command_samples,
         status: status.label,
         fingerprint: build_fingerprint(result.root.as_ref()),
     }
@@ -731,6 +743,60 @@ fn round4_family_counts(raw: &str, root: &CommandNode) -> Vec<(&'static str, usi
                 .collect(),
         ),
     ]
+}
+
+/// One ragged-command-table finding, rendered as a single audit-section
+/// line.
+fn format_ragged_command_sample(finding: &ragged_command_table::Finding) -> String {
+    format!(
+        "{:?} (alias {:?}) missing, from {:?}",
+        finding.name, finding.alias, finding.row
+    )
+}
+
+/// One wrapped-command-continuation-as-subcommand finding, rendered as a
+/// single audit-section line.
+fn format_wrapped_command_sample(finding: &wrapped_command_continuation::Finding) -> String {
+    format!(
+        "{:?} fabricated from the line {:?}",
+        finding.name, finding.line
+    )
+}
+
+/// [`ragged_command_table::detect`] and
+/// [`wrapped_command_continuation::detect`], run over one tool's already-
+/// captured text and tree — split out of [`score_one`] for the same
+/// line-count reason as [`family_detector_counts`].
+fn ragged_family_detector_counts(
+    raw: Option<String>,
+    root: Option<&CommandNode>,
+) -> (usize, Vec<String>, usize, Vec<String>) {
+    let (Some(raw), Some(root)) = (raw, root) else {
+        return (0, Vec::new(), 0, Vec::new());
+    };
+    if raw.trim().is_empty() {
+        return (0, Vec::new(), 0, Vec::new());
+    }
+    let rc = ragged_command_table::detect(&raw, root);
+    let rc_samples = rc
+        .findings
+        .iter()
+        .take(FAMILY_DETECTOR_SAMPLES_PER_ROW)
+        .map(format_ragged_command_sample)
+        .collect();
+    let wc = wrapped_command_continuation::detect(&raw, root);
+    let wc_samples = wc
+        .findings
+        .iter()
+        .take(FAMILY_DETECTOR_SAMPLES_PER_ROW)
+        .map(format_wrapped_command_sample)
+        .collect();
+    (
+        rc.finding_count(),
+        rc_samples,
+        wc.finding_count(),
+        wc_samples,
+    )
 }
 
 /// True when the root's captured `--help` output was detected as a

--- a/xtask/src/detector/commands.rs
+++ b/xtask/src/detector/commands.rs
@@ -341,3 +341,55 @@ pub fn check_round6_family_ratchets(
     }
     Ok(all_hold)
 }
+
+/// One family's fleet count, ratcheted at zero, for a family whose
+/// `(tools, flags)` pair lives in its own two [`crate::coverage::Aggregate`]
+/// fields rather than in `vim_family`'s generic list. Same shape and
+/// reasoning as [`check_vim_family_ratchet`]; kept separate because that
+/// one is keyed on the `vim_family` field this family predates. Gated
+/// against a literal `0`, not `previous`, because the checked-in scoreboard
+/// is editable, so a commit reintroducing a defect would otherwise raise
+/// its own baseline.
+pub fn check_scalar_family_ratchet(
+    name: &'static str,
+    prev_tools: usize,
+    prev_flags: usize,
+    fresh_tools: usize,
+    fresh_flags: usize,
+) -> anyhow::Result<bool> {
+    if fresh_tools != prev_tools || fresh_flags != prev_flags {
+        println!(
+            "{name} findings changed from {prev_tools} tool(s)/{prev_flags} flag(s) to \
+             {fresh_tools} tool(s)/{fresh_flags} flag(s)",
+        );
+    }
+    let ratchet = ratchet_at_zero(find(name)?.as_ref(), fresh_tools, fresh_flags);
+    println!("\n{}", ratchet.report());
+    Ok(ratchet.holds())
+}
+
+/// pnpm's two families (atlas S-103, S-104), fixed in
+/// `mandible-extract/src/help_text/sections/{mod,scan}.rs`. Ratcheted at
+/// zero the same way as `single-dash-long`: the fix moves two tools
+/// fleet-wide, below the five-tool bar in AGENTS.md §3.1, recorded as a
+/// maintainer exception in `docs/design.md` §16.
+pub fn check_ragged_family_ratchets(
+    previous: &crate::coverage::Aggregate,
+    fresh: &crate::coverage::Aggregate,
+) -> anyhow::Result<bool> {
+    let ragged = check_scalar_family_ratchet(
+        "ragged-command-table",
+        previous.ragged_command_tools,
+        previous.ragged_command_flags,
+        fresh.ragged_command_tools,
+        fresh.ragged_command_flags,
+    )?;
+    let wrapped = check_scalar_family_ratchet(
+        "wrapped-command-continuation-as-subcommand",
+        previous.wrapped_command_tools,
+        previous.wrapped_command_flags,
+        fresh.wrapped_command_tools,
+        fresh.wrapped_command_flags,
+    )?;
+    Ok(ragged && wrapped)
+}

--- a/xtask/src/detector/detectors_misc.rs
+++ b/xtask/src/detector/detectors_misc.rs
@@ -445,3 +445,82 @@ impl Detector for UnparsedTailOperand {
         crate::tail_operand::self_checks()
     }
 }
+
+/// `ragged-command-table` (`crate::ragged_command_table`, atlas S-104): a
+/// command table whose rows carry an optional short-alias prefix
+/// ragged-indents its own rows, dropping the shallower rows and the run
+/// of siblings after them. Generalizes `unparsed-subcommand` shape E; see
+/// `mandible-core/src/audit.rs`'s own comment on that family.
+pub(crate) struct RaggedCommandTable;
+
+impl Detector for RaggedCommandTable {
+    fn name(&self) -> &'static str {
+        "ragged-command-table"
+    }
+    fn family(&self) -> Option<&'static str> {
+        Some("unparsed-subcommand")
+    }
+    fn describes(&self) -> &'static str {
+        "a run of 2+ adjacent command-table rows, one bearing a short-alias-comma prefix, whose \
+         primary name never reaches the tree"
+    }
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        crate::ragged_command_table::detect(evidence.raw, evidence.root)
+            .findings
+            .iter()
+            .map(|f| {
+                let alias = f.alias.as_deref().unwrap_or("none");
+                format!("{:?} (alias {alias:?}) missing, from {:?}", f.name, f.row)
+            })
+            .collect()
+    }
+    fn scope(&self) -> Scope {
+        Scope {
+            claim: "shape E only (a ragged alias-column table) of `unparsed-subcommand`'s five \
+                    grammars — shapes B, C and D are out of reach the same way \
+                    `unparsed-command-table` declares them, and are not re-declared here since \
+                    this detector never claimed them",
+            known_exclusions: &[],
+        }
+    }
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        crate::ragged_command_table::self_checks()
+    }
+}
+
+/// `wrapped-command-continuation-as-subcommand` (`crate::wrapped_command_continuation`,
+/// atlas S-103): a command's description wraps onto a line with no column
+/// of its own, and the grammar reads that continuation's own leading word
+/// as a fresh subcommand. See that module's own doc comment for how this
+/// differs from `wrapped-prose-row-boundary`.
+pub(crate) struct WrappedCommandContinuation;
+
+impl Detector for WrappedCommandContinuation {
+    fn name(&self) -> &'static str {
+        "wrapped-command-continuation-as-subcommand"
+    }
+    fn family(&self) -> Option<&'static str> {
+        Some("wrapped-command-continuation-as-subcommand")
+    }
+    fn describes(&self) -> &'static str {
+        "a bare single word, at the same indent as an unfinished sentence above it and with no \
+         aligned column of its own, that reached the tree as a subcommand"
+    }
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        crate::wrapped_command_continuation::detect(evidence.raw, evidence.root)
+            .findings
+            .iter()
+            .map(|f| format!("{:?} fabricated from the line {:?}", f.name, f.line))
+            .collect()
+    }
+    fn scope(&self) -> Scope {
+        Scope {
+            claim: "a continuation line's own single leading word only — see this detector's \
+                    own module doc comment",
+            known_exclusions: &[],
+        }
+    }
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        crate::wrapped_command_continuation::self_checks()
+    }
+}

--- a/xtask/src/detector/mod.rs
+++ b/xtask/src/detector/mod.rs
@@ -693,6 +693,8 @@ pub fn registry() -> Vec<Box<dyn Detector>> {
         Box::new(PositionalDescriptionBlock),
         Box::new(GenericOptionPlaceholderFlag),
         Box::new(DescriptionSubcommandsList),
+        Box::new(RaggedCommandTable),
+        Box::new(WrappedCommandContinuation),
     ]
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@ mod or_joined_alias;
 mod parenthetical_qualifier_as_value;
 mod plus_prefixed_option;
 mod queue;
+mod ragged_command_table;
 mod repeated_char;
 mod residue;
 mod rng;
@@ -34,6 +35,7 @@ mod status;
 mod tail_operand;
 mod transition;
 mod usage_only_value_name;
+mod wrapped_command_continuation;
 mod wrapped_prose;
 
 use clap::{Parser, Subcommand};
@@ -1258,6 +1260,54 @@ fn run_coverage(
 
         regressed |= !detector::check_round5_family_ratchets(&previous, &fresh)?;
         regressed |= !detector::check_round6_family_ratchets(&previous, &fresh)?;
+
+        // pnpm's two families (atlas S-103, S-104), fixed in
+        // `mandible-extract/src/help_text/sections/{mod,scan}.rs`. Ratcheted
+        // at zero the same way as `single-dash-long` above: the fix moves
+        // two tools fleet-wide, below the five-tool bar in AGENTS.md §3.1,
+        // recorded as a maintainer exception in `docs/design.md` §16.
+        if fresh.ragged_command_tools != previous.ragged_command_tools
+            || fresh.ragged_command_flags != previous.ragged_command_flags
+        {
+            println!(
+                "ragged-command-table findings changed from {} tool(s)/{} flag(s) to {} tool(s)/{} flag(s)",
+                previous.ragged_command_tools,
+                previous.ragged_command_flags,
+                fresh.ragged_command_tools,
+                fresh.ragged_command_flags,
+            );
+        }
+        let ragged_command_ratchet = detector::ratchet_at_zero(
+            detector::find("ragged-command-table")?.as_ref(),
+            fresh.ragged_command_tools,
+            fresh.ragged_command_flags,
+        );
+        println!("\n{}", ragged_command_ratchet.report());
+        if !ragged_command_ratchet.holds() {
+            regressed = true;
+        }
+
+        if fresh.wrapped_command_tools != previous.wrapped_command_tools
+            || fresh.wrapped_command_flags != previous.wrapped_command_flags
+        {
+            println!(
+                "wrapped-command-continuation-as-subcommand findings changed from {} tool(s)/{} flag(s) to {} tool(s)/{} flag(s)",
+                previous.wrapped_command_tools,
+                previous.wrapped_command_flags,
+                fresh.wrapped_command_tools,
+                fresh.wrapped_command_flags,
+            );
+        }
+        let wrapped_command_ratchet = detector::ratchet_at_zero(
+            detector::find("wrapped-command-continuation-as-subcommand")?.as_ref(),
+            fresh.wrapped_command_tools,
+            fresh.wrapped_command_flags,
+        );
+        println!("\n{}", wrapped_command_ratchet.report());
+        if !wrapped_command_ratchet.holds() {
+            regressed = true;
+        }
+
         if regressed {
             anyhow::bail!("coverage regression detected — see above");
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1173,65 +1173,29 @@ fn run_coverage(
             regressed = true;
         }
 
-        // `repeated-char-flag` (`crate::repeated_char`), the second of the
-        // three families sharing the `short && !long && value_name`
-        // fingerprint, on exactly the terms `bundled-short-flag` reached
-        // above and after the same movement: reported-and-ungated while the
-        // number had no baseline, ratcheted at a literal zero once the
-        // repair landed (`help_text::sections::repair_repeated_character_flags`).
-        // Gated against `0` and not against `previous` for the same reason —
-        // the checked-in scoreboard is editable, so a commit reintroducing
-        // the defect would otherwise raise its own baseline — and gated on
-        // the detector's own self-checks alongside the count, because a gate
-        // on `count == 0` alone is satisfied by deleting the detector.
-        if fresh.repeated_char_tools != previous.repeated_char_tools
-            || fresh.repeated_char_flags != previous.repeated_char_flags
-        {
-            println!(
-                "repeated-char-flag misreads changed from {} tool(s)/{} flag(s) to {} tool(s)/{} flag(s)",
-                previous.repeated_char_tools,
-                previous.repeated_char_flags,
-                fresh.repeated_char_tools,
-                fresh.repeated_char_flags,
-            );
-        }
-        let repeat_ratchet = detector::ratchet_at_zero(
-            detector::find("repeated-char-flag")?.as_ref(),
+        // `repeated-char-flag` and `single-dash-long`, the second and third
+        // of three families sharing the `short && !long && value_name`
+        // fingerprint (see `bundled-short-flag` above), ratcheted at zero
+        // each: see `detector::check_scalar_family_ratchet`'s doc comment
+        // for why zero and not `previous`. `single_dash_long::tests::
+        // the_real_parser_leaves_no_split_in_any_audited_fixture` separately
+        // covers the fix itself being deleted, which no fleet count catches.
+        if !detector::check_scalar_family_ratchet(
+            "repeated-char-flag",
+            previous.repeated_char_tools,
+            previous.repeated_char_flags,
             fresh.repeated_char_tools,
             fresh.repeated_char_flags,
-        );
-        println!("\n{}", repeat_ratchet.report());
-        if !repeat_ratchet.holds() {
+        )? {
             regressed = true;
         }
-
-        // `single-dash-long` (`crate::single_dash_long`), the third family
-        // sharing the `short && !long && value_name` fingerprint, ratcheted
-        // at zero the same way as the two above, gated against a literal
-        // `0` for the same editable-baseline reason. The complementary
-        // hazard — the detector staying healthy while the fix itself is
-        // deleted, which no fleet count or self-check catches — is covered
-        // separately by `single_dash_long::tests::
-        // the_real_parser_leaves_no_split_in_any_audited_fixture`, which
-        // replays frozen bytes under `cargo nextest`.
-        if fresh.single_dash_split_tools != previous.single_dash_split_tools
-            || fresh.single_dash_split_flags != previous.single_dash_split_flags
-        {
-            println!(
-                "single-dash-long splits changed from {} tool(s)/{} flag(s) to {} tool(s)/{} flag(s)",
-                previous.single_dash_split_tools,
-                previous.single_dash_split_flags,
-                fresh.single_dash_split_tools,
-                fresh.single_dash_split_flags,
-            );
-        }
-        let single_dash_ratchet = detector::ratchet_at_zero(
-            detector::find("single-dash-long")?.as_ref(),
+        if !detector::check_scalar_family_ratchet(
+            "single-dash-long",
+            previous.single_dash_split_tools,
+            previous.single_dash_split_flags,
             fresh.single_dash_split_tools,
             fresh.single_dash_split_flags,
-        );
-        println!("\n{}", single_dash_ratchet.report());
-        if !single_dash_ratchet.holds() {
+        )? {
             regressed = true;
         }
 
@@ -1260,53 +1224,7 @@ fn run_coverage(
 
         regressed |= !detector::check_round5_family_ratchets(&previous, &fresh)?;
         regressed |= !detector::check_round6_family_ratchets(&previous, &fresh)?;
-
-        // pnpm's two families (atlas S-103, S-104), fixed in
-        // `mandible-extract/src/help_text/sections/{mod,scan}.rs`. Ratcheted
-        // at zero the same way as `single-dash-long` above: the fix moves
-        // two tools fleet-wide, below the five-tool bar in AGENTS.md §3.1,
-        // recorded as a maintainer exception in `docs/design.md` §16.
-        if fresh.ragged_command_tools != previous.ragged_command_tools
-            || fresh.ragged_command_flags != previous.ragged_command_flags
-        {
-            println!(
-                "ragged-command-table findings changed from {} tool(s)/{} flag(s) to {} tool(s)/{} flag(s)",
-                previous.ragged_command_tools,
-                previous.ragged_command_flags,
-                fresh.ragged_command_tools,
-                fresh.ragged_command_flags,
-            );
-        }
-        let ragged_command_ratchet = detector::ratchet_at_zero(
-            detector::find("ragged-command-table")?.as_ref(),
-            fresh.ragged_command_tools,
-            fresh.ragged_command_flags,
-        );
-        println!("\n{}", ragged_command_ratchet.report());
-        if !ragged_command_ratchet.holds() {
-            regressed = true;
-        }
-
-        if fresh.wrapped_command_tools != previous.wrapped_command_tools
-            || fresh.wrapped_command_flags != previous.wrapped_command_flags
-        {
-            println!(
-                "wrapped-command-continuation-as-subcommand findings changed from {} tool(s)/{} flag(s) to {} tool(s)/{} flag(s)",
-                previous.wrapped_command_tools,
-                previous.wrapped_command_flags,
-                fresh.wrapped_command_tools,
-                fresh.wrapped_command_flags,
-            );
-        }
-        let wrapped_command_ratchet = detector::ratchet_at_zero(
-            detector::find("wrapped-command-continuation-as-subcommand")?.as_ref(),
-            fresh.wrapped_command_tools,
-            fresh.wrapped_command_flags,
-        );
-        println!("\n{}", wrapped_command_ratchet.report());
-        if !wrapped_command_ratchet.holds() {
-            regressed = true;
-        }
+        regressed |= !detector::check_ragged_family_ratchets(&previous, &fresh)?;
 
         if regressed {
             anyhow::bail!("coverage regression detected — see above");

--- a/xtask/src/ragged_command_table.rs
+++ b/xtask/src/ragged_command_table.rs
@@ -1,0 +1,293 @@
+//! The `ragged-command-table` detector (`unparsed-subcommand` shape E,
+//! atlas S-104): a command table whose rows carry an optional short-alias
+//! prefix (`i, install` beside `add`) ragged-indents its own rows, and a
+//! parser keyed on one fixed indent baseline drops the shallower rows and
+//! the run of siblings after them.
+//!
+//! Fixture: `corpus/pnpm/11.22.0/`. Independently reimplemented from
+//! `mandible-extract`'s own `scan_ragged_command_row` — agreeing with the
+//! thing under test is exactly what a detector must not do.
+
+use mandible_core::{is_command_name_shaped, CommandNode};
+
+/// See `mandible-extract/src/help_text/sections/emit.rs`'s
+/// `MAX_ALIAS_CHARS` — the same bound, independently applied.
+const MAX_ALIAS_CHARS: usize = 3;
+
+/// One row this detector's own grammar recognizes as a command-table
+/// entry, whose primary name is missing from the tree.
+pub struct Finding {
+    pub name: String,
+    pub alias: Option<String>,
+    pub row: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    pub fn finding_count(&self) -> usize {
+        self.findings.len()
+    }
+}
+
+fn leading_whitespace(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// The byte offset of the first run of 2+ spaces in `line`, after some
+/// non-whitespace content — this detector's own column-gap finder,
+/// independent of the parser's `find_multi_space_gap`.
+fn find_gap(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut run = 0usize;
+    let mut seen_content = false;
+    for (i, b) in bytes.iter().enumerate() {
+        if *b == b' ' {
+            run += 1;
+            if run >= 2 && seen_content {
+                return Some(i - run + 1);
+            }
+        } else {
+            if *b != b'\t' {
+                seen_content = true;
+            }
+            run = 0;
+        }
+    }
+    None
+}
+
+/// `(primary, alias)` when `name_field` is a bare command name or a short-
+/// alias-prefixed pair, mirroring the parser's own `split_ragged_alias_prefix`.
+fn split_alias(name_field: &str) -> Option<(String, Option<String>)> {
+    if let Some((left, right)) = name_field.split_once(',') {
+        let (left, right) = (left.trim(), right.trim());
+        if is_command_name_shaped(left)
+            && is_command_name_shaped(right)
+            && left.chars().count() <= MAX_ALIAS_CHARS
+            && left.chars().count() < right.chars().count()
+        {
+            return Some((right.to_string(), Some(left.to_string())));
+        }
+        return None;
+    }
+    is_command_name_shaped(name_field).then(|| (name_field.to_string(), None))
+}
+
+/// One ragged command-table row, this detector's own grammar: a gap, a
+/// non-empty description with no further gap of its own (excludes packed
+/// reference tables like `less --help`'s key-binding summary), and a name
+/// field that is a bare name or a short-alias pair.
+fn row_entry(line: &str) -> Option<(String, Option<String>)> {
+    let gap = find_gap(line)?;
+    let name_field = line.get(..gap)?.trim();
+    let desc = line.get(gap..)?.trim();
+    if desc.is_empty() || find_gap(desc).is_some() {
+        return None;
+    }
+    split_alias(name_field)
+}
+
+fn tree_has_name(node: &CommandNode, name: &str) -> bool {
+    node.subcommands.iter().any(|c| c.name == name)
+        || node.subcommands.iter().any(|c| tree_has_name(c, name))
+}
+
+/// Runs of 2+ adjacent [`row_entry`] matches, each row's own name checked
+/// against `root`. Adjacency and the run-length floor mirror the parser's
+/// own safety net against a lone false positive (`less`'s `v` row).
+pub fn detect(raw: &str, root: &CommandNode) -> Report {
+    const MIN_RUN: usize = 2;
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut findings = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let Some((name, alias)) = row_entry(lines[i]) else {
+            i += 1;
+            continue;
+        };
+        let row_indent = leading_whitespace(lines[i]);
+        let mut run: Vec<(usize, String, Option<String>)> = vec![(i, name, alias)];
+        let mut j = i + 1;
+        // Fold this row's own continuation lines exactly the way the
+        // parser does, so a wrapped description doesn't end the run early.
+        while j < lines.len() {
+            let l = lines[j];
+            if l.trim().is_empty() || leading_whitespace(l) <= row_indent || find_gap(l).is_some() {
+                break;
+            }
+            j += 1;
+        }
+        while j < lines.len() {
+            let Some((name, alias)) = row_entry(lines[j]) else {
+                break;
+            };
+            let this_indent = leading_whitespace(lines[j]);
+            run.push((j, name, alias));
+            let mut k = j + 1;
+            while k < lines.len() {
+                let l = lines[k];
+                if l.trim().is_empty()
+                    || leading_whitespace(l) <= this_indent
+                    || find_gap(l).is_some()
+                {
+                    break;
+                }
+                k += 1;
+            }
+            j = k;
+        }
+        if run.len() >= MIN_RUN {
+            for (idx, name, alias) in &run {
+                if !tree_has_name(root, name) {
+                    findings.push(Finding {
+                        name: name.clone(),
+                        alias: alias.clone(),
+                        row: lines[*idx].to_string(),
+                    });
+                }
+            }
+        }
+        i = j;
+    }
+    Report { findings }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use crate::detector::{Expect, SelfCheck};
+use mandible_core::{Provenance, Source};
+
+/// pnpm's own bytes, byte-exact (`corpus/pnpm/11.22.0/help.txt`), trimmed
+/// to the two aliased sections that exhibit the shape.
+pub(crate) const PNPM_RAGGED_HELP: &str = "\
+Manage your dependencies:
+      add                  Installs a package and any packages that it depends
+                           on. By default, any new package is installed as a
+                           prod dependency
+   i, install              Install all dependencies for a project
+  ln, link                 Connect the local project to another one
+  rm, remove               Removes packages from node_modules and from the
+                           project's package.json
+      unlink               Unlinks a package. Like yarn unlink but pnpm
+                           re-installs the dependency after removing the
+                           external link
+  up, update               Updates packages to their latest version based on the
+                           specified range
+
+Other:
+   c, config               Manage the pnpm configuration files
+      init                 Create a package.json file
+      publish              Publishes a package to the registry
+      stage                Stage packages for publishing
+";
+
+fn node(name: &str) -> CommandNode {
+    CommandNode::new(name, Provenance::single(Source::HelpText))
+}
+
+fn tree_with(names: &[&str]) -> CommandNode {
+    let mut root = node("pnpm");
+    root.subcommands = names.iter().map(|n| node(n)).collect();
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "pnpm's own bytes, every ragged row missing from an empty tree",
+            why: "the defect itself: 10 rows across two aliased sections (`i, install`, `ln, \
+                  link`, `rm, remove`, `unlink`, `up, update`, `c, config`, `init`, `publish`, \
+                  `stage`, plus `add` counted once) never reach a tree that has none of them",
+            expect: Expect::Fires(10),
+            raw: PNPM_RAGGED_HELP.to_string(),
+            root: tree_with(&[]),
+        },
+        SelfCheck {
+            name: "pnpm's own bytes, a correctly repaired tree",
+            why: "once every row's primary name is a real subcommand, the detector has nothing \
+                  left to report — the repaired-family case",
+            expect: Expect::Silent,
+            raw: PNPM_RAGGED_HELP.to_string(),
+            root: tree_with(&[
+                "add", "install", "link", "remove", "unlink", "update", "config", "init",
+                "publish", "stage",
+            ]),
+        },
+        SelfCheck {
+            name: "less's key-binding summary, never mistaken for a command table",
+            why: "the false-positive calibration this shape's own guard exists for: each row's \
+                  first 2+-space gap lands right after a single letter exactly the way a real \
+                  row's name field would, but the text after it is itself column-aligned \
+                  (`^E  j  ^N  CR  *  Forward...`), which the detector's own no-further-gap gate \
+                  refuses",
+            expect: Expect::Silent,
+            raw: "\
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+"
+            .to_string(),
+            root: tree_with(&[]),
+        },
+        SelfCheck {
+            name: "a lone ragged row with no sibling",
+            why: "the run-length floor: one matching row, cheap to produce by accident, must \
+                  not be read as a table on its own",
+            expect: Expect::Silent,
+            raw: "  v                    Edit the current file with $VISUAL or $EDITOR.\n"
+                .to_string(),
+            root: tree_with(&[]),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fires_on_every_missing_ragged_row_in_pnpms_own_bytes() {
+        let report = detect(PNPM_RAGGED_HELP, &tree_with(&[]));
+        assert_eq!(
+            report.finding_count(),
+            10,
+            "{:?}",
+            report.findings.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn stays_silent_once_every_row_is_present() {
+        let root = tree_with(&[
+            "add", "install", "link", "remove", "unlink", "update", "config", "init", "publish",
+            "stage",
+        ]);
+        assert_eq!(detect(PNPM_RAGGED_HELP, &root).finding_count(), 0);
+    }
+
+    #[test]
+    fn every_self_check_holds() {
+        for case in self_checks() {
+            let expected = match case.expect {
+                Expect::Fires(n) => n,
+                Expect::Silent => 0,
+            };
+            let report = detect(&case.raw, &case.root);
+            assert_eq!(
+                report.finding_count(),
+                expected,
+                "{}: expected {} finding(s), got {:?}",
+                case.name,
+                expected,
+                report.findings.iter().map(|f| &f.name).collect::<Vec<_>>()
+            );
+        }
+    }
+}

--- a/xtask/src/wrapped_command_continuation.rs
+++ b/xtask/src/wrapped_command_continuation.rs
@@ -1,0 +1,238 @@
+//! The `wrapped-command-continuation-as-subcommand` detector (atlas
+//! S-103): a command's description wraps onto a physical line with no
+//! column of its own, and the grammar reads that continuation's own
+//! leading word as a fresh subcommand.
+//!
+//! A sibling of `xtask::wrapped_prose` (`wrapped-prose-row-boundary`,
+//! S-027), not the same shape: that one requires the continuation's own
+//! leading spelling to start with `-` and reads it as a flag; this one
+//! requires no dash at all — subcommand names never carry one — and reads
+//! it as a subcommand instead. See the family's own doc comment in
+//! `mandible-core/src/audit.rs`.
+//!
+//! Fixture: `corpus/pnpm/11.22.0/`.
+
+use mandible_core::CommandNode;
+
+/// One fabricated subcommand: its name, and the continuation line it was
+/// read from.
+pub struct Finding {
+    pub name: String,
+    pub line: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    pub fn finding_count(&self) -> usize {
+        self.findings.len()
+    }
+}
+
+fn leading_whitespace(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// True when the trimmed content of `line` carries an internal run of 2+
+/// spaces — a real description-column gap. Scanned only after the first
+/// non-space character, so a plain indented line (all its leading
+/// whitespace is not content) never counts as its own gap.
+fn has_wide_gap(line: &str) -> bool {
+    let bytes = line.trim_start().as_bytes();
+    let mut run = 0usize;
+    for b in bytes {
+        if *b == b' ' {
+            run += 1;
+            if run >= 2 {
+                return true;
+            }
+        } else {
+            run = 0;
+        }
+    }
+    false
+}
+
+fn tree_names<'a>(node: &'a CommandNode, out: &mut Vec<&'a str>) {
+    for c in &node.subcommands {
+        out.push(c.name.as_str());
+        tree_names(c, out);
+    }
+}
+
+/// True when `lines[idx]` is itself a continuation of an unfinished row's
+/// description: bare (no gap, so it cannot be a fresh row's own name
+/// field) and, walking back through zero or more further gap-less,
+/// non-blank, non-sentence-final lines, eventually reaching a line that
+/// does carry its own description-column gap (a real row) at a shallower
+/// indent than `lines[idx]` itself. That anchor row is pnpm's own `why`/
+/// `ls, list`; the walk-back is what lets this reach a continuation's own
+/// continuation (`tree-structure`, one line further than `package`).
+///
+/// A generalization of `mandible-extract`'s
+/// `is_wrapped_prose_continuation`, not the same rule: that function
+/// requires the immediately preceding line to itself lack a description
+/// column (it never anchors on the real row directly, only on one of its
+/// own later continuations), because a flag table's row and its
+/// continuation share one indent. A ragged command table's continuation
+/// sits one indent level *deeper* than the row that owns it, so the
+/// anchor here is found by indent comparison instead. See this module's
+/// own doc comment for why the two rules differ.
+fn is_bare_continuation(lines: &[&str], idx: usize) -> bool {
+    let cur = lines[idx];
+    if cur.split_whitespace().count() != 1 || has_wide_gap(cur) {
+        return false;
+    }
+    let cur_indent = leading_whitespace(cur);
+    let mut j = idx;
+    loop {
+        if j == 0 {
+            return false;
+        }
+        j -= 1;
+        let line = lines[j];
+        if line.trim().is_empty() {
+            return false;
+        }
+        if has_wide_gap(line) {
+            return leading_whitespace(line) < cur_indent
+                && !line.trim_end().ends_with(['.', '!', '?', ':']);
+        }
+        if line.trim_end().ends_with(['.', '!', '?', ':']) {
+            return false;
+        }
+    }
+}
+
+/// Every subcommand in `root` whose name equals the sole word on a raw
+/// continuation line [`is_bare_continuation`] admits.
+pub fn detect(raw: &str, root: &CommandNode) -> Report {
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut names = Vec::new();
+    tree_names(root, &mut names);
+    let mut findings = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        let word = line.trim();
+        if word.is_empty() || !names.contains(&word) {
+            continue;
+        }
+        if is_bare_continuation(&lines, idx) {
+            findings.push(Finding {
+                name: word.to_string(),
+                line: line.to_string(),
+            });
+        }
+    }
+    Report { findings }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use crate::detector::{Expect, SelfCheck};
+use mandible_core::{Provenance, Source};
+
+/// pnpm's own bytes (`corpus/pnpm/11.22.0/help.txt`), the two rows this
+/// shape invents from.
+pub(crate) const PNPM_WRAPPED_HELP: &str = "\
+  ls, list                 Print all the versions of packages that are
+                           installed, as well as their dependencies, in a
+                           tree-structure
+      why                  Shows all packages that depend on the specified
+                           package
+";
+
+fn node(name: &str) -> CommandNode {
+    CommandNode::new(name, Provenance::single(Source::HelpText))
+}
+
+fn tree_with(names: &[&str]) -> CommandNode {
+    let mut root = node("pnpm");
+    root.subcommands = names.iter().map(|n| node(n)).collect();
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "pnpm's own bytes, the pre-fix tree carrying both inventions",
+            why: "the defect itself: `tree-structure` is the last word of `ls, list`'s wrapped \
+                  description, alone on its own continuation line; `package` opens a \
+                  continuation line under `why`. Neither is a command pnpm documents",
+            expect: Expect::Fires(2),
+            raw: PNPM_WRAPPED_HELP.to_string(),
+            root: tree_with(&["tree-structure", "package"]),
+        },
+        SelfCheck {
+            name: "pnpm's own bytes, the repaired tree",
+            why: "once the parser folds both continuations into their real rows' descriptions \
+                  instead of inventing nodes from them, the tree carries neither fabricated \
+                  name and the detector has nothing to report — the repaired-family case",
+            expect: Expect::Silent,
+            raw: PNPM_WRAPPED_HELP.to_string(),
+            root: tree_with(&["list", "why"]),
+        },
+        SelfCheck {
+            name: "a real subcommand named on its own continuation line, coincidentally",
+            why: "the detector's own reach is a coincidence hazard: `run` genuinely is a pnpm \
+                  command, so a tree that already has it must not be flagged just because a \
+                  continuation elsewhere happens to spell the same word — the tree here has no \
+                  `run` node under a continuation of the sample text, so nothing fires",
+            expect: Expect::Silent,
+            raw: "      exec                 Executes a shell command in scope of a project\n"
+                .to_string(),
+            root: tree_with(&["exec"]),
+        },
+        SelfCheck {
+            name: "a genuine two-word continuation is not a bare word",
+            why: "gate: a continuation carrying more than one word is either more prose or a \
+                  real table row this rule does not claim, never a single fabricated name",
+            expect: Expect::Silent,
+            raw: "\
+      why                  Shows all packages that depend on the
+                           specified package
+"
+            .to_string(),
+            root: tree_with(&["package"]),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fires_on_both_of_pnpms_own_inventions() {
+        let root = tree_with(&["tree-structure", "package"]);
+        let report = detect(PNPM_WRAPPED_HELP, &root);
+        assert_eq!(report.finding_count(), 2);
+    }
+
+    #[test]
+    fn stays_silent_on_the_repaired_tree() {
+        let root = tree_with(&["list", "why"]);
+        assert_eq!(detect(PNPM_WRAPPED_HELP, &root).finding_count(), 0);
+    }
+
+    #[test]
+    fn every_self_check_holds() {
+        for case in self_checks() {
+            let expected = match case.expect {
+                Expect::Fires(n) => n,
+                Expect::Silent => 0,
+            };
+            let report = detect(&case.raw, &case.root);
+            assert_eq!(
+                report.finding_count(),
+                expected,
+                "{}: expected {} finding(s)",
+                case.name,
+                expected
+            );
+        }
+    }
+}

--- a/xtask/src/wrapped_command_continuation.rs
+++ b/xtask/src/wrapped_command_continuation.rs
@@ -1,14 +1,12 @@
 //! The `wrapped-command-continuation-as-subcommand` detector (atlas
-//! S-103): a command's description wraps onto a physical line with no
-//! column of its own, and the grammar reads that continuation's own
-//! leading word as a fresh subcommand.
+//! S-103): a command's description wraps onto a line with no column of
+//! its own, read as a fresh subcommand from the continuation's own
+//! leading word.
 //!
-//! A sibling of `xtask::wrapped_prose` (`wrapped-prose-row-boundary`,
-//! S-027), not the same shape: that one requires the continuation's own
-//! leading spelling to start with `-` and reads it as a flag; this one
-//! requires no dash at all — subcommand names never carry one — and reads
-//! it as a subcommand instead. See the family's own doc comment in
-//! `mandible-core/src/audit.rs`.
+//! A sibling of `wrapped-prose-row-boundary` (S-027), not the same shape:
+//! that one requires a dash-led leading spelling and reads it as a flag;
+//! this one requires none and reads a subcommand. See
+//! `mandible-core/src/audit.rs`'s family comment.
 //!
 //! Fixture: `corpus/pnpm/11.22.0/`.
 
@@ -62,24 +60,15 @@ fn tree_names<'a>(node: &'a CommandNode, out: &mut Vec<&'a str>) {
     }
 }
 
-/// True when `lines[idx]` is itself a continuation of an unfinished row's
-/// description: bare (no gap, so it cannot be a fresh row's own name
-/// field) and, walking back through zero or more further gap-less,
-/// non-blank, non-sentence-final lines, eventually reaching a line that
-/// does carry its own description-column gap (a real row) at a shallower
-/// indent than `lines[idx]` itself. That anchor row is pnpm's own `why`/
-/// `ls, list`; the walk-back is what lets this reach a continuation's own
-/// continuation (`tree-structure`, one line further than `package`).
-///
-/// A generalization of `mandible-extract`'s
-/// `is_wrapped_prose_continuation`, not the same rule: that function
-/// requires the immediately preceding line to itself lack a description
-/// column (it never anchors on the real row directly, only on one of its
-/// own later continuations), because a flag table's row and its
-/// continuation share one indent. A ragged command table's continuation
-/// sits one indent level *deeper* than the row that owns it, so the
-/// anchor here is found by indent comparison instead. See this module's
-/// own doc comment for why the two rules differ.
+/// True when `lines[idx]` continues an unfinished row's description: bare
+/// (no gap of its own), walking back through gap-less, non-blank, non-
+/// sentence-final lines to an anchor row that does carry a gap, at a
+/// shallower indent. Generalizes `mandible-extract`'s
+/// `is_wrapped_prose_continuation`: that function anchors on the
+/// immediately preceding line at equal indent (a flag row and its
+/// continuation share one); this shape's continuation sits one indent
+/// level deeper than the row that owns it, so indent comparison finds
+/// the anchor instead. See this module's own doc comment.
 fn is_bare_continuation(lines: &[&str], idx: usize) -> bool {
     let cur = lines[idx];
     if cur.split_whitespace().count() != 1 || has_wide_gap(cur) {


### PR DESCRIPTION
pnpm's root command table writes six of its 18 rows with a short-alias prefix (`i, install`), which indents them against their unaliased siblings. The parser read the run as a heading, dropped twelve rows, and invented `package` and `tree-structure` from wrapped description lines. Fixed generically in the block scanners, gated on the document already being in a command-listing context and on a run of two or more such rows.

**This does not clear the admission bar, and that is why it is open rather than merged.** Sweep-diff over 2,264 tools: zero flag losses, zero flag gains, one field-level gain. The fix demonstrably helps two tools, pnpm and `fail2ban-client` (+5 real subcommands: echo, help, ping, status, version, each checked against its own help text). The bar is five. Both detectors' raw fleet counts are false-positive dominated and are reported, not gated, so neither is quotable either. The merge decision is the maintainer's.

See it yourself:

    PATH=<scratchpad>/pnpm-prefix/bin:$PATH mandible pnpm    # 18 commands, 6 aliases, no invented rows
    mandible fail2ban-client                                 # five more real subcommands

Atlas: docs/shapes.md S-103, S-104.