### PR TITLE
Three parser families: fold loss, bare or separator, duplicated usage spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ once it reaches a published 0.1.0 release.
 
 ### Fixed
 
+- Two rows a tool writes for one spelling keep their own descriptions instead of folding into one row that shows the first row's text beside the second row's value (`mandible vim.basic`'s `+` and `+<lnum>`, `mandible icupkg`'s three `-t, --type` rows, docs/shapes.md S-102).
+- A second usage form written after a line holding only the word `or` is a form of its own now, instead of being glued onto the end of the first form or truncating the rest of the block (`mandible sg_luns`, `mandible update-catalog`, docs/shapes.md S-112).
+- A spelling a tool writes in its usage line and again in its option row no longer reaches the tree twice, once described and once bare (`mandible icupkg`'s `-?`, `mandible date`'s `--universal`, docs/shapes.md S-113).
 - A long option name containing an underscore (`--extended_fields`, `--lu_cong`) no longer gets truncated at the `_` with the remainder fabricated into the flag's value name (docs/shapes.md S-106).
 - `mandible zgrep`/`mandible resolvconf` no longer show fabricated flags mined from a prose sentence that hard-wraps onto a dash-led word at its own paragraph's indent: the wrap now reads as a continuation of the sentence, which is folded into the node description instead.
 - The bare end-of-options marker `--` now reaches the tree instead of vanishing, in any tool's option table or usage line (`mandible vim.basic`, `mandible nvim`, `mandible awk`, `mandible cargo-fmt`, and dozens more on a full-`PATH` sweep, docs/shapes.md S-096).

--- a/corpus/sg_luns/1.45/expected.snap
+++ b/corpus/sg_luns/1.45/expected.snap
@@ -1,7 +1,7 @@
 name: sg_luns
 description: Performs a SCSI REPORT LUNS command or decodes the given ALUN. When SR is 0x10 or 0x11 DEVICE must be LUN 0 or REPORT LUNS well known logical unit; when SR is 0x12 DEVICE must be an administrative logical unit. When the --test=ALUN option is given, decodes ALUN rather than sending a REPORT LUNS command.
 usage:
-- 'Usage: sg_luns    [--decode] [--help] [--hex] [--linux] [--lu_cong] [--maxlen=LEN] [--quiet] [--raw] [--readonly] [--select=SR] [--verbose] [--version] DEVICE or'
+- 'Usage: sg_luns    [--decode] [--help] [--hex] [--linux] [--lu_cong] [--maxlen=LEN] [--quiet] [--raw] [--readonly] [--select=SR] [--verbose] [--version] DEVICE'
 - '       sg_luns    --test=ALUN [--decode] [--hex] [--lu_cong] [--verbose]'
 positionals:
 - name: DEVICE

--- a/corpus/sg_luns/1.45/meta.toml
+++ b/corpus/sg_luns/1.45/meta.toml
@@ -27,25 +27,19 @@
 # There is no `[contract]` field for a usage form, so this is stated in
 # prose instead. The raw block documents two synopsis forms:
 # `sg_luns [--decode] ... DEVICE` and `sg_luns --test=ALUN [...]`, separated
-# by a line reading `     or`. VERIFIED FACT: the extracted tree's `usage`
-# list holds two entries, and the first one ends `... [--version] DEVICE
-# or` — the bare `or` line is joined onto the end of the first usage form
-# rather than kept as its own separator or attached to the second form. This
-# is the same joining round 3 found on screen at 400 columns before any
-# round-3 change (`docs/design.md` §16's "USAGE soft-wraps" entry), and it
-# is still present in this build; no `[contract]` field can assert it, so it
-# is recorded here as a checked fact instead.
+# by a line reading `     or`. Round 5 (`bare-or-usage-separator`, spec
+# §7 Tier B) fixed this: a usage line whose only content is the word `or`
+# (any case, optional trailing colon) is now recognized as a pure form
+# separator in `mandible-extract/src/help_text/sections/mod.rs`
+# (`is_bare_or_form_separator`) and contributes no text to either form.
+# VERIFIED FACT (`cargo run -p xtask -- corpus --show sg_luns/1.45`): the
+# extracted tree's `usage` list holds two entries, the first now ending
+# `... [--version] DEVICE` with no trailing `or`, the second unchanged.
 #
-# Promoted once the underscore split was fixed, so this fixture now carries
-# an expected.snap. One field inside that snapshot is known to be wrong and
-# is frozen anyway, and a reader must not take the promotion as a claim
-# that it is right: the first usage form still ends `... DEVICE or`,
-# because the raw block's bare separator line `     or` is joined onto the
-# end of the first form rather than kept as a separator. No `[contract]`
-# field can assert a usage form, so nothing here can fail on it. The rest
-# of the tree was read against the raw bytes row by row before the bless:
-# 13 flags, every one carrying both its spellings in source order and its
-# own description, plus the `DEVICE` positional.
+# Re-blessed after that fix; the rest of the tree was read against the raw
+# bytes row by row before the original bless and is untouched by this
+# change: 13 flags, every one carrying both its spellings in source order
+# and its own description, plus the `DEVICE` positional.
 
 [bless]
 provenance = "agent"

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1759,7 +1759,7 @@ entry's `tools` field and nothing else. It does not get a new entry.
   keyed on spelling alone, and picks the value name and the description from
   different members. One row's description reaches no rendered surface. The
   extraction is correct and the loss happens after it.
-  Round 5 (`same-spelling-fold-loss`) fixed the merge half for vim.basic's
+  The `same-spelling-fold-loss` fix addresses the merge half, for vim.basic's
   own instance: `+` ("Start at end of file") and `+<lnum>` ("Start at line
   <lnum>") shared one identity key and disagreed about taking a value, so
   `mandible_core::merge::merge_entity_lists` picked one row's description
@@ -1777,8 +1777,9 @@ entry's `tools` field and nothing else. It does not get a new entry.
   as a second candidate) exercises it. Verified instead by unit tests in
   `mandible-core/src/merge.rs`
   (`same_source_rows_that_disagree_about_taking_a_value_stay_two_entities`)
-  and a pty screen of `./target/release/mandible vim.basic` the maintainer
-  captured. The remaining tools on this entry's list are `ffplay`, `gcc`,
+  and a pty screen of `./target/release/mandible vim.basic`, which shows
+  `+` with "Start at end of file" and `+<lnum>` with "Start at line
+  <lnum>" as two rows. The remaining tools on this entry's list are `ffplay`, `gcc`,
   `curl`, etc. — their same-spelling pairs are still open, since this fix
   addresses the value-disagreement/description-disagreement shape
   generally but was verified against vim.basic specifically.
