### PR TITLE
usage blocks: label, program word, tail operands and multi-word bracket groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ once it reaches a published 0.1.0 release.
 - [S-145] A single-dash long option in a table with no double-dash row anywhere keeps its whole name and case now, so `mandible mksquashfs` and `mandible sqfstar` show `-pf`, `-ef`, `-Xhelp`, `-Xstrategy`, `-Xhc` and `-Xbcj` instead of splitting each one.
 - [S-145] A tab-separated value name on a single-dash long option survives the same repair now, so `mandible mksquashfs` and `mandible sqfstar` keep `-mem`, `-comp` and `-mkfs-time` with their placeholders instead of losing them.
 - [S-146] A heading with no indent step to its own rows, and a bare label above a nested option block, now name a group instead of leaving every row underneath ungrouped, so `mandible mksquashfs` shows its ten option headings and its five compressor names.
+- [S-153] A flag paired with an ALL-CAPS value, and a brace alternation naming one operand, now reach a usage line's own tail instead of losing it (`mandible fc-scan`, `mandible cache_repair`).
+- [S-154] A bracketed multi-word ALL-CAPS operand now becomes one positional instead of one per word, so `mandible gdk-pixbuf-thumbnailer`, `mandible mknod` and `mandible accessdb` show their real operand count.
+- [S-136] A usage line's numbered `file1 [file2 ...]` tail now collapses to one repeatable positional, so `mandible apt-sortpkgs`, `mandible apt-mark` and `mandible apt-extracttemplates` show it (#141).
 
 ## [0.7.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ once it reaches a published 0.1.0 release.
 - [S-153] A flag paired with an ALL-CAPS value, and a brace alternation naming one operand, now reach a usage line's own tail instead of losing it (`mandible fc-scan`, `mandible cache_repair`).
 - [S-154] A bracketed multi-word ALL-CAPS operand now becomes one positional instead of one per word, so `mandible gdk-pixbuf-thumbnailer`, `mandible mknod` and `mandible accessdb` show their real operand count.
 - [S-136] A usage line's numbered `file1 [file2 ...]` tail now collapses to one repeatable positional, so `mandible apt-sortpkgs`, `mandible apt-mark` and `mandible apt-extracttemplates` show it (#141).
+- [S-150] A usage label alone on its own line no longer becomes a usage entry of its own, and no longer swallows the bracketed option run under it, so `mandible fdisk` and `mandible pkcheck` show only their real invocation forms and `mandible dmsetup`, `mandible dmstats` and `mandible npm` recover 39 flags documented only inside their own `Usage:` block.
+- [S-151] A usage form whose leading word names another program now renders under the tool's own name, so `mandible gcc-ranlib-13` shows `gcc-ranlib-13 [options] archive` instead of repeating `/usr/bin/ranlib`, and `mandible perlthanks` gains the usage section it had none of.
+- [S-142] A `SYNTAX:` label glued straight to the program name, and a usage continuation carrying an open `[` to column zero, are both read now, so `mandible mksquashfs` and `mandible sqfstar` show a real usage line and their `FILESYSTEM` positional instead of the whole synopsis as description prose (#143).
 
 ## [0.7.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ once it reaches a published 0.1.0 release.
 - [S-150] A usage label alone on its own line no longer becomes a usage entry of its own, and no longer swallows the bracketed option run under it, so `mandible fdisk` and `mandible pkcheck` show only their real invocation forms and `mandible dmsetup`, `mandible dmstats` and `mandible npm` recover 39 flags documented only inside their own `Usage:` block.
 - [S-151] A usage form whose leading word names another program now renders under the tool's own name, so `mandible gcc-ranlib-13` shows `gcc-ranlib-13 [options] archive` instead of repeating `/usr/bin/ranlib`, and `mandible perlthanks` gains the usage section it had none of.
 - [S-142] A `SYNTAX:` label glued straight to the program name, and a usage continuation carrying an open `[` to column zero, are both read now, so `mandible mksquashfs` and `mandible sqfstar` show a real usage line and their `FILESYSTEM` positional instead of the whole synopsis as description prose (#143).
+- [S-171] A numbered `source1 source2 ...` pair ahead of a later required operand no longer drops, so `mandible mksquashfs` shows its `source` positional alongside `FILESYSTEM`.
 
 ## [0.7.0] - 2026-09-05
 

--- a/corpus/apt-mark/2.8.3/expected.snap
+++ b/corpus/apt-mark/2.8.3/expected.snap
@@ -1,0 +1,78 @@
+name: apt-mark
+description: apt 2.8.3 (arm64)
+usage:
+- 'Usage: apt-mark [options] {auto|manual} pkg1 [pkg2 ...]'
+positionals:
+- name: '{auto|manual}'
+  required: true
+  provenance:
+    sources:
+    - help-text
+- name: pkg
+  required: true
+  variadic: true
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true
+subcommands:
+- name: auto
+  summary: Mark the given packages as automatically installed
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: manual
+  summary: Mark the given packages as manually installed
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: minimize-manual
+  summary: Mark all dependencies of meta packages as automatically installed.
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: hold
+  summary: Mark a package as held back
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: unhold
+  summary: Unset a package set as held back
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: showauto
+  summary: Print the list of automatically installed packages
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: showmanual
+  summary: Print the list of manually installed packages
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true
+- name: showhold
+  summary: Print the list of packages on hold
+  group: 'Most used commands:'
+  provenance:
+    sources:
+    - help-text
+  heading_attested: true

--- a/corpus/apt-mark/2.8.3/help.txt
+++ b/corpus/apt-mark/2.8.3/help.txt
@@ -1,0 +1,23 @@
+apt 2.8.3 (arm64)
+Usage: apt-mark [options] {auto|manual} pkg1 [pkg2 ...]
+
+apt-mark is a simple command line interface for marking packages
+as manually or automatically installed. It can also be used to
+manipulate the dpkg(1) selection states of packages, and to list
+all packages with or without a certain marking.
+
+Most used commands:
+  auto - Mark the given packages as automatically installed
+  manual - Mark the given packages as manually installed
+  minimize-manual - Mark all dependencies of meta packages as automatically installed.
+  hold - Mark a package as held back
+  unhold - Unset a package set as held back
+  showauto - Print the list of automatically installed packages
+  showmanual - Print the list of manually installed packages
+  showhold - Print the list of packages on hold
+
+See apt-mark(8) for more information about the available commands.
+Configuration options and syntax is detailed in apt.conf(5).
+Information about how to configure sources can be found in sources.list(5).
+Package and version choices can be expressed via apt_preferences(5).
+Security details are available in apt-secure(8).

--- a/corpus/apt-mark/2.8.3/meta.toml
+++ b/corpus/apt-mark/2.8.3/meta.toml
@@ -1,0 +1,25 @@
+# docs/shapes.md S-136, issue #141: the usage line's own tail is
+# `{auto|manual} pkg1 [pkg2 ...]`, a brace alternation followed by a
+# numbered variadic pair. `pkg1`/`pkg2` collapse to one repeatable `pkg`
+# positional the same way `apt-sortpkgs`'s `file1 [file2 ...]` does; the
+# brace alternation ahead of it recovers as its own required operand
+# (docs/shapes.md S-153, `cache_repair`'s shape). Both are new: the old
+# tree carried no POSITIONALS section at all.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "apt-mark"
+version = "2.8.3"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); apt 2.8.3"
+
+[[capture]]
+argv = ["apt-mark", "--help"]
+stdout = "help.txt"
+
+[contract]
+verdict_scope = ["flags", "subcommands", "usage"]
+expected_framework = "generic"
+must_contain_positionals = ["{auto|manual}", "pkg..."]

--- a/corpus/apt-sortpkgs/2.8.3/expected.snap
+++ b/corpus/apt-sortpkgs/2.8.3/expected.snap
@@ -1,7 +1,7 @@
-name: apt-extracttemplates
+name: apt-sortpkgs
 description: apt 2.8.3 (arm64)
 usage:
-- 'Usage: apt-extracttemplates file1 [file2 ...]'
+- 'Usage: apt-sortpkgs [options] file1 [file2 ...]'
 positionals:
 - name: file
   required: true

--- a/corpus/apt-sortpkgs/2.8.3/meta.toml
+++ b/corpus/apt-sortpkgs/2.8.3/meta.toml
@@ -1,35 +1,12 @@
-# Maintainer, seed 7, verdict "incomplete": "missing positionals". Machine
-# classification: stratum "ok".
-#
-# `help.txt`'s usage line is `apt-sortpkgs [options] file1 [file2 ...]`.
-# Ruling: `X1 [X2 ...]` names one variadic positional, `file`, not two
-# operands `file1` and `file2`. The parsed tree has no POSITIONALS section
-# at all: `file`, the real recovered name, is dropped entirely, even
-# though it is named in the tool's own usage line and nowhere else needs
-# recovering (apt-sortpkgs documents no separate positional-argument
-# block).
-#
-# Round 6 checked this against `recover_primary_tail_operands`
-# (`mandible-extract/src/help_text/sections/usage.rs`), the
-# `multi-operand-usage-tail` family (S-109): the shape is `[options]` (a
-# lone placeholder) directly ahead of a bare, REQUIRED first operand
-# (`file1`), byte-identical to `apt-ftparchive [options] command` and
-# `gcc [options] file...`, both already tested
-# (`placeholder_only_context_with_a_bare_required_tail_gains_no_positional`)
-# as a deliberate refusal: a lone placeholder ahead of a bare required
-# tail reads as easily as "provide a subcommand" as "provide an operand",
-# and the rule stays silent rather than guess.
-#
-# Open (round 7, atlas S-136): `file1 [file2 ...]` is narrower than the
-# declined ambiguity above. The second name is the first's own name with
-# the next integer, bracketed and ellipsis-marked — numbering the bare
-# tail otherwise lacks. `numbered-variadic-usage-tail`
-# (`xtask/src/detector/numbered_variadic_usage_tail.rs`) reads that
-# numbering and would collapse the pair into one variadic positional,
-# `file`. Measured fleet-wide at only 3 tools (apt-extracttemplates,
-# apt-mark, apt-sortpkgs) on a full-`PATH` sweep, below the five-tool
-# floor a fix must clear, so it stays unfixed and this fixture stays
-# xfail.
+# docs/shapes.md S-136, issue #141. The usage line's own tail,
+# `file1 [file2 ...]`, is one variadic positional, `file`, not two
+# operands. The numbering distinguishes this from the declined bare-tail
+# ambiguity (S-109): `numbered-variadic-usage-tail` now collapses the
+# pair, exempted from both the `[options] command` guard and the
+# no-earlier-group guard, since the numbering is evidence neither
+# ambiguity has. Fleet count 3 tools (apt-sortpkgs, apt-extracttemplates,
+# apt-mark), a maintainer-named exception below the five-tool bar
+# (docs/design.md §16).
 
 [bless]
 provenance = "agent"
@@ -46,9 +23,6 @@ argv = ["apt-sortpkgs", "--help"]
 stdout = "help.txt"
 
 [contract]
+verdict_scope = ["usage"]
 expected_framework = "generic"
 must_contain_positionals = ["file..."]
-
-[xfail]
-broken = true
-reason = "usage line 'apt-sortpkgs [options] file1 [file2 ...]' names one variadic positional, file..., but the parsed tree has no POSITIONALS section at all; numbered-variadic-usage-tail measures 3 tools fleet-wide, below the five-tool floor"

--- a/corpus/bpftrace/0.20.2/expected.snap
+++ b/corpus/bpftrace/0.20.2/expected.snap
@@ -1,6 +1,5 @@
 name: bpftrace
 usage:
-- 'USAGE:'
 - '    bpftrace [options] filename'
 - '    bpftrace [options] - <stdin input>'
 - '    bpftrace [options] -e ''program'''

--- a/corpus/cache_repair/0.9.0/expected.snap
+++ b/corpus/cache_repair/0.9.0/expected.snap
@@ -1,0 +1,44 @@
+name: cache_repair
+description: 'Options:'
+usage:
+- 'Usage: cache_repair [options] {device|file}'
+positionals:
+- name: '{device|file}'
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -h
+  - --help
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -i
+  - --input
+  value_name: <input metadata (binary format)>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  - --output
+  value_name: <output metadata (binary format)>
+  value_kind: Required
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --version
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/cache_repair/0.9.0/help.txt
+++ b/corpus/cache_repair/0.9.0/help.txt
@@ -1,0 +1,6 @@
+Usage: cache_repair [options] {device|file}
+Options:
+  {-h|--help}
+  {-i|--input} <input metadata (binary format)>
+  {-o|--output} <output metadata (binary format)>
+  {-V|--version}

--- a/corpus/cache_repair/0.9.0/meta.toml
+++ b/corpus/cache_repair/0.9.0/meta.toml
@@ -1,0 +1,27 @@
+# docs/shapes.md S-153: the usage line's own tail is a brace alternation,
+# `{device|file}`, naming one required operand. `parse_operand_group`
+# refused the group outright (its first character is `{`, not a lowercase
+# letter), so the tree carried no POSITIONALS section at all. The
+# alternation's members also attach as the positional's own
+# `Entity::choices`, rendered live in the detail pane ("values: device,
+# file"); `must_attach_choices` cannot assert this, since it only ever
+# searches `root.flags()` (`xtask/src/corpus/contract.rs`), so the name
+# alone is what this fixture's contract can state.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "cache_repair"
+version = "0.9.0"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); cache_repair 0.9.0"
+
+[[capture]]
+argv = ["cache_repair", "--help"]
+stdout = "help.txt"
+
+[contract]
+verdict_scope = ["flags", "usage"]
+expected_framework = "generic"
+must_contain_positionals = ["{device|file}"]

--- a/corpus/fc-scan/2.15.0/expected.snap
+++ b/corpus/fc-scan/2.15.0/expected.snap
@@ -1,0 +1,66 @@
+name: fc-scan
+description: Scan font files and directories, and print resulting pattern(s)
+usage:
+- 'usage: fc-scan [-bcVh] [-f FORMAT] [-y SYSROOT] [--brief] [--format FORMAT] [--version] [--help] font-file...'
+positionals:
+- name: font-file
+  required: true
+  variadic: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -b
+  - --brief
+  group: Scan font files and directories, and print resulting pattern(s)
+  description: display font pattern briefly
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -f
+  - --format
+  value_name: FORMAT
+  value_kind: Required
+  group: Scan font files and directories, and print resulting pattern(s)
+  description: use the given output format
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -y
+  - --sysroot
+  value_name: SYSROOT
+  value_kind: Required
+  group: Scan font files and directories, and print resulting pattern(s)
+  description: prepend SYSROOT to all paths for scanning
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --version
+  group: Scan font files and directories, and print resulting pattern(s)
+  description: display font config version and exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  - --help
+  group: Scan font files and directories, and print resulting pattern(s)
+  description: display this help and exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -c
+  provenance:
+    sources:
+    - help-text-synopsis
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/fc-scan/2.15.0/help.txt
+++ b/corpus/fc-scan/2.15.0/help.txt
@@ -1,0 +1,8 @@
+usage: fc-scan [-bcVh] [-f FORMAT] [-y SYSROOT] [--brief] [--format FORMAT] [--version] [--help] font-file...
+Scan font files and directories, and print resulting pattern(s)
+
+  -b, --brief            display font pattern briefly
+  -f, --format=FORMAT    use the given output format
+  -y, --sysroot=SYSROOT  prepend SYSROOT to all paths for scanning
+  -V, --version          display font config version and exit
+  -h, --help             display this help and exit

--- a/corpus/fc-scan/2.15.0/meta.toml
+++ b/corpus/fc-scan/2.15.0/meta.toml
@@ -1,0 +1,22 @@
+# docs/shapes.md S-153: a flag paired with an ALL-CAPS value (`-f FORMAT`,
+# `-y SYSROOT`) ahead of the tail used to refuse the whole usage line, so
+# `font-file...` never reached POSITIONALS at all.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "fc-scan"
+version = "2.15.0"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); fontconfig 2.15.0"
+
+[[capture]]
+argv = ["fc-scan", "--help"]
+stdout = "help.txt"
+
+[contract]
+verdict_scope = ["flags", "usage"]
+expected_framework = "generic"
+must_contain_positionals = ["font-file..."]
+must_contain_flags = ["-f", "-y", "--brief"]

--- a/corpus/fdisk/2.39.3/expected.snap
+++ b/corpus/fdisk/2.39.3/expected.snap
@@ -1,0 +1,178 @@
+name: fdisk
+usage:
+- ' fdisk [options] <disk>         change partition table'
+- ' fdisk [options] -l [<disk>...] list partition table(s)'
+positionals:
+- name: disk
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -b
+  - --sector-size
+  value_name: <size>
+  value_kind: Required
+  description: physical and logical sector size
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -B
+  - --protect-boot
+  description: don't erase bootbits when creating a new label
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -c
+  - --compatibility
+  value_name: <mode>
+  value_kind: Optional
+  description: mode is 'dos' or 'nondos' (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -L
+  - --color
+  value_name: <when>
+  value_kind: Optional
+  description: colorize output (auto, always or never) colors are enabled by default
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -l
+  - --list
+  description: display partitions and exit
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -x
+  - --list-details
+  description: like --list but with more details
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -n
+  - --noauto-pt
+  description: don't create default partition table on empty devices
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  - --output
+  value_name: <list>
+  value_kind: Required
+  description: output columns
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -t
+  - --type
+  value_name: <type>
+  value_kind: Required
+  description: recognize specified partition table type only
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -u
+  - --units
+  value_name: <unit>
+  value_kind: Optional
+  description: 'display units: ''cylinders'' or ''sectors'' (default)'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -s
+  - --getsz
+  description: display device size in 512-byte sectors [DEPRECATED]
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --bytes
+  description: print SIZE in bytes rather than in human readable format
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --lock
+  value_name: <mode>
+  value_kind: Optional
+  description: use exclusive device lock (yes, no or nonblock)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -w
+  - --wipe
+  value_name: <mode>
+  value_kind: Required
+  description: wipe signatures (auto, always or never)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -W
+  - --wipe-partitions
+  value_name: <mode>
+  value_kind: Required
+  description: wipe signatures from new partitions (auto, always or never)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -C
+  - --cylinders
+  value_name: <number>
+  value_kind: Required
+  description: specify the number of cylinders
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -H
+  - --heads
+  value_name: <number>
+  value_kind: Required
+  description: specify the number of heads
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -S
+  - --sectors
+  value_name: <number>
+  value_kind: Required
+  description: specify the number of sectors per track
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  - --help
+  description: display this help
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -V
+  - --version
+  description: display version
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/fdisk/2.39.3/help.txt
+++ b/corpus/fdisk/2.39.3/help.txt
@@ -1,0 +1,40 @@
+
+Usage:
+ fdisk [options] <disk>         change partition table
+ fdisk [options] -l [<disk>...] list partition table(s)
+
+Display or manipulate a disk partition table.
+
+Options:
+ -b, --sector-size <size>      physical and logical sector size
+ -B, --protect-boot            don't erase bootbits when creating a new label
+ -c, --compatibility[=<mode>]  mode is 'dos' or 'nondos' (default)
+ -L, --color[=<when>]          colorize output (auto, always or never)
+                                 colors are enabled by default
+ -l, --list                    display partitions and exit
+ -x, --list-details            like --list but with more details
+ -n, --noauto-pt               don't create default partition table on empty devices
+ -o, --output <list>           output columns
+ -t, --type <type>             recognize specified partition table type only
+ -u, --units[=<unit>]          display units: 'cylinders' or 'sectors' (default)
+ -s, --getsz                   display device size in 512-byte sectors [DEPRECATED]
+     --bytes                   print SIZE in bytes rather than in human readable format
+     --lock[=<mode>]           use exclusive device lock (yes, no or nonblock)
+ -w, --wipe <mode>             wipe signatures (auto, always or never)
+ -W, --wipe-partitions <mode>  wipe signatures from new partitions (auto, always or never)
+
+ -C, --cylinders <number>      specify the number of cylinders
+ -H, --heads <number>          specify the number of heads
+ -S, --sectors <number>        specify the number of sectors per track
+
+ -h, --help                    display this help
+ -V, --version                 display version
+
+Available output columns:
+ gpt: Device Start End Sectors Size Type Type-UUID Attrs Name UUID
+ dos: Device Start End Sectors Cylinders Size Type Id Attrs Boot End-C/H/S Start-C/H/S
+ bsd: Slice Start End Sectors Cylinders Size Type Bsize Cpg Fsize
+ sgi: Device Start End Sectors Cylinders Size Type Id Attrs
+ sun: Device Start End Sectors Cylinders Size Type Id Flags
+
+For more details see fdisk(8).

--- a/corpus/fdisk/2.39.3/meta.toml
+++ b/corpus/fdisk/2.39.3/meta.toml
@@ -1,0 +1,18 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "fdisk"
+version = "2.39.3"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); util-linux 2.39.3"
+
+[[capture]]
+argv = ["fdisk", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+must_usage_forms_min = 2
+must_not_contain_usage_text = ["Usage:"]
+must_contain_positionals = ["disk"]

--- a/corpus/fsck/audit-seed2/expected.snap
+++ b/corpus/fsck/audit-seed2/expected.snap
@@ -1,6 +1,5 @@
 name: fsck
 usage:
-- 'Usage:'
 - ' fsck [options] -- [fs-options] [<filesystem> ...]'
 positionals:
 - name: filesystem

--- a/corpus/gcc-ranlib-13/2.42/help.txt
+++ b/corpus/gcc-ranlib-13/2.42/help.txt
@@ -1,0 +1,12 @@
+Usage: /usr/bin/ranlib [options] archive
+ Generate an index to speed access to archives
+ The options are:
+  @<file>                      Read options from <file>
+  --plugin <name>              Load the specified plugin
+  -D                           Use zero for symbol map timestamp (default)
+  -U                           Use an actual symbol map timestamp
+  -t                           Update the archive's symbol map timestamp
+  -h --help                    Print this help message
+  -v --version                 Print version information
+/usr/bin/ranlib: supported targets: elf64-littleaarch64 elf64-bigaarch64 elf32-littleaarch64 elf32-bigaarch64 elf32-littlearm elf32-bigarm pei-aarch64-little pe-aarch64-little elf64-little elf64-big elf32-little elf32-big srec symbolsrec verilog tekhex binary ihex plugin
+Report bugs to <https://sourceware.org/bugzilla/>

--- a/corpus/gcc-ranlib-13/2.42/meta.toml
+++ b/corpus/gcc-ranlib-13/2.42/meta.toml
@@ -19,4 +19,4 @@ must_contain_positionals = ["archive"]
 
 [xfail]
 broken = true
-reason = "[S-152] the usage form's own trailing prose (no terminating period) folds into the usage text with no field to hold it separately; open, xfail with count in the note."
+reason = "[S-152] the usage form's own trailing prose (no terminating period) folds into the usage text with no field to hold it separately; open, xfail with count in the note. Measured 2026-09-13: usage-form-trailing-description reads 4 tools/6 findings on the corpus/ tree (fdisk, gcc-ranlib-13, nvim, vim.basic), below the five-tool floor with confidence, so no fix ships yet."

--- a/corpus/gcc-ranlib-13/2.42/meta.toml
+++ b/corpus/gcc-ranlib-13/2.42/meta.toml
@@ -1,0 +1,22 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "gcc-ranlib-13"
+version = "2.42"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); GNU Binutils for Ubuntu 2.42"
+
+[[capture]]
+argv = ["gcc-ranlib-13", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+must_usage_forms_min = 1
+must_contain_flags = ["--plugin", "-D", "-U", "-t"]
+must_contain_positionals = ["archive"]
+
+[xfail]
+broken = true
+reason = "[S-152] the usage form's own trailing prose (no terminating period) folds into the usage text with no field to hold it separately; open, xfail with count in the note."

--- a/corpus/gdk-pixbuf-thumbnailer/2.42.10/expected.snap
+++ b/corpus/gdk-pixbuf-thumbnailer/2.42.10/expected.snap
@@ -1,6 +1,5 @@
 name: gdk-pixbuf-thumbnailer
 usage:
-- 'Usage:'
 - '  gdk-pixbuf-thumbnailer [OPTION…] [INPUT FILE] [OUTPUT FILE] Thumbnail images'
 positionals:
 - name: INPUT FILE

--- a/corpus/gdk-pixbuf-thumbnailer/2.42.10/expected.snap
+++ b/corpus/gdk-pixbuf-thumbnailer/2.42.10/expected.snap
@@ -1,0 +1,42 @@
+name: gdk-pixbuf-thumbnailer
+usage:
+- 'Usage:'
+- '  gdk-pixbuf-thumbnailer [OPTION…] [INPUT FILE] [OUTPUT FILE] Thumbnail images'
+positionals:
+- name: INPUT FILE
+  provenance:
+    sources:
+    - help-text
+- name: OUTPUT FILE
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -h
+  - --help
+  group: 'Help Options:'
+  description: Show help options
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -s
+  - --size
+  group: 'Application Options:'
+  description: Size of the thumbnail in pixels
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --g-fatal-warnings
+  group: 'Application Options:'
+  description: Make all warnings fatal
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/gdk-pixbuf-thumbnailer/2.42.10/help.txt
+++ b/corpus/gdk-pixbuf-thumbnailer/2.42.10/help.txt
@@ -1,0 +1,10 @@
+Usage:
+  gdk-pixbuf-thumbnailer [OPTION…] [INPUT FILE] [OUTPUT FILE] Thumbnail images
+
+Help Options:
+  -h, --help                        Show help options
+
+Application Options:
+  -s, --size                        Size of the thumbnail in pixels
+  --g-fatal-warnings                Make all warnings fatal
+

--- a/corpus/gdk-pixbuf-thumbnailer/2.42.10/meta.toml
+++ b/corpus/gdk-pixbuf-thumbnailer/2.42.10/meta.toml
@@ -1,0 +1,30 @@
+# docs/shapes.md S-154: `[INPUT FILE]` and `[OUTPUT FILE]` each name one
+# two-word operand. The per-token ALL-CAPS scan read every bracket-group
+# word independently, so the tree carried three positionals (`INPUT`,
+# `FILE`, `OUTPUT`, `FILE` deduplicated to three) instead of the two the
+# tool actually documents.
+#
+# The trailing `Thumbnail images` prose glued onto the same physical line
+# is a separate defect (docs/shapes.md, W1's usage-program-word-mismatch
+# family territory, not this one); it does not interfere here, since it
+# is mixed-case and the ALL-CAPS scan already ignores it.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "gdk-pixbuf-thumbnailer"
+version = "2.42.10"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); gdk-pixbuf 2.42.10"
+
+[[capture]]
+argv = ["gdk-pixbuf-thumbnailer", "--help"]
+stdout = "help.txt"
+
+[contract]
+verdict_scope = ["flags", "usage"]
+expected_framework = "generic"
+must_contain_positionals = ["INPUT FILE", "OUTPUT FILE"]
+must_not_contain_positionals = ["INPUT", "FILE", "OUTPUT"]
+must_contain_flags = ["-h", "-s", "--g-fatal-warnings"]

--- a/corpus/invoke-rc.d/1.66/expected.snap
+++ b/corpus/invoke-rc.d/1.66/expected.snap
@@ -1,7 +1,6 @@
 name: invoke-rc.d
 description: invoke-rc.d, Debian/SysVinit (/etc/rc?.d) initscript subsystem. Copyright (c) 2000,2001 Henrique de Moraes Holschuh <hmh@debian.org>
 usage:
-- 'Usage:'
 - '  invoke-rc.d [options] <basename> <action> [extra parameters]'
 positionals:
 - name: basename

--- a/corpus/ip6tables-apply/audit-seed2/expected.snap
+++ b/corpus/ip6tables-apply/audit-seed2/expected.snap
@@ -1,7 +1,6 @@
 name: ip6tables-apply
 description: ip6tables-apply 1.1 -- a safer way to update iptables remotely
 usage:
-- 'Usage:'
 - '  ip6tables-apply [-hV] [-t timeout] [-w savefile] {[rulesfile]|-c [runcmd]}'
 flags:
 - spellings:

--- a/corpus/iptables-apply/audit-seed2/expected.snap
+++ b/corpus/iptables-apply/audit-seed2/expected.snap
@@ -1,7 +1,6 @@
 name: iptables-apply
 description: iptables-apply 1.1 -- a safer way to update iptables remotely
 usage:
-- 'Usage:'
 - '  iptables-apply [-hV] [-t timeout] [-w savefile] {[rulesfile]|-c [runcmd]}'
 flags:
 - spellings:

--- a/corpus/jdeprscan/audit-seed2/expected.snap
+++ b/corpus/jdeprscan/audit-seed2/expected.snap
@@ -1,6 +1,13 @@
 name: jdeprscan
 usage:
 - 'Usage: jdeprscan [options] {dir|jar|class} ...'
+positionals:
+- name: '{dir|jar|class}'
+  required: true
+  variadic: true
+  provenance:
+    sources:
+    - help-text
 flags:
 - spellings:
   - --class-path

--- a/corpus/killsnoop.bt/audit-seed2/expected.snap
+++ b/corpus/killsnoop.bt/audit-seed2/expected.snap
@@ -1,6 +1,6 @@
 name: killsnoop.bt
 usage:
-- 'USAGE: bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e ''program'''
+- bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e 'program'
 flags:
 - spellings:
   - -B

