### PR TITLE
xtask(audit): reclassify progress line, TUI is the audit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,10 @@ What the command does, in order:
    `t` to see the raw text, then `c`, `i`, `w` or `s` for correct, incomplete,
    wrong or skip. A note is required for wrong and incomplete. It saves after
    every verdict, so `Ctrl-C` and rerun the command to pick up where you left
-   off.
+   off. This step is `mandible --review <seed>`, and it is the only way to
+   audit: you judge the screen a user gets. `cargo xtask audit review` and
+   `emit` print the parse as text for scripts and machines with no terminal,
+   and a verdict formed from that text is not an audit.
 5. Writes `audit/submissions/<login>/<seed>.toml` and, beside it,
    `<seed>-report.txt`, the same summary `audit report` prints.
 6. Prints the commands to commit both files on a branch named

--- a/README.md
+++ b/README.md
@@ -290,11 +290,14 @@ open the pull request. Merged audits sit under your name in the tree and are
 credited in the release notes.
 
 > [!NOTE]
-> When auditing, verify by hand and by eye only. mandible does have automated
-> checks (pty renders of the TUI, and `cargo xtask audit emit`), which prints a
-> tool's raw help text beside the tree mandible built from it, however none of
-> them can tell you what was missed or which flags are wrong. That judgement
-> is the whole point of an audit. So: no AI, no CI, nothing non-manual.
+> When auditing, verify by hand and by eye only, in the interface itself:
+> `cargo xtask audit contribute` opens it for you, and `mandible --review
+> <seed>` reopens an unfinished draw. mandible does have automated checks
+> (pty renders of the TUI, and `cargo xtask audit emit` and `review`, which
+> print a tool's raw help text beside the tree as plain text for machines
+> with no terminal), however none of them can tell you what was missed or
+> which flags are wrong. That judgement is the whole point of an audit. So:
+> no AI, no CI, nothing non-manual, and no verdicts formed from the text dump.
 
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) has the details, plus writing tests and
 changing the parser.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -355,10 +355,12 @@ enum AuditAction {
         #[arg(long)]
         update: bool,
     },
-    /// The interactive review loop: raw `--help` text and the parsed tree,
-    /// side by side, one verdict at a time. Reads `<word> [note...]` lines
-    /// from stdin and saves after every tool, so an interrupted session
-    /// resumes rather than restarts.
+    /// The stdin review loop, for scripts and machines with no tty: raw
+    /// `--help` text and the parsed tree as plain text, one verdict at a
+    /// time, read as `<word> [note...]` lines from stdin, saved after every
+    /// tool. Not the way to audit by hand: that is `mandible --review
+    /// <seed>`, which opens each tool in the real TUI exactly as a user
+    /// sees it, and is what `audit contribute` runs.
     Review {
         #[arg(long)]
         seed: u64,
@@ -367,8 +369,8 @@ enum AuditAction {
     },
     /// Non-interactive twin of `review`: write every still-pending tool's
     /// raw text + parsed tree to its own file under `--emit-dir`, for a
-    /// reviewer (or a machine with no tty) to read offline. Pair with
-    /// `ingest` to apply the resulting verdicts.
+    /// machine with no tty. Pair with `ingest` to apply the resulting
+    /// verdicts. Auditing by hand goes through `mandible --review <seed>`.
     Emit {
         #[arg(long)]
         seed: u64,

--- a/xtask/src/queue.rs
+++ b/xtask/src/queue.rs
@@ -51,6 +51,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -592,6 +593,30 @@ pub fn cmd_sample(
 /// that entry's stratum untouched but counts it as missing rather than
 /// silently skipping it. Pure and side-effect-free so [`cmd_reclassify`]
 /// can run it over every entry in parallel via `rayon`.
+/// One `\r`-rewritten stderr line, `reclassify  1234/2299  12.3s`, refreshed
+/// every 16 completions and on the last one. Stderr, so a redirected stdout
+/// keeps only the report; `\r` rather than a bar crate, so xtask gains no
+/// dependency for a counter.
+fn report_progress(done: usize, total: usize, start: Instant) {
+    if !done.is_multiple_of(16) && done != total {
+        return;
+    }
+    use std::io::Write;
+    let mut err = std::io::stderr().lock();
+    let _ = write!(
+        err,
+        "\rreclassify {done:>5}/{total}  {:.1?}",
+        start.elapsed()
+    );
+    let _ = err.flush();
+}
+
+/// Ends the `\r` line so the report below starts on a fresh one.
+fn finish_progress() {
+    use std::io::Write;
+    let _ = writeln!(std::io::stderr());
+}
+
 fn reclassify_one(cdir: &Path, tool: &str) -> Option<String> {
     let recordings = load_captures_for_tool(cdir, tool).ok()?;
     let transcript: Arc<dyn mandible_extract::exec::Probe> = Arc::new(Transcript::new(recordings));
@@ -625,11 +650,18 @@ pub fn cmd_reclassify(dir: &Path, update: bool) -> anyhow::Result<()> {
     let cdir = captures_dir(dir);
 
     let start = Instant::now();
+    let total = queue.entries.len();
+    let done = AtomicUsize::new(0);
     let outcomes: Vec<Option<String>> = queue
         .entries
         .par_iter()
-        .map(|entry| reclassify_one(&cdir, &entry.tool))
+        .map(|entry| {
+            let outcome = reclassify_one(&cdir, &entry.tool);
+            report_progress(done.fetch_add(1, Ordering::Relaxed) + 1, total, start);
+            outcome
+        })
         .collect();
+    finish_progress();
 
     let mut new_strata: Vec<Option<String>> = Vec::with_capacity(queue.entries.len());
     let mut transitions: Vec<(String, String, String)> = Vec::new();


### PR DESCRIPTION
A running count on stderr while `audit reclassify` works, and the stdin review loop marked as the machine path in its help text, CONTRIBUTING and the README note. Reclassify sat silent for five minutes and the text loop could be mistaken for the way to audit.