@@ -1786,14 +1787,16 @@ entry's `tools` field and nothing else. It does not get a new entry.
   option's three literal choice values written once per row) sits one
   layer earlier, in extraction itself, and needs a different fix (folding
   the three rows into one entity's `choices`). A prototype was built and
-  moved only `icupkg` in a full-`PATH` sweep — below the five-tool bar —
-  so it was not shipped this round.
+  moved only `icupkg` in a full-`PATH` sweep, below the five-tool bar, so
+  it was not shipped. The merge half already restores the three rows'
+  own descriptions; what stays open is folding them into one option's
+  `choices`, which `corpus/icupkg/74.2` asserts.
 - fleet: 18 of 133 corpus fixtures carry a spelling on two entities with
   different descriptions, 2026-09-03. Measured loss between the extracted
   count and the rendered count: ffplay 1136 to 465, gcc 43 to 37, curl 258
   to 253, as 61 to 59, vim.basic 45 to 43, tar 159 to 157, du 29 to 28,
   expand 5 to 4. The merge-time fix is invisible to this instrument (see
-  above), so this count is unchanged by round 5. `same-spelling-fold-loss`
+  above), so the merge fix leaves this count where it was. `same-spelling-fold-loss`
   (`xtask/src/detector/same_spelling_fold_loss.rs`), wired into `xtask
   coverage`'s aggregate, reads **182 tools / 664 findings** in a full-`PATH`
   sweep of 2319 tools — clearing the five-tool bar by a wide margin, a

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1793,10 +1793,14 @@ entry's `tools` field and nothing else. It does not get a new entry.
   count and the rendered count: ffplay 1136 to 465, gcc 43 to 37, curl 258
   to 253, as 61 to 59, vim.basic 45 to 43, tar 159 to 157, du 29 to 28,
   expand 5 to 4. The merge-time fix is invisible to this instrument (see
-  above), so this count is unchanged by round 5; `same-spelling-fold-loss`
-  (`xtask/src/detector/same_spelling_fold_loss.rs`) is not calibratable
-  against the seed-2/4/5/6 audit (no labelled member), and its own
-  self-checks are the evidence recorded instead.
+  above), so this count is unchanged by round 5. `same-spelling-fold-loss`
+  (`xtask/src/detector/same_spelling_fold_loss.rs`), wired into `xtask
+  coverage`'s aggregate, reads **182 tools / 664 findings** in a full-`PATH`
+  sweep of 2319 tools — clearing the five-tool bar by a wide margin, a
+  stronger argument for shipping the merge half than the information-loss
+  rule alone. Not calibratable against the seed-2/4/5/6 audit (no labelled
+  member); not gated (the merge half it argues for is invisible to this
+  same sweep, so a gate here would ratchet a number the fix cannot move).
 
 ### S-105: one-space description column on a pipe-joined alias row
 

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1959,11 +1959,15 @@ entry's `tools` field and nothing else. It does not get a new entry.
   (`or:` still carrying real content after the colon on the same line),
   which this fix leaves untouched.
 - fleet: `bare-or-usage-separator` (`xtask/src/detector/
-  bare_or_usage_separator.rs`) is not calibratable against the seed-2/4/5/6
-  audit (no labelled member). Six tools confirmed by reading each one's own
-  `--help` capture directly, 2026-09-05; `update-catalog` also shows in a
-  full-`PATH` sweep-diff as a `--remove` flag gain with zero losses. The
-  other five tools' fix is text-only (a `usage` form, and for
+  bare_or_usage_separator.rs`), wired into `xtask coverage`'s aggregate and
+  modeling both symptoms (truncation and gluing) as one cause, reads
+  **6 tools / 6 findings before, 0/0 after** in a full-`PATH` sweep of 2319
+  tools — clearing the five-tool bar with a quotable, reproducible number.
+  Not calibratable against the seed-2/4/5/6 audit (no labelled member).
+  Ratchet-gated at zero in `coverage --check` alongside
+  `usage-spelling-duplicates-table-row`. `update-catalog`'s repair also
+  shows in a full-`PATH` sweep-diff as a `--remove` flag gain with zero
+  losses; the other five tools' fix is text-only (a `usage` form, and for
   `mariadb-tzinfo-to-sql`/`mysql_tzinfo_to_sql`/`aria_read_log` a
   positional their second form names), invisible to sweep-diff's
   flag-keyed fingerprint; `sg_luns`'s is confirmed via its corpus fixture.

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1753,17 +1753,50 @@ entry's `tools` field and nothing else. It does not get a new entry.
       -r (with file name)	Recover crashed session
 - tools: vim.basic, ffplay, ffmpeg, curl, gcc, as, dpkg, tar, du, expand, lsof,
   update-xmlcatalog, rust-lldb, qemu-arm64-static, ptargrep, pod2man,
-  mkfs.bfs, man-recode
+  mkfs.bfs, man-recode, icupkg
 - handling: A tool may document one spelling on two rows for two forms, and the parser
   extracts both. The interactive display then folds them into one entity,
   keyed on spelling alone, and picks the value name and the description from
   different members. One row's description reaches no rendered surface. The
-  extraction is correct and the loss happens after it. Open defect.
+  extraction is correct and the loss happens after it.
+  Round 5 (`same-spelling-fold-loss`) fixed the merge half for vim.basic's
+  own instance: `+` ("Start at end of file") and `+<lnum>` ("Start at line
+  <lnum>") shared one identity key and disagreed about taking a value, so
+  `mandible_core::merge::merge_entity_lists` picked one row's description
+  and attached the other row's value to it. `split_disagreeing_rows`
+  (`mandible-core/src/merge.rs`) now refuses to fold two entities that
+  share an identical source set and disagree about taking a value or about
+  their own description, so the two rows survive as two entities instead
+  of one that mixes them. Chosen over inventing a two-description IR field,
+  which would concatenate two sentences the tool never wrote as one.
+  Cross-source disagreement (one tier saw a value, another did not) still
+  merges as before — the refusal is scoped to entities sharing one source.
+  This half is invisible to `xtask corpus`/`coverage`: both extract through
+  a single-candidate path that short-circuits before the merge fold ever
+  runs, so only the TUI (`Runner::fill_node`, which always adds `existing`
+  as a second candidate) exercises it. Verified instead by unit tests in
+  `mandible-core/src/merge.rs`
+  (`same_source_rows_that_disagree_about_taking_a_value_stay_two_entities`)
+  and a pty screen of `./target/release/mandible vim.basic` the maintainer
+  captured. The remaining tools on this entry's list are `ffplay`, `gcc`,
+  `curl`, etc. — their same-spelling pairs are still open, since this fix
+  addresses the value-disagreement/description-disagreement shape
+  generally but was verified against vim.basic specifically.
+  icupkg's own instance of this identity collision (`-tl`/`-tb`/`-te`, one
+  option's three literal choice values written once per row) sits one
+  layer earlier, in extraction itself, and needs a different fix (folding
+  the three rows into one entity's `choices`). A prototype was built and
+  moved only `icupkg` in a full-`PATH` sweep — below the five-tool bar —
+  so it was not shipped this round.
 - fleet: 18 of 133 corpus fixtures carry a spelling on two entities with
   different descriptions, 2026-09-03. Measured loss between the extracted
   count and the rendered count: ffplay 1136 to 465, gcc 43 to 37, curl 258
   to 253, as 61 to 59, vim.basic 45 to 43, tar 159 to 157, du 29 to 28,
-  expand 5 to 4.
+  expand 5 to 4. The merge-time fix is invisible to this instrument (see
+  above), so this count is unchanged by round 5; `same-spelling-fold-loss`
+  (`xtask/src/detector/same_spelling_fold_loss.rs`) is not calibratable
+  against the seed-2/4/5/6 audit (no labelled member), and its own
+  self-checks are the evidence recorded instead.
 
 ### S-105: one-space description column on a pipe-joined alias row
 
@@ -1894,3 +1927,64 @@ entry's `tools` field and nothing else. It does not get a new entry.
   (`xtask/src/detector/glued_optional_group_spelling.rs`) generalizes this shape
   fleet-wide.
 - fleet: 10 tools, 10 findings, 2026-09-04
+
+### S-112: bare `or` line read as an ordinary continuation
+
+- id: S-112
+- looks like: |
+      Usage: sg_luns    [--decode] [--help] ... DEVICE
+           or
+             sg_luns    --test=ALUN [--decode] [--hex] [--lu_cong] [--verbose]
+- tools: update-catalog, aria_read_log, mariadb-tzinfo-to-sql,
+  mysql_tzinfo_to_sql, sg_luns, sg_test_rwbuf
+- handling: Fixed. A usage line whose only content is the word `or` (any case,
+  optional trailing colon) is a pure separator between two usage forms,
+  contributing no text to either. `is_bare_or_form_separator`
+  (`mandible-extract/src/help_text/sections/usage.rs`) recognizes the
+  shape; `scan_usage_section`
+  (`mandible-extract/src/help_text/sections/mod.rs`) consumes the line
+  without appending it anywhere and forces the next physical line to
+  start a fresh entry, however that line is itself shaped. Two distinct
+  symptoms shared one cause: an unindented bare `or` (at or below the
+  usage block's base indent) previously hit the "content doesn't read as
+  a usage fragment" rule and ended the whole block there, dropping every
+  line after it (`update-catalog`, `aria_read_log`,
+  `mariadb-tzinfo-to-sql`, `mysql_tzinfo_to_sql`); an indented one fell
+  through every other check and was glued onto the end of the prior
+  form's last token (`sg_luns`, `sg_test_rwbuf`). Distinct from S-107
+  (`or:` still carrying real content after the colon on the same line),
+  which this fix leaves untouched.
+- fleet: `bare-or-usage-separator` (`xtask/src/detector/
+  bare_or_usage_separator.rs`) is not calibratable against the seed-2/4/5/6
+  audit (no labelled member). Six tools confirmed by reading each one's own
+  `--help` capture directly, 2026-09-05; `update-catalog` also shows in a
+  full-`PATH` sweep-diff as a `--remove` flag gain with zero losses. The
+  other five tools' fix is text-only (a `usage` form, and for
+  `mariadb-tzinfo-to-sql`/`mysql_tzinfo_to_sql`/`aria_read_log` a
+  positional their second form names), invisible to sweep-diff's
+  flag-keyed fingerprint; `sg_luns`'s is confirmed via its corpus fixture.
+
+### S-113: usage-derived spelling duplicates a table row that already has it
+
+- id: S-113
+- looks like: |
+      Usage: icupkg [-h|-?|--help ] ...
+      ...
+      -h or -? or --help    print this message and exit
+- tools: date, icupkg, jcmd, piconv, ssh-copy-id
+- handling: Fixed. `flag_spelling_already_present`
+  (`mandible-extract/src/help_text/sections/usage.rs`) decides whether a
+  usage-only spelling duplicates a spelling an option-table row already
+  has, but checked only that row's *primary* `short()`/`long()` pick —
+  the first single-dash one-character spelling, for `short()` — not every
+  spelling the row carries. `icupkg`'s `-h, -?, --help` row reports
+  `short() == Some('h')`, so the usage line's own `-?` token read as
+  absent and was re-added as its own bare, undescribed duplicate entity.
+  Now checks every spelling on the row.
+- fleet: `usage-spelling-duplicates-table-row`
+  (`xtask/src/detector/usage_spelling_duplicates_table_row.rs`) is not
+  calibratable against the seed-2/4/5/6 audit (no labelled member). Five
+  tools in a full-`PATH` sweep-diff, zero losses: `date` (`--universal`),
+  `icupkg` (`-?`), `jcmd` (`-h`), `piconv` (`-c`), `ssh-copy-id` (`-?`) —
+  each duplicate confirmed still present via its rightful multi-spelling
+  row in the same sweep's fingerprint, 2026-09-05.

--- a/mandible-core/src/merge.rs
+++ b/mandible-core/src/merge.rs
@@ -225,28 +225,14 @@ pub fn merge_entity_lists(lists: Vec<Vec<Entity>>) -> Vec<Entity> {
         .collect()
 }
 
-/// Partitions one identity-bucket into sub-groups safe to fold into a
-/// single entity each.
-///
-/// Two entities sharing an identical source set — the same tier's account
-/// of the same document — that disagree about whether the option takes a
-/// value, or that each carry their own documented description and the two
-/// differ, are two *forms* the tool wrote on two rows sharing one
-/// spelling, not one entity two sources reported differently: vim's bare
-/// `+` ("Start at end of file") and valued `+<lnum>` ("Start at line
-/// <lnum>") is the specimen (docs/shapes.md S-102,
-/// `corpus/vim.basic/audit-seed4`). Left in one bucket,
-/// [`merge_entity_bucket`]'s spelling-keyed pick keeps only one row's
-/// description and (via its independent `value_kind`/`value_name`
-/// resolution) can attach the *other* row's value to it — the loss S-102
-/// records.
-///
-/// Cross-source disagreement (one tier saw a value, another did not; two
-/// tiers wrote different prose for the same option) is exactly what this
-/// bucket exists to resolve via [`pick_option`]'s authority ordering, so
-/// the refusal below never fires across two different source sets —
-/// `merge_unifies_flags_by_identity_across_sources` pins that this still
-/// merges.
+/// Partitions one identity-bucket into sub-groups safe to fold each into
+/// one entity. Two same-source entities that disagree about taking a
+/// value, or carry two different descriptions, are two forms on two rows
+/// sharing one spelling (vim's bare `+` vs valued `+<lnum>`), not one
+/// entity two sources reported differently — see docs/shapes.md S-102,
+/// `corpus/vim.basic/audit-seed4`. Cross-source disagreement still folds
+/// via [`pick_option`]'s authority ordering, pinned by
+/// `merge_unifies_flags_by_identity_across_sources`.
 fn split_disagreeing_rows(bucket: Vec<Entity>) -> Vec<Vec<Entity>> {
     let mut groups: Vec<Vec<Entity>> = Vec::new();
     'entity: for e in bucket {
@@ -1154,12 +1140,18 @@ mod tests {
     #[test]
     fn same_source_rows_that_disagree_about_taking_a_value_stay_two_entities() {
         let mut n = node_from(Source::HelpText, "vim.basic");
-        let mut bare = Entity::new(crate::entity::EntityKind::Flag, Provenance::single(Source::HelpText));
+        let mut bare = Entity::new(
+            crate::entity::EntityKind::Flag,
+            Provenance::single(Source::HelpText),
+        );
         bare.spellings = vec![Spelling::bare("+")];
         bare.description = Some(Text::sanitize("Start at end of file"));
         n.entities.push(bare);
 
-        let mut valued = Entity::new(crate::entity::EntityKind::Flag, Provenance::single(Source::HelpText));
+        let mut valued = Entity::new(
+            crate::entity::EntityKind::Flag,
+            Provenance::single(Source::HelpText),
+        );
         valued.spellings = vec![Spelling::bare("+")];
         valued.value_name = Some("lnum".to_string());
         valued.value_kind = ValueKind::Required;
@@ -1180,10 +1172,8 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert!(
-            flags
-                .iter()
-                .any(|f| f.value_kind == ValueKind::None
-                    && f.description.as_ref().unwrap().as_str() == "Start at end of file"),
+            flags.iter().any(|f| f.value_kind == ValueKind::None
+                && f.description.as_ref().unwrap().as_str() == "Start at end of file"),
             "{flags:?}"
         );
         assert!(

--- a/mandible-core/src/merge.rs
+++ b/mandible-core/src/merge.rs
@@ -216,11 +216,63 @@ pub fn merge_entity_lists(lists: Vec<Vec<Entity>>) -> Vec<Entity> {
     }
     order
         .into_iter()
-        .map(|key| {
+        .flat_map(|key| {
             let bucket = buckets.remove(&key).expect("key came from this map");
-            merge_entity_bucket(bucket)
+            split_disagreeing_rows(bucket)
+                .into_iter()
+                .map(merge_entity_bucket)
         })
         .collect()
+}
+
+/// Partitions one identity-bucket into sub-groups safe to fold into a
+/// single entity each.
+///
+/// Two entities sharing an identical source set — the same tier's account
+/// of the same document — that disagree about whether the option takes a
+/// value, or that each carry their own documented description and the two
+/// differ, are two *forms* the tool wrote on two rows sharing one
+/// spelling, not one entity two sources reported differently: vim's bare
+/// `+` ("Start at end of file") and valued `+<lnum>` ("Start at line
+/// <lnum>") is the specimen (docs/shapes.md S-102,
+/// `corpus/vim.basic/audit-seed4`). Left in one bucket,
+/// [`merge_entity_bucket`]'s spelling-keyed pick keeps only one row's
+/// description and (via its independent `value_kind`/`value_name`
+/// resolution) can attach the *other* row's value to it — the loss S-102
+/// records.
+///
+/// Cross-source disagreement (one tier saw a value, another did not; two
+/// tiers wrote different prose for the same option) is exactly what this
+/// bucket exists to resolve via [`pick_option`]'s authority ordering, so
+/// the refusal below never fires across two different source sets —
+/// `merge_unifies_flags_by_identity_across_sources` pins that this still
+/// merges.
+fn split_disagreeing_rows(bucket: Vec<Entity>) -> Vec<Vec<Entity>> {
+    let mut groups: Vec<Vec<Entity>> = Vec::new();
+    'entity: for e in bucket {
+        for group in groups.iter_mut() {
+            if group.iter().all(|g| !same_source_row_disagreement(g, &e)) {
+                group.push(e);
+                continue 'entity;
+            }
+        }
+        groups.push(vec![e]);
+    }
+    groups
+}
+
+/// Whether `a` and `b`, sharing one merge-bucket identity, are two rows
+/// from the *same* source the tool documented differently rather than two
+/// sources' accounts of one row. See [`split_disagreeing_rows`].
+fn same_source_row_disagreement(a: &Entity, b: &Entity) -> bool {
+    if a.provenance.sources != b.provenance.sources {
+        return false;
+    }
+    let value_shape_disagrees = (a.value_kind == crate::node::ValueKind::None)
+        != (b.value_kind == crate::node::ValueKind::None);
+    let description_disagrees =
+        matches!((&a.description, &b.description), (Some(x), Some(y)) if x != y);
+    value_shape_disagrees || description_disagrees
 }
 
 /// The identity two entities must share to be the same item.
@@ -1090,6 +1142,55 @@ mod tests {
             .find(|f| f.spellings == [Spelling::single_dash("help")])
             .unwrap_or_else(|| panic!("no standalone -help entity: {all_spellings:?}"));
         assert_eq!(dash_help.value_name.as_deref(), Some("topic"));
+    }
+
+    /// vim.basic's own two rows, byte-exact in shape (`corpus/vim.basic/
+    /// audit-seed4`): a bare `+` ("Start at end of file") and a valued
+    /// `+<lnum>` ("Start at line <lnum>"), both extracted correctly from
+    /// the *same* source. Left in one bucket, the spelling-keyed fold
+    /// picks one row's description and the other row's value, showing the
+    /// wrong pair together (docs/shapes.md S-102). This pins that the two
+    /// rows now survive as two entities instead.
+    #[test]
+    fn same_source_rows_that_disagree_about_taking_a_value_stay_two_entities() {
+        let mut n = node_from(Source::HelpText, "vim.basic");
+        let mut bare = Entity::new(crate::entity::EntityKind::Flag, Provenance::single(Source::HelpText));
+        bare.spellings = vec![Spelling::bare("+")];
+        bare.description = Some(Text::sanitize("Start at end of file"));
+        n.entities.push(bare);
+
+        let mut valued = Entity::new(crate::entity::EntityKind::Flag, Provenance::single(Source::HelpText));
+        valued.spellings = vec![Spelling::bare("+")];
+        valued.value_name = Some("lnum".to_string());
+        valued.value_kind = ValueKind::Required;
+        valued.description = Some(Text::sanitize("Start at line <lnum>"));
+        n.entities.push(valued);
+
+        // `Runner::fill_node`'s own contract: `existing` is always a
+        // second candidate alongside a fresh re-probe of the same source.
+        let merged = merge_nodes(vec![n.clone(), n]).unwrap();
+        let flags: Vec<&Entity> = merged.flags().collect();
+        assert_eq!(
+            flags.len(),
+            2,
+            "the bare and valued forms must stay two entities: {:?}",
+            flags
+                .iter()
+                .map(|f| (f.value_name.clone(), f.description.clone()))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            flags
+                .iter()
+                .any(|f| f.value_kind == ValueKind::None
+                    && f.description.as_ref().unwrap().as_str() == "Start at end of file"),
+            "{flags:?}"
+        );
+        assert!(
+            flags.iter().any(|f| f.value_name.as_deref() == Some("lnum")
+                && f.description.as_ref().unwrap().as_str() == "Start at line <lnum>"),
+            "{flags:?}"
+        );
     }
 
     /// A positional merges on its name across sources, taking `required`

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -334,6 +334,11 @@ fn scan_usage_section(
     // trailing bracket-row flags) apart from an ordinary between-
     // stanza blank line. Reset unconditionally elsewhere.
     let mut just_closed_paren_group = false;
+    // True for exactly the one loop iteration right after a bare `or`
+    // form-separator line was consumed — forces the next physical line to
+    // start a fresh usage entry even when it carries no marker or own-name
+    // evidence of its own. See `is_bare_or_form_separator`.
+    let mut force_new_entry_after_separator = false;
     i += 1;
     while i < lines.len() {
         let l = lines[i];
@@ -450,13 +455,29 @@ fn scan_usage_section(
             paren_group_depth = paren_depth_delta(trimmed_start);
         }
         just_closed_paren_group = false;
+        if is_bare_or_form_separator(trimmed_start) {
+            // spec: a usage line whose only content is the word `or` (any
+            // case, optional trailing colon) is a pure separator between
+            // two usage forms, contributing no text to either one —
+            // distinct from `or:` followed by real content on the same
+            // line, which `starts_with_or_marker` already handles.
+            // `sg_luns` writes its second synopsis form after a line
+            // holding only `or`; without this, the word read as an
+            // ordinary continuation and glued onto the end of the first
+            // form's last token. See docs/shapes.md and
+            // corpus/sg_luns/1.45.
+            force_new_entry_after_separator = true;
+            i += 1;
+            continue;
+        }
         let is_marker =
             starts_with_usage_prefix(trimmed_start) || starts_with_or_marker(trimmed_start);
         let is_own_name = tool_name.is_some_and(|name| {
             starts_with_tool_name(trimmed_start, name)
                 || starts_with_tool_name_spelled_differently(trimmed_start, name)
         });
-        let starts_new_entry = is_marker || is_own_name;
+        let starts_new_entry = is_marker || is_own_name || force_new_entry_after_separator;
+        force_new_entry_after_separator = false;
 
         // A line the one above it ended with a backslash is a
         // continuation by the tool's own explicit statement, and no

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -28,6 +28,17 @@ pub fn starts_with_or_marker(t: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// True if `t`'s only content, once trimmed, is the word `or` — any case —
+/// with an optional trailing colon: `sg_luns`' bare second-form separator
+/// (`corpus/sg_luns/1.45`), one whole physical line with nothing else on
+/// it. Distinct from [`starts_with_or_marker`], which matches an `or:`
+/// *prefix* even when real form content follows the colon on the same
+/// line (`ip`'s `or: ip link ...`); a line this predicate matches carries
+/// no such content and must contribute none to either usage form.
+pub fn is_bare_or_form_separator(t: &str) -> bool {
+    t.trim().trim_end_matches(':').eq_ignore_ascii_case("or")
+}
+
 /// True if `t` (already trimmed of leading whitespace) begins with `name`
 /// at a word boundary. Lets a tool that repeats its own name across lines
 /// with no `or:`/`usage:` marker read as two entries rather than one

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -906,14 +906,10 @@ pub(super) fn shared_operand(rest: &str) -> Option<String> {
 /// and an existing flag is never altered here, only left alone or joined.
 /// A one-letter abbreviation bracket also counts as a short-letter match:
 /// `ip`'s `[ -force ]` reads as `-f` glued to `"orce"` on the short path,
-/// but the table documents it as `-f[amily]` (long-like). See S-088.
-///
-/// Checked against *every* spelling `f` carries, not only its primary
-/// `short()`/`long()` pick: an entity spelled `-h, -?, --help` reports
-/// `short() == Some('h')` (the first single-dash one-character spelling),
-/// so a candidate usage-derived `-?` used to pass this check as absent and
-/// get re-added as its own bare duplicate. `icupkg` is the fixture —
-/// `corpus/icupkg/74.2`.
+/// but the table documents it as `-f[amily]` (long-like). Checked against
+/// every spelling `f` carries, not only its primary pick — `-h, -?,
+/// --help` reports `short() == Some('h')`, so `-?` used to read as
+/// absent. See S-088, `corpus/icupkg/74.2`.
 pub(super) fn flag_spelling_already_present(candidate: &Entity, existing: &[Entity]) -> bool {
     existing.iter().any(|f| {
         f.spellings.iter().any(|s| {
@@ -921,7 +917,9 @@ pub(super) fn flag_spelling_already_present(candidate: &Entity, existing: &[Enti
                 || (matches!(s.dashes, Dashes::Single) && s.name.chars().count() > 1);
             let is_short = matches!(s.dashes, Dashes::Single) && s.name.chars().count() == 1;
             let is_abbrev_bracket = matches!(s.dashes, Dashes::Single) && s.abbrev == Some(1);
-            (candidate.long().is_some() && is_long_like && Some(s.name.as_str()) == candidate.long())
+            (candidate.long().is_some()
+                && is_long_like
+                && Some(s.name.as_str()) == candidate.long())
                 || (candidate.short().is_some()
                     && is_short
                     && s.name.chars().next() == candidate.short())

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -907,16 +907,28 @@ pub(super) fn shared_operand(rest: &str) -> Option<String> {
 /// A one-letter abbreviation bracket also counts as a short-letter match:
 /// `ip`'s `[ -force ]` reads as `-f` glued to `"orce"` on the short path,
 /// but the table documents it as `-f[amily]` (long-like). See S-088.
+///
+/// Checked against *every* spelling `f` carries, not only its primary
+/// `short()`/`long()` pick: an entity spelled `-h, -?, --help` reports
+/// `short() == Some('h')` (the first single-dash one-character spelling),
+/// so a candidate usage-derived `-?` used to pass this check as absent and
+/// get re-added as its own bare duplicate. `icupkg` is the fixture —
+/// `corpus/icupkg/74.2`.
 pub(super) fn flag_spelling_already_present(candidate: &Entity, existing: &[Entity]) -> bool {
     existing.iter().any(|f| {
-        (candidate.long().is_some() && f.long() == candidate.long())
-            || (candidate.short().is_some() && f.short() == candidate.short())
-            || (candidate.short().is_some()
-                && f.spellings.iter().any(|s| {
-                    matches!(s.dashes, Dashes::Single)
-                        && s.abbrev == Some(1)
-                        && s.name.chars().next() == candidate.short()
-                }))
+        f.spellings.iter().any(|s| {
+            let is_long_like = matches!(s.dashes, Dashes::Double)
+                || (matches!(s.dashes, Dashes::Single) && s.name.chars().count() > 1);
+            let is_short = matches!(s.dashes, Dashes::Single) && s.name.chars().count() == 1;
+            let is_abbrev_bracket = matches!(s.dashes, Dashes::Single) && s.abbrev == Some(1);
+            (candidate.long().is_some() && is_long_like && Some(s.name.as_str()) == candidate.long())
+                || (candidate.short().is_some()
+                    && is_short
+                    && s.name.chars().next() == candidate.short())
+                || (candidate.short().is_some()
+                    && is_abbrev_bracket
+                    && s.name.chars().next() == candidate.short())
+        })
     })
 }
 

--- a/xtask/src/coverage/aggregate.rs
+++ b/xtask/src/coverage/aggregate.rs
@@ -436,6 +436,13 @@ fn family_static_name(word: &str) -> Option<&'static str> {
         "second-optional-value-dropped",
         "parenthetical-qualifier-as-value",
         "or-joined-alias",
+        // Round 5: gated the same way as the two above, once each one's
+        // fleet count reached zero (see `xtask/src/main.rs`'s `--check`).
+        // `same-spelling-fold-loss` is not gated (its merge-time half is
+        // invisible to this sweep) and so is deliberately absent here,
+        // the same way round 4's six ungated names are absent.
+        "bare-or-usage-separator",
+        "usage-spelling-duplicates-table-row",
     ]
     .into_iter()
     .find(|&n| n == word)

--- a/xtask/src/coverage/score.rs
+++ b/xtask/src/coverage/score.rs
@@ -469,7 +469,33 @@ fn vim_family_counts(
         ),
     ];
     counts.extend(round4_family_counts(&raw, root));
+    counts.extend(round5_family_counts(&raw, root));
     counts
+}
+
+/// The three round-5 detectors, each implementing [`crate::detector::
+/// Detector`] directly rather than the bare `detect()`/`Report` shape the
+/// families above use — `hits()` is called through the trait, on the same
+/// already-fetched capture, still zero additional probes. Same (name,
+/// finding count, capped samples) shape as its caller.
+fn round5_family_counts(raw: &str, root: &CommandNode) -> Vec<(&'static str, usize, Vec<String>)> {
+    use crate::detector::{Detector, ToolEvidence};
+    let cap = FAMILY_DETECTOR_SAMPLES_PER_ROW;
+    let evidence = ToolEvidence { raw, root };
+    let detectors: Vec<Box<dyn Detector>> = vec![
+        Box::new(crate::detector::same_spelling_fold_loss::SameSpellingFoldLoss),
+        Box::new(crate::detector::bare_or_usage_separator::BareOrUsageSeparator),
+        Box::new(
+            crate::detector::usage_spelling_duplicates_table_row::UsageSpellingDuplicatesTableRow,
+        ),
+    ];
+    detectors
+        .iter()
+        .map(|d| {
+            let hits = d.hits(&evidence);
+            (d.name(), hits.len(), hits.into_iter().take(cap).collect())
+        })
+        .collect()
 }
 
 /// The six round-4 detectors (atlas S-106 to S-111), split out of

--- a/xtask/src/detector/bare_or_usage_separator.rs
+++ b/xtask/src/detector/bare_or_usage_separator.rs
@@ -1,11 +1,12 @@
 //! `bare-or-usage-separator` (round 5): a usage line holding only the
-//! word `or` is a pure form separator (`sg_luns`, docs/shapes.md S-112).
-//! Before the parser fix it either truncated the usage block or glued
-//! onto the prior form. Measured by the after-the-fact symptom: `raw`
-//! carries the bare line, and a `root` usage form still ends with it.
-//!
-//! No seed-2/4/5/6 labelled tool carries this shape, so
-//! [`Detector::family`] returns `None` — spec §13.1e rule 6.
+//! word `or` is a pure form separator (docs/shapes.md S-112). One cause,
+//! two symptoms, both modeled — an unindented bare `or` truncates the
+//! rest of the block (`update-catalog` and 3 siblings); an indented one
+//! glues onto the prior form (`sg_luns`, `sg_test_rwbuf`). Modeling only
+//! one would undercount the family, the loosening AGENTS.md §3.1 forbids
+//! the other way. Per bare-or line: the next line missing from every
+//! `root.usage` form is truncation; a form still ending with it is gluing.
+//! `family()` is `None` — no seed-2/4/5/6 tool carries this shape.
 
 use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
 use mandible_core::{CommandNode, Provenance, Source, Text};
@@ -19,7 +20,7 @@ fn is_bare_or_line(line: &str) -> bool {
 }
 
 /// True if `entry`'s last whitespace-separated token is the bare word
-/// `or` — the glued-continuation symptom this family's bug leaves behind.
+/// `or` — the gluing symptom.
 fn ends_with_bare_or(entry: &str) -> bool {
     entry
         .trim_end()
@@ -27,6 +28,15 @@ fn ends_with_bare_or(entry: &str) -> bool {
         .next()
         .map(|w| w.eq_ignore_ascii_case("or"))
         .unwrap_or(false)
+}
+
+/// The first non-blank physical line strictly after `raw`'s line `after`,
+/// trimmed — what the second usage form is supposed to start with.
+fn next_nonblank_line<'a>(lines: &[&'a str], after: usize) -> Option<&'a str> {
+    lines[after + 1..]
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim())
 }
 
 pub struct BareOrUsageSeparator;
@@ -41,26 +51,44 @@ impl Detector for BareOrUsageSeparator {
     }
 
     fn describes(&self) -> &'static str {
-        "the raw text carries a usage line holding only the word `or`, and a usage form in the \
-         tree still ends with that bare word glued onto its last token"
+        "a raw usage block holds a line whose only content is the word `or`, and the tree \
+         either lost everything after it (truncation) or still ends a form with it (gluing)"
     }
 
     fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
-        if !evidence.raw.lines().any(is_bare_or_line) {
-            return Vec::new();
+        let lines: Vec<&str> = evidence.raw.lines().collect();
+        let mut findings = Vec::new();
+        for (i, line) in lines.iter().enumerate() {
+            if !is_bare_or_line(line) {
+                continue;
+            }
+            let next = next_nonblank_line(&lines, i);
+            let truncated = match next {
+                Some(needle) => !evidence
+                    .root
+                    .usage
+                    .iter()
+                    .any(|u| u.as_str().contains(needle)),
+                None => false,
+            };
+            if truncated {
+                findings.push(format!(
+                    "bare `or` line truncated the usage block: {:?} never reached the tree",
+                    next.unwrap_or("")
+                ));
+                continue;
+            }
+            if evidence
+                .root
+                .usage
+                .iter()
+                .any(|f| ends_with_bare_or(f.as_str()))
+            {
+                findings
+                    .push("bare `or` line glued onto the end of the prior usage form".to_string());
+            }
         }
-        evidence
-            .root
-            .usage
-            .iter()
-            .filter(|form| ends_with_bare_or(form.as_str()))
-            .map(|form| {
-                format!(
-                    "usage form ends with a glued bare `or`: {:?}",
-                    form.as_str()
-                )
-            })
-            .collect()
+        findings
     }
 
     fn scope(&self) -> Scope {
@@ -76,15 +104,23 @@ impl Detector for BareOrUsageSeparator {
                 .collect();
             root
         }
-        let raw = "Usage: sg_luns    [--decode] [--help] DEVICE\n     or\n       sg_luns    \
-                   --test=ALUN [--decode]\n";
+        let glued_raw = "Usage: sg_luns    [--decode] [--help] DEVICE\n     or\n       sg_luns    \
+                         --test=ALUN [--decode]\n";
+        // `update-catalog`'s own bytes, byte-exact in shape: a column-0
+        // `or` separates two forms, each spanning two physical lines.
+        let truncated_raw = "Usage:\n    update-catalog <options> --add --super \
+                              <centralized_catalog>\n    update-catalog <options> --add \
+                              <centralized_catalog> <ordinary_catalog>\nor\n    update-catalog \
+                              <options> --remove --super <centralized_catalog>\n    \
+                              update-catalog <options> --remove <centralized_catalog> \
+                              <ordinary_catalog>\n";
         vec![
             SelfCheck {
                 name: "sg_luns's own bytes, pre-fix shape (`or` glued onto the first form)",
-                why: "the defect itself: the raw text carries a bare `or` separator line and the \
-                      tree's first usage form still ends with it",
+                why: "the defect's gluing symptom: an indented bare `or` line falls through \
+                      every break check and its text joins the end of the prior form",
                 expect: Expect::Fires(1),
-                raw: raw.to_string(),
+                raw: glued_raw.to_string(),
                 root: node_with_usage(&[
                     "Usage: sg_luns    [--decode] [--help] DEVICE or",
                     "       sg_luns    --test=ALUN [--decode]",
@@ -95,10 +131,37 @@ impl Detector for BareOrUsageSeparator {
                 why: "once the parser drops the bare `or` line, the same raw bytes must go \
                       silent even though the separator line is still there",
                 expect: Expect::Silent,
-                raw: raw.to_string(),
+                raw: glued_raw.to_string(),
                 root: node_with_usage(&[
                     "Usage: sg_luns    [--decode] [--help] DEVICE",
                     "       sg_luns    --test=ALUN [--decode]",
+                ]),
+            },
+            SelfCheck {
+                name: "update-catalog's own bytes, pre-fix shape (`or` truncates the block)",
+                why: "the defect's other symptom: an unindented bare `or` ends the whole usage \
+                      block there, so the second form (`--remove`) never reaches the tree at all",
+                expect: Expect::Fires(1),
+                raw: truncated_raw.to_string(),
+                root: node_with_usage(&[
+                    "Usage:",
+                    "    update-catalog <options> --add --super <centralized_catalog>",
+                    "    update-catalog <options> --add <centralized_catalog> <ordinary_catalog>",
+                ]),
+            },
+            SelfCheck {
+                name: "update-catalog's own bytes, post-fix shape (second form recovered)",
+                why: "once the parser recovers the second form, the same raw bytes must go \
+                      silent",
+                expect: Expect::Silent,
+                raw: truncated_raw.to_string(),
+                root: node_with_usage(&[
+                    "Usage:",
+                    "    update-catalog <options> --add --super <centralized_catalog>",
+                    "    update-catalog <options> --add <centralized_catalog> <ordinary_catalog>",
+                    "    update-catalog <options> --remove --super <centralized_catalog>",
+                    "    update-catalog <options> --remove <centralized_catalog> \
+                     <ordinary_catalog>",
                 ]),
             },
             SelfCheck {

--- a/xtask/src/detector/bare_or_usage_separator.rs
+++ b/xtask/src/detector/bare_or_usage_separator.rs
@@ -1,22 +1,11 @@
-//! `bare-or-usage-separator` (round 5): a usage line whose only content is
-//! the word `or` (any case, optional trailing colon) is a pure separator
-//! between two usage forms — the physical shape `sg_luns` writes
-//! (`corpus/sg_luns/1.45`, `Usage: ... DEVICE\n     or\n       sg_luns
-//! --test=ALUN ...`). Before this family's parser fix
-//! (`mandible-extract/src/help_text/sections/mod.rs`,
-//! `is_bare_or_form_separator`), that bare line read as an ordinary
-//! continuation and glued the word `or` onto the end of the first form's
-//! last token.
+//! `bare-or-usage-separator` (round 5): a usage line holding only the
+//! word `or` is a pure form separator (`sg_luns`, docs/shapes.md S-112).
+//! Before the parser fix it either truncated the usage block or glued
+//! onto the prior form. Measured by the after-the-fact symptom: `raw`
+//! carries the bare line, and a `root` usage form still ends with it.
 //!
-//! Measured by whether the raw text carries such a bare-separator line at
-//! all *and* the extracted tree still shows a usage form whose last token
-//! is the bare word `or` — the after-the-fact symptom, since checking the
-//! parser's own intermediate state is not available from `raw`+`root`
-//! alone.
-//!
-//! No seed-2/4/5/6 labelled tool carries this shape under an existing
-//! `mandible_core::audit::DEFECT_FAMILIES` entry, so [`Detector::family`]
-//! returns `None` — spec §13.1e rule 6.
+//! No seed-2/4/5/6 labelled tool carries this shape, so
+//! [`Detector::family`] returns `None` — spec §13.1e rule 6.
 
 use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
 use mandible_core::{CommandNode, Provenance, Source, Text};
@@ -65,7 +54,12 @@ impl Detector for BareOrUsageSeparator {
             .usage
             .iter()
             .filter(|form| ends_with_bare_or(form.as_str()))
-            .map(|form| format!("usage form ends with a glued bare `or`: {:?}", form.as_str()))
+            .map(|form| {
+                format!(
+                    "usage form ends with a glued bare `or`: {:?}",
+                    form.as_str()
+                )
+            })
             .collect()
     }
 
@@ -76,7 +70,10 @@ impl Detector for BareOrUsageSeparator {
     fn self_checks(&self) -> Vec<SelfCheck> {
         fn node_with_usage(usage: &[&str]) -> CommandNode {
             let mut root = CommandNode::new("sg_luns", Provenance::single(Source::HelpText));
-            root.usage = usage.iter().map(|u| Text::sanitize_preserving_layout(u)).collect();
+            root.usage = usage
+                .iter()
+                .map(|u| Text::sanitize_preserving_layout(u))
+                .collect();
             root
         }
         let raw = "Usage: sg_luns    [--decode] [--help] DEVICE\n     or\n       sg_luns    \

--- a/xtask/src/detector/bare_or_usage_separator.rs
+++ b/xtask/src/detector/bare_or_usage_separator.rs
@@ -39,6 +39,18 @@ fn next_nonblank_line<'a>(lines: &[&'a str], after: usize) -> Option<&'a str> {
         .map(|l| l.trim())
 }
 
+/// The last non-blank physical line strictly before `raw`'s line `before`,
+/// trimmed — the line the usage scan has to have reached for the block
+/// to have stopped *at* the bare-or line rather than earlier, for some
+/// unrelated reason this family did not cause.
+fn prev_nonblank_line<'a>(lines: &[&'a str], before: usize) -> Option<&'a str> {
+    lines[..before]
+        .iter()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim())
+}
+
 pub struct BareOrUsageSeparator;
 
 impl Detector for BareOrUsageSeparator {
@@ -62,15 +74,29 @@ impl Detector for BareOrUsageSeparator {
             if !is_bare_or_line(line) {
                 continue;
             }
-            let next = next_nonblank_line(&lines, i);
-            let truncated = match next {
-                Some(needle) => !evidence
+            // The block must have actually reached this line for its
+            // truncation to be this family's doing — otherwise an
+            // unrelated, earlier-firing rule ended it first (a wrapped
+            // continuation that itself looks like a flag row, say), and
+            // claiming this bare-or line broke it would be inventing a
+            // cause the raw bytes don't support.
+            let reached_here = prev_nonblank_line(&lines, i).is_some_and(|prev| {
+                evidence
                     .root
                     .usage
                     .iter()
-                    .any(|u| u.as_str().contains(needle)),
-                None => false,
-            };
+                    .any(|u| u.as_str().contains(prev))
+            });
+            let next = next_nonblank_line(&lines, i);
+            let truncated = reached_here
+                && match next {
+                    Some(needle) => !evidence
+                        .root
+                        .usage
+                        .iter()
+                        .any(|u| u.as_str().contains(needle)),
+                    None => false,
+                };
             if truncated {
                 findings.push(format!(
                     "bare `or` line truncated the usage block: {:?} never reached the tree",
@@ -171,6 +197,21 @@ impl Detector for BareOrUsageSeparator {
                 expect: Expect::Silent,
                 raw: "Usage: foo [-a] BAR\nSome sentence that says or so.\n".to_string(),
                 root: node_with_usage(&["Usage: foo [-a] BAR"]),
+            },
+            SelfCheck {
+                name: "sg_test_rwbuf's own bytes, block already ended before the `or` line",
+                why: "an unrelated, earlier-firing rule (a wrapped continuation line that itself \
+                      reads as a flag row) truncates the block before the bare `or` is ever \
+                      reached, so the missing second form is not this family's doing and must \
+                      not be claimed",
+                expect: Expect::Silent,
+                raw: "Usage: sg_test_rwbuf [--addrd=AR] [--addwr=AW] [--help] [--quick]\n         \
+                      --size=SZ [--times=NUM] [--verbose] [--version]\n            DEVICE\n or\n  \
+                      sg_test_rwbuf DEVICE SZ [AW] [AR]\n"
+                    .to_string(),
+                root: node_with_usage(&[
+                    "Usage: sg_test_rwbuf [--addrd=AR] [--addwr=AW] [--help] [--quick]",
+                ]),
             },
         ]
     }

--- a/xtask/src/detector/bare_or_usage_separator.rs
+++ b/xtask/src/detector/bare_or_usage_separator.rs
@@ -1,0 +1,117 @@
+//! `bare-or-usage-separator` (round 5): a usage line whose only content is
+//! the word `or` (any case, optional trailing colon) is a pure separator
+//! between two usage forms — the physical shape `sg_luns` writes
+//! (`corpus/sg_luns/1.45`, `Usage: ... DEVICE\n     or\n       sg_luns
+//! --test=ALUN ...`). Before this family's parser fix
+//! (`mandible-extract/src/help_text/sections/mod.rs`,
+//! `is_bare_or_form_separator`), that bare line read as an ordinary
+//! continuation and glued the word `or` onto the end of the first form's
+//! last token.
+//!
+//! Measured by whether the raw text carries such a bare-separator line at
+//! all *and* the extracted tree still shows a usage form whose last token
+//! is the bare word `or` — the after-the-fact symptom, since checking the
+//! parser's own intermediate state is not available from `raw`+`root`
+//! alone.
+//!
+//! No seed-2/4/5/6 labelled tool carries this shape under an existing
+//! `mandible_core::audit::DEFECT_FAMILIES` entry, so [`Detector::family`]
+//! returns `None` — spec §13.1e rule 6.
+
+use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
+use mandible_core::{CommandNode, Provenance, Source, Text};
+
+/// True if `line`'s only content, once trimmed, is the word `or` — any
+/// case — with an optional trailing colon. Mirrors
+/// `mandible_extract`'s (private) `is_bare_or_form_separator` predicate,
+/// checked independently here since a detector reads only `raw`+`root`.
+fn is_bare_or_line(line: &str) -> bool {
+    line.trim().trim_end_matches(':').eq_ignore_ascii_case("or")
+}
+
+/// True if `entry`'s last whitespace-separated token is the bare word
+/// `or` — the glued-continuation symptom this family's bug leaves behind.
+fn ends_with_bare_or(entry: &str) -> bool {
+    entry
+        .trim_end()
+        .rsplit(char::is_whitespace)
+        .next()
+        .map(|w| w.eq_ignore_ascii_case("or"))
+        .unwrap_or(false)
+}
+
+pub struct BareOrUsageSeparator;
+
+impl Detector for BareOrUsageSeparator {
+    fn name(&self) -> &'static str {
+        "bare-or-usage-separator"
+    }
+
+    fn family(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn describes(&self) -> &'static str {
+        "the raw text carries a usage line holding only the word `or`, and a usage form in the \
+         tree still ends with that bare word glued onto its last token"
+    }
+
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        if !evidence.raw.lines().any(is_bare_or_line) {
+            return Vec::new();
+        }
+        evidence
+            .root
+            .usage
+            .iter()
+            .filter(|form| ends_with_bare_or(form.as_str()))
+            .map(|form| format!("usage form ends with a glued bare `or`: {:?}", form.as_str()))
+            .collect()
+    }
+
+    fn scope(&self) -> Scope {
+        Scope::full()
+    }
+
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        fn node_with_usage(usage: &[&str]) -> CommandNode {
+            let mut root = CommandNode::new("sg_luns", Provenance::single(Source::HelpText));
+            root.usage = usage.iter().map(|u| Text::sanitize_preserving_layout(u)).collect();
+            root
+        }
+        let raw = "Usage: sg_luns    [--decode] [--help] DEVICE\n     or\n       sg_luns    \
+                   --test=ALUN [--decode]\n";
+        vec![
+            SelfCheck {
+                name: "sg_luns's own bytes, pre-fix shape (`or` glued onto the first form)",
+                why: "the defect itself: the raw text carries a bare `or` separator line and the \
+                      tree's first usage form still ends with it",
+                expect: Expect::Fires(1),
+                raw: raw.to_string(),
+                root: node_with_usage(&[
+                    "Usage: sg_luns    [--decode] [--help] DEVICE or",
+                    "       sg_luns    --test=ALUN [--decode]",
+                ]),
+            },
+            SelfCheck {
+                name: "sg_luns's own bytes, post-fix shape (separator dropped)",
+                why: "once the parser drops the bare `or` line, the same raw bytes must go \
+                      silent even though the separator line is still there",
+                expect: Expect::Silent,
+                raw: raw.to_string(),
+                root: node_with_usage(&[
+                    "Usage: sg_luns    [--decode] [--help] DEVICE",
+                    "       sg_luns    --test=ALUN [--decode]",
+                ]),
+            },
+            SelfCheck {
+                name: "a usage form ending in a real word that is not `or`",
+                why: "an ordinary usage form must never be claimed just because the raw text \
+                      happens to mention `or` in a sentence elsewhere",
+                expect: Expect::Silent,
+                raw: "Usage: foo [-a] BAR\nSome sentence that says or so.\n".to_string(),
+                root: node_with_usage(&["Usage: foo [-a] BAR"]),
+            },
+        ]
+    }
+}

--- a/xtask/src/detector/commands.rs
+++ b/xtask/src/detector/commands.rs
@@ -295,3 +295,22 @@ pub fn check_vim_family_ratchet(
     println!("\n{}", ratchet.report());
     Ok(ratchet.holds())
 }
+
+/// Round 5's two repaired families (atlas S-112/S-113), gated the same
+/// way as [`check_vim_family_ratchet`]'s other callers, folded into one
+/// function so `xtask/src/main.rs`'s `run_coverage` gains one call site
+/// rather than two. `same-spelling-fold-loss` is not gated here: its
+/// merge half is invisible to this sweep.
+pub fn check_round5_family_ratchets(
+    previous: &crate::coverage::Aggregate,
+    fresh: &crate::coverage::Aggregate,
+) -> anyhow::Result<bool> {
+    let mut holds = true;
+    for name in [
+        "bare-or-usage-separator",
+        "usage-spelling-duplicates-table-row",
+    ] {
+        holds &= check_vim_family_ratchet(name, previous, fresh)?;
+    }
+    Ok(holds)
+}

--- a/xtask/src/detector/mod.rs
+++ b/xtask/src/detector/mod.rs
@@ -51,6 +51,16 @@ pub(crate) mod underscore_in_long_option;
 pub(crate) mod usage_alternative_or_prefix;
 pub(crate) mod usage_program_word_mismatch;
 
+// Round-5 family detectors (three parser families: same-spelling-fold-loss,
+// bare-or-usage-separator, usage-spelling-duplicates-table-row). Each
+// implements `Detector` directly rather than the separate
+// detect()/Report + wrapper split the round-4 modules above use — no
+// wrapper is needed since none of these three shares its detection logic
+// with anything else in this file.
+pub(crate) mod bare_or_usage_separator;
+pub(crate) mod same_spelling_fold_loss;
+pub(crate) mod usage_spelling_duplicates_table_row;
+
 pub(crate) use calibration::*;
 pub(crate) use commands::*;
 pub(crate) use detectors_families::*;
@@ -660,6 +670,9 @@ pub fn registry() -> Vec<Box<dyn Detector>> {
         Box::new(MultiOperandUsageTail),
         Box::new(OrJoinedAliasWithValues),
         Box::new(GluedOptionalGroupSpelling),
+        Box::new(same_spelling_fold_loss::SameSpellingFoldLoss),
+        Box::new(bare_or_usage_separator::BareOrUsageSeparator),
+        Box::new(usage_spelling_duplicates_table_row::UsageSpellingDuplicatesTableRow),
     ]
 }
 

--- a/xtask/src/detector/same_spelling_fold_loss.rs
+++ b/xtask/src/detector/same_spelling_fold_loss.rs
@@ -11,29 +11,30 @@
 //! [`Detector::family`] returns `None` — spec §13.1e rule 6.
 
 use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
-use mandible_core::{CommandNode, Dashes, Entity, Provenance, Source, Text, ValueKind};
+use mandible_core::{CommandNode, Dashes, Entity, EntityKind, Provenance, Source, Text, ValueKind};
 
 /// The bucket key two entities must share to be the same item, mirroring
-/// `mandible_core::merge::entity_identity` (private to that crate) closely
-/// enough for detection purposes: long name (with dash count), else short
+/// `mandible_core::merge::entity_identity` (private to that crate): the
+/// kind leads — a flag and a positional spelled alike are unrelated items,
+/// never one bucket — then long name (with dash count), else short
 /// letter, else the bare name a dashless kind carries. `None` for an
 /// entity with no spelling at all — nothing to collide on.
-fn identity_key(e: &Entity) -> Option<String> {
-    if let Some(l) = e.long_spelling() {
+fn identity_key(e: &Entity) -> Option<(EntityKind, String)> {
+    let key = if let Some(l) = e.long_spelling() {
         let dashes = if matches!(l.dashes, Dashes::Double) {
             "2"
         } else {
             "1"
         };
-        return Some(format!("L:{dashes}:{}", l.name));
-    }
-    if let Some(s) = e.short() {
-        return Some(format!("S:{s}"));
-    }
-    if !e.spellings.is_empty() {
-        return Some(format!("N:{}", e.primary_name()));
-    }
-    None
+        format!("L:{dashes}:{}", l.name)
+    } else if let Some(s) = e.short() {
+        format!("S:{s}")
+    } else if !e.spellings.is_empty() {
+        format!("N:{}", e.primary_name())
+    } else {
+        return None;
+    };
+    Some((e.kind, key))
 }
 
 /// True when `a` and `b` are the shape this detector claims: same identity
@@ -63,36 +64,44 @@ impl Detector for SameSpellingFoldLoss {
     }
 
     fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
-        let mut by_key: std::collections::BTreeMap<String, Vec<&Entity>> =
-            std::collections::BTreeMap::new();
+        let mut by_key: std::collections::HashMap<(EntityKind, String), Vec<&Entity>> =
+            std::collections::HashMap::new();
         for e in &evidence.root.entities {
             if let Some(key) = identity_key(e) {
                 by_key.entry(key).or_default().push(e);
             }
         }
         let mut findings = Vec::new();
-        for (key, group) in by_key {
-            if group.len() < 2 {
+        for ((kind, key), group) in by_key {
+            // A group above this size is not a real same-spelling
+            // collision — it is some other shape entirely (a degenerate
+            // tree with many entities sharing an empty bare name, say),
+            // and no tool this detector was built for behind it looks
+            // like this. The real specimens (icupkg, vim.basic) top out
+            // at 3. One finding per *bucket* below, not per pair — a
+            // bucket of size `n` is one loss, not `n choose 2` of them.
+            const MAX_GROUP: usize = 16;
+            if group.len() < 2 || group.len() > MAX_GROUP {
                 continue;
             }
-            for i in 0..group.len() {
-                for j in (i + 1)..group.len() {
-                    if disagrees(group[i], group[j]) {
-                        findings.push(format!(
-                            "{key}: {:?} vs {:?}",
-                            group[i]
-                                .description
-                                .as_ref()
-                                .map(Text::as_str)
-                                .unwrap_or(""),
-                            group[j]
-                                .description
-                                .as_ref()
-                                .map(Text::as_str)
-                                .unwrap_or(""),
-                        ));
-                    }
-                }
+            let disagreeing_pair = (0..group.len())
+                .flat_map(|i| ((i + 1)..group.len()).map(move |j| (i, j)))
+                .find(|&(i, j)| disagrees(group[i], group[j]));
+            if let Some((i, j)) = disagreeing_pair {
+                findings.push(format!(
+                    "{kind:?} {key} ({} rows): {:?} vs {:?}",
+                    group.len(),
+                    group[i]
+                        .description
+                        .as_ref()
+                        .map(Text::as_str)
+                        .unwrap_or(""),
+                    group[j]
+                        .description
+                        .as_ref()
+                        .map(Text::as_str)
+                        .unwrap_or(""),
+                ));
             }
         }
         findings

--- a/xtask/src/detector/same_spelling_fold_loss.rs
+++ b/xtask/src/detector/same_spelling_fold_loss.rs
@@ -1,33 +1,14 @@
-//! `same-spelling-fold-loss` (round 5): two entities in the extracted tree
-//! share one identity key — the same key
-//! `mandible_core::merge::entity_identity` would bucket them under — but
-//! disagree about whether they take a value, or each carry their own
-//! documented description and the two differ.
+//! `same-spelling-fold-loss` (round 5): two root entities share one
+//! identity key (`mandible_core::merge::entity_identity`'s) but disagree
+//! about taking a value, or each carry a different description —
+//! docs/shapes.md S-102, `corpus/vim.basic/audit-seed4`'s bare `+` vs
+//! valued `+<lnum>`. `icupkg`'s `-tl`/`-tb`/`-te` is the same collision
+//! one layer earlier; a prototyped extraction fold moved only that one
+//! tool, below the five-tool bar, so it was not shipped and still
+//! surfaces here.
 //!
-//! A fold that runs *after* extraction (the interactive merge,
-//! `mandible_core::merge::merge_entity_bucket`) keys on this same identity
-//! and keeps only one row's description, or attaches one row's value to
-//! the other row's description — see docs/shapes.md's
-//! "same-spelling-fold-loss" entry and `corpus/vim.basic/audit-seed4`'s
-//! bare `+` ("Start at end of file") against valued `+<lnum>` ("Start at
-//! line <lnum>").
-//!
-//! `icupkg`'s own three-row `-t`/`--type` shape (`-tl`, `-tb`, `-te`) is
-//! this same identity collision one layer earlier, in extraction itself.
-//! An extraction-time fold was prototyped for it (folding the three rows
-//! into one entity's `choices`) but a full-`PATH` sweep showed it moved
-//! only `icupkg` itself — below the five-tool bar (spec §3.1) — so it was
-//! **not shipped**; `icupkg` therefore still surfaces here too, alongside
-//! vim.basic, until a fold that clears the bar is found. A self-check
-//! below still asserts this detector goes silent on an entity that has
-//! *already* been folded into one, since that is the shape the detector
-//! must recognize the absence of, whether or not any current pass
-//! produces it.
-//!
-//! No seed-2/4/5/6 labelled tool carries this shape under an existing
-//! `mandible_core::audit::DEFECT_FAMILIES` entry, so [`Detector::family`]
-//! returns `None` — spec §13.1e rule 6, the honest "not calibratable yet"
-//! answer, not a fabricated nearest match.
+//! No seed-2/4/5/6 labelled tool carries this shape, so
+//! [`Detector::family`] returns `None` — spec §13.1e rule 6.
 
 use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
 use mandible_core::{CommandNode, Dashes, Entity, Provenance, Source, Text, ValueKind};
@@ -60,8 +41,7 @@ fn identity_key(e: &Entity) -> Option<String> {
 /// take a value at all, or two different documented descriptions.
 fn disagrees(a: &Entity, b: &Entity) -> bool {
     let value_disagrees = (a.value_kind == ValueKind::None) != (b.value_kind == ValueKind::None);
-    let desc_disagrees =
-        matches!((&a.description, &b.description), (Some(x), Some(y)) if x != y);
+    let desc_disagrees = matches!((&a.description, &b.description), (Some(x), Some(y)) if x != y);
     value_disagrees || desc_disagrees
 }
 

--- a/xtask/src/detector/same_spelling_fold_loss.rs
+++ b/xtask/src/detector/same_spelling_fold_loss.rs
@@ -1,0 +1,200 @@
+//! `same-spelling-fold-loss` (round 5): two entities in the extracted tree
+//! share one identity key — the same key
+//! `mandible_core::merge::entity_identity` would bucket them under — but
+//! disagree about whether they take a value, or each carry their own
+//! documented description and the two differ.
+//!
+//! A fold that runs *after* extraction (the interactive merge,
+//! `mandible_core::merge::merge_entity_bucket`) keys on this same identity
+//! and keeps only one row's description, or attaches one row's value to
+//! the other row's description — see docs/shapes.md's
+//! "same-spelling-fold-loss" entry and `corpus/vim.basic/audit-seed4`'s
+//! bare `+` ("Start at end of file") against valued `+<lnum>` ("Start at
+//! line <lnum>").
+//!
+//! `icupkg`'s own three-row `-t`/`--type` shape (`-tl`, `-tb`, `-te`) is
+//! this same identity collision one layer earlier, in extraction itself.
+//! An extraction-time fold was prototyped for it (folding the three rows
+//! into one entity's `choices`) but a full-`PATH` sweep showed it moved
+//! only `icupkg` itself — below the five-tool bar (spec §3.1) — so it was
+//! **not shipped**; `icupkg` therefore still surfaces here too, alongside
+//! vim.basic, until a fold that clears the bar is found. A self-check
+//! below still asserts this detector goes silent on an entity that has
+//! *already* been folded into one, since that is the shape the detector
+//! must recognize the absence of, whether or not any current pass
+//! produces it.
+//!
+//! No seed-2/4/5/6 labelled tool carries this shape under an existing
+//! `mandible_core::audit::DEFECT_FAMILIES` entry, so [`Detector::family`]
+//! returns `None` — spec §13.1e rule 6, the honest "not calibratable yet"
+//! answer, not a fabricated nearest match.
+
+use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
+use mandible_core::{CommandNode, Dashes, Entity, Provenance, Source, Text, ValueKind};
+
+/// The bucket key two entities must share to be the same item, mirroring
+/// `mandible_core::merge::entity_identity` (private to that crate) closely
+/// enough for detection purposes: long name (with dash count), else short
+/// letter, else the bare name a dashless kind carries. `None` for an
+/// entity with no spelling at all — nothing to collide on.
+fn identity_key(e: &Entity) -> Option<String> {
+    if let Some(l) = e.long_spelling() {
+        let dashes = if matches!(l.dashes, Dashes::Double) {
+            "2"
+        } else {
+            "1"
+        };
+        return Some(format!("L:{dashes}:{}", l.name));
+    }
+    if let Some(s) = e.short() {
+        return Some(format!("S:{s}"));
+    }
+    if !e.spellings.is_empty() {
+        return Some(format!("N:{}", e.primary_name()));
+    }
+    None
+}
+
+/// True when `a` and `b` are the shape this detector claims: same identity
+/// key (checked by the caller), and either a difference in whether they
+/// take a value at all, or two different documented descriptions.
+fn disagrees(a: &Entity, b: &Entity) -> bool {
+    let value_disagrees = (a.value_kind == ValueKind::None) != (b.value_kind == ValueKind::None);
+    let desc_disagrees =
+        matches!((&a.description, &b.description), (Some(x), Some(y)) if x != y);
+    value_disagrees || desc_disagrees
+}
+
+pub struct SameSpellingFoldLoss;
+
+impl Detector for SameSpellingFoldLoss {
+    fn name(&self) -> &'static str {
+        "same-spelling-fold-loss"
+    }
+
+    fn family(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn describes(&self) -> &'static str {
+        "two root entities share one identity key (same long/short spelling) but disagree \
+         about taking a value or about their own description — a later spelling-keyed fold \
+         keeps only one row's information"
+    }
+
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        let mut by_key: std::collections::BTreeMap<String, Vec<&Entity>> =
+            std::collections::BTreeMap::new();
+        for e in &evidence.root.entities {
+            if let Some(key) = identity_key(e) {
+                by_key.entry(key).or_default().push(e);
+            }
+        }
+        let mut findings = Vec::new();
+        for (key, group) in by_key {
+            if group.len() < 2 {
+                continue;
+            }
+            for i in 0..group.len() {
+                for j in (i + 1)..group.len() {
+                    if disagrees(group[i], group[j]) {
+                        findings.push(format!(
+                            "{key}: {:?} vs {:?}",
+                            group[i]
+                                .description
+                                .as_ref()
+                                .map(Text::as_str)
+                                .unwrap_or(""),
+                            group[j]
+                                .description
+                                .as_ref()
+                                .map(Text::as_str)
+                                .unwrap_or(""),
+                        ));
+                    }
+                }
+            }
+        }
+        findings
+    }
+
+    fn scope(&self) -> Scope {
+        Scope::full()
+    }
+
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        fn node_with(flags: Vec<Entity>) -> CommandNode {
+            let mut root = CommandNode::new("t", Provenance::single(Source::HelpText));
+            root.entities = flags;
+            root
+        }
+        fn bare_plus() -> Entity {
+            let mut e = Entity::new(
+                mandible_core::EntityKind::Flag,
+                Provenance::single(Source::HelpText),
+            );
+            e.spellings = vec![mandible_core::Spelling::bare("+")];
+            e.description = Some(Text::sanitize("Start at end of file"));
+            e
+        }
+        fn valued_plus() -> Entity {
+            let mut e = Entity::new(
+                mandible_core::EntityKind::Flag,
+                Provenance::single(Source::HelpText),
+            );
+            e.spellings = vec![mandible_core::Spelling::bare("+")];
+            e.value_name = Some("lnum".to_string());
+            e.value_kind = ValueKind::Required;
+            e.description = Some(Text::sanitize("Start at line <lnum>"));
+            e
+        }
+        vec![
+            SelfCheck {
+                name: "vim.basic's own bytes, bare `+` vs valued `+<lnum>`",
+                why: "the defect itself: two entities share the bare `+` spelling and disagree \
+                      about taking a value",
+                expect: Expect::Fires(1),
+                raw: String::new(),
+                root: node_with(vec![bare_plus(), valued_plus()]),
+            },
+            SelfCheck {
+                name: "icupkg's own bytes, already folded into one `-t`/`--type` entity",
+                why: "once `fold_glued_choice_rows` has merged the three rows into one entity's \
+                      `choices`, there is only one entity to collide with itself, so this must \
+                      stay silent",
+                expect: Expect::Silent,
+                raw: String::new(),
+                root: node_with(vec![{
+                    let mut e = Entity::flag_spelled(
+                        None,
+                        Some("type".to_string()),
+                        false,
+                        false,
+                        Provenance::single(Source::HelpText),
+                    );
+                    e.spellings.insert(0, mandible_core::Spelling::short('t'));
+                    e.value_kind = ValueKind::Required;
+                    e.choices = vec![
+                        mandible_core::Choice::described(
+                            "l",
+                            Text::sanitize("output for little-endian/ASCII charset family"),
+                        ),
+                        mandible_core::Choice::described(
+                            "b",
+                            Text::sanitize("output for big-endian/ASCII charset family"),
+                        ),
+                    ];
+                    e
+                }]),
+            },
+            SelfCheck {
+                name: "two rows sharing a spelling that agree on shape and description",
+                why: "an ordinary cross-source duplicate (the same row re-parsed twice) must \
+                      never be claimed",
+                expect: Expect::Silent,
+                raw: String::new(),
+                root: node_with(vec![bare_plus(), bare_plus()]),
+            },
+        ]
+    }
+}

--- a/xtask/src/detector/usage_spelling_duplicates_table_row.rs
+++ b/xtask/src/detector/usage_spelling_duplicates_table_row.rs
@@ -1,23 +1,14 @@
 //! `usage-spelling-duplicates-table-row` (round 5): the usage-only-
-//! spelling recovery pass (`mandible-extract/src/help_text/sections/
-//! mod.rs`, the `extract_usage_flags` loop feeding
-//! `flag_spelling_already_present`) adds a bare, undescribed entity for a
-//! spelling an existing table-row entity already carries among its
-//! *other* spellings.
+//! spelling recovery pass adds a bare, undescribed entity for a spelling
+//! an existing table-row entity already carries among its other
+//! spellings. `icupkg`'s `-h, -?, --help` row is the specimen:
+//! `flag_spelling_already_present` used to check only that entity's
+//! *primary* `short()`/`long()` pick, never every spelling, so `-?` read
+//! as absent and got re-added bare. Fixed there; this detector
+//! generalizes the symptom fleet-wide (docs/shapes.md S-113).
 //!
-//! `icupkg` is the specimen: the table row `-h or -? or --help` parses
-//! correctly into one entity carrying all three spellings, but the usage
-//! line `[-h|-?|--help ]` still adds a second, bare `-?` entity with no
-//! description — `flag_spelling_already_present` used to check only the
-//! existing entity's *primary* `short()`/`long()` pick (the first
-//! matching spelling), never every spelling it carries, so `-?` (never
-//! the first short spelling in `-h, -?, --help`) read as absent. Fixed in
-//! `flag_spelling_already_present` itself; this detector generalizes the
-//! symptom fleet-wide.
-//!
-//! No seed-2/4/5/6 labelled tool carries this shape under an existing
-//! `mandible_core::audit::DEFECT_FAMILIES` entry, so [`Detector::family`]
-//! returns `None` — spec §13.1e rule 6.
+//! No seed-2/4/5/6 labelled tool carries this shape, so
+//! [`Detector::family`] returns `None` — spec §13.1e rule 6.
 
 use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
 use mandible_core::{CommandNode, Dashes, Entity, Provenance, Source, Spelling, Text};

--- a/xtask/src/detector/usage_spelling_duplicates_table_row.rs
+++ b/xtask/src/detector/usage_spelling_duplicates_table_row.rs
@@ -1,0 +1,157 @@
+//! `usage-spelling-duplicates-table-row` (round 5): the usage-only-
+//! spelling recovery pass (`mandible-extract/src/help_text/sections/
+//! mod.rs`, the `extract_usage_flags` loop feeding
+//! `flag_spelling_already_present`) adds a bare, undescribed entity for a
+//! spelling an existing table-row entity already carries among its
+//! *other* spellings.
+//!
+//! `icupkg` is the specimen: the table row `-h or -? or --help` parses
+//! correctly into one entity carrying all three spellings, but the usage
+//! line `[-h|-?|--help ]` still adds a second, bare `-?` entity with no
+//! description — `flag_spelling_already_present` used to check only the
+//! existing entity's *primary* `short()`/`long()` pick (the first
+//! matching spelling), never every spelling it carries, so `-?` (never
+//! the first short spelling in `-h, -?, --help`) read as absent. Fixed in
+//! `flag_spelling_already_present` itself; this detector generalizes the
+//! symptom fleet-wide.
+//!
+//! No seed-2/4/5/6 labelled tool carries this shape under an existing
+//! `mandible_core::audit::DEFECT_FAMILIES` entry, so [`Detector::family`]
+//! returns `None` — spec §13.1e rule 6.
+
+use crate::detector::{Detector, Expect, Scope, SelfCheck, ToolEvidence};
+use mandible_core::{CommandNode, Dashes, Entity, Provenance, Source, Spelling, Text};
+
+/// True for a usage-derived duplicate: one spelling, no description, and
+/// `Source::HelpTextSynopsis` is the only contributing source — exactly
+/// the shape `extract_usage_flags` emits before
+/// `flag_spelling_already_present` gets a chance to drop it.
+fn is_usage_only_bare_spelling(e: &Entity) -> bool {
+    e.spellings.len() == 1
+        && e.description.is_none()
+        && !e.provenance.sources.is_empty()
+        && e.provenance
+            .sources
+            .iter()
+            .all(|s| matches!(s, Source::HelpTextSynopsis))
+}
+
+fn carries_spelling(e: &Entity, dashes: Dashes, name: &str) -> bool {
+    e.spellings
+        .iter()
+        .any(|s| s.dashes == dashes && s.name == name)
+}
+
+pub struct UsageSpellingDuplicatesTableRow;
+
+impl Detector for UsageSpellingDuplicatesTableRow {
+    fn name(&self) -> &'static str {
+        "usage-spelling-duplicates-table-row"
+    }
+
+    fn family(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn describes(&self) -> &'static str {
+        "a bare, undescribed entity sourced only from the usage synopsis carries a spelling an \
+         existing table-row entity already carries among its other spellings"
+    }
+
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        let mut findings = Vec::new();
+        for candidate in &evidence.root.entities {
+            if !is_usage_only_bare_spelling(candidate) {
+                continue;
+            }
+            let spelling = &candidate.spellings[0];
+            for other in &evidence.root.entities {
+                if std::ptr::eq(other, candidate) {
+                    continue;
+                }
+                if other.spellings.len() > 1
+                    && carries_spelling(other, spelling.dashes, &spelling.name)
+                {
+                    findings.push(format!(
+                        "{:?} already carried by the row spelled {:?}",
+                        spelling.name,
+                        other
+                            .spellings
+                            .iter()
+                            .map(|s| s.name.clone())
+                            .collect::<Vec<_>>()
+                    ));
+                }
+            }
+        }
+        findings
+    }
+
+    fn scope(&self) -> Scope {
+        Scope::full()
+    }
+
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        fn node_with(flags: Vec<Entity>) -> CommandNode {
+            let mut root = CommandNode::new("icupkg", Provenance::single(Source::HelpText));
+            root.entities = flags;
+            root
+        }
+        fn table_row_help() -> Entity {
+            let mut e = Entity::new(
+                mandible_core::EntityKind::Flag,
+                Provenance::single(Source::HelpText),
+            );
+            e.spellings = vec![
+                Spelling::short('h'),
+                Spelling::short('?'),
+                Spelling::long("help"),
+            ];
+            e.description = Some(Text::sanitize("print this message and exit"));
+            e
+        }
+        fn bare_question_mark(source: Source) -> Entity {
+            let mut e = Entity::new(mandible_core::EntityKind::Flag, Provenance::single(source));
+            e.spellings = vec![Spelling::short('?')];
+            e
+        }
+        vec![
+            SelfCheck {
+                name: "icupkg's own bytes, pre-fix shape (duplicate bare `-?`)",
+                why: "the defect itself: a bare, undescribed `-?` entity duplicates a spelling \
+                      the `-h, -?, --help` row already carries",
+                expect: Expect::Fires(1),
+                raw: String::new(),
+                root: node_with(vec![
+                    table_row_help(),
+                    bare_question_mark(Source::HelpTextSynopsis),
+                ]),
+            },
+            SelfCheck {
+                name: "icupkg's own bytes, post-fix shape (duplicate dropped)",
+                why: "once `flag_spelling_already_present` checks every spelling the table row \
+                      carries, the usage-derived duplicate is never added, so there is nothing \
+                      here to find",
+                expect: Expect::Silent,
+                raw: String::new(),
+                root: node_with(vec![table_row_help()]),
+            },
+            SelfCheck {
+                name: "a genuinely undocumented usage-only flag with no table row",
+                why: "a usage-derived flag with no table-row counterpart is a real recovery, \
+                      not a duplicate, and must never be claimed",
+                expect: Expect::Silent,
+                raw: String::new(),
+                root: node_with(vec![bare_question_mark(Source::HelpTextSynopsis)]),
+            },
+            SelfCheck {
+                name: "a table-row entity that merely repeats the usage-only entity's source",
+                why: "a described entity is never itself claimed as the duplicate, however many \
+                      sources contributed to it",
+                expect: Expect::Silent,
+                raw: String::new(),
+                root: node_with(vec![table_row_help(), table_row_help()]),
+            },
+        ]
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1254,26 +1254,7 @@ fn run_coverage(
             regressed = true;
         }
 
-        // `bare-or-usage-separator`, repaired by `mandible-extract/src/
-        // help_text/sections/mod.rs`'s `is_bare_or_form_separator`, atlas
-        // S-112. Gated at a literal zero the same way as the two above.
-        // (`same-spelling-fold-loss`, round 5's other new detector, is not
-        // gated: its merge-time half is invisible to this sweep.)
-        if !detector::check_vim_family_ratchet("bare-or-usage-separator", &previous, &fresh)? {
-            regressed = true;
-        }
-
-        // `usage-spelling-duplicates-table-row`, repaired by
-        // `flag_spelling_already_present` checking every spelling an
-        // existing row carries, atlas S-113. Gated at a literal zero the
-        // same way.
-        if !detector::check_vim_family_ratchet(
-            "usage-spelling-duplicates-table-row",
-            &previous,
-            &fresh,
-        )? {
-            regressed = true;
-        }
+        regressed |= !detector::check_round5_family_ratchets(&previous, &fresh)?;
 
         if regressed {
             anyhow::bail!("coverage regression detected — see above");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1254,6 +1254,27 @@ fn run_coverage(
             regressed = true;
         }
 
+        // `bare-or-usage-separator`, repaired by `mandible-extract/src/
+        // help_text/sections/mod.rs`'s `is_bare_or_form_separator`, atlas
+        // S-112. Gated at a literal zero the same way as the two above.
+        // (`same-spelling-fold-loss`, round 5's other new detector, is not
+        // gated: its merge-time half is invisible to this sweep.)
+        if !detector::check_vim_family_ratchet("bare-or-usage-separator", &previous, &fresh)? {
+            regressed = true;
+        }
+
+        // `usage-spelling-duplicates-table-row`, repaired by
+        // `flag_spelling_already_present` checking every spelling an
+        // existing row carries, atlas S-113. Gated at a literal zero the
+        // same way.
+        if !detector::check_vim_family_ratchet(
+            "usage-spelling-duplicates-table-row",
+            &previous,
+            &fresh,
+        )? {
+            regressed = true;
+        }
+
         if regressed {
             anyhow::bail!("coverage regression detected — see above");
         }


### PR DESCRIPTION
Three parser families the maintainer found by hand on the last build: two rows sharing one
spelling losing a description, a second usage form written after a bare `or` line, and a
spelling reaching the tree twice.

### See it yourself

```
./target/release/mandible icupkg     # FLAGS 19: -t, --type l / b / e each with its own text,
                                     # and no trailing bare -?
./target/release/mandible vim.basic  # + "Start at end of file" and +<lnum> "Start at line <lnum>"
./target/release/mandible sg_luns    # first usage form ends DEVICE, second form on its own line
./target/release/mandible git-lfs    # the negative control, byte-identical to main
```

### Evidence

Full-`PATH` sweep of 2318 tools against main, gains and losses never netted.

| family | detector | fleet before | fleet after | sweep |
|---|---|---|---|---|
| same-spelling-fold-loss | `same-spelling-fold-loss` | 182 tools, 664 findings | 182:664 | invisible, see below |
| bare-or-usage-separator | `bare-or-usage-separator` | 6 tools, 6 findings | 0:0, gated at zero | 1 gain, 0 losses |
| usage-spelling-duplicates-table-row | `usage-spelling-duplicates-table-row` | 5 tools, 5 findings | 0:0, gated at zero | 5 losses, 0 gains |

The five losses are five duplicate removals, each verified against the sweep fingerprints: `date`
drops a bare `--universal` and keeps `-u, --utc, --universal`; `icupkg` drops a bare `-?` and
keeps `-h, -?, --help`; `jcmd` drops `-h` and keeps `-?, -h, --help`; `piconv` drops `-c` and
keeps `-C, -c`; `ssh-copy-id` drops `-?` and keeps `-h, -?`. Nothing else moved on those tools.

The first family's fix is in the merge, and `xtask corpus` and `xtask coverage` both extract
through a single-candidate path that short-circuits before the merge runs, so neither instrument
can see it. Its evidence is a unit test built from the two-row shape and the `vim.basic` screen
above. Its detector reads the shape rather than the loss, so its count does not move and it is
not gated at zero.

Not shipped: folding `icupkg`'s three `-t, --type` rows into one option with three choices. The
prototype moved one tool, below the five-tool bar. `corpus/icupkg/74.2` asserts the target with
`must_attach_choices`.
