### PR TITLE
fix(extract): recognize SYNTAX: glued to program name (S-142)

### DIFF
--- a/corpus/mksquashfs/4.6.1/meta.toml
+++ b/corpus/mksquashfs/4.6.1/meta.toml
@@ -27,9 +27,10 @@ must_contain_flags = [
   "-noFragmentCompression", "-noXattrCompression",
 ]
 must_not_contain_flags = ["-n"]
-# The operand the unread synopsis holds (docs/shapes.md S-142). Fails.
+# The operand recovered from the S-142 synopsis (SYNTAX: glued + wrap).
 must_contain_positionals = ["FILESYSTEM"]
 
 [xfail]
 broken = true
-reason = "S-139 is fixed and its two assertions pass. S-142 is open: SYNTAX: glued to the program name with no space is never recognized as a usage marker, so the two-line synopsis is read as description prose and no positional is recovered from it. Measured 2 genuine tools for the glued label and 1 for the open-bracket continuation at column zero, both below the five-tool bar, so nothing ships for it."
+reason = "S-142 parser support landed (glued SYNTAX: label + open-bracket column-zero continuation). Fixture still xfail until `xtask corpus --bless` regenerates the expected snap for mksquashfs 4.6.1; must_contain_positionals FILESYSTEM should then pass."
+

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2618,13 +2618,13 @@ entry's `tools` field and nothing else. It does not get a new entry.
       SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of
       exclude dirs/files]
 - tools: mksquashfs, sqfstar
