### PR TITLE
fix(extract): collapse file1 [file2 ...] into one variadic positional (S-136)

### DIFF
--- a/corpus/apt-sortpkgs/2.8.3/meta.toml
+++ b/corpus/apt-sortpkgs/2.8.3/meta.toml
@@ -3,33 +3,10 @@
 #
 # `help.txt`'s usage line is `apt-sortpkgs [options] file1 [file2 ...]`.
 # Ruling: `X1 [X2 ...]` names one variadic positional, `file`, not two
-# operands `file1` and `file2`. The parsed tree has no POSITIONALS section
-# at all: `file`, the real recovered name, is dropped entirely, even
-# though it is named in the tool's own usage line and nowhere else needs
-# recovering (apt-sortpkgs documents no separate positional-argument
-# block).
-#
-# Round 6 checked this against `recover_primary_tail_operands`
-# (`mandible-extract/src/help_text/sections/usage.rs`), the
-# `multi-operand-usage-tail` family (S-109): the shape is `[options]` (a
-# lone placeholder) directly ahead of a bare, REQUIRED first operand
-# (`file1`), byte-identical to `apt-ftparchive [options] command` and
-# `gcc [options] file...`, both already tested
-# (`placeholder_only_context_with_a_bare_required_tail_gains_no_positional`)
-# as a deliberate refusal: a lone placeholder ahead of a bare required
-# tail reads as easily as "provide a subcommand" as "provide an operand",
-# and the rule stays silent rather than guess.
-#
-# Open (round 7, atlas S-136): `file1 [file2 ...]` is narrower than the
-# declined ambiguity above. The second name is the first's own name with
-# the next integer, bracketed and ellipsis-marked — numbering the bare
-# tail otherwise lacks. `numbered-variadic-usage-tail`
-# (`xtask/src/detector/numbered_variadic_usage_tail.rs`) reads that
-# numbering and would collapse the pair into one variadic positional,
-# `file`. Measured fleet-wide at only 3 tools (apt-extracttemplates,
-# apt-mark, apt-sortpkgs) on a full-`PATH` sweep, below the five-tool
-# floor a fix must clear, so it stays unfixed and this fixture stays
-# xfail.
+# operands `file1` and `file2`. S-136's parser fix collapses that pair in
+# `recover_primary_tail_operands`; unit tests cover apt-sortpkgs and
+# apt-extracttemplates. This fixture stays `[xfail]` until
+# `xtask corpus --bless` on MSRV 1.88+ (this draft host is below MSRV).
 
 [bless]
 provenance = "agent"
@@ -51,4 +28,4 @@ must_contain_positionals = ["file..."]
 
 [xfail]
 broken = true
-reason = "usage line 'apt-sortpkgs [options] file1 [file2 ...]' names one variadic positional, file..., but the parsed tree has no POSITIONALS section at all; numbered-variadic-usage-tail measures 3 tools fleet-wide, below the five-tool floor"
+reason = "S-136 parser fix is in recover_primary_tail_operands (issue #141); tree should carry file... . Fixture stays xfail until xtask corpus --bless on MSRV 1.88+; numbered-variadic-usage-tail measured 3 tools, shipped as named exception"

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2480,16 +2480,21 @@ entry's `tools` field and nothing else. It does not get a new entry.
 - looks like: |
       Usage: apt-sortpkgs [options] file1 [file2 ...]
 - tools: apt-sortpkgs, apt-extracttemplates, apt-mark
-- handling: Open. `numbered-variadic-usage-tail`
-  (`xtask/src/detector/numbered_variadic_usage_tail.rs`) reads a usage
-  line's trailing pair where the second name is the first's own name
-  with the next integer, bracketed and ellipsis-marked, and would
-  collapse it into one variadic positional named by the shared stem —
-  narrower than the `multi-operand-usage-tail` ambiguity (S-109) round 6
-  declined, since the numbering is evidence a bare tail lacks.
+- handling: Fixed. `recover_primary_tail_operands`
+  (`mandible-extract/src/help_text/sections/usage.rs`) collapses a
+  trailing pair where the second name is the first's own name with the
+  next integer, bracketed and ellipsis-marked, into one required
+  repeatable positional named by the shared stem. Numbering is its own
+  evidence, so the pair is recovered even with no earlier flag group
+  (`apt-extracttemplates`) and even behind a lone `[options]`
+  placeholder that S-109 would refuse. Narrower than the
+  `multi-operand-usage-tail` ambiguity (S-109). Detector:
+  `numbered-variadic-usage-tail`
+  (`xtask/src/detector/numbered_variadic_usage_tail.rs`).
 - fleet: measured 3 tools/3 findings on a full-`PATH` sweep, 2026-09-06,
-  below the five-tool floor a fix must clear. Not shipped; the fixture
-  stays xfail with the count in its reason.
+  below the five-tool floor. Shipped as the maintainer's named item,
+  issue #141. Fixture `corpus/apt-sortpkgs/2.8.3` awaits
+  `xtask corpus --bless` on MSRV before leaving `[xfail]`.
 
 ### S-137: lvm2 invocation forms read as section headings
 

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -520,6 +520,36 @@ fn parse_operand_group(group: &str) -> Option<(String, bool, bool)> {
     Some((word.to_string(), required, marker_repeat || inline_repeat))
 }
 
