### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches a published 0.1.0 release.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-05
+
 ### Added
 
 - `cargo xtask audit contribute` walks a contributor through auditing mandible against their own installed tools — login, a random 20-tool draw excluding anything already audited, review, and a verdict file ready to submit (CONTRIBUTING.md §2).
@@ -2243,6 +2245,8 @@ Known gaps are tracked as issues; busybox's applet list is
 <summary>Development history</summary>
 
 ## [Unreleased]
+
+## [0.7.0] - 2026-09-05
 
 ### Added (batch 6 part 6, framework-support workflow)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mandible"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "directories",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-extract"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bindgen",
  "brush-parser",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-search"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "mandible-core",
  "nucleo",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "mandible-tui"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "base64",
@@ -2365,7 +2365,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xtask"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 strip = "symbols"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -32,10 +32,10 @@ authors = ["Sadig Akhund <sadigaxund@gmail.com>"]
 # and then failed to resolve the moment the workspace reached 0.2.0. Caught by
 # a local build; after a tag it would have failed mid-release, with some crates
 # already published and unpublishable again.
-mandible-core = { path = "mandible-core", version = "0.6.1" }
-mandible-extract = { path = "mandible-extract", version = "0.6.1" }
-mandible-search = { path = "mandible-search", version = "0.6.1" }
-mandible-tui = { path = "mandible-tui", version = "0.6.1" }
+mandible-core = { path = "mandible-core", version = "0.7.0" }
+mandible-extract = { path = "mandible-extract", version = "0.7.0" }
+mandible-search = { path = "mandible-search", version = "0.7.0" }
+mandible-tui = { path = "mandible-tui", version = "0.7.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Version 0.7.0: rounds 3 to 6 of the parser families, the same-as-ancestor node view, short-then-long spelling order, and the audit contribute flow. The tag follows the merge on the maintainer's word.