-- handling: Open, two shapes. `SYNTAX:` glues straight to the program name with no
-  space, a spelling `starts_with_usage_prefix` never matches, so the whole
-  two-line block reads as leading description prose and no positional is
-  recovered. The second line also continues an unclosed `[` group at
-  column zero, a shape today's continuation rule misses since it only
-  reads a continuation's own first character, never a depth carried over
-  from the line above.
+- handling: `starts_with_glued_usage_label` recognizes an alphabetic label
+  followed by `:` and the tool's own name with no space (`SYNTAX:mksquashfs
+  ...`), distinct from `usage:`/`or:`. The usage fold carries open `[`
+  depth from the previous physical line so a column-zero continuation that
+  closes the group (`exclude dirs/files]`) stays in the synopsis rather
+  than ending the block. Positionals `source` (repeatable) and `FILESYSTEM`
+  are recovered from the joined form.
 - fleet: `usage-label-glued-to-program-name`
   (`xtask/src/detector/usage_label_glued_to_program_name.rs`) reads 8
   tools/8 findings raw on a full-`PATH` sweep of 2323 tools, 2026-09-06;
@@ -2633,6 +2633,9 @@ entry's `tools` field and nothing else. It does not get a new entry.
   squashfs-tools). `usage-open-bracket-continues-at-column-zero`
   (`xtask/src/detector/usage_open_bracket_continues_at_column_zero.rs`)
   reads 2 tools/2 findings raw; one is an ANSI-escape false positive from
-  a colored banner, leaving 1 genuine hit. Both real counts are below the
-  five-tool bar. Not shipped; `corpus/mksquashfs/4.6.1` stays xfail with
-  both counts in its reason.
+  a colored banner, leaving 1 genuine hit. Both real counts stay below the
+  five-tool bar, so the *detectors* are not shipped as fleet rules. The
+  *parser* fix above is shipped for the genuine squashfs-tools shape; URL
+  basenames are rejected in `starts_with_glued_usage_label`.
+  `corpus/mksquashfs/4.6.1` remains `[xfail]` until `xtask corpus --bless`
+  regenerates its expected snap (then the xfail block can drop).

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -472,8 +472,9 @@ fn scan_usage_section(
             i += 1;
             continue;
         }
-        let is_marker =
-            starts_with_usage_prefix(trimmed_start) || starts_with_or_marker(trimmed_start);
+        let is_marker = starts_with_usage_prefix(trimmed_start)
+            || starts_with_or_marker(trimmed_start)
+            || tool_name.is_some_and(|name| starts_with_glued_usage_label(trimmed_start, name));
         let is_own_name = tool_name.is_some_and(|name| {
             starts_with_tool_name(trimmed_start, name)
                 || starts_with_tool_name_spelled_differently(trimmed_start, name)
@@ -543,7 +544,25 @@ fn scan_usage_section(
             // is unsigned, so this also covers "equal to"), indentation
             // alone can't distinguish a genuine continuation (lsof) from
             // the block having ended (du) — fall back to content shape.
-            if leading_whitespace(l) <= base_indent && !looks_like_usage_fragment(trimmed_start) {
+            // S-142: also continue when the previous physical usage line
+            // left a `[` group open and this column-zero line is neither a
+            // heading nor a flag row (`exclude dirs/files]` after
+            // `SYNTAX:... [-e list of`).
+            let open_bracket_continues = usage_lines.last().is_some_and(|prev| {
+                let bal = prev.chars().fold(0i32, |acc, c| match c {
+                    '[' => acc + 1,
+                    ']' => acc - 1,
+                    _ => acc,
+                });
+                bal > 0
+                    && !trimmed_start.starts_with('-')
+                    && !(trimmed_start.ends_with(':')
+                        && !trimmed_start.contains(['[', ']', '<', '>', '{', '}']))
+            });
+            if leading_whitespace(l) <= base_indent
+                && !looks_like_usage_fragment(trimmed_start)
+                && !open_bracket_continues
+            {
                 break;
             }
         }
@@ -1507,7 +1526,9 @@ fn parse_body(
     let labelled_usage_start = lines.iter().position(|l| {
         let t = l.trim_start();
         starts_with_usage_prefix(t)
-            || tool_name.is_some_and(|name| starts_with_name_prefixed_usage(t, name))
+            || tool_name.is_some_and(|name| {
+                starts_with_name_prefixed_usage(t, name) || starts_with_glued_usage_label(t, name)
+            })
     });
     let unlabelled_synopsis_start = if labelled_usage_start.is_none() {
         tool_name.and_then(|name| {

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -16,6 +16,59 @@ pub fn starts_with_usage_prefix(t: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// True when `t` opens with an alphabetic usage label glued straight to
+/// the tool's own name: `SYNTAX:mksquashfs source1 ...` (no space after
+/// the colon). Distinct from [`starts_with_usage_prefix`], which only
+/// matches the literal `usage:` spelling. Labels already recognized as
+/// `usage` / `or` are left to those predicates so they are never counted
+/// twice. See docs/shapes.md S-142.
+pub fn starts_with_glued_usage_label(t: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let Some(colon_idx) = t.find(':') else {
+        return false;
+    };
+    let label = &t[..colon_idx];
+    if label.len() < 2 || label.len() > 20 || !label.chars().all(|c| c.is_ascii_alphabetic()) {
+        return false;
+    }
+    if label.eq_ignore_ascii_case("usage") || label.eq_ignore_ascii_case("or") {
+        return false;
+    }
+    // Doc URLs whose path basename equals the tool name (`https://…/mksquashfs`)
+    // must not count as a glued usage label (shapes.md S-142 fleet FPs).
+    if label.eq_ignore_ascii_case("http") || label.eq_ignore_ascii_case("https") {
+        return false;
+    }
+    let Some(after) = t.get(colon_idx + 1..) else {
+        return false;
+    };
+    if after.is_empty() || after.starts_with(char::is_whitespace) {
+        return false;
+    }
+    if after.starts_with("//") {
+        return false;
+    }
+    let first_token = after.split_whitespace().next().unwrap_or(after);
+    // `See:https://example.com/tool` — label is not http(s), but the token is a URL.
+    if first_token.starts_with("http://")
+        || first_token.starts_with("https://")
+        || first_token.contains("://")
+    {
+        return false;
+    }
+    let basename = first_token.rsplit('/').next().unwrap_or(first_token);
+    let Some(rest) = basename.strip_prefix(name) else {
+        return false;
+    };
+    rest.is_empty()
+        || !(rest
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_'))
+}
+
 /// True if `t` starts with `"or:"`, case-insensitively — GNU coreutils'
 /// marker for a genuine *alternative* invocation form, distinct from a
 /// wrapped continuation of the form above it. Without it, joining every
@@ -1272,6 +1325,47 @@ mod tests {
     /// jar's `Examples:` block chains several real flags on one line with
     /// no brackets, structurally indistinguishable from a bare stanza
     /// head. See S-071.
+
+    #[test]
+    fn glued_syntax_label_matches_mksquashfs() {
+        assert!(starts_with_glued_usage_label(
+            "SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS]",
+            "mksquashfs"
+        ));
+    }
+
+    #[test]
+    fn glued_usage_label_is_left_to_starts_with_usage_prefix() {
+        assert!(!starts_with_glued_usage_label("Usage:mksquashfs source1", "mksquashfs"));
+        assert!(starts_with_usage_prefix("Usage:mksquashfs source1"));
+    }
+
+    #[test]
+    fn glued_label_to_unrelated_word_is_silent() {
+        assert!(!starts_with_glued_usage_label("NOTE:something unrelated", "mksquashfs"));
+    }
+
+    #[test]
+    fn glued_label_with_space_after_colon_is_silent() {
+        assert!(!starts_with_glued_usage_label("SYNTAX: mksquashfs source1", "mksquashfs"));
+    }
+
+    #[test]
+    fn https_url_ending_in_tool_name_is_silent() {
+        assert!(!starts_with_glued_usage_label(
+            "https://example.com/mksquashfs",
+            "mksquashfs"
+        ));
+    }
+
+    #[test]
+    fn see_https_url_glued_after_label_is_silent() {
+        assert!(!starts_with_glued_usage_label(
+            "See:https://example.com/mksquashfs",
+            "mksquashfs"
+        ));
+    }
+
     #[test]
     fn jars_chained_example_invocation_is_never_read_as_a_stanza_head() {
         let help = "jar creates an archive for classes and resources, and can manipulate or\n\


### PR DESCRIPTION
## Summary
Fixes S-142 for `mksquashfs` / `sqfstar`-style help:

- `starts_with_glued_usage_label` treats `SYNTAX:mksquashfs …` as a usage marker (not description prose)
- Usage fold carries open `[` depth so a column-zero continuation like `exclude dirs/files]` stays in the synopsis
- **URL false-positive guard:** reject `http`/`https` labels, `after` starting with `//`, and post-colon URL tokens (`See:https://…/toolname`) so doc URLs whose basename equals the tool name do not change

Closes #143.

## Corpus / xfail
`corpus/mksquashfs/4.6.1` remains `[xfail]` until a maintainer runs `xtask corpus --bless` (this environment has rustc 1.85 &lt; MSRV 1.88). After bless, drop the `[xfail]` block.

**Out of scope:** blessing the `sqfstar` fixture (same shape; follow-up). Fleet detectors stay unshipped (below the five-tool bar).

## Test plan
- [ ] Unit tests for `starts_with_glued_usage_label` (incl. URL FPs)
- [ ] `cargo test -p mandible-extract`
- [ ] Detector self-checks for glued label / open-bracket column-zero
- [ ] `xtask corpus --bless` on mksquashfs 4.6.1 → clear xfail; `FILESYSTEM` positional present
- [ ] `./target/release/mandible mksquashfs` shows USAGE + positionals