### PR TITLE
test(tui): state the glyph set instead of reading it from the locale

### DIFF
--- a/mandible-tui/src/render/detail_pane/mod.rs
+++ b/mandible-tui/src/render/detail_pane/mod.rs
@@ -3767,7 +3767,10 @@ mod tests {
         root.usage = vec![Text::sanitize_preserving_layout(
             "Usage: sg_luns [--alpha] [--brief] [--decode] [--hex] [--inhex=FN] [--lu_cong] [--maxlen=LEN] [--quiet] [--raw] [--readonly] [--select=SR] [--verbose] [--version] [DEVICE]",
         )];
-        let app = App::new("sg_luns".to_string(), root);
+        let mut app = App::new("sg_luns".to_string(), root);
+        // Stated, never read from the locale: `glyphs::from_env` returns the
+        // ASCII set outside a UTF-8 locale, and this test assumes the rounded one.
+        app.glyphs = crate::glyphs::UNICODE;
 
         let buffer = frame_of(&app);
         let rows: Vec<String> = (0..buffer.area.height)

--- a/mandible-tui/tests/border_integrity.rs
+++ b/mandible-tui/tests/border_integrity.rs
@@ -106,6 +106,9 @@ fn adversarial_tree() -> CommandNode {
 fn build_app() -> App {
     let root = adversarial_tree();
     let mut app = App::new("git".to_string(), root);
+    // Stated, never read from the locale: `glyphs::from_env` returns the
+    // ASCII set outside a UTF-8 locale, and these tests assert the rounded one.
+    app.glyphs = mandible_tui::glyphs::UNICODE;
     // Expand root so all adversarial children are visible tree rows.
     app.expand_selected(); // no-op: root already expanded by App::new, kept for clarity
     app.ensure_rows_fresh();
@@ -312,6 +315,7 @@ fn borders_survive_a_node_with_unparsed_raw_help_text() {
         for &height in &[10u16, 24] {
             for focus in [mandible_tui::Focus::Tree, mandible_tui::Focus::Detail] {
                 let mut app = App::new("mystery".to_string(), root.clone());
+                app.glyphs = mandible_tui::glyphs::UNICODE;
                 app.focus = focus;
                 let backend = TestBackend::new(width, height);
                 let mut terminal = Terminal::new(backend).unwrap();
@@ -442,6 +446,7 @@ fn detail_pane_hscroll_affordance_marks_overflow_without_corrupting_the_border()
     root.unparsed = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
 
     let mut app = App::new("wide".to_string(), root);
+    app.glyphs = mandible_tui::glyphs::UNICODE;
     app.focus = mandible_tui::Focus::Detail;
     assert!(app.horizontal_scroll_enabled, "default is on");
 
@@ -583,6 +588,7 @@ fn detail_pane_hscroll_affordance_shows_even_with_the_tree_focused() {
     root.unparsed = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
 
     let mut app = App::new("wide".to_string(), root);
+    app.glyphs = mandible_tui::glyphs::UNICODE;
     app.focus = mandible_tui::Focus::Tree;
     assert!(app.horizontal_scroll_enabled, "default is on");
 
@@ -660,6 +666,7 @@ fn detail_pane_hscroll_affordance_absent_when_the_config_toggle_is_off() {
     root.usage = vec![Text::sanitize(&format!("wide {}", "x".repeat(200)))];
 
     let mut app = App::new("wide".to_string(), root);
+    app.glyphs = mandible_tui::glyphs::UNICODE;
     app.focus = mandible_tui::Focus::Detail;
     app.horizontal_scroll_enabled = false;
 

--- a/mandible-tui/tests/detail_sections.rs
+++ b/mandible-tui/tests/detail_sections.rs
@@ -94,6 +94,9 @@ fn node_with_every_section() -> CommandNode {
 
 fn app_for(node: CommandNode) -> App {
     let mut app = App::new("tool".to_string(), node);
+    // Stated, never read from the locale: `glyphs::from_env` returns the
+    // ASCII set outside a UTF-8 locale, and these tests assert the rounded one.
+    app.glyphs = mandible_tui::glyphs::UNICODE;
     app.focus = mandible_tui::Focus::Detail;
     app
 }

--- a/mandible-tui/tests/unverified_notice_wrap.rs
+++ b/mandible-tui/tests/unverified_notice_wrap.rs
@@ -26,6 +26,9 @@ fn notice_app(notice: &str) -> App {
     root.children_filled = true;
 
     let mut app = App::new("apt-ftparchive".to_string(), root);
+    // Stated, never read from the locale: `glyphs::from_env` returns the
+    // ASCII set outside a UTF-8 locale, and these tests assert the rounded one.
+    app.glyphs = mandible_tui::glyphs::UNICODE;
     app.ensure_rows_fresh();
     app.move_down();
     assert_eq!(


### PR DESCRIPTION
Closes the first cause in #136.

**What this changes**

15 tests state their glyph set instead of inheriting it. Three integration test files set it in the factory that builds their `App`. Four tests in `border_integrity.rs` build an `App` inline and set it there. One unit test in `render/detail_pane` does the same.

Nothing outside test code moves. Three of the four files are integration test targets, and the fourth hunk sits inside `#[cfg(test)] mod tests`, so the shipped binary cannot change.

**Why**

`App::new` takes its glyphs from `glyphs::from_env`, which returns the ASCII set unless `LC_ALL`, `LC_CTYPE` or `LANG` names UTF-8. These 15 tests assert the rounded set. A non-login shell exports none of the three, so the tests fail there. `cargo nextest run --workspace` is a required gate before a pull request, which made the gate unrunnable on such a host.

The file already held the pattern. `border_integrity.rs` set `ASCII` explicitly in two tests and `UNICODE` in one. These 15 set neither.

**How it was verified**

Before, on this branch's parent:

```console
$ env -u LANG -u LC_ALL -u LC_CTYPE cargo nextest run -p mandible-tui --no-fail-fast
Summary [0.557s] 294 tests run: 279 passed, 15 failed, 0 skipped
```

After, in three locale conditions:

```console
$ env -u LANG -u LC_ALL -u LC_CTYPE cargo nextest run -p mandible-tui --no-fail-fast
Summary [0.584s] 294 tests run: 294 passed, 0 skipped

$ LANG=en_US.UTF-8 cargo nextest run -p mandible-tui --no-fail-fast
Summary [0.714s] 294 tests run: 294 passed, 0 skipped

$ LC_ALL=C cargo nextest run -p mandible-tui --no-fail-fast
Summary [0.653s] 294 tests run: 294 passed, 0 skipped
```

The render is unchanged. `cargo build --release` succeeds and a pty screen through `scripts/pty_screenshot.py 90 20 ./target/release/mandible caffeinate` draws the same frame as before.

Two things a reviewer should know.

`exec::spawn::tests::captures_stdout_and_exit_code` still fails sometimes in a workspace run, once in five runs even at `--test-threads 1`. That is the second cause in #136 and this branch does not touch it. Its crate is `mandible-extract`; this change touches only `mandible-tui`.

`border_integrity.rs`'s `hscroll_clip_markers_mark_only_the_clipped_lines` still builds its `App` without stating a glyph set. It asserts the literal clip marker `>` that `draw_clip_marker_rails` writes, not `more_left` or `more_right`, so its result does not depend on which set it gets. I left it alone rather than widen the change. Say the word if you want it stated too.

Verified on macOS 26.6.2 arm64, rustc 1.97.1, cargo-nextest 0.9.143.

- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
      Run as `cargo nextest run --workspace` per AGENTS.md §3.8. Serially: 1634 tests, 1633 passed, 1 failed, and that one is the #136 flake above. `scripts/ratchet_check.sh` and `scripts/shape_guard.sh` are clean. `cargo run -p xtask -- corpus` reports 149 fixtures, 132 ok, 17 xfail as expected, 0 failed.
- [ ] `cargo xtask coverage --check ...` (if extraction changed)
      Extraction does not change. No file outside `mandible-tui` is touched.
- [x] No tool-name-keyed logic added