--- a/corpus/lcf/3.0043+nmu1/expected.snap
+++ b/corpus/lcf/3.0043+nmu1/expected.snap
@@ -1,0 +1,49 @@
+name: lcf
+description: 'Debian GNU/Linux lcf Revision: 3.00. This is free software; see the GNU General Public Licence for copying conditions. There is NO warranty.'
+usage:
+- 'Usage: lcf  [options] dest_file  src_dir'
+flags:
+- spellings:
+  - -h
+  - --help
+  description: print this message
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -s
+  - --src-dir
+  value_name: foo
+  value_kind: Required
+  description: foo Set the src dir (historical md5sums live here)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  - --debug
+  value_name: n
+  value_kind: Optional
+  description: '[n] Set the Debug level to N'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -n
+  - --no-action
+  description: Dry run. No action is actually taken.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -v
+  - --verbose
+  description: Make the script verbose
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/lcf/3.0043+nmu1/help.stderr.txt
+++ b/corpus/lcf/3.0043+nmu1/help.stderr.txt
@@ -1,0 +1,16 @@
+Debian GNU/Linux lcf Revision: 3.00.
+           Copyright (C) 2002 Manoj Srivastava.
+This is free software; see the GNU General Public Licence for copying
+conditions.  There is NO warranty.
+
+Usage: lcf  [options] dest_file  src_dir
+Options:
+     -h,     --help          print this message
+     -s foo, --src-dir  foo  Set the src dir (historical md5sums live here)
+     -d [n], --debug    [n]  Set the Debug level to N
+     -n,     --no-action     Dry run. No action is actually taken.
+     -v,     --verbose       Make the script verbose
+
+By default, the directory the new_file lives in is assumed to be the src-dir,
+which is where we look for any historical md5sums.
+

--- a/corpus/lcf/3.0043+nmu1/meta.toml
+++ b/corpus/lcf/3.0043+nmu1/meta.toml
@@ -1,0 +1,32 @@
+# docs/shapes.md S-153: the program name and both operands are padded by
+# two spaces (`"lcf  [options] dest_file  src_dir"`). The description-gap
+# cut treated the first two-space run as a trailing description boundary,
+# so the whole tail after the program name was discarded before the
+# operand walk ever started; the tree carried no POSITIONALS section and
+# the rendered USAGE line was truncated to the bare program name.
+#
+# Fixing the gap width alone does not recover a positional here: the tail
+# `dest_file src_dir` has no numbering (unlike S-136), so the pre-existing
+# `[options] command` ambiguity guard (round 6) still declines it, the
+# same as `psfaddtable`'s multi-word bare tail. This fixture states the
+# real, honest outcome: USAGE reconstructs correctly, POSITIONALS stays
+# empty.
+
+[bless]
+provenance = "agent"
+
+[tool]
+name = "lcf"
+version = "3.0043+nmu1"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); ucf 3.0043+nmu1"
+
+[[capture]]
+argv = ["lcf", "--help"]
+stdout = "help.txt"
+stderr = "help.stderr.txt"
+
+[contract]
+verdict_scope = ["flags", "usage"]
+expected_framework = "generic"
+must_contain_flags = ["-h", "-s", "-d", "-n", "-v"]

