### PR TITLE
docs: Add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ sudo dnf install mandible
 nix run github:AS-FOSS/mandible
 ```
 
+**[X-CMD](https://www.x-cmd.com/)**
+
+```console
+x eget use AS-FOSS/mandible
+```
+
 **Homebrew** (macOS or Linux)
 
 ```console


### PR DESCRIPTION
I'd like to suggest adding `x eget` as an installation method for mandible.

`x eget` is a command-line tool from [x-cmd](https://www.x-cmd.com/) that can install binaries directly from GitHub releases.

For mandible, users can install it with:

```sh
x eget use AS-FOSS/mandible
```

This could be a convenient installation option for users who already have x-cmd installed.