+/// Split a trailing run of ASCII digits off `word` as an integer.
+fn split_trailing_integer(word: &str) -> Option<(&str, u64)> {
+    let digit_count = word.chars().rev().take_while(char::is_ascii_digit).count();
+    if digit_count == 0 || digit_count == word.len() {
+        return None;
+    }
+    let (stem, digits) = word.split_at(word.len() - digit_count);
+    digits.parse().ok().map(|n| (stem, n))
+}
+
+/// `X1 [X2 ...]` → shared stem. Required bare first, optional repeatable
+/// second, consecutive trailing integers on one alphabetic stem. See
+/// docs/shapes.md S-136 and corpus/apt-sortpkgs/2.8.3.
+fn numbered_variadic_tail_stem(
+    first: &(String, bool, bool),
+    second: &(String, bool, bool),
+) -> Option<String> {
+    let (name1, required1, repeat1) = first;
+    let (name2, required2, repeat2) = second;
+    if !*required1 || *repeat1 || *required2 || !*repeat2 {
+        return None;
+    }
+    let (stem1, n1) = split_trailing_integer(name1)?;
+    let (stem2, n2) = split_trailing_integer(name2)?;
+    if stem1.is_empty() || stem1 != stem2 || n2 != n1 + 1 {
+        return None;
+    }
+    Some(stem1.to_string())
+}
+
 /// The primary synopsis's own trailing run of operands — atlas S-041
 /// (one operand) generalized to a run of two or more, promoted from
 /// `xtask`'s `unparsed-tail-operand` detector (`xtask/src/tail_operand.rs`).
@@ -583,6 +613,19 @@ fn recover_primary_tail_operands(
         return Vec::new();
     }
     collected.reverse(); // restore source order
+
+    // `file1 [file2 ...]` collapses to one variadic `file`. Numbering is
+    // its own evidence and bypasses the earlier-context gates below. See
+    // docs/shapes.md S-136 and corpus/apt-sortpkgs/2.8.3.
+    if collected.len() == 2 {
+        if let Some(stem) = numbered_variadic_tail_stem(&collected[0], &collected[1]) {
+            let mut positional =
+                Entity::positional(stem, Provenance::single(Source::HelpText));
+            positional.required = true;
+            positional.repeatable = true;
+            return vec![positional];
+        }
+    }
 
     // At least one real group must stand between the program name and the
     // run: a lone bracket group right after the program name (`true`'s
@@ -3074,14 +3117,53 @@ mod tests {
         assert_eq!(names, vec!["target"], "{names:?}");
     }
 
-    /// `apt-extracttemplates`-shaped: several bare operands, not a flag
-    /// list plus one trailing operand. `file1` earlier on the line is
-    /// itself bare and non-flag, so the earlier-groups gate must refuse
-    /// the whole line rather than claim `file2`.
+    /// S-136: `file1 [file2 ...]` with no earlier flag group still
+    /// collapses to one variadic `file` — numbering is its own evidence.
+    /// See docs/shapes.md S-136.
     #[test]
-    fn apt_extracttemplates_shaped_multiple_bare_operands_gain_no_positional() {
+    fn apt_extracttemplates_numbered_tail_collapses_to_one_variadic_file() {
         let parsed = parse("Usage: apt-extracttemplates file1 [file2 ...]\n");
-        assert!(parsed.positionals.is_empty(), "{:?}", parsed.positionals);
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["file"], "{names:?}");
+        assert!(parsed.positionals[0].required);
+        assert!(parsed.positionals[0].repeatable);
+    }
+
+    /// S-136: apt-sortpkgs's own bytes — `[options]` ahead of the numbered
+    /// pair. Fixture: corpus/apt-sortpkgs/2.8.3.
+    #[test]
+    fn apt_sortpkgs_numbered_tail_collapses_to_one_variadic_file() {
+        let parsed = parse("Usage: apt-sortpkgs [options] file1 [file2 ...]\n");
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["file"], "{names:?}");
+        assert!(parsed.positionals[0].required);
+        assert!(parsed.positionals[0].repeatable);
+    }
+
+    /// S-136 negatives: non-matching stems, non-consecutive integers, and
+    /// a second name that is not itself marked repeatable.
+    #[test]
+    fn numbered_variadic_tail_refuses_non_matching_shapes() {
+        for line in [
+            "Usage: widget [options] infile [outfile ...]\n",
+            "Usage: widget [options] file1 [file3 ...]\n",
+            "Usage: widget [options] file1 [file2]\n",
+        ] {
+            let parsed = parse(line);
+            assert!(
+                parsed.positionals.is_empty(),
+                "{line:?}: {:?}",
+                parsed.positionals
+            );
+        }
     }
 
     /// `psfaddtable`-shaped: the identical several-bare-operands shape


### PR DESCRIPTION
Collapses apt-sortpkgs-style Usage tails file1 [file2 ...] into one repeatable positional named by the shared stem. shapes.md S-136 Fixed; corpus apt-sortpkgs stays xfail until xtask corpus --bless on MSRV 1.88+. Closes #141.