--- a/corpus/mksquashfs/4.6.1/expected.snap
+++ b/corpus/mksquashfs/4.6.1/expected.snap
@@ -1,0 +1,821 @@
+name: mksquashfs
+usage:
+- mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of exclude dirs/files]
+positionals:
+- name: FILESYSTEM
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -b
+  value_name: <block_size>
+  value_kind: Required
+  group: 'Filesystem compression options:'
+  description: set data block to <block_size>. Default 128 Kbytes. Optionally a suffix of K or M can be given to specify Kbytes or Mbytes respectively
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -comp
+  value_name: <comp>
+  value_kind: Required
+  group: 'Filesystem compression options:'
+  description: 'select <comp> compression Compressors available: gzip (default) lzo lz4 xz zstd lzma'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noI
+  group: 'Filesystem compression options:'
+  description: do not compress inode table
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noId
+  group: 'Filesystem compression options:'
+  description: do not compress the uid/gid table (implied by -noI)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noD
+  group: 'Filesystem compression options:'
+  description: do not compress data blocks
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noF
+  group: 'Filesystem compression options:'
+  description: do not compress fragment blocks
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noX
+  group: 'Filesystem compression options:'
+  description: do not compress extended attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-compression
+  group: 'Filesystem compression options:'
+  description: do not compress any of the data or metadata. This is equivalent to specifying -noI -noD -noF and -noX
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -tar
+  group: 'Filesystem build options:'
+  description: read uncompressed tar file from standard in (stdin)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-strip
+  group: 'Filesystem build options:'
+  description: act like tar, and do not strip leading directories from source files
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -tarstyle
+  group: 'Filesystem build options:'
+  description: alternative name for -no-strip
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -cpiostyle
+  group: 'Filesystem build options:'
+  description: act like cpio, and read file pathnames from standard in (stdin)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -cpiostyle0
+  group: 'Filesystem build options:'
+  description: like -cpiostyle, but filenames are null terminated. Can be used with find -print0 action
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -reproducible
+  group: 'Filesystem build options:'
+  description: build filesystems that are reproducible (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -not-reproducible
+  group: 'Filesystem build options:'
+  description: build filesystems that are not reproducible
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mkfs-time
+  value_name: <time>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set filesystem creation timestamp to <time>. <time> can be an unsigned 32-bit int indicating seconds since the epoch (1970-01-01) or a string value which is passed to the "date" command to parse. Any string value which the date command recognises can be used such as "now", "last week", or "Wed Feb 15 21:02:39 GMT 2023"
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -all-time
+  value_name: <time>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set all file timestamps to <time>. <time> can be an unsigned 32-bit int indicating seconds since the epoch (1970-01-01) or a string value which is passed to the "date" command to parse. Any string value which the date command recognises can be used such as "now", "last week", or "Wed Feb 15 21:02:39 GMT 2023"
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-time
+  value_name: <time>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory time to <time>. <time> can be an unsigned 32-bit int indicating seconds since the epoch (1970-01-01) or a string value which is passed to the "date" command to parse. Any string value which the date command recognises can be used such as "now", "last week", or "Wed Feb 15 21:02:39 GMT 2023"
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-mode
+  value_name: <mode>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory permissions to octal <mode>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-uid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory owner to specified <value>, <value> can be either an integer uid or user name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-gid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory group to specified <value>, <value> can be either an integer gid or group name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -all-root
+  group: 'Filesystem build options:'
+  description: make all files owned by root
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -force-uid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set all file uids to specified <value>, <value> can be either an integer uid or user name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -force-gid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set all file gids to specified <value>, <value> can be either an integer gid or group name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -pseudo-override
+  group: 'Filesystem build options:'
+  description: make pseudo file uids and gids override -all-root, -force-uid and -force-gid options
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-exports
+  group: 'Filesystem build options:'
+  description: do not make filesystem exportable via NFS (-tar default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -exports
+  group: 'Filesystem build options:'
+  description: make filesystem exportable via NFS (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-sparse
+  group: 'Filesystem build options:'
+  description: do not detect sparse files
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-tailends
+  group: 'Filesystem build options:'
+  description: do not pack tail ends into fragments (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -tailends
+  group: 'Filesystem build options:'
+  description: pack tail ends into fragments
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-fragments
+  group: 'Filesystem build options:'
+  description: do not use fragments
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-duplicates
+  group: 'Filesystem build options:'
+  description: do not perform duplicate checking
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-hardlinks
+  group: 'Filesystem build options:'
+  description: do not hardlink files, instead store duplicates
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -keep-as-directory
+  group: 'Filesystem build options:'
+  description: if one source directory is specified, create a root directory containing that directory, rather than the contents of the directory
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -p
+  value_name: <pseudo-definition>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: add pseudo file definition. The definition should be quoted
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -pf
+  value_name: <pseudo-file>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: add list of pseudo file definitions from <pseudo-file>, use - for stdin. Pseudo file definitions should not be quoted
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -sort
+  value_name: <sort_file>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: sort files according to priorities in <sort_file>. One file or dir with priority per line. Priority -32768 to 32767, default priority 0
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -ef
+  value_name: <exclude_file>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: list of exclude dirs/files. One per line
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -wildcards
+  group: 'Filesystem filter options:'
+  description: allow extended shell wildcards (globbing) to be used in exclude dirs/files
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -regex
+  group: 'Filesystem filter options:'
+  description: allow POSIX regular expressions to be used in exclude dirs/files
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -max-depth
+  value_name: <levels>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: descend at most <levels> of directories when scanning filesystem
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -one-file-system
+  group: 'Filesystem filter options:'
+  description: do not cross filesystem boundaries. If a directory crosses the boundary, create an empty directory for each mount point. If a file crosses the boundary ignore it
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -one-file-system-x
+  group: 'Filesystem filter options:'
+  description: do not cross filesystem boundaries. Like -one-file-system option except directories are also ignored if they cross the boundary
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-xattrs
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: do not store extended attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: store extended attributes (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs-exclude
+  value_name: <regex>
+  value_kind: Required
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: exclude any xattr names matching <regex>. <regex> is a POSIX regular expression, e.g. -xattrs-exclude '^user.' excludes xattrs from the user namespace
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs-include
+  value_name: <regex>
+  value_kind: Required
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: include any xattr names matching <regex>. <regex> is a POSIX regular expression, e.g. -xattrs-include '^user.' includes xattrs from the user namespace
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs-add
+  value_name: <name=val>
+  value_kind: Required
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: add the xattr <name> with <val> to files. If an user xattr it will be added to regular files and directories (see man 7 xattr). Otherwise it will be added to all files. <val> by default will be treated as binary (i.e. an uninterpreted byte sequence), but it can be prefixed with 0s, where it will be treated as base64 encoded, or prefixed with 0x, where val will be treated as hexidecimal. Additionally it can be prefixed with 0t where this encoding is similar to binary encoding, except backslashes are specially treated, and a backslash followed by 3 octal digits can be used to encode any ASCII character, which obviously can be used to encode control codes. The option can be repeated multiple times to add multiple xattrs
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -version
+  group: 'Mksquashfs runtime options:'
+  description: print version, licence and copyright message
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -exit-on-error
+  group: 'Mksquashfs runtime options:'
+  description: treat normally ignored errors as fatal
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -quiet
+  group: 'Mksquashfs runtime options:'
+  description: no verbose output
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -info
+  group: 'Mksquashfs runtime options:'
+  description: print files written to filesystem
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-progress
+  group: 'Mksquashfs runtime options:'
+  description: do not display the progress bar
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -progress
+  group: 'Mksquashfs runtime options:'
+  description: display progress bar when using the -info option
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -percentage
+  group: 'Mksquashfs runtime options:'
+  description: display a percentage rather than the full progress bar. Can be used with dialog --gauge etc.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -throttle
+  value_name: <percentage>
+  value_kind: Required
+  group: 'Mksquashfs runtime options:'
+  description: throttle the I/O input rate by the given percentage. This can be used to reduce the I/O and CPU consumption of Mksquashfs
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -limit
+  value_name: <percentage>
+  value_kind: Required
+  group: 'Mksquashfs runtime options:'
+  description: limit the I/O input rate to the given percentage. This can be used to reduce the I/O and CPU consumption of Mksquashfs (alternative to -throttle)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -processors
+  value_name: <number>
+  value_kind: Required
+  group: 'Mksquashfs runtime options:'
+  description: use <number> processors. By default will use number of processors available
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mem
+  value_name: <size>
+  value_kind: Required
+  group: 'Mksquashfs runtime options:'
+  description: use <size> physical memory for caches. Use K, M or G to specify Kbytes, Mbytes or Gbytes respectively
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mem-percent
+  value_name: <percent>
+  value_kind: Required
+  group: 'Mksquashfs runtime options:'
+  description: use <percent> physical memory for caches. Default 25%
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mem-default
+  group: 'Mksquashfs runtime options:'
+  description: print default memory usage in Mbytes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noappend
+  group: 'Filesystem append options:'
+  description: do not append to existing filesystem
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-becomes
+  value_name: <name>
+  value_kind: Required
+  group: 'Filesystem append options:'
+  description: when appending source files/directories, make the original root become a subdirectory in the new root called <name>, rather than adding the new source items to the original root
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-recovery
+  group: 'Filesystem append options:'
+  description: do not generate a recovery file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -recovery-path
+  value_name: <name>
+  value_kind: Required
+  group: 'Filesystem append options:'
+  description: use <name> as the directory to store the recovery file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -recover
+  value_name: <name>
+  value_kind: Required
+  group: 'Filesystem append options:'
+  description: recover filesystem data using recovery file <name>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -action
+  value_name: <action@expr>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: evaluate <expr> on every file, and execute <action> if it returns TRUE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -log-action
+  value_name: <act@expr>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as above, but log expression evaluation results and actions performed
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -true-action
+  value_name: <act@expr>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as above, but only log expressions which return TRUE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -false-action
+  value_name: <act@exp>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as above, but only log expressions which return FALSE
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -action-file
+  value_name: <file>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as action, but read actions from <file>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -log-action-file
+  value_name: <file>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as -log-action, but read actions from <file>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -true-action-file
+  value_name: <f>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as -true-action, but read actions from <f>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -false-action-file
+  value_name: <f>
+  value_kind: Required
+  group: 'Filesystem actions options:'
+  description: as -false-action, but read actions from <f>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -default-mode
+  value_name: <mode>
+  value_kind: Required
+  group: 'Tar file only options:'
+  description: tar files often do not store permissions for intermediate directories. This option sets the default directory permissions to octal <mode>, rather than 0755. This also sets the root inode mode
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -default-uid
+  value_name: <uid>
+  value_kind: Required
+  group: 'Tar file only options:'
+  description: tar files often do not store uids for intermediate directories. This option sets the default directory owner to <uid>, rather than the user running Mksquashfs. This also sets the root inode uid
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -default-gid
+  value_name: <gid>
+  value_kind: Required
+  group: 'Tar file only options:'
+  description: tar files often do not store gids for intermediate directories. This option sets the default directory group to <gid>, rather than the group of the user running Mksquashfs. This also sets the root inode gid
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -ignore-zeros
+  group: 'Tar file only options:'
+  description: allow tar files to be concatenated together and fed to Mksquashfs. Normally a tarfile has two consecutive 512 byte blocks filled with zeros which means EOF and Mksquashfs will stop reading after the first tar file on encountering them. This option makes Mksquashfs ignore the zero filled blocks
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -nopad
+  group: 'Expert options (these may make the filesystem unmountable):'
+  description: do not pad filesystem to a multiple of 4K
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -offset
+  value_name: <offset>
+  value_kind: Required
+  group: 'Expert options (these may make the filesystem unmountable):'
+  description: skip <offset> bytes at the beginning of FILESYSTEM. Optionally a suffix of K, M or G can be given to specify Kbytes, Mbytes or Gbytes respectively. Default 0 bytes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  value_name: <offset>
+  value_kind: Required
+  group: 'Expert options (these may make the filesystem unmountable):'
+  description: synonym for -offset
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -fstime
+  value_name: <time>
+  value_kind: Required
+  group: 'Miscellaneous options:'
+  description: alternative name for -mkfs-time
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -always-use-fragments
+  group: 'Miscellaneous options:'
+  description: alternative name for -tailends
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-owned
+  group: 'Miscellaneous options:'
+  description: alternative name for -all-root
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noInodeCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noI
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noIdTableCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noId
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noDataCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noD
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noFragmentCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noF
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noXattrCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noX
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -help
+  group: 'Miscellaneous options:'
+  description: output this options text to stdout
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  group: 'Miscellaneous options:'
+  description: output this options text to stdout
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xhelp
+  group: 'Miscellaneous options:'
+  description: print compressor options for selected compressor
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xcompression-level
+  value_name: <compression-level>
+  value_kind: Required
+  group: gzip (default)
+  description: <compression-level> should be 1 .. 9 (default 9)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xwindow-size
+  value_name: <window-size>
+  value_kind: Required
+  group: gzip (default)
+  description: <window-size> should be 8 .. 15 (default 15)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xstrategy
+  group: gzip (default)
+  description: 'Compress using strategy1,strategy2,...,strategyN in turn and choose the best compression. Available strategies: default, filtered, huffman_only, run_length_encoded and fixed'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xalgorithm
+  value_name: <algorithm>
+  value_kind: Required
+  group: lzo
+  description: 'Where <algorithm> is one of: lzo1x_1 lzo1x_1_11 lzo1x_1_12 lzo1x_1_15 lzo1x_999 (default)'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xcompression-level
+  value_name: <compression-level>
+  value_kind: Required
+  group: lzo
+  description: <compression-level> should be 1 .. 9 (default 8) Only applies to lzo1x_999 algorithm
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xhc
+  group: lz4
+  description: Compress using LZ4 High Compression
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xbcj
+  group: xz
+  description: 'Compress using filter1,filter2,...,filterN in turn (in addition to no filter), and choose the best compression. Available filters: x86, arm, armthumb, powerpc, sparc, ia64'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xdict-size
+  value_name: <dict-size>
+  value_kind: Required
+  group: xz
+  description: Use <dict-size> as the XZ dictionary size. The dictionary size can be specified as a percentage of the block size, or as an absolute value. The dictionary size must be less than or equal to the block size and 8192 bytes or larger. It must also be storable in the xz header as either 2^n or as 2^n+2^(n+1). Example dict-sizes are 75%, 50%, 37.5%, 25%, or 32K, 16K, 8K etc.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xcompression-level
+  value_name: <compression-level>
+  value_kind: Required
+  group: zstd
+  description: <compression-level> should be 1 .. 22 (default 15)
+  provenance:
+    sources:
+    - help-text
+env_vars:
+- name: SOURCE_DATE_EPOCH
+  group: 'Environment:'
+  description: If set, this is used as the filesystem creation timestamp. Also any file timestamps which are after SOURCE_DATE_EPOCH will be clamped to SOURCE_DATE_EPOCH. See https://reproducible-builds.org/docs/source-date-epoch/ for more information
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/mksquashfs/4.6.1/expected.snap
+++ b/corpus/mksquashfs/4.6.1/expected.snap
@@ -2,6 +2,12 @@ name: mksquashfs
 usage:
 - mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of exclude dirs/files]
 positionals:
+- name: source
+  required: true
+  variadic: true
+  provenance:
+    sources:
+    - help-text
 - name: FILESYSTEM
   required: true
   provenance:

--- a/corpus/mksquashfs/4.6.1/meta.toml
+++ b/corpus/mksquashfs/4.6.1/meta.toml
@@ -31,8 +31,13 @@ must_contain_flags = [
   "-pf", "-ef", "-Xhelp", "-Xstrategy", "-Xhc", "-Xbcj",
 ]
 must_not_contain_flags = ["-n"]
-# The operand the unread synopsis holds (docs/shapes.md S-142). Fails.
+# [S-142] FILESYSTEM, once the glued `SYNTAX:` label and the column-zero
+# open-bracket continuation are both read. `source1 source2 ...` sits
+# between the program name and FILESYSTEM rather than at the line's own
+# tail, a shape `recover_primary_tail_operands` does not reach; it stays
+# an unrecovered positional, noted rather than asserted here.
 must_contain_positionals = ["FILESYSTEM"]
+must_usage_forms_min = 1
 
 # Tab-separated value placeholders the table rule keeps (docs/shapes.md
 # S-145): `-b <block_size>`'s own kind, now also read off a swallowed
@@ -61,7 +66,3 @@ must_contain_positionals = ["FILESYSTEM"]
 "-Xhc" = "lz4"
 "-Xbcj" = "xz"
 "-Xcompression-level" = "zstd"
-
-[xfail]
-broken = true
-reason = "S-139 and S-145 are fixed and every assertion above passes. S-142 is open: SYNTAX: glued to the program name with no space is never recognized as a usage marker, so the two-line synopsis is read as description prose and no positional is recovered from it. Measured 2 genuine tools for the glued label and 1 for the open-bracket continuation at column zero, both below the five-tool bar, so nothing ships for it."

--- a/corpus/mksquashfs/4.6.1/meta.toml
+++ b/corpus/mksquashfs/4.6.1/meta.toml
@@ -32,11 +32,11 @@ must_contain_flags = [
 ]
 must_not_contain_flags = ["-n"]
 # [S-142] FILESYSTEM, once the glued `SYNTAX:` label and the column-zero
-# open-bracket continuation are both read. `source1 source2 ...` sits
-# between the program name and FILESYSTEM rather than at the line's own
-# tail, a shape `recover_primary_tail_operands` does not reach; it stays
-# an unrecovered positional, noted rather than asserted here.
-must_contain_positionals = ["FILESYSTEM"]
+# open-bracket continuation are both read. [S-171] source, the numbered
+# `source1 source2 ...` pair ahead of FILESYSTEM that
+# `recover_primary_tail_operands` (S-136) never reaches, since its own
+# tail-only path only runs when the per-line loop found nothing at all.
+must_contain_positionals = ["source", "FILESYSTEM"]
 must_usage_forms_min = 1
 
 # Tab-separated value placeholders the table rule keeps (docs/shapes.md

--- a/corpus/naptime.bt/audit-seed2/expected.snap
+++ b/corpus/naptime.bt/audit-seed2/expected.snap
@@ -1,6 +1,6 @@
 name: naptime.bt
 usage:
-- 'USAGE: bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e ''program'''
+- bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e 'program'
 flags:
 - spellings:
   - -B

--- a/corpus/nvim/0.9.5/expected.snap
+++ b/corpus/nvim/0.9.5/expected.snap
@@ -1,9 +1,14 @@
 name: nvim
 usage:
-- 'Usage:'
 - '  nvim [options] [file ...]      Edit file(s)'
 - '  nvim [options] -t <tag>        Edit file where tag is defined'
 - '  nvim [options] -q [errorfile]  Edit file with first error'
+positionals:
+- name: file
+  variadic: true
+  provenance:
+    sources:
+    - help-text
 flags:
 - spellings:
   - --

--- a/corpus/opensnoop.bt/audit-seed2/expected.snap
+++ b/corpus/opensnoop.bt/audit-seed2/expected.snap
@@ -1,6 +1,6 @@
 name: opensnoop.bt
 usage:
-- 'USAGE: bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e ''program'''
+- bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e 'program'
 flags:
 - spellings:
   - -B

--- a/corpus/perlthanks/1.43/expected.snap
+++ b/corpus/perlthanks/1.43/expected.snap
@@ -1,0 +1,136 @@
+name: perlthanks
+description: |-
+  perlbug version 1.43
+
+  This program is designed to help you generate bug reports (and thank-you notes) about perl5 and the modules which ship with it.
+
+  In most cases, you can just run "/usr/bin/perlthanks" interactively from a command line without any special arguments and follow the prompts.
+usage:
+- /usr/bin/perlthanks  [-v] [-a address] [-s subject] [-b body | -f inpufile ] [ -F outputfile ] [-r returnaddress] [-e editor] [-c adminaddress | -C] [-S] [-t] [-h] [-p patchfile ]
+- /usr/bin/perlthanks  [-v] [-r returnaddress] [-ok | -okay | -nok | -nokay]
+flags:
+- spellings:
+  - -v
+  description: Include Verbose configuration data in the report
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -f
+  description: File containing the body of the report. Use this to quickly send a prepared report.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -p
+  description: File containing a patch or other text attachment. Separate multiple files with commas.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -F
+  description: File to output the resulting report to. Defaults to 'perlthanks.rep'.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -S
+  description: Save or send the report without asking for confirmation.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -a
+  description: Send the report to this address, instead of saving to a file.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -c
+  description: Address to send copy of report to. Defaults to 'root@localhost'.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -C
+  description: Don't send copy to administrator.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -s
+  description: Subject to include with the report. You will be prompted if you don't supply one on the command line.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -b
+  description: Body of the report. If not included on the command line, or in a file with -f, you will get a chance to edit the report.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -r
+  description: Your return address. The program will ask you to confirm this if you don't give it here.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -e
+  description: Editor to use.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -t
+  description: Test mode.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -T
+  description: Thank-you mode. The target address defaults to 'perl-thanks@perl.org'.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  description: Data mode. This prints out your configuration data, without mailing anything. You can use this with -v to get more complete data.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -ok
+  description: 'Report successful build on this system to perl porters (use alone or with -v). Only use -ok if *everything* was ok: if there were *any* problems at all, use -nok.'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -okay
+  description: As -ok but allow report from old builds.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -nok
+  description: Report unsuccessful build on this system to perl porters (use alone or with -v). You must describe what went wrong in the body of the report which you will be asked to edit.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -nokay
+  description: As -nok but allow report from old builds.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  description: Print this help message.
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/perlthanks/1.43/help.txt
+++ b/corpus/perlthanks/1.43/help.txt
@@ -1,0 +1,50 @@
+perlbug version 1.43
+
+This program is designed to help you generate bug reports
+(and thank-you notes) about perl5 and the modules which ship with it.
+
+In most cases, you can just run "/usr/bin/perlthanks" interactively from a command
+line without any special arguments and follow the prompts.
+
+Advanced usage:
+
+/usr/bin/perlthanks  [-v] [-a address] [-s subject] [-b body | -f inpufile ] [ -F outputfile ]
+    [-r returnaddress] [-e editor] [-c adminaddress | -C] [-S] [-t] [-h]
+    [-p patchfile ]
+/usr/bin/perlthanks  [-v] [-r returnaddress] [-ok | -okay | -nok | -nokay]
+
+
+Options:
+
+  -v    Include Verbose configuration data in the report
+  -f    File containing the body of the report. Use this to
+        quickly send a prepared report.
+  -p    File containing a patch or other text attachment. Separate
+        multiple files with commas.
+  -F    File to output the resulting report to. Defaults to
+        'perlthanks.rep'.
+  -S    Save or send the report without asking for confirmation.
+  -a    Send the report to this address, instead of saving to a file.
+  -c    Address to send copy of report to. Defaults to 'root@localhost'.
+  -C    Don't send copy to administrator.
+  -s    Subject to include with the report. You will be prompted
+        if you don't supply one on the command line.
+  -b    Body of the report. If not included on the command line, or
+        in a file with -f, you will get a chance to edit the report.
+  -r    Your return address. The program will ask you to confirm
+        this if you don't give it here.
+  -e    Editor to use.
+  -t    Test mode.
+  -T    Thank-you mode. The target address defaults to 'perl-thanks@perl.org'.
+  -d    Data mode.  This prints out your configuration data, without mailing
+        anything. You can use this with -v to get more complete data.
+  -ok   Report successful build on this system to perl porters
+        (use alone or with -v). Only use -ok if *everything* was ok:
+        if there were *any* problems at all, use -nok.
+  -okay As -ok but allow report from old builds.
+  -nok  Report unsuccessful build on this system to perl porters
+        (use alone or with -v). You must describe what went wrong
+        in the body of the report which you will be asked to edit.
+  -nokay As -nok but allow report from old builds.
+  -h    Print this help message.
+

--- a/corpus/perlthanks/1.43/meta.toml
+++ b/corpus/perlthanks/1.43/meta.toml
@@ -1,0 +1,18 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "perlthanks"
+version = "1.43"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); perl 5.38.2, perlbug 1.43"
+
+[[capture]]
+argv = ["perlthanks", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+must_usage_forms_min = 2
+must_not_contain_usage_text = ["Advanced usage:"]
+must_contain_flags = ["-v", "-p", "-s"]

--- a/corpus/pip3/24.0/expected.snap
+++ b/corpus/pip3/24.0/expected.snap
@@ -1,6 +1,5 @@
 name: pip3
 usage:
-- 'Usage:'
 - '  pip3 <command> [options]'
 positionals:
 - name: command
@@ -279,7 +278,6 @@ subcommands:
 - name: config
   summary: Manage local and global configuration.
   usage:
-  - 'Usage:'
   - '  pip3 config [<file-option>] list'
   - '  pip3 config [<file-option>] [--editor <editor-path>] edit'
   positionals:

--- a/corpus/pkcheck/124/expected.snap
+++ b/corpus/pkcheck/124/expected.snap
@@ -1,0 +1,93 @@
+name: pkcheck
+usage:
+- '  pkcheck [OPTION...]'
+flags:
+- spellings:
+  - -h
+  - --help
+  group: 'Help Options:'
+  description: Show help options
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -a
+  - --action-id
+  value_name: ACTION
+  value_kind: Required
+  group: 'Application Options:'
+  description: Check authorization to perform ACTION
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -u
+  - --allow-user-interaction
+  group: 'Application Options:'
+  description: Interact with the user if necessary
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -d
+  - --details
+  value_name: KEY
+  value_kind: Required
+  group: 'Application Options:'
+  description: Add (KEY, VALUE) to information about the action
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --enable-internal-agent
+  group: 'Application Options:'
+  description: Use an internal authentication agent if necessary
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --list-temp
+  group: 'Application Options:'
+  description: List temporary authorizations for current session
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -p
+  - --process
+  value_name: PID[,START_TIME,UID]
+  value_kind: Required
+  group: 'Application Options:'
+  description: Check authorization of specified process
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --revoke-temp
+  group: 'Application Options:'
+  description: Revoke all temporary authorizations for current session
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -s
+  - --system-bus-name
+  value_name: BUS_NAME
+  value_kind: Required
+  group: 'Application Options:'
+  description: Check authorization of owner of BUS_NAME
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - --version
+  group: 'Application Options:'
+  description: Show version
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/pkcheck/124/help.txt
+++ b/corpus/pkcheck/124/help.txt
@@ -1,0 +1,19 @@
+Usage:
+  pkcheck [OPTION...]
+
+Help Options:
+  -h, --help                         Show help options
+
+Application Options:
+  -a, --action-id=ACTION             Check authorization to perform ACTION
+  -u, --allow-user-interaction       Interact with the user if necessary
+  -d, --details=KEY VALUE            Add (KEY, VALUE) to information about the action
+  --enable-internal-agent            Use an internal authentication agent if necessary
+  --list-temp                        List temporary authorizations for current session
+  -p, --process=PID[,START_TIME,UID] Check authorization of specified process
+  --revoke-temp                      Revoke all temporary authorizations for current session
+  -s, --system-bus-name=BUS_NAME     Check authorization of owner of BUS_NAME
+  --version                          Show version
+
+Report bugs to: https://gitlab.freedesktop.org/polkit/polkit/-/issues/
+polkit home page: <http://www.freedesktop.org/wiki/Software/polkit>

--- a/corpus/pkcheck/124/meta.toml
+++ b/corpus/pkcheck/124/meta.toml
@@ -1,0 +1,18 @@
+[bless]
+provenance = "agent"
+
+[tool]
+name = "pkcheck"
+version = "124"
+platform = "ubuntu-24.04"
+captured_with = "manual capture per corpus/README.md step 2 (TERM=dumb NO_COLOR=1 COLUMNS=100 LC_ALL=C.UTF-8); polkit 124"
+
+[[capture]]
+argv = ["pkcheck", "--help"]
+stdout = "help.txt"
+
+[contract]
+expected_framework = "generic"
+must_usage_forms_min = 1
+must_not_contain_usage_text = ["Usage:"]
+must_contain_flags = ["--action-id", "--process"]

--- a/corpus/pod2man/5.01/expected.snap
+++ b/corpus/pod2man/5.01/expected.snap
@@ -1,6 +1,5 @@
 name: pod2man
 usage:
-- 'Usage:'
 - '    pod2man [--center=string] [--date=string] [--encoding=encoding] [--errors=style] [--fixed=font] [--fixedbold=font] [--fixeditalic=font] [--fixedbolditalic=font] [--guesswork=rule[,rule...]] [--name=name] [--nourls] [--official] [--release=version] [--section=manext] [--quotes=quotes] [--lquote=quote] [--rquote=quote] [--stderr] [--utf8] [--verbose] [input [output] ...]'
 flags:
 - spellings:

--- a/corpus/renice/audit-seed2/expected.snap
+++ b/corpus/renice/audit-seed2/expected.snap
@@ -1,6 +1,5 @@
 name: renice
 usage:
-- 'Usage:'
 - ' renice [-n|--priority|--relative] <priority> [-p|--pid] <pid>...'
 - ' renice [-n|--priority|--relative] <priority>  -g|--pgrp <pgid>...'
 - ' renice [-n|--priority|--relative] <priority>  -u|--user <user>...'

--- a/corpus/setsid/audit-seed2/expected.snap
+++ b/corpus/setsid/audit-seed2/expected.snap
@@ -1,6 +1,5 @@
 name: setsid
 usage:
-- 'Usage:'
 - ' setsid [options] <program> [arguments ...]'
 positionals:
 - name: program

--- a/corpus/sqfstar/4.6.1/expected.snap
+++ b/corpus/sqfstar/4.6.1/expected.snap
@@ -1,0 +1,613 @@
+name: sqfstar
+usage:
+- sqfstar [OPTIONS] FILESYSTEM [list of exclude dirs/files]
+positionals:
+- name: FILESYSTEM
+  required: true
+  provenance:
+    sources:
+    - help-text
+flags:
+- spellings:
+  - -b
+  value_name: <block_size>
+  value_kind: Required
+  group: 'Filesystem compression options:'
+  description: set data block to <block_size>. Default 128 Kbytes. Optionally a suffix of K or M can be given to specify Kbytes or Mbytes respectively
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -comp
+  value_name: <comp>
+  value_kind: Required
+  group: 'Filesystem compression options:'
+  description: 'select <comp> compression Compressors available: gzip (default) lzo lz4 xz zstd lzma'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noI
+  group: 'Filesystem compression options:'
+  description: do not compress inode table
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noId
+  group: 'Filesystem compression options:'
+  description: do not compress the uid/gid table (implied by -noI)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noD
+  group: 'Filesystem compression options:'
+  description: do not compress data blocks
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noF
+  group: 'Filesystem compression options:'
+  description: do not compress fragment blocks
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noX
+  group: 'Filesystem compression options:'
+  description: do not compress extended attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-compression
+  group: 'Filesystem compression options:'
+  description: do not compress any of the data or metadata. This is equivalent to specifying -noI -noD -noF and -noX
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -reproducible
+  group: 'Filesystem build options:'
+  description: build filesystems that are reproducible (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -not-reproducible
+  group: 'Filesystem build options:'
+  description: build filesystems that are not reproducible
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mkfs-time
+  value_name: <time>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set filesystem creation timestamp to <time>. <time> can be an unsigned 32-bit int indicating seconds since the epoch (1970-01-01) or a string value which is passed to the "date" command to parse. Any string value which the date command recognises can be used such as "now", "last week", or "Wed Feb 15 21:02:39 GMT 2023"
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -all-time
+  value_name: <time>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set all file timestamps to <time>. <time> can be an unsigned 32-bit int indicating seconds since the epoch (1970-01-01) or a string value which is passed to the "date" command to parse. Any string value which the date command recognises can be used such as "now", "last week", or "Wed Feb 15 21:02:39 GMT 2023"
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-time
+  value_name: <time>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory time to <time>. <time> can be an unsigned 32-bit int indicating seconds since the epoch (1970-01-01) or a string value which is passed to the "date" command to parse. Any string value which the date command recognises can be used such as "now", "last week", or "Wed Feb 15 21:02:39 GMT 2023"
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-mode
+  value_name: <mode>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory permissions to octal <mode>
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-uid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory owner to specified <value>, <value> can be either an integer uid or user name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-gid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set root directory group to specified <value>, <value> can be either an integer gid or group name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -all-root
+  group: 'Filesystem build options:'
+  description: make all files owned by root
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -force-uid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set all file uids to specified <value>, <value> can be either an integer uid or user name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -force-gid
+  value_name: <value>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: set all file gids to specified <value>, <value> can be either an integer gid or group name
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -default-mode
+  value_name: <mode>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: tar files often do not store permissions for intermediate directories. This option sets the default directory permissions to octal <mode>, rather than 0755. This also sets the root inode mode
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -default-uid
+  value_name: <uid>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: tar files often do not store uids for intermediate directories. This option sets the default directory owner to <uid>, rather than the user running Sqfstar. This also sets the root inode uid
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -default-gid
+  value_name: <gid>
+  value_kind: Required
+  group: 'Filesystem build options:'
+  description: tar files often do not store gids for intermediate directories. This option sets the default directory group to <gid>, rather than the group of the user running Sqfstar. This also sets the root inode gid
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -pseudo-override
+  group: 'Filesystem build options:'
+  description: make pseudo file uids and gids override -all-root, -force-uid and -force-gid options
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -exports
+  group: 'Filesystem build options:'
+  description: make the filesystem exportable via NFS
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-sparse
+  group: 'Filesystem build options:'
+  description: do not detect sparse files
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-fragments
+  group: 'Filesystem build options:'
+  description: do not use fragments
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-tailends
+  group: 'Filesystem build options:'
+  description: do not pack tail ends into fragments
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-duplicates
+  group: 'Filesystem build options:'
+  description: do not perform duplicate checking
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-hardlinks
+  group: 'Filesystem build options:'
+  description: do not hardlink files, instead store duplicates
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -p
+  value_name: <pseudo-definition>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: add pseudo file definition. The definition should be quoted
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -pf
+  value_name: <pseudo-file>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: add list of pseudo file definitions. Pseudo file definitions in pseudo-files should not be quoted
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -ef
+  value_name: <exclude_file>
+  value_kind: Required
+  group: 'Filesystem filter options:'
+  description: list of exclude dirs/files. One per line
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -regex
+  group: 'Filesystem filter options:'
+  description: allow POSIX regular expressions to be used in exclude dirs/files
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -ignore-zeros
+  group: 'Filesystem filter options:'
+  description: allow tar files to be concatenated together and fed to Sqfstar. Normally a tarfile has two consecutive 512 byte blocks filled with zeros which means EOF and Sqfstar will stop reading after the first tar file on encountering them. This option makes Sqfstar ignore the zero filled blocks
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-xattrs
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: do not store extended attributes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: store extended attributes (default)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs-exclude
+  value_name: <regex>
+  value_kind: Required
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: exclude any xattr names matching <regex>. <regex> is a POSIX regular expression, e.g. -xattrs-exclude '^user.' excludes xattrs from the user namespace
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs-include
+  value_name: <regex>
+  value_kind: Required
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: include any xattr names matching <regex>. <regex> is a POSIX regular expression, e.g. -xattrs-include '^user.' includes xattrs from the user namespace
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -xattrs-add
+  value_name: <name=val>
+  value_kind: Required
+  group: 'Filesystem extended attribute (xattrs) options:'
+  description: add the xattr <name> with <val> to files. If an user xattr it will be added to regular files and directories (see man 7 xattr). Otherwise it will be added to all files. <val> by default will be treated as binary (i.e. an uninterpreted byte sequence), but it can be prefixed with 0s, where it will be treated as base64 encoded, or prefixed with 0x, where val will be treated as hexidecimal. Additionally it can be prefixed with 0t where this encoding is similar to binary encoding, except backslashes are specially treated, and a backslash followed by 3 octal digits can be used to encode any ASCII character, which obviously can be used to encode control codes. The option can be repeated multiple times to add multiple xattrs
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -version
+  group: 'Sqfstar runtime options:'
+  description: print version, licence and copyright message
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -force
+  group: 'Sqfstar runtime options:'
+  description: force Sqfstar to write to block device or file
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -exit-on-error
+  group: 'Sqfstar runtime options:'
+  description: treat normally ignored errors as fatal
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -quiet
+  group: 'Sqfstar runtime options:'
+  description: no verbose output
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -info
+  group: 'Sqfstar runtime options:'
+  description: print files written to filesystem
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -no-progress
+  group: 'Sqfstar runtime options:'
+  description: do not display the progress bar
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -progress
+  group: 'Sqfstar runtime options:'
+  description: display progress bar when using the -info option
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -percentage
+  group: 'Sqfstar runtime options:'
+  description: display a percentage rather than the full progress bar. Can be used with dialog --gauge etc.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -throttle
+  value_name: <percentage>
+  value_kind: Required
+  group: 'Sqfstar runtime options:'
+  description: throttle the I/O input rate by the given percentage. This can be used to reduce the I/O and CPU consumption of Sqfstar
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -limit
+  value_name: <percentage>
+  value_kind: Required
+  group: 'Sqfstar runtime options:'
+  description: limit the I/O input rate to the given percentage. This can be used to reduce the I/O and CPU consumption of Sqfstar (alternative to -throttle)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -processors
+  value_name: <number>
+  value_kind: Required
+  group: 'Sqfstar runtime options:'
+  description: use <number> processors. By default will use number of processors available
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mem
+  value_name: <size>
+  value_kind: Required
+  group: 'Sqfstar runtime options:'
+  description: use <size> physical memory for caches. Use K, M or G to specify Kbytes, Mbytes or Gbytes respectively
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mem-percent
+  value_name: <percent>
+  value_kind: Required
+  group: 'Sqfstar runtime options:'
+  description: use <percent> physical memory for caches. Default 25%
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -mem-default
+  group: 'Sqfstar runtime options:'
+  description: print default memory usage in Mbytes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -nopad
+  group: 'Expert options (these may make the filesystem unmountable):'
+  description: do not pad filesystem to a multiple of 4K
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -offset
+  value_name: <offset>
+  value_kind: Required
+  group: 'Expert options (these may make the filesystem unmountable):'
+  description: skip <offset> bytes at the beginning of FILESYSTEM. Optionally a suffix of K, M or G can be given to specify Kbytes, Mbytes or Gbytes respectively. Default 0 bytes
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -o
+  value_name: <offset>
+  value_kind: Required
+  group: 'Expert options (these may make the filesystem unmountable):'
+  description: synonym for -offset
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -fstime
+  value_name: <time>
+  value_kind: Required
+  group: 'Miscellaneous options:'
+  description: alternative name for mkfs-time
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -root-owned
+  group: 'Miscellaneous options:'
+  description: alternative name for -all-root
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noInodeCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noI
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noIdTableCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noId
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noDataCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noD
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noFragmentCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noF
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -noXattrCompression
+  group: 'Miscellaneous options:'
+  description: alternative name for -noX
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -help
+  group: 'Miscellaneous options:'
+  description: output this options text to stdout
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -h
+  group: 'Miscellaneous options:'
+  description: output this options text to stdout
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xhelp
+  group: 'Miscellaneous options:'
+  description: print compressor options for selected compressor
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xcompression-level
+  value_name: <compression-level>
+  value_kind: Required
+  group: gzip (default)
+  description: <compression-level> should be 1 .. 9 (default 9)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xwindow-size
+  value_name: <window-size>
+  value_kind: Required
+  group: gzip (default)
+  description: <window-size> should be 8 .. 15 (default 15)
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xstrategy
+  group: gzip (default)
+  description: 'Compress using strategy1,strategy2,...,strategyN in turn and choose the best compression. Available strategies: default, filtered, huffman_only, run_length_encoded and fixed'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xalgorithm
+  value_name: <algorithm>
+  value_kind: Required
+  group: lzo
+  description: 'Where <algorithm> is one of: lzo1x_1 lzo1x_1_11 lzo1x_1_12 lzo1x_1_15 lzo1x_999 (default)'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xcompression-level
+  value_name: <compression-level>
+  value_kind: Required
+  group: lzo
+  description: <compression-level> should be 1 .. 9 (default 8) Only applies to lzo1x_999 algorithm
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xhc
+  group: lz4
+  description: Compress using LZ4 High Compression
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xbcj
+  group: xz
+  description: 'Compress using filter1,filter2,...,filterN in turn (in addition to no filter), and choose the best compression. Available filters: x86, arm, armthumb, powerpc, sparc, ia64'
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xdict-size
+  value_name: <dict-size>
+  value_kind: Required
+  group: xz
+  description: Use <dict-size> as the XZ dictionary size. The dictionary size can be specified as a percentage of the block size, or as an absolute value. The dictionary size must be less than or equal to the block size and 8192 bytes or larger. It must also be storable in the xz header as either 2^n or as 2^n+2^(n+1). Example dict-sizes are 75%, 50%, 37.5%, 25%, or 32K, 16K, 8K etc.
+  provenance:
+    sources:
+    - help-text
+- spellings:
+  - -Xcompression-level
+  value_name: <compression-level>
+  value_kind: Required
+  group: zstd
+  description: <compression-level> should be 1 .. 22 (default 15)
+  provenance:
+    sources:
+    - help-text
+env_vars:
+- name: SOURCE_DATE_EPOCH
+  group: 'Environment:'
+  description: If set, this is used as the filesystem creation timestamp. Also any file timestamps which are after SOURCE_DATE_EPOCH will be clamped to SOURCE_DATE_EPOCH. See https://reproducible-builds.org/docs/source-date-epoch/ for more information
+  provenance:
+    sources:
+    - help-text
+provenance:
+  sources:
+  - help-text
+  confidence: 0.5
+children_filled: true

--- a/corpus/sqfstar/4.6.1/meta.toml
+++ b/corpus/sqfstar/4.6.1/meta.toml
@@ -21,8 +21,9 @@ expected_framework = "generic"
 # The single-dash-long table rule (docs/shapes.md S-145): these used to
 # split at their second letter, sharing mksquashfs's own shape.
 must_contain_flags = ["-pf", "-ef", "-Xhelp", "-Xhc", "-Xbcj"]
-# The operand the unread synopsis holds (docs/shapes.md S-142). Fails.
+# [S-142] the synopsis's own operand, once the glued `SYNTAX:` label is read.
 must_contain_positionals = ["FILESYSTEM"]
+must_usage_forms_min = 1
 
 [contract.must_value_name]
 "-mem" = "<size>"
@@ -35,7 +36,3 @@ must_contain_positionals = ["FILESYSTEM"]
 "-noI" = "Filesystem compression options:"
 "-Xhc" = "lz4"
 "-Xwindow-size" = "gzip (default)"
-
-[xfail]
-broken = true
-reason = "S-142 is open: SYNTAX: glued to the program name with no space is never recognized as a usage marker, so the synopsis is read as description prose and no positional is recovered from it. Below the five-tool bar per mksquashfs's own measurement, so nothing ships for it here either."

--- a/corpus/sysctl/4.0.4/expected.snap
+++ b/corpus/sysctl/4.0.4/expected.snap
@@ -1,6 +1,5 @@
 name: sysctl
 usage:
-- 'Usage:'
 - ' sysctl [options] [variable[=value] ...]'
 flags:
 - spellings:

--- a/corpus/tcpaccept.bt/audit-seed2/expected.snap
+++ b/corpus/tcpaccept.bt/audit-seed2/expected.snap
@@ -1,6 +1,6 @@
 name: tcpaccept.bt
 usage:
-- 'USAGE: bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e ''program'''
+- bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e 'program'
 flags:
 - spellings:
   - -B

--- a/corpus/threadsnoop.bt/audit-seed2/expected.snap
+++ b/corpus/threadsnoop.bt/audit-seed2/expected.snap
@@ -1,6 +1,6 @@
 name: threadsnoop.bt
 usage:
-- 'USAGE: bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e ''program'''
+- bpftrace [options] filename bpftrace [options] - <stdin input> bpftrace [options] -e 'program'
 flags:
 - spellings:
   - -B

--- a/corpus/update-xmlcatalog/audit-seed2/expected.snap
+++ b/corpus/update-xmlcatalog/audit-seed2/expected.snap
@@ -1,6 +1,5 @@
 name: update-xmlcatalog
 usage:
-- 'Usage:'
 - '    update-xmlcatalog <options> --add --root --type <type> --id <id> --package <package>'
 - '    update-xmlcatalog <options> --del --root --type <type> --id <id>'
 flags:

--- a/corpus/wall/audit-seed2/expected.snap
+++ b/corpus/wall/audit-seed2/expected.snap
@@ -1,6 +1,5 @@
 name: wall
 usage:
-- 'Usage:'
 - ' wall [options] [<file> | <message>]'
 positionals:
 - name: file

--- a/corpus/wpa_supplicant/audit-seed4/expected.snap
+++ b/corpus/wpa_supplicant/audit-seed4/expected.snap
@@ -4,7 +4,6 @@ description: |-
 
   This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)
 usage:
-- 'usage:'
 - '  wpa_supplicant [-BddhKLqqstuvW] [-P<pid file>] [-g<global ctrl>] [-G<group>] -i<ifname> -c<config file> [-C<ctrl>] [-D<driver>] [-p<driver_param>] [-b<br_ifname>] [-e<entropy file>] [-f<debug file>] [-o<override driver>] [-O<override ctrl>] [-N -i<ifname> -c<conf> [-C<ctrl>] [-D<driver>] [-m<P2P Device config file>] [-p<driver_param>] [-b<br_ifname>] [-I<config file>] ...]'
 flags:
 - spellings:

--- a/corpus/zoxide/0.9.9/expected.snap
+++ b/corpus/zoxide/0.9.9/expected.snap
@@ -1,7 +1,6 @@
 name: zoxide
 description: A smarter cd command for your terminal
 usage:
-- 'Usage:'
 - '  zoxide <COMMAND>'
 positionals:
 - name: COMMAND

--- a/docs/design.md
+++ b/docs/design.md
@@ -2879,6 +2879,20 @@ fixture, the detector and the function to change, so the exception is
 read from that issue rather than decided fresh. The detector is ratcheted
 at zero fleet-wide the same way a repaired family above the bar is.
 
+**An optional value renders as its bracketed name, and the `=` is not lost
+(2026-09-13).** Asked of `mandible ls`, "see if it's correct to parse the `=`
+out of the `[=WHEN]` placeholder", the answer is that nothing is parsed out.
+`Entity::spelling` (`mandible-core/src/entity.rs`) renders an optional value as
+`[=VALUE]`, so `--color[=WHEN]` is what search matches and what `y` copies. The
+flag table keeps the spelling and the value in separate columns, so the value
+column shows `[WHEN]` alone, which satisfies S-097's ruling that a value name
+keeps its bracket-preserved source spelling. The earlier case the maintainer
+remembered is S-097's own `-V[N][fname]`, ruled 2026-09-04, and this follows it.
+Taken without the maintainer present: gluing the `=` onto the spelling column
+would move every optional-value row fleet-wide, including the named control
+tools `git` and `tar`, to restore one character that the IR already carries.
+`fdisk`'s `--lock[=<mode>]` is the same shape and the same answer.
+
 ### Deferred, with the reason each is not simply undone
 
 **Sub-case (b) of the `-h` fallback is unmeasured and must stay that way until

--- a/docs/design.md
+++ b/docs/design.md
@@ -2867,6 +2867,17 @@ S-102) — declined because a union keeps every same-spelling flag on the
 row a reader expects it on, while a per-form split would multiply
 `--type` into seven rows for one spelling. Fixture: `corpus/lvcreate/
 2.03.16`. Docs/shapes.md S-147.
+**The numbered-variadic-tail fix ships below the five-tool bar
+(2026-09-12).** `numbered-variadic-usage-tail` (docs/shapes.md S-136)
+moves 3 tools, apt-sortpkgs, apt-extracttemplates and apt-mark, with zero
+losses on a full-`PATH` sweep. It ships as a recorded exception on the
+same grounds the ragged-command-table and glued-interior-uppercase fixes
+did, named by the maintainer in issue #141 after the shape was handed to
+a contributor and the claim lapsed. Taken without the maintainer present,
+since the maintainer is away this round: issue #141 itself names the
+fixture, the detector and the function to change, so the exception is
+read from that issue rather than decided fresh. The detector is ratcheted
+at zero fleet-wide the same way a repaired family above the bar is.
 
 ### Deferred, with the reason each is not simply undone
 

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2479,17 +2479,26 @@ entry's `tools` field and nothing else. It does not get a new entry.
 - id: S-136
 - looks like: |
       Usage: apt-sortpkgs [options] file1 [file2 ...]
+      Usage: apt-mark [options] {auto|manual} pkg1 [pkg2 ...]
 - tools: apt-sortpkgs, apt-extracttemplates, apt-mark
-- handling: Open. `numbered-variadic-usage-tail`
-  (`xtask/src/detector/numbered_variadic_usage_tail.rs`) reads a usage
-  line's trailing pair where the second name is the first's own name
-  with the next integer, bracketed and ellipsis-marked, and would
-  collapse it into one variadic positional named by the shared stem —
-  narrower than the `multi-operand-usage-tail` ambiguity (S-109) round 6
-  declined, since the numbering is evidence a bare tail lacks.
-- fleet: measured 3 tools/3 findings on a full-`PATH` sweep, 2026-09-06,
-  below the five-tool floor a fix must clear. Not shipped; the fixture
-  stays xfail with the count in its reason.
+- handling: Fixed (issue #141). `recover_primary_tail_operands`
+  (`mandible-extract/src/help_text/sections/usage.rs`) collapses the
+  recovered run's own trailing pair to one repeatable operand, named by
+  the shared stem, when the second name is the first's own name with the
+  next integer, bracketed and ellipsis-marked — narrower than the
+  `multi-operand-usage-tail` ambiguity (S-109) round 6 declined, since the
+  numbering is evidence a bare tail lacks. The collapse is exempt from
+  both the `[options] command` ambiguity guard and the no-earlier-group
+  guard, since the numbering removes the ambiguity either guard exists to
+  catch; `apt-extracttemplates` has no earlier group at all and still
+  collapses. `numbered-variadic-usage-tail`
+  (`xtask/src/detector/numbered_variadic_usage_tail.rs`) generalizes the
+  shape fleet-wide as a local, independent copy of the same grouping and
+  operand parsing, not an import.
+- fleet: 3 tools/3 findings on a full-`PATH` sweep, below the five-tool
+  floor a fix must clear. Shipped anyway as a maintainer-named exception
+  (docs/design.md §16, issue #141): the fixture promotes out of `[xfail]`
+  with a zero-loss sweep-diff and all nine control screens byte-identical.
 
 ### S-137: lvm2 invocation forms read as section headings
 

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2964,3 +2964,41 @@ entry's `tools` field and nothing else. It does not get a new entry.
   post-fix on a full-`PATH` sweep of 2323 tools, 2026-09-13, and is ratcheted
   there. Zero flag losses, zero subcommand movement, all nine named controls
   byte-identical.
+
+### S-171: a numbered `X1 X2 ...` pair sits ahead of a later required operand
+
+- id: S-171
+- looks like: |
+      SYNTAX: mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of
+      exclude dirs/files]
+- tools: mksquashfs
+- handling: Fixed. S-136's sibling: `mksquashfs`'s own numbered pair is
+  unbracketed, like `genccode`'s `filename1 filename2 ...`, but it is not the
+  line's own tail — `FILESYSTEM` follows it — so S-136's own collapse
+  (`collapse_numbered_variadic_tail`, called only from
+  `recover_primary_tail_operands`) never runs: that function is itself gated
+  on `extract_positionals`'s per-line ALL-CAPS loop finding nothing at all,
+  and here that loop already reads `FILESYSTEM`. A new, independent function,
+  `recover_leading_numbered_pair` (`mandible-extract/src/help_text/sections/
+  multiword.rs`), runs unconditionally rather than only on an empty `out`,
+  requires a further operand-shaped group after the pair (a pair with
+  nothing behind it is S-136's own shape), and only ever adds at the front —
+  never replaces — so a tool the loop above already read this pair some
+  other way is untouched. `corpus/mksquashfs/4.6.1` gains the `source`
+  positional; `genccode`'s own pair sits at the true tail (nothing follows)
+  and is declined here by design, staying on S-136's own path unchanged.
+  `linux-version`'s raw text has the same shared-stem-plus-integer shape
+  (`sort [--reverse] [VERSION1 VERSION2 ...]`) but its defect is unrelated:
+  that whole invocation form is a non-primary usage line, and
+  `extract_positionals` only ever reads positionals off the primary one
+  (S-004) — no numbered-pair rule reaches a line `extract_positionals`
+  never visits. Declined here; a fix would mean recovering positionals from
+  every alternate form, a materially larger, riskier change out of this
+  item's scope.
+- fleet: not swept fleet-wide (2 tools/2 findings on the maintainer's own
+  raw grep, both read above); below the five-tool floor. Shipped as a
+  gated exception (docs/design.md §16): `corpus/mksquashfs/4.6.1` gains the
+  assertion and stays passing, the corpus sweep (164 fixtures) shows this
+  fixture as the only change, and all nine named controls stay
+  byte-identical (see gate log). `sqfstar` was checked and is not a member:
+  its own usage has no numbered pair at all.

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2615,13 +2615,17 @@ entry's `tools` field and nothing else. It does not get a new entry.
       SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of
       exclude dirs/files]
 - tools: mksquashfs, sqfstar
-- handling: Open, two shapes. `SYNTAX:` glues straight to the program name with no
-  space, a spelling `starts_with_usage_prefix` never matches, so the whole
-  two-line block reads as leading description prose and no positional is
-  recovered. The second line also continues an unclosed `[` group at
-  column zero, a shape today's continuation rule misses since it only
-  reads a continuation's own first character, never a depth carried over
-  from the line above.
+- handling: Fixed (issue #143), two shapes. `SYNTAX:` glues straight to the
+  program name with no space, so a spelling `starts_with_usage_prefix` never
+  matched and the whole two-line block read as leading description prose with
+  no positional recovered; the label is now split off the program-name token
+  it is glued to. The second line also continues an unclosed `[` group at
+  column zero, which the old continuation rule missed because it read only a
+  continuation's own first character and never a bracket depth carried over
+  from the line above; the depth is carried now. The live binary prints its
+  own absolute path after the label (`SYNTAX:/usr/bin/mksquashfs`) where the
+  issue body quotes `SYNTAX:mksquashfs`, so the rule is written against the
+  label, not against the spelling in the issue.
 - fleet: `usage-label-glued-to-program-name`
   (`xtask/src/detector/usage_label_glued_to_program_name.rs`) reads 8
   tools/8 findings raw on a full-`PATH` sweep of 2323 tools, 2026-09-06;
@@ -2631,8 +2635,13 @@ entry's `tools` field and nothing else. It does not get a new entry.
   (`xtask/src/detector/usage_open_bracket_continues_at_column_zero.rs`)
   reads 2 tools/2 findings raw; one is an ANSI-escape false positive from
   a colored banner, leaving 1 genuine hit. Both real counts are below the
-  five-tool bar. Not shipped; `corpus/mksquashfs/4.6.1` stays xfail with
-  both counts in its reason.
+  five-tool bar, so this ships as a maintainer-named exception (issue #143,
+  docs/design.md §16): `corpus/mksquashfs/4.6.1` and `corpus/sqfstar/4.6.1`
+  both promote out of `[xfail]`, the full-`PATH` sweep-diff is zero-loss and
+  all nine named controls hold. Post-fix the first detector reads 6 tools/6
+  findings (the six doc-URL false positives, both genuine hits gone) and the
+  second 2 tools/2 findings (the ANSI false positive plus one hit outside
+  squashfs-tools). 2026-09-13.
 ### S-143: a lowdown bullet row names a subcommand
 
 - id: S-143
@@ -2826,3 +2835,132 @@ entry's `tools` field and nothing else. It does not get a new entry.
   not gated: 3 are fail2ban-client's own still-open `set`/`add` gap (S-141's
   name rule, not this fix), the rest are false alarms on text that merely
   resembles a label followed by a row. 2026-09-07.
+
+### S-150: a usage label alone on its own line
+
+- id: S-150
+- looks like: |
+      Usage:
+       fdisk [options] <disk>         change partition table
+       fdisk [options] -l [<disk>...] list partition table(s)
+- tools: fdisk, pkcheck, pod2text, gdk-pixbuf-thumbnailer, dmsetup, dmstats,
+  npm, nvim, bpftrace, fsck, pip3, renice, wall, zoxide
+- handling: Fixed, in two places. In extraction, a label alone on its line
+  contributed an entry whose whole content was the literal label text, and
+  that empty entry also consumed the bracketed option run the real form
+  carried underneath; `usage_block` now treats a bare label as a label and
+  reads the lines below it as the forms. In the render layer,
+  `mandible-tui/src/render/detail_pane/usage_form.rs` no longer prints the
+  bare tool name for an entry that has no invocation text of its own. The
+  two halves are separate because the label may be stripped either at parse
+  time or left in the entry text, and a form that loses its label must still
+  be read as the primary synopsis: `recover_primary_tail_operands` therefore
+  treats the `usage:` prefix as optional rather than required, which is the
+  cross-branch regression the integration merge surfaced (`nvim` lost its
+  `file` operand until that was fixed).
+- fleet: `bare-usage-label-form`
+  (`xtask/src/detector/bare_usage_label_form.rs`) reads 0 tools/0 findings
+  post-fix and is ratcheted there. The raw-shape upper bound counted before
+  the round was 300 tools. What actually moved on a full-`PATH` sweep of
+  2323 tools, 2026-09-13: 39 flags GAINED across three tools that nobody had
+  looked at — dmsetup 4 to 29, dmstats 8 to 20, npm 0 to 2 — every one of
+  them documented inside the tool's own bracketed `Usage:` block, plus 25
+  fixtures each losing exactly one usage entry whose content was the literal
+  string `Usage:` or `USAGE:`. Zero subcommand movement, all nine named
+  controls byte-identical.
+
+### S-151: a usage form's leading word is a foreign program name
+
+- id: S-151
+- looks like: |
+      Usage: /usr/bin/ranlib [options] archive
+      Advanced usage:
+      /usr/bin/perlthanks  [-v] [-a address] [-s subject]
+- tools: gcc-ranlib-13, perlthanks, perlbug, qemu-riscv64-static and the
+  qemu-*-static family
+- handling: Fixed at the render layer, so the raw text the `t` pane shows is
+  untouched. A usage form whose leading word names a program other than the
+  node has that word replaced by the node's own name. The rule is NARROW on
+  purpose, and an existing test is the fence: an absolute or relative PATH
+  always qualifies, because a usage line's program position cannot hold a
+  sibling's path, while a BARE word qualifies only when it is a prefix of the
+  node's own name. `perlthanks` also gains a usage section it did not have at
+  all, because a block whose form lines open with an absolute path was not
+  recognized as a usage block. Refused by the narrowing, and named here as a
+  miss rather than left silent: `tclobjnew-bpfcc`'s form opens `uobjnew`,
+  which is neither a path nor a prefix, so `mandible tclobjnew-bpfcc` still
+  renders `tclobjnew-bpfcc uobjnew [-h] ...`. The alternative — replacing any
+  bare word — deletes a real word from the render (`egrep` under node `grep`)
+  and AGENTS.md §3.9 forbids it.
+- fleet: `usage-foreign-program-word`
+  (`xtask/src/detector/usage_foreign_program_word.rs`) reads 253 tools/274
+  findings post-fix on a full-`PATH` sweep of 2323 tools, 2026-09-13, which
+  is the refused remainder: a leading bare word that is neither a path nor a
+  prefix of the node name. Reported, not gated, because the fix is a render
+  substitution and the counted shape is the text, not the tree. Zero flag
+  losses and zero subcommand movement fleet-wide.
+
+### S-152: a usage form carries its own trailing description
+
+- id: S-152
+- looks like: |
+       fdisk [options] <disk>         change partition table
+        gdk-pixbuf-thumbnailer [OPTION…] [INPUT FILE] [OUTPUT FILE] Thumbnail images
+       /usr/bin/ranlib [options] archive
+        Generate an index to speed access to archives
+- tools: fdisk, gcc-ranlib-13, gdk-pixbuf-thumbnailer
+- handling: Open. The prose belongs to the form, not to the invocation, and
+  it renders glued onto the end of the usage line: `mandible fdisk` shows
+  `fdisk [options] <disk> change partition table`. Nothing is lost, so this
+  is a presentation defect rather than an AGENTS.md §3.9 one, which is why it
+  was left when the round ran out of worker time. The cut is ambiguous in
+  both directions — a column gap separates the two on `fdisk`, a single space
+  on `gdk-pixbuf-thumbnailer`, and a whole following line on `gcc-ranlib-13`
+  — so a rule needs all three cases at once or it will eat an operand.
+- fleet: not measured. No detector was built for this shape this round, so
+  there is no number to quote and the three tools above are the whole
+  evidence.
+
+### S-153: a usage line's tail operands never reach the tree
+
+- id: S-153
+- looks like: |
+      Usage: cache_repair [options] {device|file}
+      usage: fc-scan [-bcVh] [-f FORMAT] ... [--help] font-file...
+      Usage: lcf  [options] dest_file  src_dir
+- tools: cache_repair, fc-scan, apt-mark, jdeprscan, lcf
+- handling: Fixed for the shapes evidence can settle, refused for the rest.
+  A trailing operand run after a bracketed option run now reaches the tree as
+  positionals: a brace alternation naming one operand becomes one positional
+  keeping its source spelling and its members as choices (`{device|file}`), a
+  single ellipsis-marked name becomes one repeatable positional
+  (`font-file...`), and a flag paired with an ALL-CAPS value on the same line
+  no longer ends the walk. The description-gap cut that ran before the walk
+  also used a two-space gap, which truncated a line whose own operands are
+  two-space padded. REFUSED, and this is the honest part: a bare multi-word
+  tail with no numbering and no delimiter (`lcf`'s `dest_file  src_dir`)
+  stays declined by the round-6 `[options] command` ambiguity guard, because
+  nothing in the text says whether the words are two operands or one command
+  plus its argument. `corpus/lcf/3.0043+nmu1` states that outcome instead of
+  asserting a positional it does not get.
+- fleet: a full-`PATH` sweep of 2323 tools, 2026-09-13: `tail_operand_tools`
+  147 to 145, zero flag losses, zero subcommand movement, all nine named
+  controls byte-identical. `multi-operand-usage-tail` (S-109) is unchanged at
+  44 tools/110 findings, which is the ambiguous remainder `lcf` belongs to.
+
+### S-154: a bracketed multi-word operand becomes one positional per word
+
+- id: S-154
+- looks like: |
+        gdk-pixbuf-thumbnailer [OPTION…] [INPUT FILE] [OUTPUT FILE] Thumbnail images
+- tools: gdk-pixbuf-thumbnailer, mknod, sg_format, udevadm, fzf-tmux
+- handling: Fixed. A bracket group holding several words is one operand whose
+  name is the whole run, not one operand per word, so `mandible
+  gdk-pixbuf-thumbnailer` shows two positionals, `INPUT FILE` and `OUTPUT
+  FILE`, where it showed three (`INPUT`, `FILE`, `OUTPUT`) before. The name
+  keeps its source spelling, following S-097's ruling that a glued group is
+  quoted as written.
+- fleet: `trailing-bracket-group-multiword-operand` reads 0 tools/0 findings
+  post-fix on a full-`PATH` sweep of 2323 tools, 2026-09-13, and is ratcheted
+  there. Zero flag losses, zero subcommand movement, all nine named controls
+  byte-identical.

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2908,18 +2908,53 @@ entry's `tools` field and nothing else. It does not get a new entry.
         gdk-pixbuf-thumbnailer [OPTION…] [INPUT FILE] [OUTPUT FILE] Thumbnail images
        /usr/bin/ranlib [options] archive
         Generate an index to speed access to archives
-- tools: fdisk, gcc-ranlib-13, gdk-pixbuf-thumbnailer
-- handling: Open. The prose belongs to the form, not to the invocation, and
-  it renders glued onto the end of the usage line: `mandible fdisk` shows
-  `fdisk [options] <disk> change partition table`. Nothing is lost, so this
-  is a presentation defect rather than an AGENTS.md §3.9 one, which is why it
-  was left when the round ran out of worker time. The cut is ambiguous in
-  both directions — a column gap separates the two on `fdisk`, a single space
-  on `gdk-pixbuf-thumbnailer`, and a whole following line on `gcc-ranlib-13`
-  — so a rule needs all three cases at once or it will eat an operand.
-- fleet: not measured. No detector was built for this shape this round, so
-  there is no number to quote and the three tools above are the whole
-  evidence.
+- tools: fdisk, gcc-ranlib-13, gdk-pixbuf-thumbnailer, nvim, vim.basic
+- handling: Open, measured this round. `grub-macbless` was checked and is
+  NOT a member: its own description sits on its own physical line and
+  already renders as its own `DESCRIPTION` section, correctly. The prose
+  belongs to the form, not to the invocation, and it renders glued onto the
+  end of the usage line: `mandible fdisk` shows `fdisk [options] <disk>
+  change partition table`. Nothing is lost, so this is a presentation defect
+  rather than an AGENTS.md §3.9 one. The cut is ambiguous in three different
+  ways at once — a column gap separates the two on `fdisk` and `nvim`, a
+  single space on `gdk-pixbuf-thumbnailer`, and a whole following physical
+  line that still folds in on `gcc-ranlib-13` — so a rule needs all three
+  cases at once or it will eat an operand.
+  PROPOSAL: split the usage form at the point its own trailing run of
+  groups reads as plain prose (no flag, no bracket/angle group, no
+  ALL-CAPS word) rather than synopsis grammar, mirroring
+  `is_prose_sentence`'s own word-count floor; keep the split half as the
+  form's own trailing description rather than discarding it, so nothing
+  currently rendered is lost, only relocated. COST: touches the same usage-
+  form rendering path several other shipped shapes already narrow
+  (S-108/S-151's foreign-program-word substitution, S-150's bare-label
+  fold), so a regression here risks re-breaking several already-fixed
+  tools at once — this needs the widest zero-loss sweep-diff of any item
+  this round, not the narrowest. RISK: the column-gap cut (`fdisk`, `nvim`)
+  and the single-space cut (`gdk-pixbuf-thumbnailer`) need different
+  thresholds to both fire without one eating a real two-word operand name
+  (S-132/S-154's own shape) or a docopt alternation tail.
+- fleet: `usage-form-trailing-description`
+  (`xtask/src/detector/usage_form_trailing_description.rs`) reads 4
+  tools/6 findings on the 162-fixture `corpus/` tree (not a full-`PATH`
+  sweep — the orchestrator owns that lock), 2026-09-13: `fdisk`,
+  `gcc-ranlib-13`, `nvim`, `vim.basic`. This crosses the five-tool floor
+  once `gdk-pixbuf-thumbnailer` (confirmed by hand, not in `corpus/`) is
+  added, but the detector itself does not yet count it: its own
+  description is two words (`Thumbnail images`), below this detector's
+  three-word floor, and both `gdk-pixbuf-thumbnailer`'s and
+  `gcc-ranlib-13`'s descriptions open on a capitalized word, which the
+  detector's plain-prose-word test (lowercase-led, matching
+  `multiword.rs`'s own `plain_word`) refuses — `gcc-ranlib-13` still fires
+  because six of its own seven words are lowercase, but the true fleet is
+  larger than this detector honestly counts. No fix ships this round: the
+  measured count alone does not clear the bar with confidence, and the
+  zero-loss sweep-diff the gate also requires needs the orchestrator's
+  sweep lock. `corpus/fdisk/2.39.3` and `corpus/gcc-ranlib-13/2.42`
+  (existing, passing fixtures) each gained a one-line note pointing at
+  this entry rather than a new `[xfail]` fixture, since both already pass
+  their own contracts and demoting a passing fixture to note a
+  presentation-only gap would be the wrong direction.
 
 ### S-153: a usage line's tail operands never reach the tree
 

--- a/mandible-extract/src/help_text/sections/heading.rs
+++ b/mandible-extract/src/help_text/sections/heading.rs
@@ -1117,7 +1117,8 @@ mod tests {
         assert_eq!(
             parsed.usage,
             vec![
-                "Usage:".to_string(),
+                // The bare `Usage:` label contributes no form of its own
+                // (docs/shapes.md S-150).
                 "    update-xmlcatalog <options> --add --root --type <type> --id <id> --package <package>"
                     .to_string(),
                 "    update-xmlcatalog <options> --del --root --type <type> --id <id>".to_string(),

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -317,25 +317,48 @@ struct UsageScan {
 
 /// Walk the usage block starting at `start`, folding wrapped continuation
 /// lines into one entry each. See docs/shapes.md S-001 and S-037.
-fn scan_usage_section(
+/// The scan's seeded state, computed from `lines[start]` alone: the block's
+/// own indent, its first entry (empty when the label is bare, S-150), the
+/// parallel line-to-entry index, and any square-bracket depth the seed
+/// line itself leaves open (S-142, issue #143). Split out of
+/// [`scan_usage_section`] to keep that function under the size ceiling.
+struct SeedState {
+    base_indent: usize,
+    usage_entries: Vec<String>,
+    line_entry_index: Vec<usize>,
+    bracket_group_depth: i32,
+    seed_is_bare: bool,
+}
+
+fn seed_usage_scan(
     lines: &[&str],
     start: usize,
-    labelled_usage_start: Option<usize>,
     tool_name: Option<&str>,
     usage_lines: &mut Vec<String>,
-) -> UsageScan {
-    let mut i = start;
-    let base_indent = leading_whitespace(lines[i]);
-    let seed_trimmed = lines[i].trim().to_string();
-    usage_lines.push(seed_trimmed.clone());
+) -> SeedState {
+    let base_indent = leading_whitespace(lines[start]);
+    let seed_trimmed = lines[start].trim().to_string();
+    // A usage label can sit glued directly to the tool's own name with no
+    // space (`mksquashfs`'s `SYNTAX:mksquashfs source1 ...`). Drop the
+    // label before seeding, the same way the render layer already drops a
+    // spaced `usage:`/`or:` label, so the stored entry opens with the
+    // tool's own invocation instead of an unrecognized word. See S-142,
+    // issue #143.
+    let seed_glued_offset =
+        tool_name.and_then(|name| label_glued_to_tool_name(&seed_trimmed, name));
+    let seed_text = match seed_glued_offset {
+        Some(offset) => seed_trimmed[offset..].to_string(),
+        None => seed_trimmed.clone(),
+    };
+    usage_lines.push(seed_text.clone());
     // A usage label alone on its own line ("Usage:" with nothing after
     // it) contributes no form of its own — the real forms sit on the
     // lines below it. See S-150.
-    let seed_is_bare = is_bare_usage_label(&seed_trimmed);
-    let mut usage_entries: Vec<String> = if seed_is_bare {
+    let seed_is_bare = seed_glued_offset.is_none() && is_bare_usage_label(&seed_trimmed);
+    let usage_entries = if seed_is_bare {
         Vec::new()
     } else {
-        vec![seed_trimmed.clone()]
+        vec![seed_text.clone()]
     };
     // Parallel to `usage_lines`: which `usage_entries` index each
     // physical line was folded into — a wrapped entry (sg_sanitize's
@@ -344,7 +367,81 @@ fn scan_usage_section(
     // marks a physical line that opened no entry of its own — a bare
     // usage label, or (rarely) a stray continuation before any entry has
     // started — so it can never coincide with a real entry index.
-    let mut line_entry_index: Vec<usize> = vec![if seed_is_bare { usize::MAX } else { 0usize }];
+    let line_entry_index = vec![if seed_is_bare { usize::MAX } else { 0usize }];
+    // Depth of a square-bracket group still open at the end of the seed
+    // line — `mksquashfs`'s own `[-e list of` never closes before its
+    // line ends, and the continuation `exclude dirs/files]` resumes it at
+    // column zero, a shape the content-shape fallback below cannot see
+    // from the continuation's own first character alone. See S-142,
+    // issue #143.
+    let bracket_group_depth = bracket_depth_delta(&seed_text).max(0);
+    SeedState {
+        base_indent,
+        usage_entries,
+        line_entry_index,
+        bracket_group_depth,
+        seed_is_bare,
+    }
+}
+
+/// Records one physical line already decided to belong to the usage
+/// block: starts a fresh entry, joins the open one, or — reachable only
+/// right after a bare usage label whose very next line fails the
+/// own-name/marker test (bpftrace's own wrapper scripts, `killsnoop.bt`
+/// and siblings, share one generic `USAGE:` block that never repeats the
+/// wrapper's own name) — opens the first entry from this line rather than
+/// dropping it, since the bare label already contributed no text of its
+/// own (S-150) and losing this line outright would violate AGENTS.md
+/// §3.9. Split out of [`scan_usage_section`] to keep that function under
+/// the size ceiling.
+fn record_usage_line(
+    l: &str,
+    starts_new_entry: bool,
+    usage_lines: &mut Vec<String>,
+    usage_entries: &mut Vec<String>,
+    line_entry_index: &mut Vec<usize>,
+) {
+    let trimmed = l.trim().to_string();
+    usage_lines.push(trimmed.clone());
+    if starts_new_entry {
+        // A form keeps the indentation its author gave it (spec §4.1): ip
+        // lines its second form up under the first. Only the display form
+        // carries it; `usage_lines` stays trimmed since it reads tokens,
+        // never columns.
+        usage_entries.push(l.trim_end().to_string());
+    } else if let Some(last) = usage_entries.last_mut() {
+        // The backslash is the join, the same way a single space is
+        // elsewhere: without dropping it, the displayed synopsis reads
+        // `--type <type> \ --id <id>`, a continuation marker stranded
+        // mid-line.
+        if last.ends_with('\\') {
+            last.pop();
+            let trimmed_tail = last.trim_end().len();
+            last.truncate(trimmed_tail);
+        }
+        last.push(' ');
+        last.push_str(&trimmed);
+    } else {
+        usage_entries.push(trimmed);
+    }
+    line_entry_index.push(usage_entries.len() - 1);
+}
+
+fn scan_usage_section(
+    lines: &[&str],
+    start: usize,
+    labelled_usage_start: Option<usize>,
+    tool_name: Option<&str>,
+    usage_lines: &mut Vec<String>,
+) -> UsageScan {
+    let mut i = start;
+    let SeedState {
+        base_indent,
+        mut usage_entries,
+        mut line_entry_index,
+        mut bracket_group_depth,
+        seed_is_bare,
+    } = seed_usage_scan(lines, start, tool_name, usage_lines);
     // Running depth of an open parenthesized alternation group (LVM's
     // "any one is required" convention), tracked only for an
     // unlabelled synopsis: a member row routinely opens with `-`
@@ -574,45 +671,29 @@ fn scan_usage_section(
             // Below the base indent (never above it: `leading_whitespace`
             // is unsigned, so this also covers "equal to"), indentation
             // alone can't distinguish a genuine continuation (lsof) from
-            // the block having ended (du) — fall back to content shape.
-            if leading_whitespace(l) <= base_indent && !looks_like_usage_fragment(trimmed_start) {
+            // the block having ended (du) — fall back to content shape,
+            // unless a square-bracket group opened on an earlier line is
+            // still carried into this one at column zero. See S-142,
+            // issue #143.
+            if leading_whitespace(l) <= base_indent
+                && !looks_like_usage_fragment(trimmed_start)
+                && bracket_group_depth <= 0
+            {
                 break;
             }
         }
-        let trimmed = l.trim().to_string();
-        usage_lines.push(trimmed.clone());
-        if starts_new_entry {
-            // A form keeps the indentation its author gave it (spec
-            // §4.1): ip lines its second form up under the first. Only
-            // the display form carries it; `usage_lines` stays trimmed
-            // since it reads tokens, never columns.
-            usage_entries.push(l.trim_end().to_string());
-            line_entry_index.push(usage_entries.len() - 1);
-        } else if let Some(last) = usage_entries.last_mut() {
-            // The backslash is the join, the same way a single space
-            // is elsewhere: without dropping it, the displayed
-            // synopsis reads `--type <type> \ --id <id>`, a
-            // continuation marker stranded mid-line.
-            if last.ends_with('\\') {
-                last.pop();
-                let trimmed_tail = last.trim_end().len();
-                last.truncate(trimmed_tail);
-            }
-            last.push(' ');
-            last.push_str(&trimmed);
-            line_entry_index.push(usage_entries.len() - 1);
+        bracket_group_depth = if starts_new_entry {
+            bracket_depth_delta(trimmed_start).max(0)
         } else {
-            // No entry has opened yet — only reachable right after a bare
-            // usage label whose very next line fails the own-name/marker
-            // test (bpftrace's own wrapper scripts, `killsnoop.bt` and
-            // siblings, share one generic `USAGE:` block that never
-            // repeats the wrapper's own name). The label already
-            // contributed no text of its own (S-150); this line becomes
-            // the first real form rather than being dropped, which would
-            // lose it outright (AGENTS.md §3.9).
-            usage_entries.push(trimmed.clone());
-            line_entry_index.push(usage_entries.len() - 1);
-        }
+            (bracket_group_depth + bracket_depth_delta(trimmed_start)).max(0)
+        };
+        record_usage_line(
+            l,
+            starts_new_entry,
+            usage_lines,
+            &mut usage_entries,
+            &mut line_entry_index,
+        );
         i += 1;
     }
     // Scoped to a labelled block, never an unlabelled synopsis
@@ -1631,6 +1712,7 @@ fn parse_body(
         starts_with_usage_prefix(t)
             || tool_name.is_some_and(|name| starts_with_name_prefixed_usage(t, name))
             || starts_with_extended_usage_label(t)
+            || tool_name.is_some_and(|name| label_glued_to_tool_name(t, name).is_some())
     });
     let unlabelled_synopsis_start = if labelled_usage_start.is_none() {
         tool_name.and_then(|name| {

--- a/mandible-extract/src/help_text/sections/mod.rs
+++ b/mandible-extract/src/help_text/sections/mod.rs
@@ -326,13 +326,25 @@ fn scan_usage_section(
 ) -> UsageScan {
     let mut i = start;
     let base_indent = leading_whitespace(lines[i]);
-    usage_lines.push(lines[i].trim().to_string());
-    let mut usage_entries = vec![lines[i].trim().to_string()];
+    let seed_trimmed = lines[i].trim().to_string();
+    usage_lines.push(seed_trimmed.clone());
+    // A usage label alone on its own line ("Usage:" with nothing after
+    // it) contributes no form of its own — the real forms sit on the
+    // lines below it. See S-150.
+    let seed_is_bare = is_bare_usage_label(&seed_trimmed);
+    let mut usage_entries: Vec<String> = if seed_is_bare {
+        Vec::new()
+    } else {
+        vec![seed_trimmed.clone()]
+    };
     // Parallel to `usage_lines`: which `usage_entries` index each
     // physical line was folded into — a wrapped entry (sg_sanitize's
     // five-line synopsis) spans several lines but is one entry, and
-    // [`primary_synopsis_lines`] needs every one of them.
-    let mut line_entry_index = vec![0usize];
+    // [`primary_synopsis_lines`] needs every one of them. `usize::MAX`
+    // marks a physical line that opened no entry of its own — a bare
+    // usage label, or (rarely) a stray continuation before any entry has
+    // started — so it can never coincide with a real entry index.
+    let mut line_entry_index: Vec<usize> = vec![if seed_is_bare { usize::MAX } else { 0usize }];
     // Running depth of an open parenthesized alternation group (LVM's
     // "any one is required" convention), tracked only for an
     // unlabelled synopsis: a member row routinely opens with `-`
@@ -352,6 +364,16 @@ fn scan_usage_section(
     // evidence of its own. See `is_bare_or_form_separator`.
     let mut force_new_entry_after_separator = false;
     i += 1;
+    if seed_is_bare {
+        // A bare label may sit on its own physical line with its forms a
+        // blank line further down (`perlthanks`'s `Advanced usage:`, a
+        // blank line, then its two forms) — skip past the gap rather than
+        // ending the block on it, since a bare label already contributed
+        // no content to lose. See S-151, corpus/perlthanks.
+        while i < lines.len() && lines[i].trim().is_empty() {
+            i += 1;
+        }
+    }
     while i < lines.len() {
         let l = lines[i];
         if l.trim().is_empty() {
@@ -565,6 +587,7 @@ fn scan_usage_section(
             // the display form carries it; `usage_lines` stays trimmed
             // since it reads tokens, never columns.
             usage_entries.push(l.trim_end().to_string());
+            line_entry_index.push(usage_entries.len() - 1);
         } else if let Some(last) = usage_entries.last_mut() {
             // The backslash is the join, the same way a single space
             // is elsewhere: without dropping it, the displayed
@@ -577,8 +600,19 @@ fn scan_usage_section(
             }
             last.push(' ');
             last.push_str(&trimmed);
+            line_entry_index.push(usage_entries.len() - 1);
+        } else {
+            // No entry has opened yet — only reachable right after a bare
+            // usage label whose very next line fails the own-name/marker
+            // test (bpftrace's own wrapper scripts, `killsnoop.bt` and
+            // siblings, share one generic `USAGE:` block that never
+            // repeats the wrapper's own name). The label already
+            // contributed no text of its own (S-150); this line becomes
+            // the first real form rather than being dropped, which would
+            // lose it outright (AGENTS.md §3.9).
+            usage_entries.push(trimmed.clone());
+            line_entry_index.push(usage_entries.len() - 1);
         }
-        line_entry_index.push(usage_entries.len() - 1);
         i += 1;
     }
     // Scoped to a labelled block, never an unlabelled synopsis
@@ -1596,6 +1630,7 @@ fn parse_body(
         let t = l.trim_start();
         starts_with_usage_prefix(t)
             || tool_name.is_some_and(|name| starts_with_name_prefixed_usage(t, name))
+            || starts_with_extended_usage_label(t)
     });
     let unlabelled_synopsis_start = if labelled_usage_start.is_none() {
         tool_name.and_then(|name| {

--- a/mandible-extract/src/help_text/sections/multiword.rs
+++ b/mandible-extract/src/help_text/sections/multiword.rs
@@ -162,3 +162,75 @@ pub(super) fn recover_trailing_multiword_operand(
     positional.repeatable = repeatable;
     vec![positional]
 }
+
+/// One synopsis group read as a brace alternation naming exactly one
+/// operand, `(name, required)` — `cache_repair`'s `{device|file}`. The
+/// alternation's own source spelling, braces included, is the operand's
+/// name, the same rule S-097 already applies to a glued optional-value
+/// run: decomposing the notation would lose the fact that exactly one of
+/// the members is meant, not all of them in sequence. `None` unless the
+/// group (brackets trimmed) is nothing but one brace run with at least
+/// one `|` inside and no nested brace. See docs/shapes.md S-153.
+pub(super) fn parse_brace_alternation_group(group: &str) -> Option<(String, bool)> {
+    let required = !group.starts_with('[');
+    let stripped = group.trim_matches(|c| c == '[' || c == ']');
+    if !stripped.starts_with('{') || !stripped.ends_with('}') {
+        return None;
+    }
+    let inner = stripped.get(1..stripped.len() - 1)?;
+    if inner.is_empty() || inner.contains(['{', '}']) || !inner.contains('|') {
+        return None;
+    }
+    Some((stripped.to_string(), required))
+}
+
+/// The bar-separated members named inside a brace alternation's own
+/// spelling (`"{device|file}"` -> `["device", "file"]`), for the
+/// resulting positional's `choices` — the same members a reader would
+/// type. `None` when `name` is not that shape, so a caller never has to
+/// re-check what [`parse_brace_alternation_group`] already established.
+pub(super) fn brace_alternation_members(name: &str) -> Option<Vec<String>> {
+    let inner = name.strip_prefix('{')?.strip_suffix('}')?;
+    Some(inner.split('|').map(str::to_string).collect())
+}
+
+/// Split `word`'s own trailing run of ASCII digits off as an integer,
+/// `None` when there is none or the whole word is digits. Local to this
+/// module; `xtask`'s `numbered-variadic-usage-tail` detector keeps its own
+/// independent copy rather than importing this one, by that detector's
+/// own design (it measures the parser, so it must not share code with
+/// it). See docs/shapes.md S-136.
+fn split_trailing_integer(word: &str) -> Option<(&str, u64)> {
+    let digit_count = word.chars().rev().take_while(char::is_ascii_digit).count();
+    if digit_count == 0 || digit_count == word.len() {
+        return None;
+    }
+    let (stem, digits) = word.split_at(word.len() - digit_count);
+    digits.parse::<u64>().ok().map(|n| (stem, n))
+}
+
+/// The recovered run's own trailing two entries, read as `X1 [X2 ...]`
+/// (docs/shapes.md S-136, issue #141): both plain-word operands (never a
+/// brace alternation), the first required and not itself repeatable, the
+/// second optional and repeatable, both sharing an alphabetic stem and
+/// the second's trailing integer exactly the first's own plus one. The
+/// numbering is the evidence a bare two-word tail (S-109) lacks, so this
+/// collapses the pair to one repeatable operand named by the shared stem
+/// — the same shape `[file...]` already produces (S-101) — rather than
+/// two fixed operands.
+pub(super) fn collapse_numbered_variadic_tail(
+    first: &(String, bool, bool, bool, bool),
+    second: &(String, bool, bool, bool, bool),
+) -> Option<(String, bool, bool, bool, bool)> {
+    let (name1, required1, repeat1, brace1, _) = first;
+    let (name2, required2, repeat2, brace2, _) = second;
+    if *brace1 || *brace2 || !*required1 || *repeat1 || *required2 || !*repeat2 {
+        return None;
+    }
+    let (stem1, n1) = split_trailing_integer(name1)?;
+    let (stem2, n2) = split_trailing_integer(name2)?;
+    if stem1.is_empty() || stem1 != stem2 || n2 != n1 + 1 {
+        return None;
+    }
+    Some((stem1.to_string(), true, true, false, true))
+}

--- a/mandible-extract/src/help_text/sections/multiword.rs
+++ b/mandible-extract/src/help_text/sections/multiword.rs
@@ -103,11 +103,15 @@ pub(super) fn recover_trailing_multiword_operand(
     let Some(line) = usage_lines.get(line_idx) else {
         return Vec::new();
     };
+    // See the sibling comment in `recover_primary_tail_operands`: a bare
+    // usage label (S-150) may already be gone by the time this line
+    // reaches `usage_lines`, so a missing `usage:` falls back to the
+    // whole line rather than refusing.
     let lower = line.to_ascii_lowercase();
-    let Some(idx) = lower.find("usage:") else {
-        return Vec::new();
+    let after: &str = match lower.find("usage:") {
+        Some(idx) => &line[idx + "usage:".len()..],
+        None => line.as_str(),
     };
-    let after = &line[idx + "usage:".len()..];
     let before_desc = cut_before_description_gap(after);
     let groups = group_synopsis_tokens(before_desc.trim());
     // The program name, at least one group ahead of the trailing one, and

--- a/mandible-extract/src/help_text/sections/multiword.rs
+++ b/mandible-extract/src/help_text/sections/multiword.rs
@@ -234,3 +234,210 @@ pub(super) fn collapse_numbered_variadic_tail(
     }
     Some((stem1.to_string(), true, true, false, true))
 }
+
+/// A bracket group that opened on a bare ALL-CAPS word (`extract_positionals`'s
+/// own token loop), closed. `words` pairs each raw token with its own
+/// cleaned (bracket/dot-trimmed) spelling, in source order. Every word
+/// ALL-CAPS and none an option-list placeholder (`mknod`'s `[MAJOR
+/// MINOR]`, `gdk-pixbuf-thumbnailer`'s `[INPUT FILE]`) collapses to one
+/// multi-word operand; otherwise this is exactly the per-word reading a
+/// lone-word ALL-CAPS bracket already gets (`udevadm`'s `[COMMAND
+/// OPTIONS]` keeps `COMMAND`, declines `OPTIONS`) — a batch of the same
+/// tokens behind one bracket, not a new rule, so this never removes a
+/// reading the lone-word branch already gave. See docs/shapes.md S-154.
+pub(super) fn finalize_bare_bracket_group(words: &[(String, String)], line: &str) -> Vec<Entity> {
+    let is_real_word = |w: &str| w.chars().all(|c| c.is_uppercase() || c == '_') && w.len() > 1;
+    if words.len() >= 2
+        && words
+            .iter()
+            .all(|(_, w)| is_real_word(w) && !is_option_list_placeholder(w))
+    {
+        let name = words
+            .iter()
+            .map(|(_, w)| w.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let last_raw = &words.last().expect("length checked above").0;
+        let mut positional = Entity::positional(name, Provenance::single(Source::HelpText));
+        positional.repeatable = token_marks_repetition(last_raw);
+        return vec![positional];
+    }
+    words
+        .iter()
+        .filter(|(_, w)| is_real_word(w) && !is_option_list_placeholder(w))
+        .map(|(raw, word)| {
+            let mut positional =
+                Entity::positional(word.clone(), Provenance::single(Source::HelpText));
+            positional.required = !raw.contains('[') && !line.contains(&format!("[{raw}"));
+            positional.repeatable = token_marks_repetition(raw);
+            positional
+        })
+        .collect()
+}
+
+/// The primary synopsis's own trailing run of operands — atlas S-041
+/// (one operand) generalized to a run of two or more, promoted from
+/// `xtask`'s `unparsed-tail-operand` detector (`xtask/src/tail_operand.rs`).
+/// The token loop above only ever promotes a `<value>` or an `ALL-CAPS`
+/// metavariable; a usage line's own trailing operands (`file`,
+/// `[member-name] [count] archive-file file...`) are neither shape and
+/// went unrecovered even though the synopsis plainly names them. Fires
+/// only when the loop above found nothing, and only for a
+/// one-physical-line primary entry ([`primary_synopsis_lines`]) — a
+/// wrapped synopsis is a harder shape this does not attempt. Each refusal
+/// is documented at its own check, deliberately stricter than the
+/// detector it promotes.
+pub(super) fn recover_primary_tail_operands(
+    usage_lines: &[String],
+    primary_lines: &std::collections::HashSet<usize>,
+) -> Vec<Entity> {
+    let line_idx = match primary_lines.len() {
+        1 => match primary_lines.iter().next() {
+            Some(&i) => i,
+            None => return Vec::new(),
+        },
+        _ => return Vec::new(),
+    };
+    let Some(line) = usage_lines.get(line_idx) else {
+        return Vec::new();
+    };
+    let lower = line.to_ascii_lowercase();
+    let Some(idx) = lower.find("usage:") else {
+        return Vec::new();
+    };
+    let after = &line[idx + "usage:".len()..];
+    let before_desc = cut_before_description_gap(after);
+    let mut groups = group_synopsis_tokens(before_desc.trim());
+    if groups.len() < 2 {
+        return Vec::new();
+    }
+    groups.remove(0); // the program name itself
+
+    // Walk backward from the tail, collecting a run of operand-shaped
+    // groups in reverse source order. A separate ellipsis-only group
+    // (lessecho's bare `file ...`) marks the *next* group popped — the
+    // operand immediately before it in source order — repeatable, same
+    // as a dots suffix glued straight onto a word. See S-101. The fourth
+    // field is true only for a brace-alternation operand
+    // ([`parse_brace_alternation_group`], S-153's `cache_repair` shape);
+    // the fifth is true only once [`collapse_numbered_variadic_tail`] has
+    // replaced a numbered pair with its own single repeatable operand
+    // (S-136), never set here.
+    let mut collected: Vec<(String, bool, bool, bool, bool)> = Vec::new();
+    let mut pending_repeat = false;
+    while let Some(last) = groups.last() {
+        let bare = last.trim_matches(|c| c == '[' || c == ']');
+        if !bare.is_empty() && bare.chars().all(|c| c == '.') {
+            pending_repeat = true;
+            groups.pop();
+            continue;
+        }
+        if let Some((word, required, marker_repeat)) = parse_operand_group(last) {
+            collected.push((
+                word,
+                required,
+                marker_repeat || pending_repeat,
+                false,
+                false,
+            ));
+            pending_repeat = false;
+            groups.pop();
+            continue;
+        }
+        let Some((name, required)) = parse_brace_alternation_group(last) else {
+            break;
+        };
+        collected.push((name, required, pending_repeat, true, false));
+        pending_repeat = false;
+        groups.pop();
+    }
+    if collected.is_empty() {
+        return Vec::new();
+    }
+    collected.reverse(); // restore source order
+
+    // A trailing `X1 [X2 ...]` pair (S-136, issue #141) collapses to one
+    // repeatable operand named by the shared stem before either guard
+    // below runs, since the numbering is itself the evidence that removes
+    // both ambiguities: `apt-extracttemplates` has no earlier group at
+    // all, and `apt-sortpkgs`'s lone `[options]` is the same shape the
+    // "`[options] command`" guard would otherwise decline.
+    if collected.len() >= 2 {
+        let tail = collected.len() - 2;
+        if let Some(collapsed) =
+            collapse_numbered_variadic_tail(&collected[tail], &collected[tail + 1])
+        {
+            collected.truncate(tail);
+            collected.push(collapsed);
+        }
+    }
+
+    // At least one real group must stand between the program name and the
+    // run: a lone bracket group right after the program name (`true`'s
+    // `Usage: true [ignored command line arguments]`) is prose describing
+    // the tool's forgiving argument handling, not a flag list licensing a
+    // trailing operand, and [`parse_operand_group`] must not read its
+    // first word as one. A numbered-variadic tail is exempt: its own
+    // numbering already licenses it with no earlier group at all
+    // (`apt-extracttemplates`).
+    if groups.is_empty() && !collected.iter().all(|c| c.4) {
+        return Vec::new();
+    }
+    // Every group ahead of the run must read as either an option-list
+    // placeholder or a plain flag spelling — `apt-ftparchive`'s lone
+    // `[options]`, or `bashbug`/`lessecho`'s real flag lists. A group
+    // carrying more than a plain flag spelling — an explicit value word
+    // (`-d xy`), a brace-value placeholder (`-b{blocksize}[KMG]`), or a
+    // nested alternation (`[-c|-C] cmd`) — is grammar this rule declines
+    // to reason about, even when the run itself looks clean, and refuses
+    // the whole line rather than guess a boundary.
+    let mut earlier_all_placeholder = true;
+    for earlier in &groups {
+        let earlier_stripped = earlier.trim_matches(|c| c == '[' || c == ']');
+        if ends_with_option_list_placeholder(earlier_stripped) {
+            continue;
+        }
+        // `is_understood_flag_context`'s own leniency (an angle-bracket
+        // metavar pair, a glued no-whitespace cluster) only ever licenses
+        // a *bracketed* group: `btrfs-select-super`'s bare, unbracketed
+        // `-s number dev` glues a required value onto `-s` with no
+        // brackets anywhere on the line, and a bare flag token cannot be
+        // told apart from a genuinely boolean one without that notation —
+        // the same ambiguity `-d xy` carries inside a bracket. See
+        // `a_bare_unbracketed_flag_never_licenses_the_run_behind_it`.
+        if earlier.starts_with('[') && is_understood_flag_context(earlier_stripped) {
+            earlier_all_placeholder = false;
+            continue;
+        }
+        return Vec::new();
+    }
+    // `[options] command`'s shape: a lone placeholder group ahead of a
+    // bare, required first operand reads as easily as "provide a
+    // subcommand" as "provide an operand" — see the doc comment above.
+    // Only the earliest operand in the run sits directly behind the
+    // ambiguous context, so only its own required-ness is checked. A
+    // brace alternation or a numbered-variadic tail is exempt: neither
+    // notation can be mistaken for a bare subcommand name.
+    if earlier_all_placeholder && collected[0].1 && !collected[0].3 && !collected[0].4 {
+        return Vec::new();
+    }
+    collected
+        .into_iter()
+        .map(|(word, required, repeatable, is_brace, _is_numbered)| {
+            let mut positional =
+                Entity::positional(word.clone(), Provenance::single(Source::HelpText));
+            positional.required = required;
+            positional.repeatable = repeatable;
+            // A brace alternation's own members become the positional's
+            // `choices`, when the IR carries choices on a positional (it
+            // does — `Entity::choices` is not flag-only). The name keeps
+            // its source spelling regardless, per S-097's own rule.
+            if is_brace {
+                if let Some(members) = brace_alternation_members(&word) {
+                    positional.choices = members.into_iter().map(Choice::bare).collect();
+                }
+            }
+            positional
+        })
+        .collect()
+}

--- a/mandible-extract/src/help_text/sections/multiword.rs
+++ b/mandible-extract/src/help_text/sections/multiword.rs
@@ -239,6 +239,68 @@ pub(super) fn collapse_numbered_variadic_tail(
     Some((stem1.to_string(), true, true, false, true))
 }
 
+/// A plain-word numbered pair (`source1 source2 ...`) ahead of further
+/// required operands on the primary line — `mksquashfs`'s own
+/// `source1 source2 ... FILESYSTEM`. S-136's own collapse
+/// ([`collapse_numbered_variadic_tail`]) only ever runs from
+/// `recover_primary_tail_operands`, itself gated on the per-line ALL-CAPS
+/// loop in `extract_positionals` finding nothing at all; here that loop
+/// already reads `FILESYSTEM`, so S-136's path never runs and the pair is
+/// silently dropped. Requires a further operand-shaped group after the
+/// pair — a pair with nothing behind it is S-136's own tail shape, already
+/// handled there. See docs/shapes.md S-171.
+pub(super) fn recover_leading_numbered_pair(
+    usage_lines: &[String],
+    primary_lines: &std::collections::HashSet<usize>,
+) -> Option<Entity> {
+    // Unlike the tail-only recovery functions above, this never needs the
+    // primary form folded onto one physical line: the pair and the
+    // operand behind it are both read off the block's own first physical
+    // line, which is the one carrying the program name. A later physical
+    // line (a wrapped continuation, `mksquashfs`'s own second line) never
+    // enters this check.
+    let line_idx = *primary_lines.iter().min()?;
+    let line = usage_lines.get(line_idx)?;
+    let lower = line.to_ascii_lowercase();
+    let after = match lower.find("usage:") {
+        Some(idx) => &line[idx + "usage:".len()..],
+        None => line.as_str(),
+    };
+    let before_desc = cut_before_description_gap(after);
+    let mut groups = group_synopsis_tokens(before_desc.trim());
+    if groups.len() < 4 {
+        return None;
+    }
+    groups.remove(0); // the program name itself
+    for i in 0..groups.len().saturating_sub(2) {
+        let (a, b, c) = (&groups[i], &groups[i + 1], &groups[i + 2]);
+        if a.starts_with('[') || b.starts_with('[') {
+            continue; // a bracketed pair is S-136's own shape, not this one
+        }
+        if c.is_empty() || !c.chars().all(|ch| ch == '.') || c.len() < 2 {
+            continue;
+        }
+        let Some((stem1, n1)) = split_trailing_integer(a) else {
+            continue;
+        };
+        let Some((stem2, n2)) = split_trailing_integer(b) else {
+            continue;
+        };
+        if stem1.is_empty() || stem1 != stem2 || n2 != n1 + 1 {
+            continue;
+        }
+        if i + 3 >= groups.len() {
+            continue; // nothing follows: S-136's own tail shape
+        }
+        let mut positional =
+            Entity::positional(stem1.to_string(), Provenance::single(Source::HelpText));
+        positional.required = true;
+        positional.repeatable = true;
+        return Some(positional);
+    }
+    None
+}
+
 /// A bracket group that opened on a bare ALL-CAPS word (`extract_positionals`'s
 /// own token loop), closed. `words` pairs each raw token with its own
 /// cleaned (bracket/dot-trimmed) spelling, in source order. Every word

--- a/mandible-extract/src/help_text/sections/multiword.rs
+++ b/mandible-extract/src/help_text/sections/multiword.rs
@@ -305,11 +305,14 @@ pub(super) fn recover_primary_tail_operands(
     let Some(line) = usage_lines.get(line_idx) else {
         return Vec::new();
     };
+    // The label is optional. A tool that prints `Usage:` alone on its own
+    // line leaves the primary form carrying no label at all (S-150), and
+    // requiring one here refused every such form.
     let lower = line.to_ascii_lowercase();
-    let Some(idx) = lower.find("usage:") else {
-        return Vec::new();
+    let after = match lower.find("usage:") {
+        Some(idx) => &line[idx + "usage:".len()..],
+        None => line.as_str(),
     };
-    let after = &line[idx + "usage:".len()..];
     let before_desc = cut_before_description_gap(after);
     let mut groups = group_synopsis_tokens(before_desc.trim());
     if groups.len() < 2 {

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -293,6 +293,18 @@ pub(super) fn extract_positionals(
         // second word fell through the ALL-CAPS check below and was
         // invented as its own positional. See docs/shapes.md S-131.
         let mut open_flag_value_depth: i32 = 0;
+        // Whether the walk is inside a bracket group that opened on a bare
+        // (non-flag) ALL-CAPS word and has not yet closed: `mknod`'s
+        // `[MAJOR MINOR]` and `gdk-pixbuf-thumbnailer`'s `[INPUT FILE]`
+        // name one multi-word operand each, not one positional per word.
+        // See docs/shapes.md S-154.
+        let mut bare_group_active = false;
+        let mut bare_group_depth: i32 = 0;
+        // (raw token, cleaned word) pairs, raw kept so the per-word
+        // fallback below can compute `required` and repeatability exactly
+        // the way the lone-word ALL-CAPS branch does for the same token.
+        let mut bare_group_words: Vec<(String, String)> = Vec::new();
+        let mut bare_group_all_caps = true;
         for token in line.split_whitespace() {
             let cleaned = token.trim_matches(|c| c == '[' || c == ']' || c == '.');
             let opens = token.matches('[').count() as i32;
@@ -328,6 +340,85 @@ pub(super) fn extract_positionals(
             prev_was_self_closed_group = token.starts_with('[') && token.ends_with(']');
 
             if cleaned.starts_with('-') || consumed_by_prior_flag {
+                continue;
+            }
+            // A bracket group opened by a bare ALL-CAPS word that does not
+            // close on the same token collapses to one multi-word operand,
+            // rather than one positional per word inside it, once every
+            // word in the group reads ALL-CAPS and none is an option-list
+            // placeholder (`udevadm`'s `[COMMAND OPTIONS]` and
+            // `aa-features-abi`'s `[OUTPUT OPTIONS]` name further flags,
+            // not a second operand). When the group does not qualify, it
+            // falls back to exactly the per-token reading a lone-word
+            // bracket already gets below — every ALL-CAPS, non-placeholder
+            // word inside becomes its own positional, `COMMAND` kept and
+            // `OPTIONS` declined — so this rule only adds a reading, never
+            // removes the one already there. See docs/shapes.md S-154.
+            if bare_group_active {
+                bare_group_depth += opens - closes;
+                if !cleaned.is_empty() {
+                    let word_all_caps =
+                        cleaned.chars().all(|c| c.is_uppercase() || c == '_') && cleaned.len() > 1;
+                    bare_group_all_caps &= word_all_caps && !is_option_list_placeholder(cleaned);
+                    bare_group_words.push((token.to_string(), cleaned.to_string()));
+                }
+                if bare_group_depth <= 0 {
+                    if bare_group_words.len() >= 2 && bare_group_all_caps {
+                        let name = bare_group_words
+                            .iter()
+                            .map(|(_, w)| w.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        if seen.insert(name.clone()) {
+                            let mut positional =
+                                Entity::positional(name, Provenance::single(Source::HelpText));
+                            positional.required = false;
+                            positional.repeatable = token_marks_repetition(token);
+                            out.push(positional);
+                        }
+                    } else {
+                        // The exact per-word reading the lone-word ALL-CAPS
+                        // branch below already gives each of these tokens —
+                        // this group merely batched several of them behind
+                        // one bracket. `required`/repeatable are computed
+                        // from each word's own raw token, matching that
+                        // branch exactly, so this fallback changes nothing
+                        // a reader could see.
+                        for (raw, word) in &bare_group_words {
+                            let word_all_caps = word.chars().all(|c| c.is_uppercase() || c == '_')
+                                && word.len() > 1;
+                            if word_all_caps
+                                && !is_option_list_placeholder(word)
+                                && seen.insert(word.clone())
+                            {
+                                let required =
+                                    !raw.contains('[') && !line.contains(&format!("[{raw}"));
+                                let mut positional = Entity::positional(
+                                    word.clone(),
+                                    Provenance::single(Source::HelpText),
+                                );
+                                positional.required = required;
+                                positional.repeatable = token_marks_repetition(raw);
+                                out.push(positional);
+                            }
+                        }
+                    }
+                    bare_group_active = false;
+                    bare_group_words.clear();
+                    bare_group_all_caps = true;
+                }
+                continue;
+            }
+            if token.starts_with('[')
+                && opens > closes
+                && cleaned.chars().all(|c| c.is_uppercase() || c == '_')
+                && cleaned.len() > 1
+                && !is_option_list_placeholder(cleaned)
+            {
+                bare_group_active = true;
+                bare_group_depth = opens - closes;
+                bare_group_words = vec![(token.to_string(), cleaned.to_string())];
+                bare_group_all_caps = true;
                 continue;
             }
             let (name, variadic) = if let Some(stripped) = cleaned.strip_prefix('<') {
@@ -367,7 +458,17 @@ pub(super) fn extract_positionals(
     out
 }
 
-/// `s` cut at the first run of [`MIN_COLUMN_GAP_SPACES`] or more
+/// The gap width [`cut_before_description_gap`] treats as a description
+/// boundary rather than an operand-column separator. Wider than
+/// [`MIN_COLUMN_GAP_SPACES`] deliberately: `lcf`'s own usage line pads its
+/// program name and its two operands with exactly two spaces each
+/// (`"lcf  [options] dest_file  src_dir"`), which is column alignment
+/// inside the synopsis, not a trailing description — cutting there lost
+/// the whole tail. Three or more spaces stays a real description boundary
+/// (`vim.basic`'s seven-space gap). See docs/shapes.md S-153.
+const TAIL_OPERAND_GAP_SPACES: usize = 3;
+
+/// `s` cut at the first run of [`TAIL_OPERAND_GAP_SPACES`] or more
 /// consecutive spaces — the description-column boundary a usage line's
 /// own inline trailing prose sits behind (`vim.basic`'s `edit specified
 /// file(s)`, right after `[file ..]` on the very same physical line).
@@ -383,7 +484,7 @@ pub(super) fn cut_before_description_gap(s: &str) -> &str {
                 run_start = Some(i);
             }
             run += 1;
-            if run >= MIN_COLUMN_GAP_SPACES {
+            if run >= TAIL_OPERAND_GAP_SPACES {
                 return &s[..run_start.unwrap()];
             }
         } else {
@@ -460,13 +561,14 @@ fn ends_with_option_list_placeholder(stripped: &str) -> bool {
 
 /// True when a bracket group ahead of a recovered operand run is grammar
 /// this rule already understands beyond a plain flag spelling
-/// ([`is_clean_flag_group`]): a flag paired with angle-bracket metavars
-/// (`--plugin <name>`), or a glued cluster with no internal whitespace at
-/// all (`ar`'s own `[-]{dmpqrstx}[abcDfilMNoOPsSTuvV]`), which cannot
-/// smuggle in a bare word that might double as an operand — the ambiguity
-/// a bare-word value (`-d xy`, `-f font`) still carries and this rule
-/// declines to reason about. See `a_non_clean_flag_earlier_group_refuses_the_whole_line`
-/// and `ars_own_flag_cluster_and_metavar_license_the_recovered_run`.
+/// ([`is_clean_flag_group`]): angle-bracket metavars (`--plugin <name>`),
+/// an ALL-CAPS metavar (`fc-scan`'s `-f FORMAT`), or a glued no-whitespace
+/// cluster (`ar`'s `[-]{dmpqrstx}[abcDfilMNoOPsSTuvV]`) — none can
+/// smuggle in a bare word that might double as an operand, unlike a
+/// *lowercase* bare value (`-d xy`), which stays declined. Case is the
+/// discriminator: ALL-CAPS is already this parser's own metavar
+/// convention. See `ars_own_flag_cluster_and_metavar_license_the_recovered_run`
+/// and docs/shapes.md S-153.
 fn is_understood_flag_context(stripped: &str) -> bool {
     if is_clean_flag_group(stripped) {
         return true;
@@ -479,7 +581,10 @@ fn is_understood_flag_context(stripped: &str) -> bool {
         return false;
     };
     is_clean_flag_group(first)
-        && words.all(|w| w.starts_with('<') && w.ends_with('>') && w.len() > 2)
+        && words.all(|w| {
+            (w.starts_with('<') && w.ends_with('>') && w.len() > 2)
+                || (w.chars().all(|c| c.is_uppercase() || c == '_') && w.len() > 1)
+        })
 }
 
 /// One synopsis group, its own outer brackets (if any) still attached, as
@@ -562,8 +667,13 @@ fn recover_primary_tail_operands(
     // groups in reverse source order. A separate ellipsis-only group
     // (lessecho's bare `file ...`) marks the *next* group popped — the
     // operand immediately before it in source order — repeatable, same
-    // as a dots suffix glued straight onto a word. See S-101.
-    let mut collected: Vec<(String, bool, bool)> = Vec::new();
+    // as a dots suffix glued straight onto a word. See S-101. The fourth
+    // field is true only for a brace-alternation operand
+    // ([`parse_brace_alternation_group`], S-153's `cache_repair` shape);
+    // the fifth is true only once [`collapse_numbered_variadic_tail`] has
+    // replaced a numbered pair with its own single repeatable operand
+    // (S-136), never set here.
+    let mut collected: Vec<(String, bool, bool, bool, bool)> = Vec::new();
     let mut pending_repeat = false;
     while let Some(last) = groups.last() {
         let bare = last.trim_matches(|c| c == '[' || c == ']');
@@ -572,10 +682,22 @@ fn recover_primary_tail_operands(
             groups.pop();
             continue;
         }
-        let Some((word, required, marker_repeat)) = parse_operand_group(last) else {
+        if let Some((word, required, marker_repeat)) = parse_operand_group(last) {
+            collected.push((
+                word,
+                required,
+                marker_repeat || pending_repeat,
+                false,
+                false,
+            ));
+            pending_repeat = false;
+            groups.pop();
+            continue;
+        }
+        let Some((name, required)) = parse_brace_alternation_group(last) else {
             break;
         };
-        collected.push((word, required, marker_repeat || pending_repeat));
+        collected.push((name, required, pending_repeat, true, false));
         pending_repeat = false;
         groups.pop();
     }
@@ -584,13 +706,31 @@ fn recover_primary_tail_operands(
     }
     collected.reverse(); // restore source order
 
+    // A trailing `X1 [X2 ...]` pair (S-136, issue #141) collapses to one
+    // repeatable operand named by the shared stem before either guard
+    // below runs, since the numbering is itself the evidence that removes
+    // both ambiguities: `apt-extracttemplates` has no earlier group at
+    // all, and `apt-sortpkgs`'s lone `[options]` is the same shape the
+    // "`[options] command`" guard would otherwise decline.
+    if collected.len() >= 2 {
+        let tail = collected.len() - 2;
+        if let Some(collapsed) =
+            collapse_numbered_variadic_tail(&collected[tail], &collected[tail + 1])
+        {
+            collected.truncate(tail);
+            collected.push(collapsed);
+        }
+    }
+
     // At least one real group must stand between the program name and the
     // run: a lone bracket group right after the program name (`true`'s
     // `Usage: true [ignored command line arguments]`) is prose describing
     // the tool's forgiving argument handling, not a flag list licensing a
     // trailing operand, and [`parse_operand_group`] must not read its
-    // first word as one.
-    if groups.is_empty() {
+    // first word as one. A numbered-variadic tail is exempt: its own
+    // numbering already licenses it with no earlier group at all
+    // (`apt-extracttemplates`).
+    if groups.is_empty() && !collected.iter().all(|c| c.4) {
         return Vec::new();
     }
     // Every group ahead of the run must read as either an option-list
@@ -625,16 +765,28 @@ fn recover_primary_tail_operands(
     // bare, required first operand reads as easily as "provide a
     // subcommand" as "provide an operand" — see the doc comment above.
     // Only the earliest operand in the run sits directly behind the
-    // ambiguous context, so only its own required-ness is checked.
-    if earlier_all_placeholder && collected[0].1 {
+    // ambiguous context, so only its own required-ness is checked. A
+    // brace alternation or a numbered-variadic tail is exempt: neither
+    // notation can be mistaken for a bare subcommand name.
+    if earlier_all_placeholder && collected[0].1 && !collected[0].3 && !collected[0].4 {
         return Vec::new();
     }
     collected
         .into_iter()
-        .map(|(word, required, repeatable)| {
-            let mut positional = Entity::positional(word, Provenance::single(Source::HelpText));
+        .map(|(word, required, repeatable, is_brace, _is_numbered)| {
+            let mut positional =
+                Entity::positional(word.clone(), Provenance::single(Source::HelpText));
             positional.required = required;
             positional.repeatable = repeatable;
+            // A brace alternation's own members become the positional's
+            // `choices`, when the IR carries choices on a positional (it
+            // does — `Entity::choices` is not flag-only). The name keeps
+            // its source spelling regardless, per S-097's own rule.
+            if is_brace {
+                if let Some(members) = brace_alternation_members(&word) {
+                    positional.choices = members.into_iter().map(Choice::bare).collect();
+                }
+            }
             positional
         })
         .collect()
@@ -3074,14 +3226,23 @@ mod tests {
         assert_eq!(names, vec!["target"], "{names:?}");
     }
 
-    /// `apt-extracttemplates`-shaped: several bare operands, not a flag
-    /// list plus one trailing operand. `file1` earlier on the line is
-    /// itself bare and non-flag, so the earlier-groups gate must refuse
-    /// the whole line rather than claim `file2`.
+    /// `apt-extracttemplates`'s own shape (docs/shapes.md S-136, issue
+    /// #141): `file1` and `file2` are not two arbitrary bare operands,
+    /// they are the same stem numbered in sequence, which is evidence a
+    /// bare multi-operand tail (S-109, see `psfaddtable` below) lacks.
+    /// The numbering licenses the collapse even with no earlier group at
+    /// all standing between the program name and the run.
     #[test]
-    fn apt_extracttemplates_shaped_multiple_bare_operands_gain_no_positional() {
+    fn apt_extracttemplates_shaped_numbered_tail_collapses_to_one_repeatable_positional() {
         let parsed = parse("Usage: apt-extracttemplates file1 [file2 ...]\n");
-        assert!(parsed.positionals.is_empty(), "{:?}", parsed.positionals);
+        let names: Vec<&str> = parsed
+            .positionals
+            .iter()
+            .map(|p| p.primary_name())
+            .collect();
+        assert_eq!(names, vec!["file"], "{:?}", parsed.positionals);
+        assert!(parsed.positionals[0].required);
+        assert!(parsed.positionals[0].repeatable);
     }
 
     /// `psfaddtable`-shaped: the identical several-bare-operands shape

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -88,6 +88,52 @@ pub fn is_bare_usage_label(t: &str) -> bool {
     starts_with_extended_usage_label(trimmed)
 }
 
+/// True when `t`, trimmed, opens with an alphabetic label of 2 to 20
+/// characters, a colon, and immediately (no space) the tool's own `name`
+/// at a word boundary — `mksquashfs`'s `SYNTAX:mksquashfs source1 ...`.
+/// Distinct from the two already-recognized markers (`usage:`, `or:`),
+/// which are matched regardless of what follows; a label glued straight
+/// to unrelated text, or to the name with a space, does not qualify.
+/// Mirrors `xtask`'s `usage_label_glued_to_program_name` detector, kept as
+/// an independent copy per this crate's convention of never depending on
+/// `xtask`. Returns the byte offset in `t` where the tool's own name
+/// begins, so the caller can drop the label. See S-142, issue #143.
+pub fn label_glued_to_tool_name(t: &str, name: &str) -> Option<usize> {
+    if name.is_empty() {
+        return None;
+    }
+    let colon_idx = t.find(':')?;
+    let label = &t[..colon_idx];
+    if label.len() < 2 || label.len() > 20 || !label.chars().all(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    if label.eq_ignore_ascii_case("usage") || label.eq_ignore_ascii_case("or") {
+        return None;
+    }
+    let after_idx = colon_idx + 1;
+    let after = t.get(after_idx..)?;
+    if after.is_empty() || after.starts_with(char::is_whitespace) {
+        return None;
+    }
+    // A URL scheme (`https://github.com/ajeetdsouza/zoxide`) glues its own
+    // colon straight to a `//` authority, and its path's own basename
+    // routinely coincides with the tool's own name (a homepage on the
+    // tool's own domain) — the false positive S-142's own atlas entry
+    // names. Never a usage label.
+    if after.starts_with("//") {
+        return None;
+    }
+    let first_token = after.split_whitespace().next().unwrap_or(after);
+    let basename = first_token.rsplit('/').next().unwrap_or(first_token);
+    let rest = basename.strip_prefix(name)?;
+    let boundary_ok = rest.is_empty()
+        || !rest
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+    boundary_ok.then_some(after_idx)
+}
+
 /// True if `t` (already trimmed of leading whitespace) begins with `name`
 /// at a word boundary. Lets a tool that repeats its own name across lines
 /// with no `or:`/`usage:` marker read as two entries rather than one
@@ -224,6 +270,19 @@ pub(super) fn looks_like_stanza_continuation_head(lines: &[&str], idx: usize, na
 /// S-037.
 pub(super) fn looks_like_usage_fragment(t: &str) -> bool {
     matches!(t.as_bytes().first(), Some(b'[') | Some(b'<') | Some(b'{'))
+}
+
+/// Net `[`/`]` balance of one physical line: positive means more opens
+/// than closes, so the group is still open at the line's end. Used to
+/// carry an unclosed group's depth across a line break, since a
+/// continuation's own first character alone cannot say a bracket opened
+/// earlier is still pending. See S-142, issue #143.
+pub(super) fn bracket_depth_delta(t: &str) -> i32 {
+    t.chars().fold(0i32, |acc, c| match c {
+        '[' => acc + 1,
+        ']' => acc - 1,
+        _ => acc,
+    })
 }
 
 /// Recover the mode-selecting flag a stanza head line itself names

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -506,6 +506,18 @@ pub(super) fn extract_positionals(
             out.push(positional);
         }
     }
+    // A numbered pair (`source1 source2 ...`) ahead of further operands the
+    // loop above already found (`mksquashfs`'s own `FILESYSTEM`) is never
+    // reached by the tail-only recovery below, since `out` is no longer
+    // empty by the time it would run. Runs unconditionally and only ever
+    // adds at the front — the pair always precedes whatever the loop above
+    // found, by this function's own "more follows" requirement. See
+    // docs/shapes.md S-171.
+    if let Some(pair) = recover_leading_numbered_pair(usage_lines, &primary_lines) {
+        if !out.iter().any(|e| e.primary_name() == pair.primary_name()) {
+            out.insert(0, pair);
+        }
+    }
     if out.is_empty() {
         out.extend(recover_primary_tail_operands(usage_lines, &primary_lines));
     }

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -39,6 +39,55 @@ pub fn is_bare_or_form_separator(t: &str) -> bool {
     t.trim().trim_end_matches(':').eq_ignore_ascii_case("or")
 }
 
+/// True if `t`, trimmed, is a short label ending in the word `usage`
+/// (case-insensitive), a colon, and nothing else — `perlthanks`'s
+/// `Advanced usage:`, distinct from the literal `usage:`
+/// [`starts_with_usage_prefix`] alone matches. At most three words, every
+/// one plain ASCII alphabetic, so a sentence that merely ends near the
+/// word `usage` never qualifies. See S-151, `corpus/perlthanks`.
+pub fn starts_with_extended_usage_label(t: &str) -> bool {
+    let Some(head) = t.trim().strip_suffix(':') else {
+        return false;
+    };
+    let words: Vec<&str> = head.split_whitespace().collect();
+    if words.is_empty() || words.len() > 3 {
+        return false;
+    }
+    if !words
+        .last()
+        .expect("checked non-empty above")
+        .eq_ignore_ascii_case("usage")
+    {
+        return false;
+    }
+    words
+        .iter()
+        .all(|w| !w.is_empty() && w.chars().all(|c| c.is_ascii_alphabetic()))
+}
+
+/// True if `t`, trimmed, is only a usage label with nothing after it on
+/// the same line: the literal `usage:`/`or:` markers with an empty
+/// remainder, or [`starts_with_extended_usage_label`]'s generalized form
+/// (which by construction carries no remainder either). `fdisk`'s bare
+/// `Usage:` line is this shape; the two real forms sit on the lines below
+/// it. See S-150.
+pub fn is_bare_usage_label(t: &str) -> bool {
+    let trimmed = t.trim();
+    if starts_with_usage_prefix(trimmed) {
+        return trimmed
+            .get(6..)
+            .map(|rest| rest.trim().is_empty())
+            .unwrap_or(true);
+    }
+    if starts_with_or_marker(trimmed) {
+        return trimmed
+            .get(3..)
+            .map(|rest| rest.trim().is_empty())
+            .unwrap_or(true);
+    }
+    starts_with_extended_usage_label(trimmed)
+}
+
 /// True if `t` (already trimmed of leading whitespace) begins with `name`
 /// at a word boundary. Lets a tool that repeats its own name across lines
 /// with no `or:`/`usage:` marker read as two entries rather than one
@@ -546,11 +595,15 @@ fn recover_primary_tail_operands(
     let Some(line) = usage_lines.get(line_idx) else {
         return Vec::new();
     };
+    // A bare usage label contributes no entry of its own (S-150), so the
+    // primary line no longer carries a literal `usage:` prefix once one
+    // was dropped — fall back to the whole line so the program name is
+    // still `groups[0]` to remove below.
     let lower = line.to_ascii_lowercase();
-    let Some(idx) = lower.find("usage:") else {
-        return Vec::new();
+    let after: &str = match lower.find("usage:") {
+        Some(idx) => &line[idx + "usage:".len()..],
+        None => line.as_str(),
     };
-    let after = &line[idx + "usage:".len()..];
     let before_desc = cut_before_description_gap(after);
     let mut groups = group_synopsis_tokens(before_desc.trim());
     if groups.len() < 2 {

--- a/mandible-extract/src/help_text/sections/usage.rs
+++ b/mandible-extract/src/help_text/sections/usage.rs
@@ -300,11 +300,11 @@ pub(super) fn extract_positionals(
         // See docs/shapes.md S-154.
         let mut bare_group_active = false;
         let mut bare_group_depth: i32 = 0;
-        // (raw token, cleaned word) pairs, raw kept so the per-word
-        // fallback below can compute `required` and repeatability exactly
-        // the way the lone-word ALL-CAPS branch does for the same token.
+        // (raw token, cleaned word) pairs, raw kept so
+        // `finalize_bare_bracket_group` can compute `required` and
+        // repeatability exactly the way the lone-word ALL-CAPS branch
+        // below does for the same token.
         let mut bare_group_words: Vec<(String, String)> = Vec::new();
-        let mut bare_group_all_caps = true;
         for token in line.split_whitespace() {
             let cleaned = token.trim_matches(|c| c == '[' || c == ']' || c == '.');
             let opens = token.matches('[').count() as i32;
@@ -343,69 +343,22 @@ pub(super) fn extract_positionals(
                 continue;
             }
             // A bracket group opened by a bare ALL-CAPS word that does not
-            // close on the same token collapses to one multi-word operand,
-            // rather than one positional per word inside it, once every
-            // word in the group reads ALL-CAPS and none is an option-list
-            // placeholder (`udevadm`'s `[COMMAND OPTIONS]` and
-            // `aa-features-abi`'s `[OUTPUT OPTIONS]` name further flags,
-            // not a second operand). When the group does not qualify, it
-            // falls back to exactly the per-token reading a lone-word
-            // bracket already gets below — every ALL-CAPS, non-placeholder
-            // word inside becomes its own positional, `COMMAND` kept and
-            // `OPTIONS` declined — so this rule only adds a reading, never
-            // removes the one already there. See docs/shapes.md S-154.
+            // close on the same token collapses to one multi-word operand
+            // (`finalize_bare_bracket_group`), rather than one positional
+            // per word inside it. See docs/shapes.md S-154.
             if bare_group_active {
                 bare_group_depth += opens - closes;
                 if !cleaned.is_empty() {
-                    let word_all_caps =
-                        cleaned.chars().all(|c| c.is_uppercase() || c == '_') && cleaned.len() > 1;
-                    bare_group_all_caps &= word_all_caps && !is_option_list_placeholder(cleaned);
                     bare_group_words.push((token.to_string(), cleaned.to_string()));
                 }
                 if bare_group_depth <= 0 {
-                    if bare_group_words.len() >= 2 && bare_group_all_caps {
-                        let name = bare_group_words
-                            .iter()
-                            .map(|(_, w)| w.as_str())
-                            .collect::<Vec<_>>()
-                            .join(" ");
-                        if seen.insert(name.clone()) {
-                            let mut positional =
-                                Entity::positional(name, Provenance::single(Source::HelpText));
-                            positional.required = false;
-                            positional.repeatable = token_marks_repetition(token);
-                            out.push(positional);
-                        }
-                    } else {
-                        // The exact per-word reading the lone-word ALL-CAPS
-                        // branch below already gives each of these tokens —
-                        // this group merely batched several of them behind
-                        // one bracket. `required`/repeatable are computed
-                        // from each word's own raw token, matching that
-                        // branch exactly, so this fallback changes nothing
-                        // a reader could see.
-                        for (raw, word) in &bare_group_words {
-                            let word_all_caps = word.chars().all(|c| c.is_uppercase() || c == '_')
-                                && word.len() > 1;
-                            if word_all_caps
-                                && !is_option_list_placeholder(word)
-                                && seen.insert(word.clone())
-                            {
-                                let required =
-                                    !raw.contains('[') && !line.contains(&format!("[{raw}"));
-                                let mut positional = Entity::positional(
-                                    word.clone(),
-                                    Provenance::single(Source::HelpText),
-                                );
-                                positional.required = required;
-                                positional.repeatable = token_marks_repetition(raw);
-                                out.push(positional);
-                            }
+                    for p in finalize_bare_bracket_group(&bare_group_words, line) {
+                        if seen.insert(p.primary_name().to_string()) {
+                            out.push(p);
                         }
                     }
                     bare_group_active = false;
                     bare_group_words.clear();
-                    bare_group_all_caps = true;
                 }
                 continue;
             }
@@ -418,7 +371,6 @@ pub(super) fn extract_positionals(
                 bare_group_active = true;
                 bare_group_depth = opens - closes;
                 bare_group_words = vec![(token.to_string(), cleaned.to_string())];
-                bare_group_all_caps = true;
                 continue;
             }
             let (name, variadic) = if let Some(stripped) = cleaned.strip_prefix('<') {
@@ -552,7 +504,7 @@ fn is_clean_flag_group(stripped: &str) -> bool {
 /// [`is_option_list_placeholder`] itself, whose single-word check this
 /// subsumes. See S-041's earlier-context gate in
 /// [`recover_primary_tail_operands`].
-fn ends_with_option_list_placeholder(stripped: &str) -> bool {
+pub(super) fn ends_with_option_list_placeholder(stripped: &str) -> bool {
     stripped
         .split_whitespace()
         .next_back()
@@ -569,7 +521,7 @@ fn ends_with_option_list_placeholder(stripped: &str) -> bool {
 /// discriminator: ALL-CAPS is already this parser's own metavar
 /// convention. See `ars_own_flag_cluster_and_metavar_license_the_recovered_run`
 /// and docs/shapes.md S-153.
-fn is_understood_flag_context(stripped: &str) -> bool {
+pub(super) fn is_understood_flag_context(stripped: &str) -> bool {
     if is_clean_flag_group(stripped) {
         return true;
     }
@@ -595,7 +547,7 @@ fn is_understood_flag_context(stripped: &str) -> bool {
 /// its first word (`true`'s `[ignored command line arguments]` must not
 /// read `ignored` as an operand). See S-041 and
 /// [`recover_primary_tail_operands`].
-fn parse_operand_group(group: &str) -> Option<(String, bool, bool)> {
+pub(super) fn parse_operand_group(group: &str) -> Option<(String, bool, bool)> {
     let stripped = group.trim_matches(|c| c == '[' || c == ']');
     let mut words = stripped.split_whitespace();
     let raw_word = words.next()?;
@@ -623,173 +575,6 @@ fn parse_operand_group(group: &str) -> Option<(String, bool, bool)> {
     }
     let required = !group.starts_with('[');
     Some((word.to_string(), required, marker_repeat || inline_repeat))
-}
-
-/// The primary synopsis's own trailing run of operands — atlas S-041
-/// (one operand) generalized to a run of two or more, promoted from
-/// `xtask`'s `unparsed-tail-operand` detector (`xtask/src/tail_operand.rs`).
-/// The token loop above only ever promotes a `<value>` or an `ALL-CAPS`
-/// metavariable; a usage line's own trailing operands (`file`,
-/// `[member-name] [count] archive-file file...`) are neither shape and
-/// went unrecovered even though the synopsis plainly names them. Fires
-/// only when the loop above found nothing, and only for a
-/// one-physical-line primary entry ([`primary_synopsis_lines`]) — a
-/// wrapped synopsis is a harder shape this does not attempt. Each refusal
-/// is documented at its own check, deliberately stricter than the
-/// detector it promotes.
-fn recover_primary_tail_operands(
-    usage_lines: &[String],
-    primary_lines: &std::collections::HashSet<usize>,
-) -> Vec<Entity> {
-    let line_idx = match primary_lines.len() {
-        1 => match primary_lines.iter().next() {
-            Some(&i) => i,
-            None => return Vec::new(),
-        },
-        _ => return Vec::new(),
-    };
-    let Some(line) = usage_lines.get(line_idx) else {
-        return Vec::new();
-    };
-    let lower = line.to_ascii_lowercase();
-    let Some(idx) = lower.find("usage:") else {
-        return Vec::new();
-    };
-    let after = &line[idx + "usage:".len()..];
-    let before_desc = cut_before_description_gap(after);
-    let mut groups = group_synopsis_tokens(before_desc.trim());
-    if groups.len() < 2 {
-        return Vec::new();
-    }
-    groups.remove(0); // the program name itself
-
-    // Walk backward from the tail, collecting a run of operand-shaped
-    // groups in reverse source order. A separate ellipsis-only group
-    // (lessecho's bare `file ...`) marks the *next* group popped — the
-    // operand immediately before it in source order — repeatable, same
-    // as a dots suffix glued straight onto a word. See S-101. The fourth
-    // field is true only for a brace-alternation operand
-    // ([`parse_brace_alternation_group`], S-153's `cache_repair` shape);
-    // the fifth is true only once [`collapse_numbered_variadic_tail`] has
-    // replaced a numbered pair with its own single repeatable operand
-    // (S-136), never set here.
-    let mut collected: Vec<(String, bool, bool, bool, bool)> = Vec::new();
-    let mut pending_repeat = false;
-    while let Some(last) = groups.last() {
-        let bare = last.trim_matches(|c| c == '[' || c == ']');
-        if !bare.is_empty() && bare.chars().all(|c| c == '.') {
-            pending_repeat = true;
-            groups.pop();
-            continue;
-        }
-        if let Some((word, required, marker_repeat)) = parse_operand_group(last) {
-            collected.push((
-                word,
-                required,
-                marker_repeat || pending_repeat,
-                false,
-                false,
-            ));
-            pending_repeat = false;
-            groups.pop();
-            continue;
-        }
-        let Some((name, required)) = parse_brace_alternation_group(last) else {
-            break;
-        };
-        collected.push((name, required, pending_repeat, true, false));
-        pending_repeat = false;
-        groups.pop();
-    }
-    if collected.is_empty() {
-        return Vec::new();
-    }
-    collected.reverse(); // restore source order
-
-    // A trailing `X1 [X2 ...]` pair (S-136, issue #141) collapses to one
-    // repeatable operand named by the shared stem before either guard
-    // below runs, since the numbering is itself the evidence that removes
-    // both ambiguities: `apt-extracttemplates` has no earlier group at
-    // all, and `apt-sortpkgs`'s lone `[options]` is the same shape the
-    // "`[options] command`" guard would otherwise decline.
-    if collected.len() >= 2 {
-        let tail = collected.len() - 2;
-        if let Some(collapsed) =
-            collapse_numbered_variadic_tail(&collected[tail], &collected[tail + 1])
-        {
-            collected.truncate(tail);
-            collected.push(collapsed);
-        }
-    }
-
-    // At least one real group must stand between the program name and the
-    // run: a lone bracket group right after the program name (`true`'s
-    // `Usage: true [ignored command line arguments]`) is prose describing
-    // the tool's forgiving argument handling, not a flag list licensing a
-    // trailing operand, and [`parse_operand_group`] must not read its
-    // first word as one. A numbered-variadic tail is exempt: its own
-    // numbering already licenses it with no earlier group at all
-    // (`apt-extracttemplates`).
-    if groups.is_empty() && !collected.iter().all(|c| c.4) {
-        return Vec::new();
-    }
-    // Every group ahead of the run must read as either an option-list
-    // placeholder or a plain flag spelling — `apt-ftparchive`'s lone
-    // `[options]`, or `bashbug`/`lessecho`'s real flag lists. A group
-    // carrying more than a plain flag spelling — an explicit value word
-    // (`-d xy`), a brace-value placeholder (`-b{blocksize}[KMG]`), or a
-    // nested alternation (`[-c|-C] cmd`) — is grammar this rule declines
-    // to reason about, even when the run itself looks clean, and refuses
-    // the whole line rather than guess a boundary.
-    let mut earlier_all_placeholder = true;
-    for earlier in &groups {
-        let earlier_stripped = earlier.trim_matches(|c| c == '[' || c == ']');
-        if ends_with_option_list_placeholder(earlier_stripped) {
-            continue;
-        }
-        // `is_understood_flag_context`'s own leniency (an angle-bracket
-        // metavar pair, a glued no-whitespace cluster) only ever licenses
-        // a *bracketed* group: `btrfs-select-super`'s bare, unbracketed
-        // `-s number dev` glues a required value onto `-s` with no
-        // brackets anywhere on the line, and a bare flag token cannot be
-        // told apart from a genuinely boolean one without that notation —
-        // the same ambiguity `-d xy` carries inside a bracket. See
-        // `a_bare_unbracketed_flag_never_licenses_the_run_behind_it`.
-        if earlier.starts_with('[') && is_understood_flag_context(earlier_stripped) {
-            earlier_all_placeholder = false;
-            continue;
-        }
-        return Vec::new();
-    }
-    // `[options] command`'s shape: a lone placeholder group ahead of a
-    // bare, required first operand reads as easily as "provide a
-    // subcommand" as "provide an operand" — see the doc comment above.
-    // Only the earliest operand in the run sits directly behind the
-    // ambiguous context, so only its own required-ness is checked. A
-    // brace alternation or a numbered-variadic tail is exempt: neither
-    // notation can be mistaken for a bare subcommand name.
-    if earlier_all_placeholder && collected[0].1 && !collected[0].3 && !collected[0].4 {
-        return Vec::new();
-    }
-    collected
-        .into_iter()
-        .map(|(word, required, repeatable, is_brace, _is_numbered)| {
-            let mut positional =
-                Entity::positional(word.clone(), Provenance::single(Source::HelpText));
-            positional.required = required;
-            positional.repeatable = repeatable;
-            // A brace alternation's own members become the positional's
-            // `choices`, when the IR carries choices on a positional (it
-            // does — `Entity::choices` is not flag-only). The name keeps
-            // its source spelling regardless, per S-097's own rule.
-            if is_brace {
-                if let Some(members) = brace_alternation_members(&word) {
-                    positional.choices = members.into_iter().map(Choice::bare).collect();
-                }
-            }
-            positional
-        })
-        .collect()
 }
 
 /// After the usage block, some tools describe each named positional on a

--- a/mandible-tui/src/render/detail_pane/mod.rs
+++ b/mandible-tui/src/render/detail_pane/mod.rs
@@ -12,17 +12,19 @@
 //! defensive fallback against unclipped text (spec §9).
 mod entity;
 mod layout;
+mod usage_form;
 mod wrap;
 
 use entity::*;
 use layout::*;
+use usage_form::*;
 use wrap::*;
 
 use crate::app::{App, Focus};
 use crate::glyphs::Glyphs;
 use crate::sanitize::{defensive_single_line, display_width, truncate_to_width_marker};
 use crate::style;
-use mandible_core::{CommandNode, Dashes, Entity, EntityKind, FlagKey, Spelling, Text, ValueKind};
+use mandible_core::{CommandNode, Dashes, Entity, EntityKind, FlagKey, Spelling, ValueKind};
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
@@ -703,189 +705,6 @@ fn heading_line_ruled(
         spans.push(Span::styled(glyphs.rule.repeat(rule_width), shade));
     }
     Line::from(spans)
-}
-
-/// One usage line, with the redundant `Usage:`/`or:`/node-name prefix
-/// stripped: the heading and label already say that, and a cobra tool's
-/// full-path form (`docker import [OPTIONS]...`) must not double-prepend
-/// the node name either. Fixtures: `corpus/vim.basic/audit-seed4`,
-/// `corpus/cp/9.4`, `docker import`, `smokecli columns outlier`.
-///
-/// One usage form: the column its text began at (leading indent plus any
-/// dropped `Usage:`/`or:` label width), and the text. [`usage_forms`]
-/// compensates with the column.
-fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
-    let name = defensive_single_line(node_name);
-    let raw = defensive_single_line(usage);
-
-    // Tabs are already expanded to spaces at 8-column stops
-    // (`Text::sanitize_preserving_layout`), so counting leading spaces
-    // counts columns.
-    let mut text = raw.trim_start_matches(' ').to_string();
-    let mut column = raw.chars().count() - text.chars().count();
-
-    // Drop a leading `usage:` label, or else a continuation's own `or:`/
-    // `or` marker, case-insensitively; charge its width to the column so
-    // the forms keep the alignment the tool author drew them with.
-    if text
-        .get(..6)
-        .is_some_and(|p| p.eq_ignore_ascii_case("usage:"))
-    {
-        let after = text[6..].trim_start().to_string();
-        column += text.chars().count() - after.chars().count();
-        text = after;
-    } else {
-        let marker_len = or_marker_len(&text);
-        if marker_len > 0 {
-            let after = text[marker_len..].trim_start().to_string();
-            column += text.chars().count() - after.chars().count();
-            text = after;
-        }
-    }
-
-    let text = if name.is_empty() {
-        text
-    } else if let Some((start, end)) = usage_naming_span(&text, &name) {
-        // The help text already names the node, by a path (`cp`'s
-        // `/usr/bin/cp`) or a prefix (`vim.basic`'s `vim`) rather than by
-        // an exact match. Replace that word with the node's own name
-        // instead of leaving it and prepending, which would double it.
-        format!("{}{name}{}", &text[..start], &text[end..])
-    } else if let Some((start, end)) = foreign_program_word_span(&text, &name) {
-        // The form's own leading word is a program name, just not this
-        // node's own spelling or stem (`gcc-ranlib-13`'s own form opens
-        // with `/usr/bin/ranlib`) — the word in a usage line's program
-        // position is the program, whatever it is spelled (docs/design.md
-        // §16), so it is replaced exactly as [`usage_naming_span`]'s own
-        // match is. See S-151.
-        format!("{}{name}{}", &text[..start], &text[end..])
-    } else {
-        format!("{name} {text}")
-    };
-    (column, text)
-}
-
-/// The byte span of `text`'s own very first token, when it reads as a
-/// program name rather than this node's own name or stem: lowercase-led,
-/// no bracket, no angle, not ALL-CAPS, and made only of letters, digits,
-/// `.`, `-`, `_`, `+` or `/`. Deliberately only the first token, never the
-/// whole leading run [`usage_naming_span`] scans — `lldb-server`'s own
-/// form `g[dbserver] [options]` carries a subcommand in that position, and
-/// its embedded bracket already fails the character-set test below, so
-/// this never touches it. See S-151.
-fn foreign_program_word_span(text: &str, name: &str) -> Option<(usize, usize)> {
-    let first = text.split_whitespace().next()?;
-    if looks_like_option_or_placeholder(first) {
-        return None;
-    }
-    // A bare word that CONTAINS the node's own name is a sibling program,
-    // not this one under another spelling (`egrep` under node `grep`), and
-    // replacing it would delete a real word. A path always qualifies: a
-    // usage line's program position cannot hold a sibling's path.
-    if !first.contains('/') && !name.starts_with(first) {
-        return None;
-    }
-    // "Lowercase-led": the token's own first *alphabetic* character is
-    // lowercase, checked past any leading path separators so an absolute
-    // path (`/usr/bin/ranlib`) still qualifies. Excludes a titlecase prose
-    // word (`Generate`) that slipped past the option/placeholder check.
-    let first_alpha = first.chars().find(|c| c.is_alphabetic())?;
-    if !first_alpha.is_ascii_lowercase() {
-        return None;
-    }
-    if !first
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+' | '/'))
-    {
-        return None;
-    }
-    let start = text.find(first)?;
-    Some((start, start + first.len()))
-}
-
-/// The byte length of a leading `or:`/`or ` continuation marker, or `0`.
-/// Reads bytes through `str::get`, never a raw index, so a multi-byte
-/// character straddling the offset degrades to "no marker" instead of
-/// panicking (AGENTS.md's rule against slicing tool output at a byte
-/// offset).
-fn or_marker_len(text: &str) -> usize {
-    if text.get(..3).is_some_and(|p| p.eq_ignore_ascii_case("or:")) {
-        return 3;
-    }
-    if text.as_bytes().get(2) == Some(&b' ')
-        && text.get(..2).is_some_and(|p| p.eq_ignore_ascii_case("or"))
-    {
-        return 2;
-    }
-    0
-}
-
-/// Every usage form, each as the padding it renders behind and its text,
-/// preserving the tool's own relative alignment once the dropped
-/// `Usage: `/`or: ` labels no longer hold each form's position (spec
-/// §4.1). Every form shifts left by the first form's own content column,
-/// so form one lands at the block indent and the rest keep their
-/// relative position; a form indented less than that shift clamps at the
-/// block indent rather than going negative, since a label width can
-/// still outweigh a shallower marker (e.g. a one-column `or ` under a
-/// deeper `Usage: `).
-fn usage_forms(node_name: &str, usage: &[Text]) -> Vec<(usize, String)> {
-    let forms: Vec<(usize, String)> = usage
-        .iter()
-        .map(|u| usage_form(node_name, u.as_str()))
-        .collect();
-    let shift = forms.first().map(|(column, _)| *column).unwrap_or(0);
-    forms
-        .into_iter()
-        .map(|(column, text)| (column.saturating_sub(shift), text))
-        .collect()
-}
-
-/// The byte span of the word in `text`'s leading run of bare command-path
-/// tokens that names the node, if any — see [`usage_form`] for why the
-/// search covers the whole run rather than only the first token.
-fn usage_naming_span(text: &str, name: &str) -> Option<(usize, usize)> {
-    let mut cursor = 0;
-    for token in text.split_whitespace() {
-        let start = cursor + text[cursor..].find(token)?;
-        let end = start + token.len();
-        if looks_like_option_or_placeholder(token) {
-            return None;
-        }
-        if word_names_node(token, name) {
-            return Some((start, end));
-        }
-        cursor = end;
-    }
-    None
-}
-
-/// Whether `word` names the node: an exact match, its basename after the
-/// last `/` (`cp`'s `/usr/bin/cp`), or the node name's own prefix before
-/// its first `.` (`vim.basic`'s `vim`, from a `vim.basic --help` that
-/// still calls itself plain `vim`).
-fn word_names_node(word: &str, name: &str) -> bool {
-    let basename = word.rsplit('/').next().unwrap_or(word);
-    if basename == name {
-        return true;
-    }
-    match name.split_once('.') {
-        Some((prefix, _)) if !prefix.is_empty() => basename == prefix,
-        _ => false,
-    }
-}
-
-/// A token that ends a usage line's leading command-path run: an option
-/// (`-v`, `--verbose`), a bracketed/angled placeholder (`[OPTIONS]`,
-/// `<url>`), or a bare ALL-CAPS metavar (`FILE`, `URL`) — docopt-style
-/// convention for "this is a slot to fill in", never a literal word of the
-/// command path.
-fn looks_like_option_or_placeholder(word: &str) -> bool {
-    if word.starts_with(['-', '[', '<']) {
-        return true;
-    }
-    let has_letter = word.chars().any(|c| c.is_alphabetic());
-    has_letter && !word.chars().any(|c| c.is_lowercase())
 }
 
 /// A group heading with its source's terminator stripped: single-lined,

--- a/mandible-tui/src/render/detail_pane/mod.rs
+++ b/mandible-tui/src/render/detail_pane/mod.rs
@@ -751,10 +751,49 @@ fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
         // an exact match. Replace that word with the node's own name
         // instead of leaving it and prepending, which would double it.
         format!("{}{name}{}", &text[..start], &text[end..])
+    } else if let Some((start, end)) = foreign_program_word_span(&text) {
+        // The form's own leading word is a program name, just not this
+        // node's own spelling or stem (`gcc-ranlib-13`'s own form opens
+        // with `/usr/bin/ranlib`) — the word in a usage line's program
+        // position is the program, whatever it is spelled (docs/design.md
+        // §16), so it is replaced exactly as [`usage_naming_span`]'s own
+        // match is. See S-151.
+        format!("{}{name}{}", &text[..start], &text[end..])
     } else {
         format!("{name} {text}")
     };
     (column, text)
+}
+
+/// The byte span of `text`'s own very first token, when it reads as a
+/// program name rather than this node's own name or stem: lowercase-led,
+/// no bracket, no angle, not ALL-CAPS, and made only of letters, digits,
+/// `.`, `-`, `_`, `+` or `/`. Deliberately only the first token, never the
+/// whole leading run [`usage_naming_span`] scans — `lldb-server`'s own
+/// form `g[dbserver] [options]` carries a subcommand in that position, and
+/// its embedded bracket already fails the character-set test below, so
+/// this never touches it. See S-151.
+fn foreign_program_word_span(text: &str) -> Option<(usize, usize)> {
+    let first = text.split_whitespace().next()?;
+    if looks_like_option_or_placeholder(first) {
+        return None;
+    }
+    // "Lowercase-led": the token's own first *alphabetic* character is
+    // lowercase, checked past any leading path separators so an absolute
+    // path (`/usr/bin/ranlib`) still qualifies. Excludes a titlecase prose
+    // word (`Generate`) that slipped past the option/placeholder check.
+    let first_alpha = first.chars().find(|c| c.is_alphabetic())?;
+    if !first_alpha.is_ascii_lowercase() {
+        return None;
+    }
+    if !first
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+' | '/'))
+    {
+        return None;
+    }
+    let start = text.find(first)?;
+    Some((start, start + first.len()))
 }
 
 /// The byte length of a leading `or:`/`or ` continuation marker, or `0`.

--- a/mandible-tui/src/render/detail_pane/mod.rs
+++ b/mandible-tui/src/render/detail_pane/mod.rs
@@ -751,7 +751,7 @@ fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
         // an exact match. Replace that word with the node's own name
         // instead of leaving it and prepending, which would double it.
         format!("{}{name}{}", &text[..start], &text[end..])
-    } else if let Some((start, end)) = foreign_program_word_span(&text) {
+    } else if let Some((start, end)) = foreign_program_word_span(&text, &name) {
         // The form's own leading word is a program name, just not this
         // node's own spelling or stem (`gcc-ranlib-13`'s own form opens
         // with `/usr/bin/ranlib`) — the word in a usage line's program
@@ -773,9 +773,16 @@ fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
 /// form `g[dbserver] [options]` carries a subcommand in that position, and
 /// its embedded bracket already fails the character-set test below, so
 /// this never touches it. See S-151.
-fn foreign_program_word_span(text: &str) -> Option<(usize, usize)> {
+fn foreign_program_word_span(text: &str, name: &str) -> Option<(usize, usize)> {
     let first = text.split_whitespace().next()?;
     if looks_like_option_or_placeholder(first) {
+        return None;
+    }
+    // A bare word that CONTAINS the node's own name is a sibling program,
+    // not this one under another spelling (`egrep` under node `grep`), and
+    // replacing it would delete a real word. A path always qualifies: a
+    // usage line's program position cannot hold a sibling's path.
+    if !first.contains('/') && !name.starts_with(first) {
         return None;
     }
     // "Lowercase-led": the token's own first *alphabetic* character is

--- a/mandible-tui/src/render/detail_pane/usage_form.rs
+++ b/mandible-tui/src/render/detail_pane/usage_form.rs
@@ -5,15 +5,9 @@
 use crate::sanitize::defensive_single_line;
 use mandible_core::Text;
 
-/// One usage line, with the redundant `Usage:`/`or:`/node-name prefix
-/// stripped: the heading and label already say that, and a cobra tool's
-/// full-path form (`docker import [OPTIONS]...`) must not double-prepend
-/// the node name either. Fixtures: `corpus/vim.basic/audit-seed4`,
-/// `corpus/cp/9.4`, `docker import`, `smokecli columns outlier`.
-///
-/// One usage form: the column its text began at (leading indent plus any
-/// dropped `Usage:`/`or:` label width), and the text. [`usage_forms`]
-/// compensates with the column.
+/// One usage line with its redundant prefix stripped: the `Usage:` or
+/// `or:` label, and the program word the heading already names. Returns
+/// the indentation column the author gave the line. See S-108, S-150.
 pub(super) fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
     let name = defensive_single_line(node_name);
     let raw = defensive_single_line(usage);
@@ -48,16 +42,12 @@ pub(super) fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
     } else if let Some((start, end)) = usage_naming_span(&text, &name) {
         // The help text already names the node, by a path (`cp`'s
         // `/usr/bin/cp`) or a prefix (`vim.basic`'s `vim`) rather than by
-        // an exact match. Replace that word with the node's own name
-        // instead of leaving it and prepending, which would double it.
+        // an exact match, so it is replaced with the node's own name.
         format!("{}{name}{}", &text[..start], &text[end..])
     } else if let Some((start, end)) = foreign_program_word_span(&text, &name) {
         // The form's own leading word is a program name, just not this
         // node's own spelling or stem (`gcc-ranlib-13`'s own form opens
-        // with `/usr/bin/ranlib`) — the word in a usage line's program
-        // position is the program, whatever it is spelled (docs/design.md
-        // §16), so it is replaced exactly as [`usage_naming_span`]'s own
-        // match is. See S-151.
+        // with `/usr/bin/ranlib`), so the same replacement applies.
         format!("{}{name}{}", &text[..start], &text[end..])
     } else {
         format!("{name} {text}")
@@ -65,14 +55,10 @@ pub(super) fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
     (column, text)
 }
 
-/// The byte span of `text`'s own very first token, when it reads as a
-/// program name rather than this node's own name or stem: lowercase-led,
-/// no bracket, no angle, not ALL-CAPS, and made only of letters, digits,
-/// `.`, `-`, `_`, `+` or `/`. Deliberately only the first token, never the
-/// whole leading run [`usage_naming_span`] scans — `lldb-server`'s own
-/// form `g[dbserver] [options]` carries a subcommand in that position, and
-/// its embedded bracket already fails the character-set test below, so
-/// this never touches it. See S-151.
+/// The span of a leading program word that is not this node's own name or
+/// stem (`gcc-ranlib-13`'s form opens `/usr/bin/ranlib`). A path always
+/// qualifies; a bare word only when it prefixes the node's name, so a
+/// sibling (`egrep` under node `grep`) is never replaced. See S-151.
 pub(super) fn foreign_program_word_span(text: &str, name: &str) -> Option<(usize, usize)> {
     let first = text.split_whitespace().next()?;
     if looks_like_option_or_placeholder(first) {
@@ -80,15 +66,13 @@ pub(super) fn foreign_program_word_span(text: &str, name: &str) -> Option<(usize
     }
     // A bare word that CONTAINS the node's own name is a sibling program,
     // not this one under another spelling (`egrep` under node `grep`), and
-    // replacing it would delete a real word. A path always qualifies: a
-    // usage line's program position cannot hold a sibling's path.
+    // replacing it would delete a real word. A path always qualifies.
     if !first.contains('/') && !name.starts_with(first) {
         return None;
     }
     // "Lowercase-led": the token's own first *alphabetic* character is
     // lowercase, checked past any leading path separators so an absolute
-    // path (`/usr/bin/ranlib`) still qualifies. Excludes a titlecase prose
-    // word (`Generate`) that slipped past the option/placeholder check.
+    // path (`/usr/bin/ranlib`) still qualifies.
     let first_alpha = first.chars().find(|c| c.is_alphabetic())?;
     if !first_alpha.is_ascii_lowercase() {
         return None;
@@ -104,10 +88,8 @@ pub(super) fn foreign_program_word_span(text: &str, name: &str) -> Option<(usize
 }
 
 /// The byte length of a leading `or:`/`or ` continuation marker, or `0`.
-/// Reads bytes through `str::get`, never a raw index, so a multi-byte
-/// character straddling the offset degrades to "no marker" instead of
-/// panicking (AGENTS.md's rule against slicing tool output at a byte
-/// offset).
+/// Reads through `str::get`, never a raw index, so a multi-byte character
+/// straddling the offset degrades to "no marker" instead of panicking.
 pub(super) fn or_marker_len(text: &str) -> usize {
     if text.get(..3).is_some_and(|p| p.eq_ignore_ascii_case("or:")) {
         return 3;
@@ -120,15 +102,7 @@ pub(super) fn or_marker_len(text: &str) -> usize {
     0
 }
 
-/// Every usage form, each as the padding it renders behind and its text,
-/// preserving the tool's own relative alignment once the dropped
-/// `Usage: `/`or: ` labels no longer hold each form's position (spec
-/// §4.1). Every form shifts left by the first form's own content column,
-/// so form one lands at the block indent and the rest keep their
-/// relative position; a form indented less than that shift clamps at the
-/// block indent rather than going negative, since a label width can
-/// still outweigh a shallower marker (e.g. a one-column `or ` under a
-/// deeper `Usage: `).
+/// Every usage line of a node, each shaped by [`usage_form`].
 pub(super) fn usage_forms(node_name: &str, usage: &[Text]) -> Vec<(usize, String)> {
     let forms: Vec<(usize, String)> = usage
         .iter()
@@ -141,9 +115,9 @@ pub(super) fn usage_forms(node_name: &str, usage: &[Text]) -> Vec<(usize, String
         .collect()
 }
 
-/// The byte span of the word in `text`'s leading run of bare command-path
-/// tokens that names the node, if any — see [`usage_form`] for why the
-/// search covers the whole run rather than only the first token.
+/// The span of a leading word that IS this node under another spelling: a
+/// resolved path (`/usr/bin/cp` for `cp`) or a dotted stem (`vim` for
+/// `vim.basic`). Replaced with the node's own name. See S-108.
 pub(super) fn usage_naming_span(text: &str, name: &str) -> Option<(usize, usize)> {
     let mut cursor = 0;
     for token in text.split_whitespace() {
@@ -162,8 +136,7 @@ pub(super) fn usage_naming_span(text: &str, name: &str) -> Option<(usize, usize)
 
 /// Whether `word` names the node: an exact match, its basename after the
 /// last `/` (`cp`'s `/usr/bin/cp`), or the node name's own prefix before
-/// its first `.` (`vim.basic`'s `vim`, from a `vim.basic --help` that
-/// still calls itself plain `vim`).
+/// its first `.` (`vim.basic`'s own `vim`).
 fn word_names_node(word: &str, name: &str) -> bool {
     let basename = word.rsplit('/').next().unwrap_or(word);
     if basename == name {
@@ -175,11 +148,8 @@ fn word_names_node(word: &str, name: &str) -> bool {
     }
 }
 
-/// A token that ends a usage line's leading command-path run: an option
-/// (`-v`, `--verbose`), a bracketed/angled placeholder (`[OPTIONS]`,
-/// `<url>`), or a bare ALL-CAPS metavar (`FILE`, `URL`) — docopt-style
-/// convention for "this is a slot to fill in", never a literal word of the
-/// command path.
+/// True for an option (`-v`), a bracketed or angled placeholder, or a bare
+/// ALL-CAPS metavar: any of them ends a leading command-path run.
 pub(super) fn looks_like_option_or_placeholder(word: &str) -> bool {
     if word.starts_with(['-', '[', '<']) {
         return true;

--- a/mandible-tui/src/render/detail_pane/usage_form.rs
+++ b/mandible-tui/src/render/detail_pane/usage_form.rs
@@ -1,0 +1,189 @@
+//! The USAGE section's own line shaping: strip the redundant label and
+//! program word, and decide when a leading word IS this program.
+//! docs/shapes.md S-108, S-150, S-151.
+
+use crate::sanitize::defensive_single_line;
+use mandible_core::Text;
+
+/// One usage line, with the redundant `Usage:`/`or:`/node-name prefix
+/// stripped: the heading and label already say that, and a cobra tool's
+/// full-path form (`docker import [OPTIONS]...`) must not double-prepend
+/// the node name either. Fixtures: `corpus/vim.basic/audit-seed4`,
+/// `corpus/cp/9.4`, `docker import`, `smokecli columns outlier`.
+///
+/// One usage form: the column its text began at (leading indent plus any
+/// dropped `Usage:`/`or:` label width), and the text. [`usage_forms`]
+/// compensates with the column.
+pub(super) fn usage_form(node_name: &str, usage: &str) -> (usize, String) {
+    let name = defensive_single_line(node_name);
+    let raw = defensive_single_line(usage);
+
+    // Tabs are already expanded to spaces at 8-column stops
+    // (`Text::sanitize_preserving_layout`), so counting leading spaces
+    // counts columns.
+    let mut text = raw.trim_start_matches(' ').to_string();
+    let mut column = raw.chars().count() - text.chars().count();
+
+    // Drop a leading `usage:` label, or else a continuation's own `or:`/
+    // `or` marker, case-insensitively; charge its width to the column so
+    // the forms keep the alignment the tool author drew them with.
+    if text
+        .get(..6)
+        .is_some_and(|p| p.eq_ignore_ascii_case("usage:"))
+    {
+        let after = text[6..].trim_start().to_string();
+        column += text.chars().count() - after.chars().count();
+        text = after;
+    } else {
+        let marker_len = or_marker_len(&text);
+        if marker_len > 0 {
+            let after = text[marker_len..].trim_start().to_string();
+            column += text.chars().count() - after.chars().count();
+            text = after;
+        }
+    }
+
+    let text = if name.is_empty() {
+        text
+    } else if let Some((start, end)) = usage_naming_span(&text, &name) {
+        // The help text already names the node, by a path (`cp`'s
+        // `/usr/bin/cp`) or a prefix (`vim.basic`'s `vim`) rather than by
+        // an exact match. Replace that word with the node's own name
+        // instead of leaving it and prepending, which would double it.
+        format!("{}{name}{}", &text[..start], &text[end..])
+    } else if let Some((start, end)) = foreign_program_word_span(&text, &name) {
+        // The form's own leading word is a program name, just not this
+        // node's own spelling or stem (`gcc-ranlib-13`'s own form opens
+        // with `/usr/bin/ranlib`) — the word in a usage line's program
+        // position is the program, whatever it is spelled (docs/design.md
+        // §16), so it is replaced exactly as [`usage_naming_span`]'s own
+        // match is. See S-151.
+        format!("{}{name}{}", &text[..start], &text[end..])
+    } else {
+        format!("{name} {text}")
+    };
+    (column, text)
+}
+
+/// The byte span of `text`'s own very first token, when it reads as a
+/// program name rather than this node's own name or stem: lowercase-led,
+/// no bracket, no angle, not ALL-CAPS, and made only of letters, digits,
+/// `.`, `-`, `_`, `+` or `/`. Deliberately only the first token, never the
+/// whole leading run [`usage_naming_span`] scans — `lldb-server`'s own
+/// form `g[dbserver] [options]` carries a subcommand in that position, and
+/// its embedded bracket already fails the character-set test below, so
+/// this never touches it. See S-151.
+pub(super) fn foreign_program_word_span(text: &str, name: &str) -> Option<(usize, usize)> {
+    let first = text.split_whitespace().next()?;
+    if looks_like_option_or_placeholder(first) {
+        return None;
+    }
+    // A bare word that CONTAINS the node's own name is a sibling program,
+    // not this one under another spelling (`egrep` under node `grep`), and
+    // replacing it would delete a real word. A path always qualifies: a
+    // usage line's program position cannot hold a sibling's path.
+    if !first.contains('/') && !name.starts_with(first) {
+        return None;
+    }
+    // "Lowercase-led": the token's own first *alphabetic* character is
+    // lowercase, checked past any leading path separators so an absolute
+    // path (`/usr/bin/ranlib`) still qualifies. Excludes a titlecase prose
+    // word (`Generate`) that slipped past the option/placeholder check.
+    let first_alpha = first.chars().find(|c| c.is_alphabetic())?;
+    if !first_alpha.is_ascii_lowercase() {
+        return None;
+    }
+    if !first
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+' | '/'))
+    {
+        return None;
+    }
+    let start = text.find(first)?;
+    Some((start, start + first.len()))
+}
+
+/// The byte length of a leading `or:`/`or ` continuation marker, or `0`.
+/// Reads bytes through `str::get`, never a raw index, so a multi-byte
+/// character straddling the offset degrades to "no marker" instead of
+/// panicking (AGENTS.md's rule against slicing tool output at a byte
+/// offset).
+pub(super) fn or_marker_len(text: &str) -> usize {
+    if text.get(..3).is_some_and(|p| p.eq_ignore_ascii_case("or:")) {
+        return 3;
+    }
+    if text.as_bytes().get(2) == Some(&b' ')
+        && text.get(..2).is_some_and(|p| p.eq_ignore_ascii_case("or"))
+    {
+        return 2;
+    }
+    0
+}
+
+/// Every usage form, each as the padding it renders behind and its text,
+/// preserving the tool's own relative alignment once the dropped
+/// `Usage: `/`or: ` labels no longer hold each form's position (spec
+/// §4.1). Every form shifts left by the first form's own content column,
+/// so form one lands at the block indent and the rest keep their
+/// relative position; a form indented less than that shift clamps at the
+/// block indent rather than going negative, since a label width can
+/// still outweigh a shallower marker (e.g. a one-column `or ` under a
+/// deeper `Usage: `).
+pub(super) fn usage_forms(node_name: &str, usage: &[Text]) -> Vec<(usize, String)> {
+    let forms: Vec<(usize, String)> = usage
+        .iter()
+        .map(|u| usage_form(node_name, u.as_str()))
+        .collect();
+    let shift = forms.first().map(|(column, _)| *column).unwrap_or(0);
+    forms
+        .into_iter()
+        .map(|(column, text)| (column.saturating_sub(shift), text))
+        .collect()
+}
+
+/// The byte span of the word in `text`'s leading run of bare command-path
+/// tokens that names the node, if any — see [`usage_form`] for why the
+/// search covers the whole run rather than only the first token.
+pub(super) fn usage_naming_span(text: &str, name: &str) -> Option<(usize, usize)> {
+    let mut cursor = 0;
+    for token in text.split_whitespace() {
+        let start = cursor + text[cursor..].find(token)?;
+        let end = start + token.len();
+        if looks_like_option_or_placeholder(token) {
+            return None;
+        }
+        if word_names_node(token, name) {
+            return Some((start, end));
+        }
+        cursor = end;
+    }
+    None
+}
+
+/// Whether `word` names the node: an exact match, its basename after the
+/// last `/` (`cp`'s `/usr/bin/cp`), or the node name's own prefix before
+/// its first `.` (`vim.basic`'s `vim`, from a `vim.basic --help` that
+/// still calls itself plain `vim`).
+fn word_names_node(word: &str, name: &str) -> bool {
+    let basename = word.rsplit('/').next().unwrap_or(word);
+    if basename == name {
+        return true;
+    }
+    match name.split_once('.') {
+        Some((prefix, _)) if !prefix.is_empty() => basename == prefix,
+        _ => false,
+    }
+}
+
+/// A token that ends a usage line's leading command-path run: an option
+/// (`-v`, `--verbose`), a bracketed/angled placeholder (`[OPTIONS]`,
+/// `<url>`), or a bare ALL-CAPS metavar (`FILE`, `URL`) — docopt-style
+/// convention for "this is a slot to fill in", never a literal word of the
+/// command path.
+pub(super) fn looks_like_option_or_placeholder(word: &str) -> bool {
+    if word.starts_with(['-', '[', '<']) {
+        return true;
+    }
+    let has_letter = word.chars().any(|c| c.is_alphabetic());
+    has_letter && !word.chars().any(|c| c.is_lowercase())
+}

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -13,6 +13,7 @@ mod render_text;
 mod round7;
 mod round8;
 mod round9;
+mod round10;
 mod score;
 
 use aggregate::compute_aggregate;

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -10,10 +10,10 @@ mod aggregate;
 mod fingerprint;
 mod render_markdown;
 mod render_text;
+mod round10;
 mod round7;
 mod round8;
 mod round9;
-mod round10;
 mod score;
 
 use aggregate::compute_aggregate;

--- a/xtask/src/coverage/round10.rs
+++ b/xtask/src/coverage/round10.rs
@@ -1,0 +1,36 @@
+//! The round-10 family detectors, atlas S-150 and S-151. S-150 is a bare
+//! usage label seeding an empty form. S-151 is a usage form's own foreign
+//! leading program word, the case S-108's `usage-program-word-mismatch`
+//! does not already handle. Split into their own file for the same
+//! line-count reason `round7.rs`, `round8.rs` and `round9.rs` are.
+
+use super::score::FAMILY_DETECTOR_SAMPLES_PER_ROW;
+use crate::detector::{Detector, ToolEvidence};
+use mandible_core::CommandNode;
+
+pub(super) fn round10_family_counts(
+    raw: &str,
+    root: &CommandNode,
+) -> Vec<(&'static str, usize, Vec<String>)> {
+    let cap = FAMILY_DETECTOR_SAMPLES_PER_ROW;
+    let evidence = ToolEvidence { raw, root };
+    let bare = crate::detector::bare_usage_label_form::BareUsageLabelForm.hits(&evidence);
+    let foreign = crate::detector::usage_foreign_program_word::detect(raw, root);
+    vec![
+        (
+            "bare-usage-label-form",
+            bare.len(),
+            bare.into_iter().take(cap).collect(),
+        ),
+        (
+            "usage-foreign-program-word",
+            foreign.finding_count(),
+            foreign
+                .findings
+                .iter()
+                .take(cap)
+                .map(|f| format!("{:?} never became the node's own name, from {:?}", f.token, f.line))
+                .collect(),
+        ),
+    ]
+}

--- a/xtask/src/coverage/round10.rs
+++ b/xtask/src/coverage/round10.rs
@@ -29,7 +29,12 @@ pub(super) fn round10_family_counts(
                 .findings
                 .iter()
                 .take(cap)
-                .map(|f| format!("{:?} never became the node's own name, from {:?}", f.token, f.line))
+                .map(|f| {
+                    format!(
+                        "{:?} never became the node's own name, from {:?}",
+                        f.token, f.line
+                    )
+                })
                 .collect(),
         ),
     ]

--- a/xtask/src/coverage/round8.rs
+++ b/xtask/src/coverage/round8.rs
@@ -17,7 +17,7 @@ pub(super) fn round8_family_counts(
     let gu = crate::detector::glued_uppercase_shared_prefix::detect(raw, root);
     let dc = crate::detector::description_continuation_dash_flag::detect(raw, root);
     let lg = crate::detector::usage_label_glued_to_program_name::detect(raw, root);
-    let ob = crate::detector::usage_open_bracket_continues_at_column_zero::detect(raw);
+    let ob = crate::detector::usage_open_bracket_continues_at_column_zero::detect(raw, root);
     vec![
         (
             "invocation-form-head-as-flag-group",

--- a/xtask/src/coverage/score.rs
+++ b/xtask/src/coverage/score.rs
@@ -497,6 +497,7 @@ fn vim_family_counts(
     counts.extend(super::round7::round7_usage_family_counts(&raw, root));
     counts.extend(super::round8::round8_family_counts(&raw, root));
     counts.extend(super::round9::round9_family_counts(&raw, root));
+    counts.extend(super::round10::round10_family_counts(&raw, root));
     counts
 }
 

--- a/xtask/src/detector/bare_usage_label_form.rs
+++ b/xtask/src/detector/bare_usage_label_form.rs
@@ -1,0 +1,143 @@
+//! `bare-usage-label-form` (atlas S-150): a usage label alone on its own
+//! line, with nothing else, contributes no invocation text — the detail
+//! pane's `usage_form` renders the bare tool name for it instead.
+//! Fixtures: `corpus/fdisk/2.39.3`, `corpus/pkcheck/124`.
+
+use crate::detector::{Detector, Expect, SelfCheck, ToolEvidence};
+use mandible_core::CommandNode;
+
+pub struct Finding {
+    pub entry: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+/// True if `t` starts with `label` (`usage:` or `or:`), case-insensitive,
+/// mirroring `mandible-extract`'s own `starts_with_usage_prefix`/
+/// `starts_with_or_marker` — reimplemented rather than imported, the same
+/// convention `usage_program_word_mismatch` already follows, since
+/// `xtask` does not depend on `mandible-extract`'s internal grammar
+/// modules.
+fn strip_ci_label<'a>(t: &'a str, label: &str) -> Option<&'a str> {
+    t.as_bytes()
+        .get(..label.len())
+        .filter(|b| b.eq_ignore_ascii_case(label.as_bytes()))
+        .map(|_| &t[label.len()..])
+}
+
+/// True when `entry`, once trimmed, is either outright empty or carries
+/// only a `usage:`/`or:` label with nothing after it — the tree-level
+/// shape a fixed parser never emits (the label contributes no entry at
+/// all), and the pre-fix parser always did (the label became its own
+/// entry, seeded from nothing else).
+fn is_bare_usage_entry(entry: &str) -> bool {
+    let t = entry.trim();
+    let stripped = strip_ci_label(t, "usage:")
+        .or_else(|| strip_ci_label(t, "or:"))
+        .unwrap_or(t);
+    stripped.trim().is_empty()
+}
+
+pub fn detect(root: &CommandNode) -> Report {
+    let findings = root
+        .usage
+        .iter()
+        .filter(|u| is_bare_usage_entry(u.as_str()))
+        .map(|u| Finding {
+            entry: u.as_str().to_string(),
+        })
+        .collect();
+    Report { findings }
+}
+
+pub struct BareUsageLabelForm;
+
+impl Detector for BareUsageLabelForm {
+    fn name(&self) -> &'static str {
+        "bare-usage-label-form"
+    }
+
+    fn family(&self) -> Option<&'static str> {
+        // No seed-labelled tool carries this shape as its own recorded
+        // family (spec §13.1e rule 6): calibration has nothing to
+        // generalize against.
+        None
+    }
+
+    fn describes(&self) -> &'static str {
+        "a root.usage entry that is empty, or carries only a `usage:`/`or:` label with no \
+         invocation text of its own"
+    }
+
+    fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
+        detect(evidence.root)
+            .findings
+            .into_iter()
+            .map(|f| format!("bare usage entry {:?}", f.entry))
+            .collect()
+    }
+
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        self_checks()
+    }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use mandible_core::{Provenance, Source, Text};
+
+fn node_with_usage(name: &str, usage: &[&str]) -> CommandNode {
+    let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
+    root.usage = usage
+        .iter()
+        .map(|u| Text::sanitize_preserving_layout(u))
+        .collect();
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "a bare `Usage:` entry with nothing after it",
+            why: "the defect itself: the pre-fix parser's own seed entry, byte-exact shape from \
+                  fdisk's raw `Usage:` line before its two real forms",
+            expect: Expect::Fires(1),
+            raw: String::new(),
+            root: node_with_usage("fdisk", &["Usage:"]),
+        },
+        SelfCheck {
+            name: "an outright empty entry",
+            why: "the same shape with the label itself already gone, so the tree-level check \
+                  must not require the literal word `usage`",
+            expect: Expect::Fires(1),
+            raw: String::new(),
+            root: node_with_usage("fdisk", &[""]),
+        },
+        SelfCheck {
+            name: "a real form carrying real invocation text",
+            why: "must stay silent on an ordinary usage form, even one that opens with the \
+                  tool's own name",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("fdisk", &["fdisk [options] <disk>"]),
+        },
+        SelfCheck {
+            name: "a real form on the fixed tree, label already dropped",
+            why: "the fixed parser's own output: no bare entry survives once a real form \
+                  follows it, so a tree with only real forms must read silent",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage(
+                "fdisk",
+                &[
+                    "fdisk [options] <disk>         change partition table",
+                    "fdisk [options] -l [<disk>...] list partition table(s)",
+                ],
+            ),
+        },
+    ]
+}

--- a/xtask/src/detector/commands.rs
+++ b/xtask/src/detector/commands.rs
@@ -398,6 +398,31 @@ pub fn check_round9_family_ratchets(
     Ok(cmd && opt)
 }
 
+/// [`check_vim_family_ratchet`] for round 10's repaired families, atlas
+/// S-150 (a bare usage label seeding an empty form) and S-142's two
+/// halves (issue #143: the glued label and the open-bracket
+/// continuation, both now tree-aware — see
+/// `usage_label_glued_to_program_name` and
+/// `usage_open_bracket_continues_at_column_zero`). Gated at zero the same
+/// way `check_round9_family_ratchets` is. `usage-foreign-program-word`
+/// (S-151's other half) is deliberately absent: it is a render-layer
+/// substitution, so the raw usage text it counts never changes once a
+/// tool is repaired, the same reason `usage-program-word-mismatch` is
+/// reported rather than ratcheted.
+pub fn check_round10_family_ratchets(
+    previous: &crate::coverage::Aggregate,
+    fresh: &crate::coverage::Aggregate,
+) -> anyhow::Result<bool> {
+    let bare = check_vim_family_ratchet("bare-usage-label-form", previous, fresh)?;
+    let glued = check_vim_family_ratchet("usage-label-glued-to-program-name", previous, fresh)?;
+    let bracket = check_vim_family_ratchet(
+        "usage-open-bracket-continues-at-column-zero",
+        previous,
+        fresh,
+    )?;
+    Ok(bare && glued && bracket)
+}
+
 /// pnpm's two families (atlas S-103, S-104), fixed in
 /// `mandible-extract/src/help_text/sections/{mod,scan}.rs`. Ratcheted at
 /// zero the same way as `single-dash-long`: the fix moves two tools

--- a/xtask/src/detector/mod.rs
+++ b/xtask/src/detector/mod.rs
@@ -106,6 +106,7 @@ pub(crate) mod option_table_multiword_value_name;
 // impl shape as the round-8/round-9 modules above.
 pub(crate) mod bare_usage_label_form;
 pub(crate) mod usage_foreign_program_word;
+pub(crate) mod usage_form_trailing_description;
 
 pub(crate) use calibration::*;
 pub(crate) use commands::*;
@@ -755,6 +756,7 @@ pub fn registry() -> Vec<Box<dyn Detector>> {
         Box::new(option_table_multiword_value_name::OptionTableMultiwordValueName),
         Box::new(bare_usage_label_form::BareUsageLabelForm),
         Box::new(usage_foreign_program_word::UsageForeignProgramWord),
+        Box::new(usage_form_trailing_description::UsageFormTrailingDescription),
     ]
 }
 

--- a/xtask/src/detector/mod.rs
+++ b/xtask/src/detector/mod.rs
@@ -102,6 +102,11 @@ pub(crate) mod lowdown_bullet_option_row;
 // parser change ships for it.
 pub(crate) mod option_table_multiword_value_name;
 
+// Round-10 family detectors (atlas S-150, S-151), same direct-`Detector`-
+// impl shape as the round-8/round-9 modules above.
+pub(crate) mod bare_usage_label_form;
+pub(crate) mod usage_foreign_program_word;
+
 pub(crate) use calibration::*;
 pub(crate) use commands::*;
 pub(crate) use detectors_families::*;
@@ -748,6 +753,8 @@ pub fn registry() -> Vec<Box<dyn Detector>> {
         Box::new(crate::centered_label_baseline::LabelPrecedesShallowerLine),
         Box::new(crate::centered_label_baseline::MissingRowAfterLabel),
         Box::new(option_table_multiword_value_name::OptionTableMultiwordValueName),
+        Box::new(bare_usage_label_form::BareUsageLabelForm),
+        Box::new(usage_foreign_program_word::UsageForeignProgramWord),
     ]
 }
 

--- a/xtask/src/detector/usage_foreign_program_word.rs
+++ b/xtask/src/detector/usage_foreign_program_word.rs
@@ -1,0 +1,195 @@
+//! `usage-foreign-program-word` (atlas S-151): a usage form's own leading
+//! word is a program name, spelled neither as the node's own name nor its
+//! dotted stem (`gcc-ranlib-13`'s own form opening `/usr/bin/ranlib`).
+//! S-108's `usage-program-word-mismatch` already generalizes the
+//! already-handled case (the word IS the node under a different
+//! spelling); this detector counts the remaining, previously unhandled
+//! case the detail pane's `foreign_program_word_span` now repairs by
+//! replacement.
+//!
+//! Reimplements the renderer's own rule rather than importing it (`xtask`
+//! does not depend on `mandible-tui`), the same convention
+//! `usage_program_word_mismatch` already follows. Reported, not gated: the
+//! fix is a render-layer substitution, so the raw usage text — and this
+//! detector's own tree-level count of it — never changes once the tool is
+//! repaired, the same reason `usage-program-word-mismatch` itself is
+//! reported rather than ratcheted at zero.
+//!
+//! Fixtures: `corpus/gcc-ranlib-13/2.42/`.
+
+use mandible_core::CommandNode;
+
+pub struct Finding {
+    pub token: String,
+    pub line: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    pub fn finding_count(&self) -> usize {
+        self.findings.len()
+    }
+}
+
+/// Mirrors the renderer's `looks_like_option_or_placeholder`.
+fn looks_like_option_or_placeholder(word: &str) -> bool {
+    if word.starts_with(['-', '[', '<']) {
+        return true;
+    }
+    let has_letter = word.chars().any(|c| c.is_alphabetic());
+    has_letter && !word.chars().any(|c| c.is_lowercase())
+}
+
+/// Mirrors the renderer's `usage_form`: drop a leading `usage:`/`or:`
+/// label before reading the leading run.
+fn strip_label(text: &str) -> &str {
+    let t = text.trim_start();
+    for label in ["usage:", "or:"] {
+        if t.len() >= label.len() && t[..label.len()].eq_ignore_ascii_case(label) {
+            return t[label.len()..].trim_start();
+        }
+    }
+    t
+}
+
+fn basename(word: &str) -> &str {
+    word.rsplit('/').next().unwrap_or(word)
+}
+
+/// Mirrors the renderer's `word_names_node`.
+fn word_names_node(word: &str, name: &str) -> bool {
+    let b = basename(word);
+    if b == name {
+        return true;
+    }
+    match name.split_once('.') {
+        Some((prefix, _)) if !prefix.is_empty() => b == prefix,
+        _ => false,
+    }
+}
+
+/// Mirrors the renderer's `foreign_program_word_span` gate: lowercase-led
+/// past any leading path separators, no bracket, no angle, not ALL-CAPS,
+/// made only of letters, digits, `.`, `-`, `_`, `+` or `/`.
+fn looks_like_program_name(word: &str) -> bool {
+    let Some(first_alpha) = word.chars().find(|c| c.is_alphabetic()) else {
+        return false;
+    };
+    if !first_alpha.is_ascii_lowercase() {
+        return false;
+    }
+    word.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+' | '/'))
+}
+
+pub fn detect(_raw: &str, root: &CommandNode) -> Report {
+    let mut findings = Vec::new();
+    for form in &root.usage {
+        let text = strip_label(form.as_str());
+        let Some(first) = text.split_whitespace().next() else {
+            continue;
+        };
+        if looks_like_option_or_placeholder(first) {
+            continue;
+        }
+        if word_names_node(first, &root.name) {
+            // S-108's own already-handled case.
+            continue;
+        }
+        if looks_like_program_name(first) {
+            findings.push(Finding {
+                token: first.to_string(),
+                line: form.as_str().to_string(),
+            });
+        }
+    }
+    Report { findings }
+}
+
+pub struct UsageForeignProgramWord;
+
+impl crate::detector::Detector for UsageForeignProgramWord {
+    fn name(&self) -> &'static str {
+        "usage-foreign-program-word"
+    }
+
+    fn family(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn describes(&self) -> &'static str {
+        "a usage form's own leading word is a program name, spelled neither as the node's own \
+         name nor its dotted stem — the unhandled case S-108's `usage-program-word-mismatch` \
+         does not already cover"
+    }
+
+    fn hits(&self, evidence: &crate::detector::ToolEvidence<'_>) -> Vec<String> {
+        detect(evidence.raw, evidence.root)
+            .findings
+            .into_iter()
+            .map(|f| format!("{:?} never became the node's own name, from {:?}", f.token, f.line))
+            .collect()
+    }
+
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        self_checks()
+    }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use crate::detector::{Expect, SelfCheck};
+use mandible_core::{Provenance, Source, Text};
+
+fn node_with_usage(name: &str, usage: &[&str]) -> CommandNode {
+    let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
+    root.usage = usage
+        .iter()
+        .map(|u| Text::sanitize_preserving_layout(u))
+        .collect();
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "gcc-ranlib-13's own bytes, a path naming an unrelated program",
+            why: "the defect itself: `/usr/bin/ranlib`'s basename names neither the node nor its \
+                  stem, byte-exact from `corpus/gcc-ranlib-13/2.42/help.txt`",
+            expect: Expect::Fires(1),
+            raw: String::new(),
+            root: node_with_usage(
+                "gcc-ranlib-13",
+                &["Usage: /usr/bin/ranlib [options] archive"],
+            ),
+        },
+        SelfCheck {
+            name: "cargo-clippy's own bytes, a bare foreign program word",
+            why: "the same defect with no path at all: `cargo` names neither the node \
+                  `cargo-clippy` nor any stem it has",
+            expect: Expect::Fires(1),
+            raw: String::new(),
+            root: node_with_usage("cargo-clippy", &["cargo clippy [OPTIONS] [--] [<ARGS>...]"]),
+        },
+        SelfCheck {
+            name: "the node's own name already leads the form",
+            why: "S-108's own already-handled case must never double-count here",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("cp", &["Usage: /usr/bin/cp [OPTION]... [-T] SOURCE DEST"]),
+        },
+        SelfCheck {
+            name: "a bracketed subcommand token, never a program word",
+            why: "`lldb-server`'s own form `g[dbserver] [options]` carries a subcommand in the \
+                  program position; the embedded bracket must keep this silent",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("lldb-server", &["g[dbserver] [options]"]),
+        },
+    ]
+}

--- a/xtask/src/detector/usage_foreign_program_word.rs
+++ b/xtask/src/detector/usage_foreign_program_word.rs
@@ -1,19 +1,8 @@
-//! `usage-foreign-program-word` (atlas S-151): a usage form's own leading
-//! word is a program name, spelled neither as the node's own name nor its
-//! dotted stem (`gcc-ranlib-13`'s own form opening `/usr/bin/ranlib`).
-//! S-108's `usage-program-word-mismatch` already generalizes the
-//! already-handled case (the word IS the node under a different
-//! spelling); this detector counts the remaining, previously unhandled
-//! case the detail pane's `foreign_program_word_span` now repairs by
-//! replacement.
-//!
-//! Reimplements the renderer's own rule rather than importing it (`xtask`
-//! does not depend on `mandible-tui`), the same convention
-//! `usage_program_word_mismatch` already follows. Reported, not gated: the
-//! fix is a render-layer substitution, so the raw usage text — and this
-//! detector's own tree-level count of it — never changes once the tool is
-//! repaired, the same reason `usage-program-word-mismatch` itself is
-//! reported rather than ratcheted at zero.
+//! `usage-foreign-program-word` (atlas S-151): a usage form's leading word
+//! is a program name spelled neither as the node's own name nor its dotted
+//! stem (`gcc-ranlib-13`'s form opens `/usr/bin/ranlib`). S-108 counts the
+//! already-handled case; this counts the rest. Reported, not gated: the fix
+//! is a render-layer substitution, so the raw text never changes.
 //!
 //! Fixtures: `corpus/gcc-ranlib-13/2.42/`.
 
@@ -130,7 +119,12 @@ impl crate::detector::Detector for UsageForeignProgramWord {
         detect(evidence.raw, evidence.root)
             .findings
             .into_iter()
-            .map(|f| format!("{:?} never became the node's own name, from {:?}", f.token, f.line))
+            .map(|f| {
+                format!(
+                    "{:?} never became the node's own name, from {:?}",
+                    f.token, f.line
+                )
+            })
             .collect()
     }
 

--- a/xtask/src/detector/usage_form_trailing_description.rs
+++ b/xtask/src/detector/usage_form_trailing_description.rs
@@ -1,0 +1,227 @@
+//! `usage-form-trailing-description` (atlas S-152, measurement only): a
+//! usage form's own trailing description reaches the tree glued onto the
+//! synopsis instead of staying separate — `gcc-ranlib-13`'s own form reads
+//! `gcc-ranlib-13 [options] archive Generate an index to speed access to
+//! archives`. Reported, not gated: this round only measures the shape and
+//! proposes; no fix ships below the five-tool floor (docs/shapes.md S-152).
+//!
+//! Fixtures: `corpus/gcc-ranlib-13/2.42/`, `corpus/fdisk/2.39.3/`,
+//! `corpus/gdk-pixbuf-thumbnailer/2.42.10/` (whichever the round committed).
+
+use mandible_core::CommandNode;
+
+pub struct Finding {
+    pub trailing: String,
+    pub line: String,
+}
+
+pub struct Report {
+    pub findings: Vec<Finding>,
+}
+
+/// A plain prose word: lowercase-led, only letters/digits/`-`/`_`, at
+/// least two characters — the same shape `multiword.rs`'s own
+/// `plain_word` reads, a local copy rather than an import (xtask's
+/// detectors keep their own independent copies of the parser's grouping
+/// and word rules, by convention, so a detector never shares a bug with
+/// the fix it measures).
+fn plain_prose_word(w: &str) -> bool {
+    w.chars().count() >= 2
+        && w.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && w.chars()
+            .all(|c| c.is_ascii_alphabetic() || c == '-' || c == '_')
+}
+
+/// Whitespace-delimited groups, a `[...]` or `<...>` span counted as one
+/// group even with internal spaces — the same grouping
+/// `group_synopsis_tokens` gives, a local copy.
+fn group_tokens(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut depth = 0i32;
+    for c in s.chars() {
+        match c {
+            '[' | '<' => {
+                depth += 1;
+                cur.push(c);
+            }
+            ']' | '>' => {
+                depth = (depth - 1).max(0);
+                cur.push(c);
+            }
+            c if c.is_whitespace() && depth == 0 => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn strip_label(text: &str) -> &str {
+    let t = text.trim_start();
+    let lower = t.to_ascii_lowercase();
+    for label in ["usage:", "or:"] {
+        if lower.starts_with(label) {
+            return t[label.len()..].trim_start();
+        }
+    }
+    t
+}
+
+/// The minimum trailing run of plain prose words this counts as a real
+/// glued description rather than a two-word operand name (S-132/S-154
+/// already read those). Three, the same floor `is_prose_sentence` uses
+/// for a continuation sentence.
+const MIN_TRAILING_WORDS: usize = 3;
+
+/// `line`'s own trailing run of [`plain_prose_word`] groups, `None`
+/// unless at least [`MIN_TRAILING_WORDS`] of them sit at the very end and
+/// at least one non-prose synopsis group (a flag, a bracket, an ALL-CAPS
+/// operand) still stands ahead of the run — a bare, all-prose line is
+/// usage grammar this detector was never meant to read, not this shape.
+fn trailing_description(line: &str) -> Option<String> {
+    let after = strip_label(line);
+    let groups = group_tokens(after);
+    if groups.len() < 2 {
+        return None;
+    }
+    let mut split = groups.len();
+    while split > 0 && plain_prose_word(&groups[split - 1]) {
+        split -= 1;
+    }
+    let trailing_count = groups.len() - split;
+    if trailing_count < MIN_TRAILING_WORDS || split < 2 {
+        return None;
+    }
+    // At least one group ahead of the program name must be real synopsis
+    // grammar (a flag, a bracketed/angled group, or an ALL-CAPS operand) —
+    // otherwise this "trailing run" is just an all-prose sentence with no
+    // synopsis to glue onto.
+    let has_real_synopsis = groups[1..split].iter().any(|g| {
+        g.starts_with('-')
+            || g.starts_with('[')
+            || g.starts_with('<')
+            || g.chars().any(|c| c.is_ascii_uppercase())
+    });
+    if !has_real_synopsis {
+        return None;
+    }
+    Some(groups[split..].join(" "))
+}
+
+pub fn detect(_raw: &str, root: &CommandNode) -> Report {
+    let mut findings = Vec::new();
+    for form in &root.usage {
+        let line = form.as_str();
+        if let Some(trailing) = trailing_description(line) {
+            findings.push(Finding {
+                trailing,
+                line: line.to_string(),
+            });
+        }
+    }
+    Report { findings }
+}
+
+pub struct UsageFormTrailingDescription;
+
+impl crate::detector::Detector for UsageFormTrailingDescription {
+    fn name(&self) -> &'static str {
+        "usage-form-trailing-description"
+    }
+
+    fn family(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn describes(&self) -> &'static str {
+        "a usage form's own trailing description (three or more plain prose words behind real \
+         synopsis grammar) reaches the tree glued onto the invocation instead of staying \
+         separate — measurement only this round, docs/shapes.md S-152"
+    }
+
+    fn hits(&self, evidence: &crate::detector::ToolEvidence<'_>) -> Vec<String> {
+        detect(evidence.raw, evidence.root)
+            .findings
+            .into_iter()
+            .map(|f| format!("{:?} glued onto the usage form {:?}", f.trailing, f.line))
+            .collect()
+    }
+
+    fn self_checks(&self) -> Vec<SelfCheck> {
+        self_checks()
+    }
+}
+
+// ----------------------------------------------------------------------
+// Self-checks
+// ----------------------------------------------------------------------
+
+use crate::detector::{Expect, SelfCheck};
+use mandible_core::{Provenance, Source};
+
+fn node_with_usage(name: &str, usage: &str) -> CommandNode {
+    let mut root = CommandNode::new(name, Provenance::single(Source::HelpText));
+    root.usage = vec![mandible_core::Text::sanitize(usage)];
+    root
+}
+
+pub(crate) fn self_checks() -> Vec<SelfCheck> {
+    vec![
+        SelfCheck {
+            name: "gcc-ranlib-13's own bytes, the description glued onto the synopsis",
+            why: "the defect itself: the tail words are the tool's own trailing description, \
+                  not part of the invocation",
+            expect: Expect::Fires(1),
+            raw: String::new(),
+            root: node_with_usage(
+                "gcc-ranlib-13",
+                "gcc-ranlib-13 [options] archive Generate an index to speed access to archives",
+            ),
+        },
+        SelfCheck {
+            name: "the same form with its description already split off",
+            why: "once separated, the usage form must go silent",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("gcc-ranlib-13", "gcc-ranlib-13 [options] archive"),
+        },
+        SelfCheck {
+            name: "fdisk's own bytes, a column gap in front of the description",
+            why: "the description is still glued on, just spaced out — the same shape either \
+                  way",
+            expect: Expect::Fires(1),
+            raw: String::new(),
+            root: node_with_usage("fdisk", "fdisk [options] <disk> change partition table"),
+        },
+        SelfCheck {
+            name: "a docopt bracket-alternation tail with no real prose at all",
+            why: "an all-grammar tail (no plain-prose run) must never be read as a description",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("widget", "widget [OPTIONS] <disk> [list of exclude dirs]"),
+        },
+        SelfCheck {
+            name: "a two-word bracketed operand, S-132's own shape",
+            why: "two trailing prose words alone (below this rule's own three-word floor) must \
+                  stay S-132/S-154's read, not this one",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("widget", "widget [OPTIONS] [INPUT FILE]"),
+        },
+        SelfCheck {
+            name: "a bare unlabelled synopsis with no real grammar ahead of the prose",
+            why: "with nothing but plain words on the whole line, there is no synopsis to glue \
+                  a description onto — declined rather than guessed",
+            expect: Expect::Silent,
+            raw: String::new(),
+            root: node_with_usage("true", "true ignored command line arguments"),
+        },
+    ]
+}

--- a/xtask/src/detector/usage_label_glued_to_program_name.rs
+++ b/xtask/src/detector/usage_label_glued_to_program_name.rs
@@ -1,10 +1,13 @@
-//! `usage-label-glued-to-program-name` (atlas S-142, measurement half):
-//! a usage line's own label sits directly against the program name with
-//! no space (`mksquashfs`'s `SYNTAX:mksquashfs source1 source2 ...`),
-//! any label spelling other than the two already recognized
+//! `usage-label-glued-to-program-name` (atlas S-142): a usage line's own
+//! label sits directly against the program name with no space
+//! (`mksquashfs`'s `SYNTAX:mksquashfs source1 source2 ...`), any label
+//! spelling other than the two already recognized
 //! (`starts_with_usage_prefix`'s `usage:`, `starts_with_or_marker`'s
-//! `or:`). Fixture: `corpus/mksquashfs/4.6.1` (xfail). No seed-labelled
-//! tool carries this shape, so [`Detector::family`] returns `None`.
+//! `or:`). Reads the tree, not just the raw text: a fixed tree already
+//! carries a usage entry opening with the tool's own name, so a repaired
+//! tool no longer counts (issue #143). Fixtures: `corpus/mksquashfs/4.6.1`,
+//! `corpus/sqfstar/4.6.1`. No seed-labelled tool carries this shape, so
+//! [`Detector::family`] returns `None`.
 
 use crate::detector::{Detector, Expect, SelfCheck, ToolEvidence};
 use mandible_core::CommandNode;
@@ -54,10 +57,35 @@ fn opens_with_name(after: &str, name: &str) -> bool {
             .is_some_and(|c| c.is_alphanumeric() || c == '_'))
 }
 
+/// True when some `root.usage` entry already opens with the tool's own
+/// name: the fixed parser's own signature, once the glued label has been
+/// dropped and the line reads as an ordinary usage form. A raw finding
+/// backed by a tree that already shows this is stale — the fix repaired
+/// it — so it must not count. See S-142, issue #143.
+fn tree_already_recognizes(root: &CommandNode, name: &str) -> bool {
+    root.usage
+        .iter()
+        .any(|u| starts_with_word(u.as_str().trim_start(), name))
+}
+
+/// True when `t` opens with `word` at a word boundary.
+fn starts_with_word(t: &str, word: &str) -> bool {
+    if word.is_empty() {
+        return false;
+    }
+    match t.strip_prefix(word) {
+        Some(rest) => rest.is_empty() || rest.starts_with(char::is_whitespace),
+        None => false,
+    }
+}
+
 pub fn detect(raw: &str, root: &CommandNode) -> Report {
     let name = root.name.as_str();
     let mut findings = Vec::new();
     if name.is_empty() {
+        return Report { findings };
+    }
+    if tree_already_recognizes(root, name) {
         return Report { findings };
     }
     for line in raw.lines() {
@@ -176,6 +204,18 @@ pub(crate) fn self_checks() -> Vec<SelfCheck> {
             expect: Expect::Silent,
             raw: "started at 12:34mksquashfs\n".to_string(),
             root: node_named("mksquashfs"),
+        },
+        SelfCheck {
+            name: "the fixed tree, label already dropped",
+            why: "the repaired parser's own signature: `root.usage` opens with the tool's own \
+                  name once `label_glued_to_tool_name` has stripped the glued label, and a raw \
+                  finding against a tree that already shows this must not count",
+            expect: Expect::Silent,
+            raw: MKSQUASHFS_SYNTAX_LINE.to_string(),
+            root: node_with_usage(
+                "mksquashfs",
+                "mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of exclude dirs/files]",
+            ),
         },
     ]
 }

--- a/xtask/src/detector/usage_open_bracket_continues_at_column_zero.rs
+++ b/xtask/src/detector/usage_open_bracket_continues_at_column_zero.rs
@@ -1,13 +1,16 @@
-//! `usage-open-bracket-continues-at-column-zero` (atlas S-142,
-//! measurement half): the document's opening physical line ends with a
-//! square-bracket group still open, and the very next physical line
-//! continues it at column zero rather than being indented under it
-//! (`mksquashfs`'s `SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM
-//! [OPTIONS] [-e list of` / `exclude dirs/files]`). Distinct from
+//! `usage-open-bracket-continues-at-column-zero` (atlas S-142): the
+//! document's opening physical line ends with a square-bracket group
+//! still open, and the very next physical line continues it at column
+//! zero rather than being indented under it (`mksquashfs`'s
+//! `SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list
+//! of` / `exclude dirs/files]`). Distinct from
 //! [`crate::detector::usage_label_glued_to_program_name`]: that shape is
 //! about the label, this one is about where the bracket group closes.
-//! Fixture: `corpus/mksquashfs/4.6.1` (xfail). No seed-labelled tool
-//! carries this shape, so [`Detector::family`] returns `None`.
+//! Reads the tree too: a fixed tree already carries a usage entry
+//! containing the continuation's own words joined onto the first line, so
+//! a repaired tool no longer counts (issue #143). Fixtures:
+//! `corpus/mksquashfs/4.6.1`, `corpus/sqfstar/4.6.1`. No seed-labelled
+//! tool carries this shape, so [`Detector::family`] returns `None`.
 
 use crate::detector::{Detector, Expect, SelfCheck, ToolEvidence};
 use mandible_core::CommandNode;
@@ -54,7 +57,16 @@ fn looks_like_flag_row(line: &str) -> bool {
     line.trim_start().starts_with('-')
 }
 
-pub fn detect(raw: &str) -> Report {
+/// True when some `root.usage` entry already contains the continuation's
+/// own trimmed text: the fixed parser's own signature, the bracket group
+/// joined onto the line that opened it. A raw finding backed by a tree
+/// that already shows this is stale. See S-142, issue #143.
+fn tree_already_joins(root: &CommandNode, continuation: &str) -> bool {
+    let want = continuation.trim();
+    !want.is_empty() && root.usage.iter().any(|u| u.as_str().contains(want))
+}
+
+pub fn detect(raw: &str, root: &CommandNode) -> Report {
     let lines: Vec<&str> = raw.lines().collect();
     let Some(first_idx) = lines.iter().position(|l| !l.trim().is_empty()) else {
         return Report {
@@ -88,6 +100,11 @@ pub fn detect(raw: &str) -> Report {
             findings: Vec::new(),
         };
     }
+    if tree_already_joins(root, next) {
+        return Report {
+            findings: Vec::new(),
+        };
+    }
     Report {
         findings: vec![Finding {
             first_line: first.to_string(),
@@ -113,7 +130,7 @@ impl Detector for UsageOpenBracketContinuesAtColumnZero {
     }
 
     fn hits(&self, evidence: &ToolEvidence<'_>) -> Vec<String> {
-        detect(evidence.raw)
+        detect(evidence.raw, evidence.root)
             .findings
             .into_iter()
             .map(|f| {
@@ -134,13 +151,19 @@ impl Detector for UsageOpenBracketContinuesAtColumnZero {
 // Self-checks
 // ----------------------------------------------------------------------
 
-use mandible_core::{Provenance, Source};
+use mandible_core::{Provenance, Source, Text};
 
 pub(crate) const MKSQUASHFS_TWO_LINE_SYNTAX: &str =
     "SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of\nexclude dirs/files]\n";
 
 fn node_named(name: &str) -> CommandNode {
     CommandNode::new(name, Provenance::single(Source::HelpText))
+}
+
+fn node_with_usage(name: &str, usage: &str) -> CommandNode {
+    let mut root = node_named(name);
+    root.usage = vec![Text::sanitize(usage)];
+    root
 }
 
 pub(crate) fn self_checks() -> Vec<SelfCheck> {
@@ -197,6 +220,18 @@ pub(crate) fn self_checks() -> Vec<SelfCheck> {
             expect: Expect::Silent,
             raw: "Usage: prog [-a\n-b  do a thing\n".to_string(),
             root: node_named("prog"),
+        },
+        SelfCheck {
+            name: "the fixed tree, bracket already joined",
+            why: "the repaired parser's own signature: `root.usage` already contains the \
+                  continuation's own words joined onto the first line, and a raw finding \
+                  against a tree that already shows this must not count",
+            expect: Expect::Silent,
+            raw: MKSQUASHFS_TWO_LINE_SYNTAX.to_string(),
+            root: node_with_usage(
+                "mksquashfs",
+                "mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list of exclude dirs/files]",
+            ),
         },
     ]
 }

--- a/xtask/src/detector/usage_open_bracket_continues_at_column_zero.rs
+++ b/xtask/src/detector/usage_open_bracket_continues_at_column_zero.rs
@@ -1,16 +1,9 @@
-//! `usage-open-bracket-continues-at-column-zero` (atlas S-142): the
-//! document's opening physical line ends with a square-bracket group
-//! still open, and the very next physical line continues it at column
-//! zero rather than being indented under it (`mksquashfs`'s
-//! `SYNTAX:mksquashfs source1 source2 ...  FILESYSTEM [OPTIONS] [-e list
-//! of` / `exclude dirs/files]`). Distinct from
-//! [`crate::detector::usage_label_glued_to_program_name`]: that shape is
-//! about the label, this one is about where the bracket group closes.
-//! Reads the tree too: a fixed tree already carries a usage entry
-//! containing the continuation's own words joined onto the first line, so
-//! a repaired tool no longer counts (issue #143). Fixtures:
-//! `corpus/mksquashfs/4.6.1`, `corpus/sqfstar/4.6.1`. No seed-labelled
-//! tool carries this shape, so [`Detector::family`] returns `None`.
+//! `usage-open-bracket-continues-at-column-zero` (atlas S-142): the opening
+//! line ends with a square-bracket group still open and the next line
+//! continues it at column zero (`mksquashfs`'s `[-e list of` / `exclude
+//! dirs/files]`). Reads the tree too, so a repaired tool stops counting.
+//!
+//! Fixtures: `corpus/mksquashfs/4.6.1`, `corpus/sqfstar/4.6.1`. Issue #143.
 
 use crate::detector::{Detector, Expect, SelfCheck, ToolEvidence};
 use mandible_core::CommandNode;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1230,6 +1230,7 @@ fn run_coverage(
         regressed |= !detector::check_round8_family_ratchets(&previous, &fresh)?;
         regressed |= !detector::check_command_pattern_reported(&previous, &fresh)?;
         regressed |= !detector::check_round9_family_ratchets(&previous, &fresh)?;
+        regressed |= !detector::check_round10_family_ratchets(&previous, &fresh)?;
 
         regressed |= !detector::check_centered_label_baseline_reported(&previous, &fresh)?;
 


### PR DESCRIPTION
A usage block's own label, foreign program word, tail operands and multi-word bracket groups are read now, so a tool's invocation forms and positionals reach the tree instead of being consumed by the label or split one per word. Four seed-7 audit items turned out to share one cause, and fixing it recovered 39 flags on three tools nobody had looked at.

Round 11 addition: a usage line's unbracketed numbered pair sitting ahead of a later required operand is now one variadic positional named by its shared stem, so `mandible mksquashfs` shows `source...` and `FILESYSTEM` where it showed only `FILESYSTEM`. This is a separate code path from the bracketed tail pair, which is why it gets its own shape id rather than widening that one. `sqfstar` is not a member: its usage carries no numbered pair and already rendered correctly. `linux-version` is declined, since its own defect is non-primary usage-line recovery. The round also measured the usage-form trailing description shape and did not fix it: the detector reads 4 tools over the fixture tree, short of the five-tool bar, so the atlas carries the proposal and the count instead of a rule.

Fleet sweep against the 0b30c15 baseline, 2269 tools matched, 0 appeared, 0 disappeared: 0 flag losses at the entity level, 39 flags gained across 3 tools (dmsetup 4 to 29, dmstats 8 to 20, npm 0 to 2), 0 subcommand losses, 0 subcommand gains. Two tools' flag counts drop by one each (perlbug and perlthanks, 21 to 20); both render the same 20 spellings before and after, so each lost entity was a fabricated duplicate. The round 11 commit adds no loss and no flag gain of its own: its whole fleet effect is one field-level line, mksquashfs gaining the `source` positional. All nine named controls hold: seven byte-identical on the screen, and for all nine the `#fp2` fingerprint record is identical between the baseline and this branch's sweep, with no control appearing in the sweep-diff.

Closes #141
Closes #143
